### PR TITLE
fix(014): Embedding Map 후속 — 503/500 응답·계약·리뷰 반영

### DIFF
--- a/packages/memento-core/src/infrastructure/reflexion-worker.spec.ts
+++ b/packages/memento-core/src/infrastructure/reflexion-worker.spec.ts
@@ -2157,6 +2157,8 @@ describe('ReflexionWorker', { hookTimeout: 120000, timeout: 120000 }, () => {
       if (isLowSpecRunner) return; // 저사양 러너는 대기 전 즉시 스킵
 
       await worker.start();
+      // 프로시저 생성·start()까지의 쿼리는 제외하고, 실패 이벤트 처리 구간만 측정
+      queryCounter?.reset();
       await worker.queueFailureEvent(event);
       await waitForEventProcessing(worker, WAIT_TIMEOUT_MS);
 

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -103,8 +103,10 @@ const server = createServer(app);
 
 // HTTP 보안 헤더 (FR-005/FR-006): 모든 응답에 OWASP 최소 보안 헤더 추가
 // D3.js CDN(d3js.org)은 dashboard.html 및 graph.html에서 사용하므로 CSP에서 허용
+// frameguard: 대시보드가 동일 출처에서 /graph 를 iframe으로 포함하므로 SAMEORIGIN (외부 도메인 임베드 방지)
+// frame-src: dashboard.html 의 Memory Graph 탭 iframe 허용
 app.use(helmet({
-  frameguard: { action: 'deny' },
+  frameguard: { action: 'sameorigin' },
   referrerPolicy: { policy: 'no-referrer' },
   contentSecurityPolicy: {
     directives: {
@@ -117,7 +119,7 @@ app.use(helmet({
       fontSrc: ["'self'"],
       objectSrc: ["'none'"],
       mediaSrc: ["'self'"],
-      frameSrc: ["'none'"]
+      frameSrc: ["'self'"]
     }
   }
 }));

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts
@@ -4,11 +4,19 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+const { umapFitAsyncMock, umapFitMock } = vi.hoisted(() => {
+  const project = (X: number[][]) =>
+    X.map((row: number[]) => [row[0] ?? 0, (row[1] ?? 0) + 0.01]);
+  return {
+    umapFitAsyncMock: vi.fn((X: number[][]) => Promise.resolve(project(X))),
+    umapFitMock: vi.fn((X: number[][]) => project(X)),
+  };
+});
+
 vi.mock('umap-js', () => ({
   UMAP: class {
-    fitAsync(X: number[][]) {
-      return Promise.resolve(X.map((row: number[]) => [row[0] ?? 0, (row[1] ?? 0) + 0.01]));
-    }
+    fitAsync = umapFitAsyncMock;
+    fit = umapFitMock;
   },
 }));
 
@@ -142,6 +150,8 @@ describe('buildEmbeddingMapResponse', () => {
 
   beforeEach(() => {
     clearEmbeddingMapCacheForTests();
+    umapFitAsyncMock.mockClear();
+    umapFitMock.mockClear();
     db = new Database(':memory:');
     createMinimalSchema(db);
   });
@@ -217,6 +227,7 @@ describe('buildEmbeddingMapResponse', () => {
     expect(res.meta.k).toBe(12);
     expect(res.meta.requested_k).toBe(20);
     expect(res.meta.cached).toBe(false);
+    expect(res.meta.waited_for_in_flight).toBe(false);
     for (const p of res.points) {
       expect(p.cluster).toBeGreaterThanOrEqual(0);
       expect(p.cluster).toBeLessThan(12);
@@ -239,7 +250,20 @@ describe('buildEmbeddingMapResponse', () => {
       k: 4,
     });
     expect(b.meta.cached).toBe(true);
+    expect(b.meta.waited_for_in_flight).toBe(false);
     expect(b.meta.computed_at).toBe(t0);
+  });
+
+  it('동시 캐시 미스: in-flight 공유로 UMAP fitAsync 1회, 대기 측 waited_for_in_flight', async () => {
+    seedEmbeddings(db, 12, 'minilm');
+    umapFitAsyncMock.mockClear();
+    const params = { provider: 'minilm' as const, limit: 300, k: 6 };
+    const [a, b] = await Promise.all([
+      buildEmbeddingMapResponse(db, params),
+      buildEmbeddingMapResponse(db, params),
+    ]);
+    expect(umapFitAsyncMock).toHaveBeenCalledTimes(1);
+    expect([a, b].filter(r => r.meta.waited_for_in_flight).length).toBe(1);
   });
 
   it('캐시 만료 후 재계산: cached false, 새 computed_at', async () => {

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts
@@ -3,6 +3,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('umap-js', () => ({
+  UMAP: class {
+    fitAsync(X: number[][]) {
+      return Promise.resolve(X.map((row: number[]) => [row[0] ?? 0, (row[1] ?? 0) + 0.01]));
+    }
+  },
+}));
+
 import express from 'express';
 import http from 'http';
 import Database from 'better-sqlite3';
@@ -147,9 +156,9 @@ describe('buildEmbeddingMapResponse', () => {
     vi.useRealTimers();
   });
 
-  it('NO_EMBEDDINGS: 해당 provider 임베딩 0건', () => {
+  it('NO_EMBEDDINGS: 해당 provider 임베딩 0건', async () => {
     try {
-      buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
+      await buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
       expect.fail('expected EmbeddingMapBuildError');
     } catch (e) {
       expect(e).toBeInstanceOf(EmbeddingMapBuildError);
@@ -159,10 +168,10 @@ describe('buildEmbeddingMapResponse', () => {
     }
   });
 
-  it('NO_EMBEDDINGS: 활성 기억 없음(소프트 삭제만 있음)', () => {
+  it('NO_EMBEDDINGS: 활성 기억 없음(소프트 삭제만 있음)', async () => {
     seedEmbeddings(db, 12, 'minilm', true);
     try {
-      buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
+      await buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
       expect.fail('expected EmbeddingMapBuildError');
     } catch (e) {
       expect(e).toBeInstanceOf(EmbeddingMapBuildError);
@@ -170,10 +179,10 @@ describe('buildEmbeddingMapResponse', () => {
     }
   });
 
-  it('INSUFFICIENT_DATA: 0 < count < 10', () => {
+  it('INSUFFICIENT_DATA: 0 < count < 10', async () => {
     seedEmbeddings(db, 7, 'minilm');
     try {
-      buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
+      await buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
       expect.fail('expected EmbeddingMapBuildError');
     } catch (e) {
       expect(e).toBeInstanceOf(EmbeddingMapBuildError);
@@ -183,11 +192,11 @@ describe('buildEmbeddingMapResponse', () => {
     }
   });
 
-  it('CORRUPTED_EMBEDDINGS: 행은 있으나 JSON 파싱 후 유효 벡터 0개', () => {
+  it('CORRUPTED_EMBEDDINGS: 행은 있으나 JSON 파싱 후 유효 벡터 0개', async () => {
     seedEmbeddings(db, 12, 'minilm');
     db.exec(`UPDATE memory_embedding SET embedding = '[]'`);
     try {
-      buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
+      await buildEmbeddingMapResponse(db, { provider: 'minilm', limit: 300, k: 6 });
       expect.fail('expected EmbeddingMapBuildError');
     } catch (e) {
       expect(e).toBeInstanceOf(EmbeddingMapBuildError);
@@ -197,9 +206,9 @@ describe('buildEmbeddingMapResponse', () => {
     }
   });
 
-  it('성공 시 points/meta, k 자동 조정(requested_k 보존)', () => {
+  it('성공 시 points/meta, k 자동 조정(requested_k 보존)', async () => {
     seedEmbeddings(db, 12, 'minilm');
-    const res = buildEmbeddingMapResponse(db, {
+    const res = await buildEmbeddingMapResponse(db, {
       provider: 'minilm',
       limit: 300,
       k: 20,
@@ -214,17 +223,17 @@ describe('buildEmbeddingMapResponse', () => {
     }
   });
 
-  it('캐시 히트: 동일 파라미터 재요청 시 cached true, computed_at 동일', () => {
+  it('캐시 히트: 동일 파라미터 재요청 시 cached true, computed_at 동일', async () => {
     seedEmbeddings(db, 11, 'minilm');
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-13T10:00:00.000Z'));
-    const a = buildEmbeddingMapResponse(db, {
+    const a = await buildEmbeddingMapResponse(db, {
       provider: 'minilm',
       limit: 50,
       k: 4,
     });
     const t0 = a.meta.computed_at;
-    const b = buildEmbeddingMapResponse(db, {
+    const b = await buildEmbeddingMapResponse(db, {
       provider: 'minilm',
       limit: 50,
       k: 4,
@@ -233,18 +242,18 @@ describe('buildEmbeddingMapResponse', () => {
     expect(b.meta.computed_at).toBe(t0);
   });
 
-  it('캐시 만료 후 재계산: cached false, 새 computed_at', () => {
+  it('캐시 만료 후 재계산: cached false, 새 computed_at', async () => {
     seedEmbeddings(db, 11, 'minilm');
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-13T10:00:00.000Z'));
-    const a = buildEmbeddingMapResponse(db, {
+    const a = await buildEmbeddingMapResponse(db, {
       provider: 'minilm',
       limit: 50,
       k: 4,
     });
     const t0 = a.meta.computed_at;
     vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-    const b = buildEmbeddingMapResponse(db, {
+    const b = await buildEmbeddingMapResponse(db, {
       provider: 'minilm',
       limit: 50,
       k: 4,

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts
@@ -33,7 +33,13 @@ export interface EmbeddingMapResponse {
     k: number;
     requested_k: number;
     limit: number;
+    /** LRU 캐시 히트 여부 */
     cached: boolean;
+    /**
+     * 다른 요청이 이미 시작한 in-flight 계산을 await만 한 경우 true.
+     * `cached===false`이면서 본 요청이 UMAP을 새로 돌리지 않았음을 구분할 때 사용(모니터링).
+     */
+    waited_for_in_flight: boolean;
     computed_at: string;
   };
 }
@@ -291,13 +297,21 @@ export async function buildEmbeddingMapResponse(
       meta: {
         ...hit.data.meta,
         cached: true,
+        waited_for_in_flight: false,
       },
     };
   }
 
   const shared = inFlight.get(cacheKey);
   if (shared) {
-    return await shared;
+    const data = await shared;
+    return {
+      ...data,
+      meta: {
+        ...data.meta,
+        waited_for_in_flight: true,
+      },
+    };
   }
 
   let resolve!: (value: EmbeddingMapResponse) => void;
@@ -356,6 +370,7 @@ export async function buildEmbeddingMapResponse(
           requested_k: params.k,
           limit: params.limit,
           cached: false,
+          waited_for_in_flight: false,
           computed_at: computedAt,
         },
       };

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts
@@ -10,6 +10,9 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 
 const cache = new Map<string, { data: EmbeddingMapResponse; expiresAt: number }>();
 
+/** 동시 요청이 같은 cacheKey로 캐시 미스일 때 UMAP을 N번 돌리지 않도록 in-flight 공유 */
+const inFlight = new Map<string, Promise<EmbeddingMapResponse>>();
+
 export interface EmbeddingPoint {
   id: string;
   x: number;
@@ -56,8 +59,13 @@ export class EmbeddingMapBuildError extends Error {
 
 export function clearEmbeddingMapCacheForTests(): void {
   cache.clear();
+  inFlight.clear();
 }
 
+/**
+ * 캐시/in-flight 키: `effectiveK = min(params.k, n)`만 포함.
+ * 예: n=12이면 k=15·k=20 요청 모두 effectiveK=12로 동일 키 → 같은 결과·캐시(의도됨).
+ */
 function getCacheKey(provider: string, limit: number, effectiveK: number): string {
   return `${provider}:${limit}:${effectiveK}`;
 }
@@ -71,8 +79,36 @@ function distSq(a: number[], b: number[]): number {
   return s;
 }
 
-/** Lloyd's K-Means (max 100 iter). 클러스터 ID는 비결정적일 수 있음. */
-export function kMeans(points: number[][], k: number, maxIter = 100): number[] {
+/** FNV-1a 32-bit — 캐시 키 등으로 K-Means 시드에 사용 */
+function hash32(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/** 결정적 0~1 난수 (동일 시드 → 동일 시퀀스) */
+function mulberry32(seed: number): () => number {
+  return () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Lloyd's K-Means (max 100 iter).
+ * `rng`이 있으면 초기/빈 군집 재시드가 결정적이라 캐시 만료 후에도 같은 입력에 대해 색 라벨이 안정적입니다.
+ */
+export function kMeans(
+  points: number[][],
+  k: number,
+  maxIter = 100,
+  rng: () => number = Math.random
+): number[] {
   const n = points.length;
   if (n === 0) {
     return [];
@@ -84,7 +120,7 @@ export function kMeans(points: number[][], k: number, maxIter = 100): number[] {
   let guard = 0;
   while (centroids.length < effK && guard < n * 10) {
     guard++;
-    const idx = Math.floor(Math.random() * n);
+    const idx = Math.floor(rng() * n);
     if (used.has(idx)) {
       continue;
     }
@@ -127,7 +163,7 @@ export function kMeans(points: number[][], k: number, maxIter = 100): number[] {
 
     for (let c = 0; c < effK; c++) {
       if (counts[c] === 0) {
-        centroids[c] = [...points[Math.floor(Math.random() * n)]];
+        centroids[c] = [...points[Math.floor(rng() * n)]];
         continue;
       }
       for (let j = 0; j < d; j++) {
@@ -162,10 +198,10 @@ function parseTags(raw: string | null): string[] {
   }
 }
 
-export function buildEmbeddingMapResponse(
+export async function buildEmbeddingMapResponse(
   db: Database.Database,
   params: EmbeddingMapParams
-): EmbeddingMapResponse {
+): Promise<EmbeddingMapResponse> {
   const stmt = db.prepare(`
     SELECT
       mi.id,
@@ -259,59 +295,88 @@ export function buildEmbeddingMapResponse(
     };
   }
 
-  const vectors = parsed.map(p => p.vector);
-  const nNeighbors = Math.min(15, n - 1);
-  const started = Date.now();
+  const shared = inFlight.get(cacheKey);
+  if (shared) {
+    return await shared;
+  }
 
-  const umap = new UMAP({
-    nComponents: 2,
-    nNeighbors,
-    nEpochs: Math.min(400, Math.max(100, n * 4)),
+  let resolve!: (value: EmbeddingMapResponse) => void;
+  let reject!: (reason: unknown) => void;
+  const inflightPromise = new Promise<EmbeddingMapResponse>((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
-  const coords2d = umap.fit(vectors);
-  const clusterIds = kMeans(coords2d, effectiveK, 100);
+  inFlight.set(cacheKey, inflightPromise);
 
-  const computedAt = new Date().toISOString();
-  const points: EmbeddingPoint[] = parsed.map((p, i) => {
-    const t = p.row.type;
-    const memType = VALID_MEMORY_TYPES.has(t)
-      ? (t as EmbeddingPoint['type'])
-      : 'semantic';
-    return {
-      id: p.row.id,
-      x: coords2d[i][0]!,
-      y: coords2d[i][1]!,
-      cluster: clusterIds[i]!,
-      type: memType,
-      content: p.row.content,
-      tags: parseTags(p.row.tags),
-      importance: p.row.importance ?? 0.5,
-      created_at: p.row.created_at ?? computedAt,
-    };
-  });
+  void (async () => {
+    const started = Date.now();
+    try {
+      const vectors = parsed.map(p => p.vector);
+      const nNeighbors = Math.min(15, n - 1);
+      /**
+       * UMAP 학습 스텝: 포인트 수에 비례해 늘리되 상한 400·하한 100으로 클램프.
+       * (너무 작으면 수렴 부족, 너무 크면 지연만 증가)
+       */
+      const nEpochs = Math.min(400, Math.max(100, n * 4));
 
-  const result: EmbeddingMapResponse = {
-    points,
-    meta: {
-      total: n,
-      provider: params.provider,
-      k: effectiveK,
-      requested_k: params.k,
-      limit: params.limit,
-      cached: false,
-      computed_at: computedAt,
-    },
-  };
+      const umap = new UMAP({
+        nComponents: 2,
+        nNeighbors,
+        nEpochs,
+      });
+      const coords2d = await umap.fitAsync(vectors);
+      const kmSeed = hash32(`${cacheKey}:${n}`);
+      const clusterIds = kMeans(coords2d, effectiveK, 100, mulberry32(kmSeed));
 
-  cache.set(cacheKey, { data: result, expiresAt: now + CACHE_TTL_MS });
+      const computedAt = new Date().toISOString();
+      const points: EmbeddingPoint[] = parsed.map((p, i) => {
+        const t = p.row.type;
+        const memType = VALID_MEMORY_TYPES.has(t)
+          ? (t as EmbeddingPoint['type'])
+          : 'semantic';
+        return {
+          id: p.row.id,
+          x: coords2d[i][0]!,
+          y: coords2d[i][1]!,
+          cluster: clusterIds[i]!,
+          type: memType,
+          content: p.row.content,
+          tags: parseTags(p.row.tags),
+          importance: p.row.importance ?? 0.5,
+          created_at: p.row.created_at ?? computedAt,
+        };
+      });
 
-  logger.info('Embedding map computed', {
-    provider: params.provider,
-    limit: params.limit,
-    effectiveK,
-    durationMs: Date.now() - started,
-    pointCount: n,
-  });
+      const result: EmbeddingMapResponse = {
+        points,
+        meta: {
+          total: n,
+          provider: params.provider,
+          k: effectiveK,
+          requested_k: params.k,
+          limit: params.limit,
+          cached: false,
+          computed_at: computedAt,
+        },
+      };
 
-  return result;
+      cache.set(cacheKey, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+
+      logger.info('Embedding map computed', {
+        provider: params.provider,
+        limit: params.limit,
+        effectiveK,
+        durationMs: Date.now() - started,
+        pointCount: n,
+      });
+
+      resolve(result);
+    } catch (err) {
+      reject(err);
+    } finally {
+      inFlight.delete(cacheKey);
+    }
+  })();
+
+  return await inflightPromise;
 }

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts
@@ -51,7 +51,7 @@ function parseParams(
 }
 
 export function registerAdminEmbeddingMapRoute(router: Router, db: Database.Database | null): void {
-  router.get('/embedding-map', (req, res) => {
+  router.get('/embedding-map', async (req, res) => {
     try {
       if (!db) {
         return res.status(503).json({ error: 'Service unavailable' });
@@ -62,7 +62,7 @@ export function registerAdminEmbeddingMapRoute(router: Router, db: Database.Data
         return res.status(400).json(parsed);
       }
 
-      const result = buildEmbeddingMapResponse(db, parsed);
+      const result = await buildEmbeddingMapResponse(db, parsed);
       return res.json(result);
     } catch (error) {
       if (error instanceof EmbeddingMapBuildError) {

--- a/packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts
@@ -13,6 +13,11 @@ import {
 
 const VALID_PROVIDERS = new Set(['tfidf', 'minilm', 'openai', 'gemini']);
 
+/**
+ * 쿼리 상한: FR-001·`contracts/embedding-map-api.md`와 동일해야 함.
+ * 더 큰 초안(예: limit 2000, k 50)은 UMAP 지연·서버 부하·클러스터 가독성을 이유로 채택하지 않음.
+ * 상향 시 spec·계약·대시보드 입력(`#em-limit`, `#em-k`)·본 검증을 함께 수정할 것.
+ */
 function parseParams(
   query: Record<string, unknown>
 ): EmbeddingMapParams | { error: string; message: string } {
@@ -54,7 +59,10 @@ export function registerAdminEmbeddingMapRoute(router: Router, db: Database.Data
   router.get('/embedding-map', async (req, res) => {
     try {
       if (!db) {
-        return res.status(503).json({ error: 'Service unavailable' });
+        return res.status(503).json({
+          error: '서비스 사용 불가',
+          message: '데이터베이스에 연결되어 있지 않습니다.',
+        });
       }
 
       const parsed = parseParams(req.query as Record<string, unknown>);
@@ -98,10 +106,12 @@ export function registerAdminEmbeddingMapRoute(router: Router, db: Database.Data
 
       logger.error('Embedding map failed', {
         error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
       });
+      // 클라이언트에는 고정 문구만 전달 (상세는 logger.error)
       return res.status(500).json({
         error: '임베딩 맵 계산 실패',
-        message: error instanceof Error ? error.message : 'Unknown error',
+        message: '서버에서 UMAP 계산 중 오류가 발생했습니다. 잠시 후 다시 시도하세요.',
       });
     }
   });

--- a/packages/memento-server/src/server/routes/admin/admin-graph.routes.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-graph.routes.ts
@@ -11,7 +11,10 @@ export function registerAdminGraphRoute(router: Router, db: Database.Database | 
   router.get('/graph', (req, res) => {
     try {
       if (!db) {
-        return res.status(503).json({ error: 'Service unavailable' });
+        return res.status(503).json({
+          error: '서비스 사용 불가',
+          message: '데이터베이스에 연결되어 있지 않습니다.',
+        });
       }
 
       const typesRaw = req.query['types'] as string | undefined;

--- a/specs/014-embedding-map-dashboard/contracts/embedding-map-api.md
+++ b/specs/014-embedding-map-dashboard/contracts/embedding-map-api.md
@@ -20,6 +20,8 @@ GET /admin/embedding-map
 | `limit` | integer | `300` | 1~500 | 조회할 최대 기억 수 |
 | `k` | integer | `6` | 2~20 | K-Means 클러스터 수 |
 
+**설계 메모 (상한)**: 초기 아이디어로 더 큰 범위(예: limit 2000, k 50)가 논의될 수 있으나, **확정 스펙은 위 표와 동일**이다. 어드민 전용 UMAP 비용·이벤트 루프 부하·산점도/범례 가독성을 이유로 500/20으로 제한한다. 상향 시 본 계약·`spec.md` FR-001·라우트 검증·UI 입력 범위를 함께 갱신한다.
+
 ### Success Response: 200 OK
 
 ```json
@@ -44,6 +46,7 @@ GET /admin/embedding-map
     "requested_k": 6,
     "limit": 300,
     "cached": false,
+    "waited_for_in_flight": false,
     "computed_at": "2026-04-13T09:15:32.000Z"
   }
 }
@@ -80,7 +83,8 @@ GET /admin/embedding-map
 **503 — DB 미연결**
 ```json
 {
-  "error": "Service unavailable"
+  "error": "서비스 사용 불가",
+  "message": "데이터베이스에 연결되어 있지 않습니다."
 }
 ```
 
@@ -95,11 +99,11 @@ GET /admin/embedding-map
 }
 ```
 
-**500 — 서버 오류**
+**500 — 서버 오류** (UMAP 등 예기치 않은 예외; 상세는 서버 로그에만)
 ```json
 {
   "error": "임베딩 맵 계산 실패",
-  "message": "..."
+  "message": "서버에서 UMAP 계산 중 오류가 발생했습니다. 잠시 후 다시 시도하세요."
 }
 ```
 
@@ -107,7 +111,7 @@ GET /admin/embedding-map
 
 ## 동작 규칙
 
-1. **캐시**: 동일 파라미터 (`provider:limit:effectiveK`) 재요청 시 5분 이내면 캐시 반환 (`cached: true`)
+1. **캐시**: 동일 파라미터 (`provider:limit:effectiveK`) 재요청 시 5분 이내면 캐시 반환 (`cached: true`). 캐시 미스 직후 동시 요청은 한 번의 계산을 공유하며, 대기한 응답은 `waited_for_in_flight: true` (항상 부울로 포함).
 2. **k 자동 조정**: 요청 k > 실제 포인트 수 → k를 포인트 수로 조정. `requested_k`에 원래 값 보존.
 3. **nNeighbors**: `Math.min(15, n - 1)` 적용 (UMAP 제약)
 4. **nEpochs**: `Math.min(400, Math.max(100, n * 4))` (UMAP 학습 에폭)

--- a/specs/014-embedding-map-dashboard/data-model.md
+++ b/specs/014-embedding-map-dashboard/data-model.md
@@ -19,6 +19,7 @@
 | `importance` | REAL | 0.0~1.0, NULL 가능 (기본 0.5) |
 | `created_at` | TIMESTAMP | 생성 일시 |
 | `tags` | TEXT | JSON 배열 문자열 (`["tag1","tag2"]`) |
+| `is_deleted` | INTEGER | 소프트 삭제 플래그 (0=활성, 1=삭제됨). API는 `COALESCE(is_deleted,0)=0`인 행만 조회 |
 
 ### memory_embedding (기존)
 
@@ -66,6 +67,8 @@ interface EmbeddingMapResponse {
     requested_k: number;   // 요청된 k (조정 전)
     limit: number;         // 적용된 limit
     cached: boolean;       // 캐시에서 반환 여부
+    /** 동시 요청 시 in-flight 계산만 대기한 경우 true (모니터링용; 성공 응답에 항상 포함) */
+    waited_for_in_flight: boolean;
     computed_at: string;   // ISO 8601, 계산 완료 시각
   };
 }

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -434,6 +434,21 @@ body {
   border-radius: 4px;
 }
 
+.em-color-legend {
+  margin: 0;
+  padding: 0.5rem 1rem 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: #555;
+  background: #fff;
+  border-bottom: 1px solid #eee;
+}
+
+.em-color-legend strong {
+  font-weight: 600;
+  color: #333;
+}
+
 #em-load-btn {
   padding: 0.4rem 1rem;
   border: none;

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,5 +1,10 @@
 /* Memento Anchor Map Dashboard Styles */
 
+:root {
+  /* /graph(graph.html) 페이지 배경과 맞춰 iframe 로드 전 플래시 완화 */
+  --dashboard-graph-bg: #0f1117;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -400,6 +405,16 @@ body {
 
 .tab-panel.active {
   display: flex;
+}
+
+/* Memory Graph: /graph 페이지를 동일 출처 iframe으로 탭에 포함 */
+.dashboard-graph-iframe {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  border: 0;
+  display: block;
+  background: var(--dashboard-graph-bg);
 }
 
 .embedding-map-layout {

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -39,12 +39,13 @@
       </div>
     </header>
 
-    <div class="tab-bar" role="tablist">
-      <button type="button" class="tab-btn active" role="tab" aria-selected="true" data-tab="anchor">Anchor Map</button>
-      <button type="button" class="tab-btn" role="tab" aria-selected="false" data-tab="embedding">Embedding Map</button>
+    <div class="tab-bar" role="tablist" aria-label="대시보드 보기 전환">
+      <button type="button" id="dashboard-tab-anchor" class="tab-btn active" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-anchor-map" data-tab="anchor">Anchor Map</button>
+      <button type="button" id="dashboard-tab-embedding" class="tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-embedding-map" data-tab="embedding">Embedding Map</button>
+      <button type="button" id="dashboard-tab-graph" class="tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-graph" data-tab="graph">Memory Graph</button>
     </div>
 
-    <div id="tab-anchor-map" class="tab-panel active" role="tabpanel">
+    <div id="tab-anchor-map" class="tab-panel active" role="tabpanel" aria-labelledby="dashboard-tab-anchor" aria-hidden="false">
       <main class="dashboard-main">
         <div class="sidebar">
           <section class="anchor-info">
@@ -87,7 +88,7 @@
       </main>
     </div>
 
-    <div id="tab-embedding-map" class="tab-panel" role="tabpanel">
+    <div id="tab-embedding-map" class="tab-panel" role="tabpanel" aria-labelledby="dashboard-tab-embedding" aria-hidden="true">
       <div class="embedding-map-layout">
         <div class="em-controls">
           <label>
@@ -120,6 +121,16 @@
           <aside id="em-side-panel" class="em-side-panel" aria-hidden="true"></aside>
         </div>
       </div>
+    </div>
+
+    <div id="tab-graph" class="tab-panel" role="tabpanel" aria-labelledby="dashboard-tab-graph" aria-hidden="true">
+      <!-- iframe src는 dashboard-tabs.js의 GRAPH_IFRAME_SRC(기본 '/graph')와 동일해야 함. allow-same-origin이면 스크립트가 부모와 동일 출처로 취급되어 sandbox 완화됨; 내부 전용이면 의도된 설정 -->
+      <iframe
+        id="graph-view-iframe"
+        class="dashboard-graph-iframe"
+        title="기억 관계 그래프 (GET /graph)"
+        sandbox="allow-scripts allow-same-origin"
+      ></iframe>
     </div>
   </div>
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -124,12 +124,11 @@
     </div>
 
     <div id="tab-graph" class="tab-panel" role="tabpanel" aria-labelledby="dashboard-tab-graph" aria-hidden="true">
-      <!-- iframe src는 dashboard-tabs.js의 GRAPH_IFRAME_SRC(기본 '/graph')와 동일해야 함. allow-same-origin이면 스크립트가 부모와 동일 출처로 취급되어 sandbox 완화됨; 내부 전용이면 의도된 설정 -->
+      <!-- iframe src는 dashboard-tabs.js의 GRAPH_IFRAME_SRC(기본 '/graph')와 동일해야 함. 동일 출처·신뢰 경로(/graph)이므로 sandbox 미사용: allow-scripts+allow-same-origin 조합은 부모 DOM 접근이 가능해 사실상 격리 효과가 없음 -->
       <iframe
         id="graph-view-iframe"
         class="dashboard-graph-iframe"
         title="기억 관계 그래프 (GET /graph)"
-        sandbox="allow-scripts allow-same-origin"
       ></iframe>
     </div>
   </div>

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -110,6 +110,9 @@
           <button type="button" id="em-load-btn">Load</button>
           <span id="em-cache-info" class="em-cache-info"></span>
         </div>
+        <p class="em-color-legend">
+          점 색상은 <strong>K-Means 클러스터</strong>입니다. 같은 색은 UMAP으로 내려온 2D 좌표에서 서로 가까운 임베딩 그룹을 뜻하며, 기억 유형·중요도와는 무관합니다.
+        </p>
         <div id="em-loading" class="em-loading hidden">UMAP 계산 중...</div>
         <div id="em-error" class="em-error hidden"></div>
         <div class="embedding-plot-row">
@@ -125,43 +128,7 @@
 
   <!-- Anchor Map 시각화 스크립트 -->
   <script src="/static/js/anchor-map.js"></script>
-
-  <script>
-    (function () {
-      function activateTab(name) {
-        var anchorPanel = document.getElementById('tab-anchor-map');
-        var embedPanel = document.getElementById('tab-embedding-map');
-        var buttons = document.querySelectorAll('.tab-btn');
-        buttons.forEach(function (b) {
-          var on = b.getAttribute('data-tab') === name;
-          b.classList.toggle('active', on);
-          b.setAttribute('aria-selected', on ? 'true' : 'false');
-        });
-        if (anchorPanel) {
-          anchorPanel.classList.toggle('active', name === 'anchor');
-        }
-        if (embedPanel) {
-          embedPanel.classList.toggle('active', name === 'embedding');
-        }
-        if (name === 'embedding' && typeof window.initEmbeddingMap === 'function') {
-          window.initEmbeddingMap();
-        }
-        if (name === 'anchor') {
-          requestAnimationFrame(function () {
-            window.dispatchEvent(new Event('resize'));
-          });
-        }
-      }
-      document.querySelectorAll('.tab-btn').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-          var tab = btn.getAttribute('data-tab');
-          if (tab) {
-            activateTab(tab);
-          }
-        });
-      });
-    })();
-  </script>
+  <script src="/static/js/dashboard-tabs.js"></script>
   <script src="/static/js/embedding-map.js"></script>
 </body>
 </html>

--- a/static/js/dashboard-tabs.js
+++ b/static/js/dashboard-tabs.js
@@ -1,0 +1,41 @@
+/**
+ * Dashboard Anchor / Embedding 탭 전환
+ * CSP(script-src에 unsafe-inline 없음) 대응: 인라인 스크립트 대신 외부 파일로 로드
+ */
+(function () {
+  'use strict';
+
+  function activateTab(name) {
+    var anchorPanel = document.getElementById('tab-anchor-map');
+    var embedPanel = document.getElementById('tab-embedding-map');
+    var buttons = document.querySelectorAll('.tab-btn');
+    buttons.forEach(function (b) {
+      var on = b.getAttribute('data-tab') === name;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    if (anchorPanel) {
+      anchorPanel.classList.toggle('active', name === 'anchor');
+    }
+    if (embedPanel) {
+      embedPanel.classList.toggle('active', name === 'embedding');
+    }
+    if (name === 'embedding' && typeof window.initEmbeddingMap === 'function') {
+      window.initEmbeddingMap();
+    }
+    if (name === 'anchor') {
+      requestAnimationFrame(function () {
+        window.dispatchEvent(new Event('resize'));
+      });
+    }
+  }
+
+  document.querySelectorAll('.tab-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var tab = btn.getAttribute('data-tab');
+      if (tab) {
+        activateTab(tab);
+      }
+    });
+  });
+})();

--- a/static/js/dashboard-tabs.js
+++ b/static/js/dashboard-tabs.js
@@ -1,13 +1,37 @@
 /**
- * Dashboard Anchor / Embedding 탭 전환
+ * Dashboard Anchor / Embedding / Memory Graph 탭 전환
  * CSP(script-src에 unsafe-inline 없음) 대응: 인라인 스크립트 대신 외부 파일로 로드
+ *
+ * WAI-ARIA Tabs — Manual activation:
+ * - 좌/우/Home/End: 같은 tablist 안에서 포커스만 이동(roving tabindex); 패널은 바꾸지 않음(그래프 iframe 지연 로드 유지)
+ * - Enter/Space 또는 클릭: 해당 탭 활성화
  */
 (function () {
   'use strict';
 
+  var GRAPH_IFRAME_SRC = '/graph';
+
+  function getTabButtons() {
+    return Array.prototype.slice.call(document.querySelectorAll('.tab-bar .tab-btn'));
+  }
+
+  function dispatchGraphIframeResize(iframe) {
+    if (!iframe || !iframe.contentWindow) {
+      return;
+    }
+    iframe.contentWindow.dispatchEvent(new Event('resize'));
+  }
+
+  function setRovingTabindex(focusedBtn) {
+    getTabButtons().forEach(function (b) {
+      b.setAttribute('tabindex', b === focusedBtn ? '0' : '-1');
+    });
+  }
+
   function activateTab(name) {
     var anchorPanel = document.getElementById('tab-anchor-map');
     var embedPanel = document.getElementById('tab-embedding-map');
+    var graphPanel = document.getElementById('tab-graph');
     var buttons = document.querySelectorAll('.tab-btn');
     buttons.forEach(function (b) {
       var on = b.getAttribute('data-tab') === name;
@@ -16,18 +40,92 @@
     });
     if (anchorPanel) {
       anchorPanel.classList.toggle('active', name === 'anchor');
+      anchorPanel.setAttribute('aria-hidden', name === 'anchor' ? 'false' : 'true');
     }
     if (embedPanel) {
       embedPanel.classList.toggle('active', name === 'embedding');
+      embedPanel.setAttribute('aria-hidden', name === 'embedding' ? 'false' : 'true');
+    }
+    if (graphPanel) {
+      graphPanel.classList.toggle('active', name === 'graph');
+      graphPanel.setAttribute('aria-hidden', name === 'graph' ? 'false' : 'true');
     }
     if (name === 'embedding' && typeof window.initEmbeddingMap === 'function') {
       window.initEmbeddingMap();
     }
-    if (name === 'anchor') {
+    if (name === 'graph') {
+      var iframe = document.getElementById('graph-view-iframe');
+      if (iframe && !iframe.hasAttribute('data-loaded')) {
+        iframe.setAttribute('data-loaded', '');
+        iframe.addEventListener('load', function onGraphFrameLoad() {
+          iframe.removeEventListener('load', onGraphFrameLoad);
+          requestAnimationFrame(function () {
+            window.dispatchEvent(new Event('resize'));
+            dispatchGraphIframeResize(iframe);
+          });
+        });
+        iframe.src = GRAPH_IFRAME_SRC;
+      } else if (iframe) {
+        requestAnimationFrame(function () {
+          window.dispatchEvent(new Event('resize'));
+          dispatchGraphIframeResize(iframe);
+        });
+      }
+    } else if (name === 'anchor' || name === 'embedding') {
       requestAnimationFrame(function () {
         window.dispatchEvent(new Event('resize'));
       });
     }
+
+    var activeBtn = document.querySelector('.tab-btn[data-tab="' + name + '"]');
+    if (activeBtn) {
+      setRovingTabindex(activeBtn);
+      activeBtn.focus();
+    }
+  }
+
+  var tabBar = document.querySelector('.tab-bar');
+  if (tabBar) {
+    tabBar.addEventListener('keydown', function (e) {
+      var target = e.target;
+      if (!target || !target.classList || !target.classList.contains('tab-btn')) {
+        return;
+      }
+      var buttons = getTabButtons();
+      var idx = buttons.indexOf(target);
+      if (idx < 0) {
+        return;
+      }
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        var next = e.key === 'ArrowRight' ? idx + 1 : idx - 1;
+        if (next < 0) {
+          next = buttons.length - 1;
+        }
+        if (next >= buttons.length) {
+          next = 0;
+        }
+        var nextBtn = buttons[next];
+        setRovingTabindex(nextBtn);
+        nextBtn.focus();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        var first = buttons[0];
+        setRovingTabindex(first);
+        first.focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        var lastBtn = buttons[buttons.length - 1];
+        setRovingTabindex(lastBtn);
+        lastBtn.focus();
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        var tabName = target.getAttribute('data-tab');
+        if (tabName) {
+          activateTab(tabName);
+        }
+      }
+    });
   }
 
   document.querySelectorAll('.tab-btn').forEach(function (btn) {
@@ -38,4 +136,9 @@
       }
     });
   });
+
+  var initial = document.querySelector('.tab-btn[data-tab="anchor"]');
+  if (initial) {
+    setRovingTabindex(initial);
+  }
 })();

--- a/static/js/embedding-map.js
+++ b/static/js/embedding-map.js
@@ -21,19 +21,6 @@
   /** zoom 팬 후 의도치 않은 배경 click으로 패널이 닫히지 않도록 pointerdown 위치 보관 */
   var lastScatterPointer = null;
 
-  function escapeHtml(str) {
-    if (str == null) {
-      return '';
-    }
-    var s = String(str);
-    return s
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
   function readParams() {
     var prov = document.getElementById('em-provider');
     var lim = document.getElementById('em-limit');
@@ -68,8 +55,16 @@
 
   function showTooltip(event, point) {
     var el = ensureTooltip();
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
     var preview = point.content.length > 80 ? point.content.slice(0, 80) + '…' : point.content;
-    el.innerHTML = escapeHtml(preview) + '<br><span style="opacity:0.85">' + escapeHtml(point.type) + '</span>';
+    el.appendChild(document.createTextNode(preview));
+    el.appendChild(document.createElement('br'));
+    var typeSpan = document.createElement('span');
+    typeSpan.style.opacity = '0.85';
+    typeSpan.textContent = point.type;
+    el.appendChild(typeSpan);
     el.style.display = 'block';
     el.style.left = event.clientX + 12 + 'px';
     el.style.top = event.clientY + 12 + 'px';
@@ -89,43 +84,61 @@
     }
   }
 
+  function appendLabeledLine(parent, label, valueText) {
+    var p = document.createElement('p');
+    var strong = document.createElement('strong');
+    strong.textContent = label;
+    p.appendChild(strong);
+    p.appendChild(document.createTextNode(' ' + valueText));
+    parent.appendChild(p);
+  }
+
   function openSidePanel(point) {
     var panel = document.getElementById('em-side-panel');
     if (!panel) {
       return;
     }
+    while (panel.firstChild) {
+      panel.removeChild(panel.firstChild);
+    }
     var tags = Array.isArray(point.tags) ? point.tags.join(', ') : '';
     var imp = typeof point.importance === 'number' ? point.importance.toFixed(2) : String(point.importance);
-    panel.innerHTML =
-      '<div class="em-panel-header">' +
-      '<h3>Memory</h3>' +
-      '<button type="button" id="em-panel-close" aria-label="Close">×</button>' +
-      '</div>' +
-      '<div class="em-panel-body">' +
-      '<p><strong>Type:</strong> ' +
-      escapeHtml(point.type) +
-      '</p>' +
-      '<p><strong>Importance:</strong> ' +
-      escapeHtml(imp) +
-      '</p>' +
-      '<p><strong>Created:</strong> ' +
-      escapeHtml(point.created_at) +
-      '</p>' +
-      '<p><strong>Tags:</strong> ' +
-      escapeHtml(tags) +
-      '</p>' +
-      '<hr><pre class="em-panel-content">' +
-      escapeHtml(point.content) +
-      '</pre></div>';
+
+    var header = document.createElement('div');
+    header.className = 'em-panel-header';
+    var h3 = document.createElement('h3');
+    h3.textContent = 'Memory';
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.id = 'em-panel-close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.textContent = '×';
+    header.appendChild(h3);
+    header.appendChild(closeBtn);
+
+    var body = document.createElement('div');
+    body.className = 'em-panel-body';
+    appendLabeledLine(body, 'Type:', String(point.type));
+    appendLabeledLine(body, 'Importance:', imp);
+    appendLabeledLine(body, 'Created:', String(point.created_at));
+    appendLabeledLine(body, 'Tags:', tags);
+
+    var hr = document.createElement('hr');
+    var pre = document.createElement('pre');
+    pre.className = 'em-panel-content';
+    pre.textContent = String(point.content);
+    body.appendChild(hr);
+    body.appendChild(pre);
+
+    panel.appendChild(header);
+    panel.appendChild(body);
+
     panel.classList.add('open');
     panel.setAttribute('aria-hidden', 'false');
-    var closeBtn = document.getElementById('em-panel-close');
-    if (closeBtn) {
-      closeBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        closeSidePanel();
-      });
-    }
+    closeBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      closeSidePanel();
+    });
   }
 
   function setupChart() {
@@ -288,22 +301,26 @@
     if (!el) {
       return;
     }
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
     if (!msg) {
       el.classList.add('hidden');
-      el.innerHTML = '';
       return;
     }
     el.classList.remove('hidden');
-    var html = '<p>' + escapeHtml(msg) + '</p>';
+    var p = document.createElement('p');
+    p.textContent = msg;
+    el.appendChild(p);
     if (showRetry) {
-      html += '<button type="button" id="em-retry-btn" class="em-retry-btn">Retry</button>';
-    }
-    el.innerHTML = html;
-    var retry = document.getElementById('em-retry-btn');
-    if (retry) {
+      var retry = document.createElement('button');
+      retry.type = 'button';
+      retry.className = 'em-retry-btn';
+      retry.textContent = 'Retry';
       retry.addEventListener('click', function () {
         loadEmbeddingMap(readParams());
       });
+      el.appendChild(retry);
     }
   }
 

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -62,6 +62,11 @@
 
     // ── D3 설정 ───────────────────────────────────────────────
     let simulation = null;
+    /** @type {unknown[] | null} */
+    let lastGraphNodes = null;
+    /** @type {unknown[] | null} */
+    let lastGraphEdges = null;
+    let resizeRedrawTimer = null;
 
     function renderGraph(nodes, edges) {
       const container = document.getElementById('graph-container');
@@ -251,6 +256,8 @@
     async function loadGraph(url) {
       clearStatus();
       showLoading(true);
+      lastGraphNodes = null;
+      lastGraphEdges = null;
       d3.select(svgEl).selectAll('*').remove();
       if (simulation) { simulation.stop(); simulation = null; }
 
@@ -266,7 +273,10 @@
           return;
         }
 
-        renderGraph(data.nodes, data.edges ?? []);
+        const edges = data.edges ?? [];
+        lastGraphNodes = data.nodes;
+        lastGraphEdges = edges;
+        renderGraph(data.nodes, edges);
 
         if (data.meta?.truncated) {
           console.info(`[graph] 노드 제한 초과: 상위 ${data.nodes.length}개 표시`);
@@ -292,6 +302,17 @@
       if (!detailPanel.contains(event.target) && !svgEl.contains(event.target)) {
         closePanel();
       }
+    });
+
+    // 대시보드 iframe 탭 전환 등에서 전달되는 resize에 맞춰 캔버스 재계산
+    window.addEventListener('resize', () => {
+      if (!lastGraphNodes || lastGraphNodes.length === 0) {
+        return;
+      }
+      clearTimeout(resizeRedrawTimer);
+      resizeRedrawTimer = setTimeout(() => {
+        renderGraph(/** @type {any[]} */ (lastGraphNodes), /** @type {any[]} */ (lastGraphEdges ?? []));
+      }, 120);
     });
 
     // ── 초기 로드 ─────────────────────────────────────────────

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -304,7 +304,9 @@
       }
     });
 
-    // 대시보드 iframe 탭 전환 등에서 전달되는 resize에 맞춰 캔버스 재계산
+    // 대시보드 iframe 탭 전환 등에서 전달되는 resize에 맞춰 캔버스 재계산.
+    // 현재는 renderGraph 전체를 다시 그리며 force simulation을 새로 시작한다.
+    // 대형 그래프에서는 레이아웃이 흔들릴 수 있으므로, 필요 시 "크기만 조정·시뮬 유지" 경로는 별도 이슈로 다루는 것이 좋다.
     window.addEventListener('resize', () => {
       if (!lastGraphNodes || lastGraphNodes.length === 0) {
         return;


### PR DESCRIPTION
## 개요
PR #154(`feat(dashboard): 임베딩 맵 대시보드`) 머지 이후 **후속 커밋**을 `main`에 반영합니다.

## 주요 변경
- **Admin API**: DB 미연결 `503` 응답 본문을 한국어로 통일(embedding-map, graph).
- **임베딩 맵**: 예상치 못한 예외 시 클라이언트에는 고정 한국어 메시지, 상세는 서버 로그에만 기록.
- **메타/테스트**: in-flight 대기 구분(`waited_for_in_flight`)·모의 UMAP·동시 요청 dedup 검증 보강.
- **문서**: `contracts/embedding-map-api.md`, `data-model.md` 예시 및 `memory_item.is_deleted` 설명 동기화.
- **정적 리소스**: 대시보드 iframe 주석, `graph.js` resize 시 force 재시작 관련 메모.

## 이슈
Refs https://github.com/jee1/memento/issues/17

## 검증
- `npm run lint`, `npm run type-check`, `npm test`, `npm run test:ci:root` 통과(로컬).

Made with [Cursor](https://cursor.com)