### PR TITLE
refactor(embedding): EmbeddingMigrationService execute/rollback 분리 (이슈 #163)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-issue-160-cli-http-client.md
+++ b/docs/superpowers/plans/2026-04-18-issue-160-cli-http-client.md
@@ -1,0 +1,803 @@
+# Issue 160: CLI → HTTP 클라이언트 전환 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** CLI가 DB를 직접 열지 않고, 항상 실행 중인 서버의 HTTP 관리 엔드포인트로 도구를 호출하도록 전환한다.
+
+**Architecture:** 모든 서버 모드(HTTP, stdio MCP)는 기동 시 `~/.memento/server.json`에 관리 포트를 기록한다. CLI는 이 파일을 읽어 `POST /tools/{name}`으로 요청을 보낸다. stdio 서버는 기존 MCP 로직과 별도로 localhost-only 관리 HTTP 서버를 port :0으로 병행 기동한다.
+
+**Tech Stack:** Node.js 20+, TypeScript 5, Express 4, better-sqlite3, Vitest
+
+---
+
+## 파일 구조
+
+| 파일 | 유형 | 역할 |
+|---|---|---|
+| `packages/memento-server/src/server/server-info.ts` | 신규 | ServerInfo 읽기/쓰기/삭제, isServerAlive, callToolViaHttp |
+| `packages/memento-server/src/server/server-info.spec.ts` | 신규 | server-info.ts 유닛 테스트 |
+| `packages/memento-server/src/server/http-server.ts` | 수정 | 기동 시 writeServerInfo, 종료 시 deleteServerInfo |
+| `packages/memento-server/src/server/index.ts` | 수정 | 관리 HTTP 서버 병행 기동, server.json 라이프사이클 |
+| `packages/memento-server/src/cli.ts` | 수정 | DB 초기화 제거, HTTP 클라이언트로 교체 |
+| `packages/memento-server/src/server/cli-integration.spec.ts` | 신규 | CLI 통합 테스트 (서버 없음, 왕복, 동시성) |
+
+---
+
+## Task 1: `server-info.ts` 유틸 작성
+
+**Files:**
+- Create: `packages/memento-server/src/server/server-info.ts`
+- Create: `packages/memento-server/src/server/server-info.spec.ts`
+
+### 배경
+
+`configDir`은 `process.env.MEMENTO_CONFIG_DIR ?? path.join(os.homedir(), '.memento')`로 결정된다.
+`server.json` 경로는 `path.join(configDir, 'server.json')`이다.
+
+`isServerAlive`는 두 단계로 검증하며, **stale 파일이 감지되면 자동 삭제**한다:
+1. PID 프로세스 존재 확인 (`process.kill(pid, 0)`)
+2. `GET http://localhost:{port}/health` 응답이 2xx인지 확인
+- 어느 단계든 실패 시 false 반환. CLI에서는 false 반환 전에 stale server.json을 삭제한다.
+
+`callToolViaHttp`는 Node.js 내장 `fetch`(Node 18+)를 사용한다.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```typescript
+// packages/memento-server/src/server/server-info.spec.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  writeServerInfo,
+  readServerInfo,
+  deleteServerInfo,
+  type ServerInfo,
+} from './server-info.js';
+
+describe('server-info', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'memento-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writeServerInfo는 server.json을 생성한다', async () => {
+    await writeServerInfo(tmpDir, 51764);
+    const info = await readServerInfo(tmpDir);
+    expect(info).not.toBeNull();
+    expect(info!.port).toBe(51764);
+    expect(info!.pid).toBe(process.pid);
+    expect(info!.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('readServerInfo는 파일이 없으면 null을 반환한다', async () => {
+    const info = await readServerInfo(tmpDir);
+    expect(info).toBeNull();
+  });
+
+  it('deleteServerInfo는 server.json을 삭제한다', async () => {
+    await writeServerInfo(tmpDir, 51764);
+    await deleteServerInfo(tmpDir);
+    const info = await readServerInfo(tmpDir);
+    expect(info).toBeNull();
+  });
+
+  it('deleteServerInfo는 파일이 없어도 에러를 던지지 않는다', async () => {
+    await expect(deleteServerInfo(tmpDir)).resolves.not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 — FAIL 확인**
+
+```bash
+cd packages/memento-server && npx vitest run src/server/server-info.spec.ts 2>&1 | tail -20
+```
+
+Expected: `Cannot find module './server-info.js'`
+
+- [ ] **Step 3: `server-info.ts` 구현**
+
+```typescript
+// packages/memento-server/src/server/server-info.ts
+import { readFile, writeFile, unlink, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+export interface ServerInfo {
+  port: number;
+  pid: number;
+  startedAt: string;
+}
+
+function serverInfoPath(configDir: string): string {
+  return join(configDir, 'server.json');
+}
+
+export async function writeServerInfo(configDir: string, port: number): Promise<void> {
+  await mkdir(configDir, { recursive: true });
+  const info: ServerInfo = { port, pid: process.pid, startedAt: new Date().toISOString() };
+  await writeFile(serverInfoPath(configDir), JSON.stringify(info, null, 2), 'utf-8');
+}
+
+export async function readServerInfo(configDir: string): Promise<ServerInfo | null> {
+  try {
+    const raw = await readFile(serverInfoPath(configDir), 'utf-8');
+    return JSON.parse(raw) as ServerInfo;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteServerInfo(configDir: string): Promise<void> {
+  try {
+    await unlink(serverInfoPath(configDir));
+  } catch {
+    // 파일이 없어도 무시
+  }
+}
+
+export async function isServerAlive(info: ServerInfo): Promise<boolean> {
+  // 1단계: PID 존재 확인
+  try {
+    process.kill(info.pid, 0);
+  } catch {
+    return false;
+  }
+  // 2단계: HTTP /health 응답 확인 (PID 재사용 오탐 방지)
+  try {
+    const res = await fetch(`http://localhost:${info.port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function callToolViaHttp(
+  port: number,
+  toolName: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await fetch(`http://localhost:${port}/tools/${toolName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const body = await res.json() as Record<string, unknown>;
+
+  if (!res.ok) {
+    throw new Error(
+      (typeof body.message === 'string' ? body.message : null) ??
+      `HTTP ${res.status}: Tool ${toolName} failed`,
+    );
+  }
+
+  return body.result;
+}
+```
+
+- [ ] **Step 4: 테스트 실행 — PASS 확인**
+
+```bash
+cd packages/memento-server && npx vitest run src/server/server-info.spec.ts 2>&1 | tail -20
+```
+
+Expected: `✓ server-info` 3개 이상 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-server/src/server/server-info.ts packages/memento-server/src/server/server-info.spec.ts
+git commit -m "feat: add server-info utility for server discovery"
+```
+
+---
+
+## Task 2: HTTP 서버 — server.json 라이프사이클
+
+**Files:**
+- Modify: `packages/memento-server/src/server/http-server.ts`
+
+### 배경
+
+HTTP 서버는 이미 `server.on('listening', ...)` 콜백이 있으므로(line 610), 거기서 `writeServerInfo`를 호출한다.
+`cleanup()` 함수(line ~560)에서 `deleteServerInfo`를 호출한다.
+`configDir`은 `process.env.MEMENTO_CONFIG_DIR ?? path.join(os.homedir(), '.memento')`로 결정한다.
+
+> **Note:** HTTP 서버의 server.json 라이프사이클 통합 테스트는 Task 5의 `cli-integration.spec.ts`에서 커버한다. Task 2는 구현 후 타입 체크와 수동 검증으로 확인한다.
+
+- [ ] **Step 2: `http-server.ts` 수정**
+
+`http-server.ts` 상단 import에 추가:
+```typescript
+import { homedir } from 'os';
+import { writeServerInfo, deleteServerInfo } from './server-info.js';
+```
+
+`cleanup()` 함수 안 서비스 정리 코드 직후에 추가 (기존 `closeDatabase` 호출 전):
+```typescript
+// server.json 삭제
+const configDirForCleanup = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+try {
+  await deleteServerInfo(configDirForCleanup);
+} catch (_) {}
+```
+
+`server.on('listening', ...)` 콜백 안에 추가:
+```typescript
+server.on('listening', () => {
+  const address = server.address();
+  if (address && typeof address === 'object') {
+    logger.info('서버 바인딩 완료', { address: address.address, port: address.port });
+    // server.json 기록
+    const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+    void writeServerInfo(configDir, address.port);
+  }
+});
+```
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+cd packages/memento-server && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/memento-server/src/server/http-server.ts
+git commit -m "feat: write/delete server.json on HTTP server lifecycle"
+```
+
+---
+
+## Task 3: stdio 서버 — 관리 HTTP 포트 병행 기동
+
+**Files:**
+- Modify: `packages/memento-server/src/server/index.ts`
+
+### 배경
+
+stdio 서버는 stdout/stdin으로만 통신하므로 CLI가 접근할 HTTP 엔드포인트가 없다.
+`startServer()` 안에서 `server.connect(transport)` 직후, 관리용 Express 앱을 포트 `:0`(OS 자동 배정)으로 기동한다.
+Express 앱은 `/health`와 `POST /tools/:name`만 노출한다.
+`db`와 `serverServices`는 모듈 레벨 변수로 각 요청 시점에 읽히므로, 초기화 중이면 503을 반환한다.
+
+- [ ] **Step 1: import 추가**
+
+`index.ts` 상단에 추가:
+```typescript
+import express from 'express';
+import { createServer as createHttpServer } from 'http';
+import type { AddressInfo } from 'net';
+import { homedir } from 'os';
+import { writeServerInfo, deleteServerInfo } from './server-info.js';
+```
+
+- [ ] **Step 2: 모듈 레벨 변수 추가**
+
+기존 `let serverServices: ServerServices | null = null;` 아래에 추가:
+```typescript
+let mgmtHttpServer: ReturnType<typeof createHttpServer> | null = null;
+```
+
+- [ ] **Step 3: 관리 HTTP 서버 기동 함수 추가**
+
+`startServer()` 함수 바로 위에 추가:
+```typescript
+async function startMgmtHttpServer(): Promise<void> {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'healthy', transport: 'stdio' });
+  });
+
+  app.post('/tools/:name', async (req, res) => {
+    if (!db || !serverServices) {
+      return res.status(503).json({ error: '서버 초기화 중입니다. 잠시 후 다시 시도하세요.' });
+    }
+    const { name } = req.params;
+    try {
+      const context = createToolContext(db, serverServices);
+      const result = await executeTool(name, req.body as Record<string, unknown>, context);
+      let actual: unknown = result;
+      if (Array.isArray(result.content) && result.content[0]?.text) {
+        try { actual = JSON.parse(result.content[0].text as string); } catch {}
+      }
+      return res.json({ result: actual, tool: name, timestamp: new Date().toISOString() });
+    } catch (err) {
+      return res.status(500).json({
+        error: 'Tool execution failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  mgmtHttpServer = createHttpServer(app);
+
+  await new Promise<void>((resolve, reject) => {
+    mgmtHttpServer!.once('error', reject);
+    mgmtHttpServer!.listen(0, '127.0.0.1', async () => {
+      const addr = mgmtHttpServer!.address() as AddressInfo;
+      const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+      try {
+        await writeServerInfo(configDir, addr.port);
+      } catch (err) {
+        mcpLogger.logServer('error', `server.json 기록 실패: ${err}`);
+        reject(err);
+        return;
+      }
+      mcpLogger.logServer('info', `관리 HTTP 서버 기동 완료 (port: ${addr.port})`);
+      resolve();
+    });
+  });
+}
+```
+
+- [ ] **Step 4: `startServer()`에서 관리 HTTP 서버 기동**
+
+`await server.connect(transport);` 직후에 추가:
+```typescript
+// 관리 HTTP 서버 기동 (CLI 통신용)
+await startMgmtHttpServer();
+```
+
+- [ ] **Step 5: `cleanup()` 함수에 관리 HTTP 서버 종료 추가**
+
+`cleanup()` 함수 안 맨 앞부분에 추가:
+```typescript
+// server.json 삭제 및 관리 HTTP 서버 종료
+if (mgmtHttpServer) {
+  const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+  try {
+    await deleteServerInfo(configDir);
+  } catch (_) {}
+  await new Promise<void>((resolve) => mgmtHttpServer!.close(() => resolve()));
+  mgmtHttpServer = null;
+}
+```
+
+- [ ] **Step 6: `join` import 추가 확인**
+
+`index.ts`에는 이미 `import { basename, resolve } from 'path';`가 있다. 이 줄에 `join`을 추가하여:
+```typescript
+import { basename, join, resolve } from 'path';
+```
+**새 import 행을 추가하지 말고, 기존 path import에 `join`을 병합한다.**
+
+- [ ] **Step 7: 타입 체크**
+
+```bash
+cd packages/memento-server && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: 에러 없음
+
+- [ ] **Step 8: 수동 연기 검증**
+
+```bash
+# 터미널 1: stdio 서버 기동
+npm run dev 2>/dev/null &
+sleep 2
+# server.json이 생성되었는지 확인
+cat ~/.memento/server.json
+# 포트 확인 후 health 체크
+PORT=$(cat ~/.memento/server.json | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])")
+curl -s http://localhost:$PORT/health
+# 종료
+kill %1
+sleep 1
+# server.json이 삭제되었는지 확인
+cat ~/.memento/server.json 2>&1
+```
+
+Expected: `{"status":"healthy","transport":"stdio"}` 출력 후 종료 시 파일 없음
+
+- [ ] **Step 9: 커밋**
+
+```bash
+git add packages/memento-server/src/server/index.ts
+git commit -m "feat: add management HTTP server to stdio MCP server for CLI discovery"
+```
+
+---
+
+## Task 4: CLI — DB 초기화 제거, HTTP 클라이언트 전환
+
+**Files:**
+- Modify: `packages/memento-server/src/cli.ts`
+
+### 배경
+
+`cli.ts`는 현재 `createMementoCore()`, `cleanup()`, 신호 핸들러 등 150줄 이상의 DB/서비스 코드를 포함한다.
+이것을 모두 제거하고, `readServerInfo` + `isServerAlive` + `callToolViaHttp` 로 대체한다.
+
+`configDir` 결정 방법:
+```typescript
+const configDir = preOptions.configDir ?? process.env.MEMENTO_CONFIG_DIR ?? path.join(os.homedir(), '.memento');
+```
+
+deprecated 옵션(`--db-path`, `--env-file`): 파싱은 그대로 두되 사용하지 않고 stderr 경고 출력.
+
+- [ ] **Step 1: 불필요한 import 제거 및 새 import 추가**
+
+`cli.ts`에서 `@memento/core`에서 가져오던 import들을 정리한다.
+현재:
+```typescript
+const {
+  mementoConfig,
+  createMementoCore,
+  closeDatabase,
+  createToolContext,
+  executeTool,
+  getBatchScheduler
+} = await import('@memento/core');
+```
+
+새로 교체:
+```typescript
+const { mementoConfig } = await import('@memento/core');
+const { readServerInfo, isServerAlive, callToolViaHttp } = await import('./server/server-info.js');
+```
+
+- [ ] **Step 2: `main()` 함수 안 DB 초기화 코드 제거 및 HTTP 클라이언트 코드 삽입**
+
+현재 `main()` 내부의 아래 블록 전체를 제거한다:
+- `let db`, `let coreServices`, `let isCleaningUp` 선언
+- `cleanup()` 함수 전체
+- `process.on('exit', ...)`, `process.on('uncaughtException', ...)`, `process.on('SIGINT', ...)`, `process.on('SIGTERM', ...)` 등록
+- `const core = await createMementoCore({ dbPath });` 호출
+
+위 내용을 아래로 교체한다:
+
+```typescript
+// configDir 결정
+const configDir =
+  preOptions.configDir ??
+  process.env.MEMENTO_CONFIG_DIR ??
+  path.join(os.homedir(), '.memento');
+
+// deprecated 옵션 경고
+if (preOptions.dbPath) {
+  await writeStderr('[deprecated] --db-path 옵션은 더 이상 사용되지 않습니다. 서버가 DB를 관리합니다.\n');
+}
+if (preOptions.envFile) {
+  await writeStderr('[deprecated] --env-file 옵션은 더 이상 사용되지 않습니다.\n');
+}
+
+// 서버 발견
+const serverInfo = await readServerInfo(configDir);
+const serverAlive = serverInfo ? await isServerAlive(serverInfo) : false;
+if (!serverInfo || !serverAlive) {
+  // stale server.json이 존재하면 자동 삭제
+  if (serverInfo && !serverAlive) {
+    await deleteServerInfo(configDir);
+  }
+  await writeStderr(
+    'Memento 서버가 실행 중이지 않습니다.\n' +
+    'npm run dev 또는 npm run dev:http 로 먼저 서버를 실행하세요.\n'
+  );
+  return 1;
+}
+```
+
+- [ ] **Step 3: 각 서브커맨드 실행 부분 교체**
+
+현재 `if (subcommand === 'recall')` 등 블록들이 `executeTool('recall', params, context)` 를 호출한다.
+이를 `callToolViaHttp(serverInfo.port, 'recall', params)` 로 교체한다.
+
+예시:
+```typescript
+if (subcommand === 'recall') {
+  const params = recallParams(cmdArgv);
+  if (typeof params.query !== 'string' || !String(params.query).trim()) {
+    await writeStderr('recall requires --query <string>.\n');
+    return 1;
+  }
+  const result = await callToolViaHttp(serverInfo.port, 'recall', params as Record<string, unknown>);
+  await writeStdout(JSON.stringify(result) + '\n');
+  return 0;
+}
+```
+
+나머지 서브커맨드(`remember`, `forget`, `memory_injection`)도 동일하게 교체한다.
+
+- [ ] **Step 4: 불필요해진 환경 변수 설정 제거**
+
+```typescript
+// 제거 대상:
+process.env.MEMENTO_CLI_QUIET = '1';
+process.env.BATCH_SCHEDULER_ENABLED = 'false';
+process.env.WAL_CHECKPOINT_ENABLED = 'false';
+process.env.DB_LOCK_MONITOR_ENABLED = 'false';
+```
+
+- [ ] **Step 5: import 정리**
+
+`cli.ts`에서 더 이상 필요 없는 import:
+- `import type { ServerServices } from '@memento/core';` → 제거
+
+필요한 import 추가:
+- `import { homedir } from 'os';`
+- `import path from 'path';`
+
+- [ ] **Step 6: 타입 체크**
+
+```bash
+cd packages/memento-server && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: 에러 없음
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add packages/memento-server/src/cli.ts
+git commit -m "refactor(cli): replace direct DB access with HTTP client"
+```
+
+---
+
+## Task 5: 통합 테스트
+
+**Files:**
+- Create: `packages/memento-server/src/server/cli-integration.spec.ts`
+
+### 배경
+
+이 테스트들은 실제 HTTP 서버를 기동해 CLI HTTP 호출을 검증한다.
+`packages/memento-server/src/server/test/helpers/test-database.ts`의 헬퍼를 재사용한다.
+
+- [ ] **Step 1: 통합 테스트 작성**
+
+```typescript
+// packages/memento-server/src/server/cli-integration.spec.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+import express from 'express';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import {
+  writeServerInfo,
+  readServerInfo,
+  isServerAlive,
+  callToolViaHttp,
+  deleteServerInfo,
+} from './server-info.js';
+import {
+  setupTestDatabase,
+  cleanupTestDatabase,
+  type TestDatabaseContext,
+} from './test/helpers/test-database.js';
+import { createToolContext, executeTool } from '@memento/core';
+
+describe('CLI 통합 (server-info + callToolViaHttp)', () => {
+  let tmpDir: string;
+  let ctx: TestDatabaseContext;
+  let httpServer: ReturnType<typeof createServer>;
+  let port: number;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'memento-cli-int-'));
+    ctx = await setupTestDatabase();
+
+    // 테스트용 경량 HTTP 서버
+    const app = express();
+    app.use(express.json({ limit: '1mb' }));
+    app.get('/health', (_req, res) => res.json({ status: 'healthy' }));
+    app.post('/tools/:name', async (req, res) => {
+      try {
+        const context = createToolContext(ctx.db, ctx.services);
+        const result = await executeTool(req.params.name, req.body, context);
+        let actual: unknown = result;
+        if (Array.isArray(result.content) && result.content[0]?.text) {
+          try { actual = JSON.parse(result.content[0].text); } catch {}
+        }
+        res.json({ result: actual, tool: req.params.name, timestamp: new Date().toISOString() });
+      } catch (err) {
+        res.status(500).json({ error: String(err) });
+      }
+    });
+
+    httpServer = createServer(app);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        port = (httpServer.address() as AddressInfo).port;
+        resolve();
+      });
+    });
+    await writeServerInfo(tmpDir, port);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase(ctx);
+    await deleteServerInfo(tmpDir);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('server.json이 없으면 readServerInfo는 null을 반환한다', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'memento-empty-'));
+    try {
+      const info = await readServerInfo(emptyDir);
+      expect(info).toBeNull();
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('isServerAlive는 실행 중인 서버에 대해 true를 반환한다', async () => {
+    const info = await readServerInfo(tmpDir);
+    expect(info).not.toBeNull();
+    const alive = await isServerAlive(info!);
+    expect(alive).toBe(true);
+  });
+
+  it('isServerAlive는 존재하지 않는 PID에 대해 false를 반환한다', async () => {
+    const fakeInfo = { port, pid: 999999999, startedAt: new Date().toISOString() };
+    const alive = await isServerAlive(fakeInfo);
+    expect(alive).toBe(false);
+  });
+
+  it('callToolViaHttp로 remember 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'remember', {
+      content: '통합 테스트용 기억',
+      type: 'semantic',
+      tags: ['test'],
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('callToolViaHttp로 recall 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'recall', {
+      query: '통합 테스트용 기억',
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('callToolViaHttp로 forget 호출이 성공한다', async () => {
+    // 먼저 remember로 기억 생성
+    const remembered = await callToolViaHttp(port, 'remember', {
+      content: 'forget 테스트용 기억',
+      type: 'semantic',
+      tags: ['forget-test'],
+    }) as { id?: string };
+    expect(remembered).toBeDefined();
+    // forget 호출 (id가 반환된 경우)
+    if (remembered?.id) {
+      const result = await callToolViaHttp(port, 'forget', { id: remembered.id });
+      expect(result).toBeDefined();
+    }
+  });
+
+  it('callToolViaHttp로 memory_injection 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'memory_injection', {
+      query: '통합 테스트',
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('동시성: N회 병렬 호출 후 DB 무결성이 유지된다', async () => {
+    const N = 10;
+    const calls = Array.from({ length: N }, (_, i) =>
+      callToolViaHttp(port, 'remember', {
+        content: `동시성 테스트 ${i}`,
+        type: 'semantic',
+        tags: ['concurrency-test'],
+      })
+    );
+    const results = await Promise.all(calls);
+    expect(results).toHaveLength(N);
+    results.forEach((r) => expect(r).toBeDefined());
+
+    // recall로 기억 확인
+    const recallResult = await callToolViaHttp(port, 'recall', {
+      query: '동시성 테스트',
+    }) as { memories?: unknown[] };
+    // 기억이 저장되었음을 확인 (정확한 개수는 임베딩 결과에 따라 다를 수 있음)
+    expect(recallResult).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 — FAIL 확인**
+
+```bash
+cd packages/memento-server && npx vitest run src/server/cli-integration.spec.ts 2>&1 | tail -30
+```
+
+Expected: import 오류 또는 로직 오류로 FAIL (아직 구현 중인 부분이 있을 수 있음)
+
+- [ ] **Step 3: 테스트 실행 — PASS 확인**
+
+Task 1~4 완료 후:
+```bash
+cd packages/memento-server && npx vitest run src/server/cli-integration.spec.ts 2>&1 | tail -30
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 4: 전체 테스트 스위트 통과 확인**
+
+```bash
+npm test 2>&1 | tail -40
+```
+
+Expected: 모든 테스트 PASS, 실패 없음
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-server/src/server/cli-integration.spec.ts
+git commit -m "test: add CLI integration tests for HTTP client mode"
+```
+
+---
+
+## Task 6: 최종 검증 및 마무리
+
+- [ ] **Step 1: 린트 + 타입 체크**
+
+```bash
+npm run lint && npm run type-check
+```
+
+Expected: 에러 없음
+
+- [ ] **Step 2: 전체 테스트**
+
+```bash
+npm test
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 3: 수동 E2E 검증 (HTTP 서버)**
+
+```bash
+# 터미널 1
+npm run dev:http &
+sleep 3
+cat ~/.memento/server.json  # port, pid 확인
+
+# 터미널 2
+node packages/memento-server/dist/cli.js remember --content "E2E 테스트 기억" --type semantic
+node packages/memento-server/dist/cli.js recall --query "E2E"
+kill %1
+```
+
+Expected: `remember` 성공 JSON, `recall` 결과 JSON 출력
+
+- [ ] **Step 4: CHANGELOG.md 업데이트**
+
+`## [Unreleased]` 아래에 추가:
+```markdown
+### Fixed
+- CLI(`memento remember` 등)가 HTTP/stdio MCP 서버와 동시에 실행될 때 발생하던 WAL 체크포인트 충돌 및 DB 손상 버그 수정 (#160)
+
+### Changed
+- CLI가 DB를 직접 열지 않고 실행 중인 서버의 HTTP 관리 포트로 요청을 위임하도록 아키텍처 전환
+- stdio MCP 서버가 CLI 통신을 위한 localhost-only HTTP 관리 포트를 함께 기동
+- `--db-path`, `--env-file` CLI 옵션 deprecated (무시됨)
+```
+
+- [ ] **Step 5: 최종 커밋**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG for issue 160"
+```

--- a/docs/superpowers/plans/2026-04-18-issue-163-embedding-migration-refactor.md
+++ b/docs/superpowers/plans/2026-04-18-issue-163-embedding-migration-refactor.md
@@ -1,0 +1,312 @@
+# Issue #163 Embedding migration refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `EmbeddingMigrationService.execute()` and simplify `rollback()` in `packages/memento-core` to meet line-count, complexity, and nesting targets while preserving behavior; add a missing regression test for the zero-source-rows path.
+
+**Architecture:** Phase 1 — same file: extract named `private` methods (`resolveEffectiveMonitor`, statement builders or a single `prepareMigrationStatements`, `processMigrationRow` / batch driver, `finalizeMigrationRun` with auto-rollback + history). Replace the anonymous `processBatch` with calls to `processMigrationRow`. Refactor `rollback` with small helpers for delete vs restore. Phase 2 — only if any method still exceeds ~50 lines or complexity > 15 or nesting > 5: move the oversized block to a colocated helper module (e.g. `embedding-migration-execute-helpers.ts`).
+
+**Tech Stack:** TypeScript, Vitest, better-sqlite3, existing `vectorCompatibilityService` / `migrationHistoryService` / `migrationMonitorService`.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-issue-163-embedding-migration-refactor-design.md`
+
+**Worktree (recommended):** Branch `issue/163-embedding-migration-refactor` at `.worktrees/issue-163-embedding-migration-refactor/`.
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts` | Refactor `execute`, `rollback`; add `private` methods; optionally new interfaces for statement bundle |
+| `packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts` | Add zero-source-rows test |
+| `packages/memento-core/src/domains/embedding/services/embedding-migration-execute-helpers.ts` | **Only if Phase 2** — pure functions or class holding batch row processing |
+
+---
+
+### Task 1: Regression test — no source rows
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts`
+
+- [ ] **Step 1: Add test case**
+
+Insert after the `creates a basic migration plan with defaults` test (after line ~87), a new `it` block:
+
+```typescript
+  it('returns success immediately when no rows exist for the source provider', async () => {
+    const plan = embeddingMigrationService.createPlan('minilm', 'openai');
+    const result = await embeddingMigrationService.execute(db, plan);
+
+    expect(result.success).toBe(true);
+    expect(result.processed).toBe(0);
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.rollbackEntries).toHaveLength(0);
+    expect(result.rolledBack).toBe(false);
+    expect(result.nextResumeFromId).toBe(plan.resumeFromId ?? undefined);
+
+    const historyCount = db.prepare('SELECT COUNT(*) AS cnt FROM migration_history').get() as { cnt: number };
+    expect(historyCount.cnt).toBe(0);
+  });
+```
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cd packages/memento-core && npx vitest run src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+```
+
+Expected: all tests PASS (including the new one).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+git commit -m "test(embedding): cover execute when source provider has no rows — 이슈 #163"
+```
+
+---
+
+### Task 2: Extract `resolveEffectiveMonitor` and early-return path clarity
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts`
+
+- [ ] **Step 1: Add private method**
+
+Add:
+
+```typescript
+  private resolveEffectiveMonitor(monitor: MigrationMonitorOptions): MigrationMonitorOptions {
+    return monitor.runId && !monitor.reporter
+      ? { ...monitor, reporter: migrationMonitorService }
+      : monitor;
+  }
+```
+
+- [ ] **Step 2: Use it in `execute`**
+
+Replace the inline `effectiveMonitor` ternary at the start of `execute` with:
+
+```typescript
+    const effectiveMonitor = this.resolveEffectiveMonitor(monitor);
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd packages/memento-core && npx vitest run src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts
+git commit -m "refactor(embedding): extract resolveEffectiveMonitor — 이슈 #163"
+```
+
+---
+
+### Task 3: Extract row processing — replace anonymous `processBatch`
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts`
+
+- [ ] **Step 1: Introduce a private `processMigrationRow` (or equivalent name)**
+
+Move the **per-row** logic from inside the `processBatch` closure (lines ~303–383: loop body only, not the `for` wrapper) into:
+
+```typescript
+  private processMigrationRow(params: {
+    row: RawEmbeddingRow;
+    plan: EmbeddingMigrationPlan;
+    normalizationMode: VectorNormalization;
+    existingStatement: ReturnType<Database['prepare']>;
+    upsertStatement: ReturnType<Database['prepare']>;
+    progress: MigrationProgress;
+    errors: EmbeddingMigrationError[];
+    rollbackEntries: MigrationRollbackEntry[];
+    reportEvery: number;
+    effectiveMonitor: MigrationMonitorOptions;
+  }): void
+```
+
+Implement the same try / catch / finally as today: increment `processed`, set `lastMemoryId`, parse embedding, `vectorCompatibilityService.assessProviderCompatibility`, conditional upsert + rollback entry push, `succeeded++` or `failed++` + error push, `finally` with `updatedAt` and periodic `notifyProgress`.
+
+Use early `continue` is not applicable inside a method — keep control flow identical (no behavior change).
+
+- [ ] **Step 2: Replace `processBatch`**
+
+Implement `processBatch` as:
+
+```typescript
+    const processBatch = (batch: RawEmbeddingRow[]): void => {
+      for (const row of batch) {
+        this.processMigrationRow({
+          row,
+          plan,
+          normalizationMode,
+          existingStatement,
+          upsertStatement,
+          progress,
+          errors,
+          rollbackEntries,
+          reportEvery,
+          effectiveMonitor
+        });
+      }
+    };
+```
+
+Or inline the `for` loop in the `while` without a nested arrow — either is fine if nesting depth ≤ 5.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd packages/memento-core && npx vitest run src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "refactor(embedding): extract processMigrationRow from execute — 이슈 #163"
+```
+
+---
+
+### Task 4: Extract batch loop and/or finalization
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts`
+
+- [ ] **Step 1: Extract `runMigrationBatches`** (name flexible)
+
+Move the `while (true) { ... }` block (select batch, break if empty, process, update `lastProcessedId`, `notifyProgress`) into `private runMigrationBatches(...)` with parameters: `db`, `plan`, `selectStatement`, `processBatch` or row processor, `progress`, `lastProcessedId` ref (return updated cursor), `effectiveMonitor`.
+
+Alternatively keep a thin `while` in `execute` if extraction does not reduce complexity — goal is **shorter `execute`** and **metrics**, not a fixed number of methods.
+
+- [ ] **Step 2: Extract `finalizeExecute`**
+
+Move from `const endTime = new Date()` through `recordHistory` (exclusive of early returns) into `private finalizeMigrationExecute(...)` returning `MigrationResult`, including: `completeStep`, `notifyProgress`, conditional `rollback` on failure, building `result`, `recordHistory` when `!plan.dryRun`.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd packages/memento-core && npx vitest run src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "refactor(embedding): split batch loop and finalize path in execute — 이슈 #163"
+```
+
+---
+
+### Task 5: Refactor `rollback`
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts`
+
+- [ ] **Step 1: Add `private applyRollbackDelete` / `private applyRollbackRestore`** (or one `applyRollbackEntry`)
+
+Split the `for` loop body so `rollback` only iterates and delegates. Keep `DELETE` and `INSERT ... ON CONFLICT` SQL in prepared statements as today.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd packages/memento-core && npx vitest run src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "refactor(embedding): simplify rollback via private helpers — 이슈 #163"
+```
+
+---
+
+### Task 6: Quality gate — full package
+
+**Files:**
+- (none new unless Phase 2)
+
+- [ ] **Step 1: Lint and type-check**
+
+```bash
+npm run lint
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Full memento-core tests**
+
+```bash
+npm test --workspace packages/memento-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Optional — slop-detector / complexity**
+
+Re-run the same tooling used in issue #163. Confirm: `execute` chunks ≤ ~50 lines, complexity ≤ 15 per method, nesting ≤ 5. If any method fails: **Task 7 (Phase 2)**.
+
+- [ ] **Step 4: Commit** (only if formatting or eslint fixes)
+
+---
+
+### Task 7 (conditional): Phase 2 — helper module
+
+**Only if** Task 6 metrics fail after Task 5.
+
+**Files:**
+- Create: `packages/memento-core/src/domains/embedding/services/embedding-migration-execute-helpers.ts`
+- Modify: `embedding-migration-service.ts` — import and delegate the oversized block only.
+
+- [ ] **Step 1:** Move the smallest failing unit (usually row processing or statement preparation) into the helper file with explicit types from `migration.types.ts`.
+
+- [ ] **Step 2:** Run `npm test --workspace packages/memento-core` and `npm run lint`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "refactor(embedding): extract helpers for migration execute — 이슈 #163"
+```
+
+---
+
+## Plan self-review (spec coverage)
+
+| Spec section | Tasks |
+|--------------|-------|
+| 동작 동일 | All tasks preserve logic by move-only refactors; tests gate |
+| 수치 목표 | Task 6 + optional Task 7 |
+| 테스트 보강 (zero rows) | Task 1 |
+| 2단계 파일 분리 | Task 7 conditional |
+| rollback 단순화 | Task 5 |
+
+Placeholder scan: none.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-issue-163-embedding-migration-refactor.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — Run tasks in this session using executing-plans with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-18-issue-160-cli-http-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-160-cli-http-client-design.md
@@ -1,0 +1,142 @@
+# Issue 160: CLI → HTTP 클라이언트 전환 설계
+
+**날짜**: 2026-04-18  
+**이슈**: [#160](https://github.com/jee1/memento/issues/160) — HTTP 서버 실행 중 CLI remember 시 DB 손상  
+**상태**: 설계 확정
+
+---
+
+## 문제 요약
+
+CLI(`memento remember` 등)가 `createMementoCore()`를 직접 호출해 DB를 열고, 서버 전용 장기 실행 서비스(WalCheckpointScheduler, BatchScheduler 등)까지 초기화한다. HTTP 또는 stdio MCP 서버가 동시에 실행 중일 때 WAL 체크포인트 경합 및 stale read mark가 발생해 DB가 손상된다.
+
+---
+
+## 핵심 원칙
+
+**CLI는 DB를 직접 건드리지 않는다.**  
+모든 서버 모드(HTTP, stdio MCP)는 로컬 HTTP 관리 포트를 노출하며, CLI는 해당 포트로만 통신한다.
+
+---
+
+## 아키텍처
+
+```
+[CLI]
+  └─ server.json 읽기 → port 확인
+  └─ POST http://localhost:{port}/tools/{subcommand}
+          │
+[서버 (HTTP 또는 stdio MCP)]
+  └─ /tools/:name 라우터 처리
+  └─ DB 접근 및 결과 반환
+```
+
+---
+
+## 구성 요소
+
+### 1. 서버 정보 파일 (`server.json`)
+
+**위치**: `{configDir}/server.json` (기본: `~/.memento/server.json`)
+
+**형식**:
+```json
+{
+  "port": 51764,
+  "pid": 12345,
+  "startedAt": "2026-04-18T10:00:00.000Z"
+}
+```
+
+- 모든 서버 모드가 기동 시 기록, 종료 시 삭제
+- CLI가 서버를 발견하는 유일한 방법
+- PID 검증: 파일이 존재하더라도 해당 PID 프로세스가 살아있는지 확인 후 사용
+
+### 2. `src/server/server-info.ts` (신규)
+
+서버 정보 파일 읽기/쓰기/삭제 유틸리티:
+
+```typescript
+export interface ServerInfo {
+  port: number;
+  pid: number;
+  startedAt: string;
+}
+
+export async function writeServerInfo(configDir: string, port: number): Promise<void>
+export async function readServerInfo(configDir: string): Promise<ServerInfo | null>
+export async function deleteServerInfo(configDir: string): Promise<void>
+export async function isServerAlive(info: ServerInfo): Promise<boolean>  // PID 검증
+```
+
+### 3. stdio 서버 (`src/server/index.ts`) 변경
+
+기존 stdio MCP 로직 유지, HTTP 관리 서버 병행 기동 추가:
+
+- 기동 시 Express 앱으로 `/tools/:name` 라우터만 마운트한 HTTP 서버를 포트 `:0`(OS 자동 배정)으로 올림
+- 실제 바인딩된 포트를 `server.json`에 기록
+- `SIGINT`/`SIGTERM`/`exit` 시 HTTP 서버 닫고 `server.json` 삭제
+
+### 4. HTTP 서버 (`src/server/http-server.ts`) 변경
+
+- 기존 Express 서버가 listen 완료 후 포트를 `server.json`에 기록
+- `SIGINT`/`SIGTERM`/`exit` 시 `server.json` 삭제
+
+### 5. CLI (`src/cli.ts`) 변경
+
+`createMementoCore()` 호출 및 모든 DB/서비스 초기화 코드 제거:
+
+```typescript
+// 기존 흐름 (제거)
+const core = await createMementoCore({ dbPath });
+// ...서비스 초기화, cleanup 등
+
+// 새 흐름
+const info = await readServerInfo(configDir);
+if (!info || !(await isServerAlive(info))) {
+  await writeStderr('Memento 서버가 실행 중이지 않습니다. npm run dev 또는 npm run dev:http로 먼저 실행하세요.\n');
+  process.exit(1);
+}
+const result = await callToolViaHttp(info.port, subcommand, params);
+await writeStdout(JSON.stringify(result) + '\n');
+```
+
+`cleanup()` 함수 전체 제거 — DB 연결이 없으므로 정리할 것 없음.
+
+---
+
+## 오류 처리
+
+| 상황 | 동작 |
+|---|---|
+| `server.json` 없음 | "서버가 실행 중이지 않습니다" 에러 후 exit 1 |
+| PID 검증 실패 (stale file) | 위와 동일 |
+| HTTP 요청 실패 (연결 거부) | "서버에 연결할 수 없습니다 (port: {port})" 에러 후 exit 1 |
+| HTTP 응답 오류 (4xx/5xx) | 서버 응답 메시지를 stderr에 출력 후 exit 1 |
+| 타임아웃 | 30초 후 타임아웃, 에러 후 exit 1 |
+
+---
+
+## 변경 파일 요약
+
+| 파일 | 변경 유형 | 내용 |
+|---|---|---|
+| `packages/memento-server/src/server/server-info.ts` | 신규 | ServerInfo 읽기/쓰기/삭제 유틸 |
+| `packages/memento-server/src/server/index.ts` | 수정 | HTTP 관리 포트 병행 기동, server.json 기록/삭제 |
+| `packages/memento-server/src/server/http-server.ts` | 수정 | server.json 기록/삭제 |
+| `packages/memento-server/src/cli.ts` | 수정 | DB 초기화 제거, HTTP 클라이언트로 교체 |
+
+---
+
+## 테스트 전략
+
+- `server-info.ts` 유닛 테스트: 읽기/쓰기/삭제/PID 검증
+- CLI 통합 테스트: 서버 없을 때 에러 메시지 검증
+- CLI 통합 테스트: 실제 HTTP 서버 기동 후 `remember`/`recall` 왕복 테스트
+
+---
+
+## 마이그레이션 영향
+
+- 기존 CLI 사용자: 서버 없이 CLI만 사용하는 워크플로우는 더 이상 지원되지 않음 → 문서 및 에러 메시지로 명확히 안내
+- 환경 변수 `BATCH_SCHEDULER_ENABLED`, `WAL_CHECKPOINT_ENABLED`, `DB_LOCK_MONITOR_ENABLED`는 CLI에서 불필요 (제거 가능)

--- a/docs/superpowers/specs/2026-04-18-issue-160-cli-http-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-160-cli-http-client-design.md
@@ -50,7 +50,7 @@ CLI(`memento remember` 등)가 `createMementoCore()`를 직접 호출해 DB를 �
 
 - 모든 서버 모드가 기동 시 기록, 종료 시 삭제
 - CLI가 서버를 발견하는 유일한 방법
-- PID 검증: 파일이 존재하더라도 해당 PID 프로세스가 살아있는지 확인 후 사용
+- **서버 생존 이중 검증**: PID 프로세스 존재 확인 → `GET http://localhost:{port}/health` 응답 확인. 어느 한쪽이라도 실패하면 stale 파일로 간주하고 자동 삭제 후 에러 반환. PID만으로는 PID 재사용(다른 프로세스) 오탐이 가능하므로 HTTP 응답 확인이 필수.
 
 ### 2. `src/server/server-info.ts` (신규)
 
@@ -66,15 +66,26 @@ export interface ServerInfo {
 export async function writeServerInfo(configDir: string, port: number): Promise<void>
 export async function readServerInfo(configDir: string): Promise<ServerInfo | null>
 export async function deleteServerInfo(configDir: string): Promise<void>
-export async function isServerAlive(info: ServerInfo): Promise<boolean>  // PID 검증
+export async function isServerAlive(info: ServerInfo): Promise<boolean>  // PID + HTTP /health 이중 검증
+```
+
+`callToolViaHttp` 헬퍼도 이 파일에 포함:
+
+```typescript
+// POST http://localhost:{port}/tools/{toolName} 요청 후 result 반환
+// Body: JSON (params 객체), Content-Type: application/json
+// 인증: localhost 전용이므로 인증 없음 (Admin auth 미들웨어 localhost 바이패스 또는 /tools 라우터는 인증 불필요 확인 필요)
+// 타임아웃: 30초
+export async function callToolViaHttp(port: number, toolName: string, params: Record<string, unknown>): Promise<unknown>
 ```
 
 ### 3. stdio 서버 (`src/server/index.ts`) 변경
 
 기존 stdio MCP 로직 유지, HTTP 관리 서버 병행 기동 추가:
 
-- 기동 시 Express 앱으로 `/tools/:name` 라우터만 마운트한 HTTP 서버를 포트 `:0`(OS 자동 배정)으로 올림
+- 기동 시 Express 앱으로 `/tools/:name`, `GET /health` 라우터만 마운트한 HTTP 서버를 포트 `:0`(OS 자동 배정)으로 올림
 - 실제 바인딩된 포트를 `server.json`에 기록
+- **HTTP 포트 바인딩 실패 시 stdio 서버도 fatal 종료** — CLI가 서버를 발견할 수 없으므로 degraded mode는 허용하지 않음
 - `SIGINT`/`SIGTERM`/`exit` 시 HTTP 서버 닫고 `server.json` 삭제
 
 ### 4. HTTP 서버 (`src/server/http-server.ts`) 변경
@@ -130,13 +141,17 @@ await writeStdout(JSON.stringify(result) + '\n');
 
 ## 테스트 전략
 
-- `server-info.ts` 유닛 테스트: 읽기/쓰기/삭제/PID 검증
+- `server-info.ts` 유닛 테스트: 읽기/쓰기/삭제/PID 검증/stale file 자동 삭제
 - CLI 통합 테스트: 서버 없을 때 에러 메시지 검증
 - CLI 통합 테스트: 실제 HTTP 서버 기동 후 `remember`/`recall` 왕복 테스트
+- **동시성 통합 테스트**: HTTP 서버 기동 상태에서 CLI N회 병렬 호출 → DB 무결성(row count, WAL 상태) 검증
 
 ---
 
 ## 마이그레이션 영향
 
 - 기존 CLI 사용자: 서버 없이 CLI만 사용하는 워크플로우는 더 이상 지원되지 않음 → 문서 및 에러 메시지로 명확히 안내
+- **`--db-path` 옵션**: 서버가 이미 사용 중인 DB를 변경할 수 없으므로 deprecated 처리. CLI에서 파싱은 하되 무시하고 deprecation 경고를 stderr에 출력.
+- **`--config-dir` 옵션**: `server.json` 위치를 결정하는 데 계속 사용됨 (유지).
+- **`--env-file` 옵션**: CLI가 DB를 직접 열지 않으므로 불필요. deprecated 처리 후 무시.
 - 환경 변수 `BATCH_SCHEDULER_ENABLED`, `WAL_CHECKPOINT_ENABLED`, `DB_LOCK_MONITOR_ENABLED`는 CLI에서 불필요 (제거 가능)

--- a/docs/superpowers/specs/2026-04-18-issue-163-embedding-migration-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-163-embedding-migration-refactor-design.md
@@ -1,0 +1,106 @@
+# 설계: 이슈 #163 — EmbeddingMigrationService `execute` / `rollback` 리팩터링
+
+**상태**: 브레인스토밍 확정 (구현 전)  
+**날짜**: 2026-04-18  
+**이슈**: [GitHub #163](https://github.com/jee1/memento/issues/163) — `execute()` 분리(238줄, complexity 38), `rollback()` 단순화, 중첩 깊이 개선  
+
+**작업 브랜치·워크트리**: `issue/163-embedding-migration-refactor` — 로컬 경로 `.worktrees/issue-163-embedding-migration-refactor/` (`.cursorignore`에 포함될 수 있음 → 해당 폴더를 별도로 열거나 예외 처리)
+
+---
+
+## 1. 배경·문제
+
+| 항목 | 현황(이슈 기준) |
+|------|-----------------|
+| `execute()` | ~238줄, cyclomatic complexity ≈ 38 |
+| `rollback()` | ~62줄, complexity ≈ 15 |
+| 익명 함수(`processBatch` 등) | ~82줄, complexity ≈ 13 |
+| 최대 중첩 깊이 | 7 |
+
+**파일**: `packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts`
+
+---
+
+## 2. 목표·비기능
+
+### 2.1 동작
+
+- **공개 API**(`execute`, `rollback`, `createPlan`, `listTargets`, `listHistory` 등)와 **관찰 가능한 동작**은 기존과 동일해야 한다.
+- 행 단위 오류 처리, `dryRun`, `autoRollbackOnFailure`, 진행 콜백·모니터, `migrationHistoryService.recordHistory` 호출 조건은 **의도적으로 변경하지 않는다**.
+
+### 2.2 구조·품질 (1단계: 동일 파일)
+
+**전략 (브레인스토밍 확정)**: **하이브리드** — 오케스트레이션 단계형 private + 행/배치 처리를 이름 있는 private으로 분리; `rollback`은 DELETE/RESTORE를 짧은 private으로 분할.
+
+**수치 목표 (이름이 붙은 각 메서드 단위)**:
+
+| 메트릭 | 목표 |
+|--------|------|
+| 메서드당 줄 수 | **~50줄 이하** (가이드; 초과 시 해당 블록부터 추가 분리) |
+| Cyclomatic complexity | **≤ 15** (리포지토리에 ESLint `complexity` 규칙이 추가되면 그 상한에 맞춤) |
+| 최대 중첩 깊이 | **≤ 5** (현재 7) |
+
+`execute()` 최상위 본문은 **얇은 오케스트레이션**만 남긴다.
+
+### 2.3 2단계 (별도 파일)
+
+1단계에서 위 수치를 **어느 한 메서드에도** 만족시키기 어렵다면, **그 블록만** 별도 모듈로 분리한다 (예: `embedding-migration-execute-helpers.ts`). 전역 남발 없이 **책임 단위**로만 쪼갠다.
+
+### 2.4 검증·도구
+
+- `npm test`, `npm run lint`, `npm run type-check` 통과.
+- 이슈에서 사용한 **slop-detector(또는 동일 정적 분석)** 재실행 시 품질 지표가 개선되었는지 확인(보조).
+
+---
+
+## 3. 범위 결정 (브레인스토밍 답변)
+
+| 결정 | 선택 |
+|------|------|
+| 리팩터 범위 | **3**: 먼저 동일 파일 private 분리 → 수치 미달 시 파일 분리 |
+| 완료/확장 판단 | **1**: 스펙에 수치 기준 명시; **초과 시** 2단계 파일 분리 |
+| 테스트 | **2**: `execute` / `rollback` **핵심 경로** 단위·통합 테스트 보강 |
+
+---
+
+## 4. 제안 구조
+
+### 4.1 `execute` 분리 후보
+
+- 모니터 옵션 정규화(`effectiveMonitor`).
+- 소스 행 수 집계, `initializeProgress`, 빈 소스 **조기 반환** (`total === 0`).
+- Prepared statement 생성(`select` / `upsert` / `existing`).
+- **단일 행 처리** (파싱, 호환성 평가, upsert, rollback 엔트리, 성공/실패 집계) — 기존 익명 `processBatch` 대체.
+- 배치 루프(`while` + `notifyProgress`).
+- 종료: 스텝 완료, 자동 롤백 시도, `MigrationResult` 조립, `recordHistory` 호출.
+
+### 4.2 `rollback`
+
+- 빈 `entries` 조기 반환(유지).
+- `DELETE` / `restore` 분기 및 SQL 실행을 **짧은 private 메서드**로 분리해 중첩·길이 감소.
+
+### 4.3 데이터 흐름
+
+기존과 동일: `memory_embedding` 읽기 → 호환성·투영 → upsert → rollback 엔트리 누적 → 배치 반복 → 결과·(조건부) 히스토리 기록.
+
+---
+
+## 5. 테스트 보강
+
+- 기존 `embedding-migration-service.spec.ts`에 성공·dry-run·수동/자동 롤백 등이 이미 있다.
+- **추가**: 소스 `embedding_provider`에 해당하는 행이 **0건**일 때 `execute` — `processed === 0`, 성공 플래그, 조기 반환 경로(히스토리 미기록 등 **현재 동작**)를 고정하는 테스트 **1건**.
+- 리팩터 후 전체 스펙 회귀.
+
+---
+
+## 6. 리스크·완화
+
+- **회귀**: 테스트·린트·타입 체크를 PR 전 필수로 실행한다.
+- **동시성**: 단일 스레드 SQLite 가정 유지; 로직만 이동한다.
+- **가독성**: private 이름은 동작을 드러내는 동사구(`prepare…`, `process…`, `finalize…`)를 사용한다.
+
+---
+
+## 7. 참고
+
+- 구현 단계 상세는 `docs/superpowers/plans/2026-04-18-issue-163-embedding-migration-refactor.md`를 따른다.

--- a/packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
+++ b/packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts
@@ -86,6 +86,22 @@ describe('EmbeddingMigrationService', () => {
     expect(plan.autoRollbackOnFailure).toBe(true);
   });
 
+  it('returns success immediately when no rows exist for the source provider', async () => {
+    const plan = embeddingMigrationService.createPlan('minilm', 'openai');
+    const result = await embeddingMigrationService.execute(db, plan);
+
+    expect(result.success).toBe(true);
+    expect(result.processed).toBe(0);
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.rollbackEntries).toHaveLength(0);
+    expect(result.rolledBack).toBe(false);
+    expect(result.nextResumeFromId).toBe(plan.resumeFromId ?? undefined);
+
+    const historyCount = db.prepare('SELECT COUNT(*) AS cnt FROM migration_history').get() as { cnt: number };
+    expect(historyCount.cnt).toBe(0);
+  });
+
   it('reprojects embeddings to the target provider and inserts new rows', async () => {
     const memoryId = 'memory-001';
     seedMemoryItem(db, memoryId);

--- a/packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts
+++ b/packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts
@@ -203,15 +203,19 @@ export class EmbeddingMigrationService {
     };
   }
 
+
+  private resolveEffectiveMonitor(monitor: MigrationMonitorOptions): MigrationMonitorOptions {
+    return monitor.runId && !monitor.reporter
+      ? { ...monitor, reporter: migrationMonitorService }
+      : monitor;
+  }
+
   async execute(
     db: Database,
     plan: EmbeddingMigrationPlan,
     monitor: MigrationMonitorOptions = {}
   ): Promise<MigrationResult> {
-    const effectiveMonitor: MigrationMonitorOptions =
-      monitor.runId && !monitor.reporter
-        ? { ...monitor, reporter: migrationMonitorService }
-        : monitor;
+    const effectiveMonitor = this.resolveEffectiveMonitor(monitor);
 
     const totalRow = db
       .prepare('SELECT COUNT(*) AS count FROM memory_embedding WHERE embedding_provider = ?')

--- a/packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts
+++ b/packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts
@@ -1,4 +1,4 @@
-import type { Database } from 'better-sqlite3';
+import type { Database, Statement } from 'better-sqlite3';
 import type { EmbeddingProvider, ProjectionType, VectorNormalization } from '../../../shared/types/embedding.types.js';
 import type {
   EmbeddingMigrationError,
@@ -253,8 +253,6 @@ export class EmbeddingMigrationService {
       };
     }
 
-    let lastProcessedId = plan.resumeFromId ?? null;
-
     const selectStatement = db.prepare(
       `
       SELECT memory_id, embedding, model, embedding_provider, projection_type, dim, dimensions, created_at
@@ -306,87 +304,155 @@ export class EmbeddingMigrationService {
 
     const processBatch = (batch: RawEmbeddingRow[]): void => {
       for (const row of batch) {
-        progress.processed += 1;
-        progress.lastMemoryId = row.memory_id;
-
-        try {
-          const parsed = this.safeParseEmbedding(row.embedding);
-          const assessment = vectorCompatibilityService.assessProviderCompatibility(parsed, plan.targetProvider, {
-            targetDimensions: plan.targetDimensions,
-            normalization: normalizationMode
-          });
-
-          const storedVector = assessment.projection.vector;
-          const serialized = JSON.stringify(storedVector);
-          const projectionType = assessment.projection.projectionType;
-          const normalizedFlag = assessment.projection.normalized ? 1 : 0;
-          const targetModel = plan.targetModel ?? row.model ?? `compat-${plan.targetProvider}`;
-          const createdBy = plan.createdBy ?? DEFAULT_CREATED_BY;
-
-          if (!plan.dryRun) {
-            const existing = existingStatement.get(
-              row.memory_id,
-              plan.targetProvider,
-              projectionType
-            ) as ExistingEmbeddingRow | undefined;
-
-            upsertStatement.run(
-              row.memory_id,
-              plan.targetProvider,
-              projectionType,
-              serialized,
-              plan.targetDimensions,
-              targetModel,
-              plan.targetDimensions,
-              32,
-              normalizedFlag,
-              1,
-              createdBy
-            );
-
-            if (existing) {
-              rollbackEntries.push({
-                memoryId: row.memory_id,
-                provider: plan.targetProvider,
-                projectionType,
-                operation: 'restore',
-                embedding: existing.embedding,
-                dim: existing.dim,
-                dimensions: existing.dimensions,
-                model: existing.model,
-                precision: existing.precision,
-                normalized: existing.normalized,
-                version: existing.version,
-                createdBy: existing.created_by,
-                createdAt: existing.created_at ?? undefined
-              });
-            } else {
-              rollbackEntries.push({
-                memoryId: row.memory_id,
-                provider: plan.targetProvider,
-                projectionType,
-                operation: 'delete'
-              });
-            }
-          }
-
-          progress.succeeded += 1;
-        } catch (error) {
-          progress.failed += 1;
-          errors.push({
-            memoryId: row.memory_id,
-            provider: plan.targetProvider,
-            message: error instanceof Error ? error.message : 'Unknown error'
-          });
-        } finally {
-          progress.updatedAt = new Date();
-          if (reportEvery > 0 && progress.processed % reportEvery === 0) {
-            this.notifyProgress(progress, effectiveMonitor);
-          }
-        }
+        this.processMigrationRow({
+          row,
+          plan,
+          normalizationMode,
+          existingStatement,
+          upsertStatement,
+          progress,
+          errors,
+          rollbackEntries,
+          reportEvery,
+          effectiveMonitor
+        });
       }
     };
 
+    this.runMigrationBatchLoop(
+      plan,
+      selectStatement,
+      progress,
+      plan.resumeFromId ?? null,
+      processBatch,
+      effectiveMonitor
+    );
+
+    return this.finalizeMigrationExecution({
+      db,
+      plan,
+      progress,
+      step,
+      errors,
+      rollbackEntries,
+      effectiveMonitor
+    });
+  }
+
+  private processMigrationRow(params: {
+    row: RawEmbeddingRow;
+    plan: EmbeddingMigrationPlan;
+    normalizationMode: VectorNormalization;
+    existingStatement: Statement;
+    upsertStatement: Statement;
+    progress: MigrationProgress;
+    errors: EmbeddingMigrationError[];
+    rollbackEntries: MigrationRollbackEntry[];
+    reportEvery: number;
+    effectiveMonitor: MigrationMonitorOptions;
+  }): void {
+    const {
+      row,
+      plan,
+      normalizationMode,
+      existingStatement,
+      upsertStatement,
+      progress,
+      errors,
+      rollbackEntries,
+      reportEvery,
+      effectiveMonitor
+    } = params;
+
+    progress.processed += 1;
+    progress.lastMemoryId = row.memory_id;
+
+    try {
+      const parsed = this.safeParseEmbedding(row.embedding);
+      const assessment = vectorCompatibilityService.assessProviderCompatibility(parsed, plan.targetProvider, {
+        targetDimensions: plan.targetDimensions,
+        normalization: normalizationMode
+      });
+
+      const storedVector = assessment.projection.vector;
+      const serialized = JSON.stringify(storedVector);
+      const projectionType = assessment.projection.projectionType;
+      const normalizedFlag = assessment.projection.normalized ? 1 : 0;
+      const targetModel = plan.targetModel ?? row.model ?? `compat-${plan.targetProvider}`;
+      const createdBy = plan.createdBy ?? DEFAULT_CREATED_BY;
+
+      if (!plan.dryRun) {
+        const existing = existingStatement.get(
+          row.memory_id,
+          plan.targetProvider,
+          projectionType
+        ) as ExistingEmbeddingRow | undefined;
+
+        upsertStatement.run(
+          row.memory_id,
+          plan.targetProvider,
+          projectionType,
+          serialized,
+          plan.targetDimensions,
+          targetModel,
+          plan.targetDimensions,
+          32,
+          normalizedFlag,
+          1,
+          createdBy
+        );
+
+        if (existing) {
+          rollbackEntries.push({
+            memoryId: row.memory_id,
+            provider: plan.targetProvider,
+            projectionType,
+            operation: 'restore',
+            embedding: existing.embedding,
+            dim: existing.dim,
+            dimensions: existing.dimensions,
+            model: existing.model,
+            precision: existing.precision,
+            normalized: existing.normalized,
+            version: existing.version,
+            createdBy: existing.created_by,
+            createdAt: existing.created_at ?? undefined
+          });
+        } else {
+          rollbackEntries.push({
+            memoryId: row.memory_id,
+            provider: plan.targetProvider,
+            projectionType,
+            operation: 'delete'
+          });
+        }
+      }
+
+      progress.succeeded += 1;
+    } catch (error) {
+      progress.failed += 1;
+      errors.push({
+        memoryId: row.memory_id,
+        provider: plan.targetProvider,
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    } finally {
+      progress.updatedAt = new Date();
+      if (reportEvery > 0 && progress.processed % reportEvery === 0) {
+        this.notifyProgress(progress, effectiveMonitor);
+      }
+    }
+  }
+
+  private runMigrationBatchLoop(
+    plan: EmbeddingMigrationPlan,
+    selectStatement: Statement,
+    progress: MigrationProgress,
+    initialLastId: string | null,
+    processBatch: (batch: RawEmbeddingRow[]) => void,
+    effectiveMonitor: MigrationMonitorOptions
+  ): void {
+    let lastProcessedId = initialLastId;
     while (true) {
       const batch = selectStatement.all(
         plan.sourceProvider,
@@ -402,6 +468,18 @@ export class EmbeddingMigrationService {
       lastProcessedId = batch[batch.length - 1]?.memory_id ?? lastProcessedId;
       this.notifyProgress(progress, effectiveMonitor);
     }
+  }
+
+  private finalizeMigrationExecution(params: {
+    db: Database;
+    plan: EmbeddingMigrationPlan;
+    progress: MigrationProgress;
+    step: MigrationStep;
+    errors: EmbeddingMigrationError[];
+    rollbackEntries: MigrationRollbackEntry[];
+    effectiveMonitor: MigrationMonitorOptions;
+  }): MigrationResult {
+    const { db, plan, progress, step, errors, rollbackEntries, effectiveMonitor } = params;
 
     const endTime = new Date();
     const success = progress.failed === 0;
@@ -500,27 +578,35 @@ export class EmbeddingMigrationService {
 
     for (const entry of [...entries].reverse()) {
       if (entry.operation === 'delete') {
-        deleteStatement.run(entry.memoryId, entry.provider, entry.projectionType);
+        this.applyRollbackDelete(deleteStatement, entry);
       } else {
-        if (!entry.embedding) {
-          throw new Error(`Rollback 데이터가 누락되었습니다: ${entry.memoryId}`);
-        }
-        restoreStatement.run(
-          entry.memoryId,
-          entry.provider,
-          entry.projectionType,
-          entry.embedding,
-          entry.dim ?? entry.dimensions ?? 0,
-          entry.model ?? null,
-          entry.dimensions ?? entry.dim ?? 0,
-          entry.precision ?? 32,
-          entry.normalized ?? 0,
-          entry.version ?? 1,
-          entry.createdBy ?? DEFAULT_CREATED_BY,
-          entry.createdAt ?? new Date().toISOString()
-        );
+        this.applyRollbackRestore(restoreStatement, entry);
       }
     }
+  }
+
+  private applyRollbackDelete(deleteStatement: Statement, entry: MigrationRollbackEntry): void {
+    deleteStatement.run(entry.memoryId, entry.provider, entry.projectionType);
+  }
+
+  private applyRollbackRestore(restoreStatement: Statement, entry: MigrationRollbackEntry): void {
+    if (!entry.embedding) {
+      throw new Error(`Rollback 데이터가 누락되었습니다: ${entry.memoryId}`);
+    }
+    restoreStatement.run(
+      entry.memoryId,
+      entry.provider,
+      entry.projectionType,
+      entry.embedding,
+      entry.dim ?? entry.dimensions ?? 0,
+      entry.model ?? null,
+      entry.dimensions ?? entry.dim ?? 0,
+      entry.precision ?? 32,
+      entry.normalized ?? 0,
+      entry.version ?? 1,
+      entry.createdBy ?? DEFAULT_CREATED_BY,
+      entry.createdAt ?? new Date().toISOString()
+    );
   }
 
   listHistory(db: Database, limit: number = 20): MigrationHistoryRecord[] {

--- a/packages/memento-server/src/server/auth/session-store.spec.ts
+++ b/packages/memento-server/src/server/auth/session-store.spec.ts
@@ -4,6 +4,7 @@ import { createSessionStore } from './session-store.js';
 
 describe('createSessionStore', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -50,6 +51,49 @@ describe('createSessionStore', () => {
 
     vi.setSystemTime(new Date('2026-04-18T01:00:00.001Z'));
 
+    expect(store.get(session.sessionId)).toBeNull();
+  });
+
+  it('cleans up stale sessions when another session is accessed', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-18T00:00:00.000Z'));
+
+    const deleteSpy = vi.spyOn(Map.prototype, 'delete');
+    const store = createSessionStore({
+      idleTtlMs: 15 * 60 * 1000,
+      absoluteTtlMs: 60 * 60 * 1000,
+    });
+
+    const staleSession = store.create();
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+
+    const freshSession = store.create();
+    deleteSpy.mockClear();
+
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    expect(store.touch(freshSession.sessionId)).not.toBeNull();
+    expect(deleteSpy).toHaveBeenCalledWith(staleSession.sessionId);
+    expect(store.get(staleSession.sessionId)).toBeNull();
+  });
+
+  it('returns null when touch is called after expiry and evicts the session', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-18T00:00:00.000Z'));
+
+    const deleteSpy = vi.spyOn(Map.prototype, 'delete');
+    const store = createSessionStore({
+      idleTtlMs: 15 * 60 * 1000,
+      absoluteTtlMs: 60 * 60 * 1000,
+    });
+
+    const session = store.create();
+
+    vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+
+    expect(store.touch(session.sessionId)).toBeNull();
+    expect(deleteSpy).toHaveBeenCalledWith(session.sessionId);
     expect(store.get(session.sessionId)).toBeNull();
   });
 });

--- a/packages/memento-server/src/server/auth/session-store.spec.ts
+++ b/packages/memento-server/src/server/auth/session-store.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSessionStore } from './session-store.js';
+
+describe('createSessionStore', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('expires sessions after the idle timeout when they are not touched', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-18T00:00:00.000Z'));
+
+    const store = createSessionStore({
+      idleTtlMs: 15 * 60 * 1000,
+      absoluteTtlMs: 8 * 60 * 60 * 1000,
+    });
+
+    const session = store.create();
+
+    expect(store.get(session.sessionId)).toMatchObject(session);
+
+    vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+
+    expect(store.get(session.sessionId)).toBeNull();
+  });
+
+  it('touch refreshes idle expiry without extending the absolute timeout', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-18T00:00:00.000Z'));
+
+    const store = createSessionStore({
+      idleTtlMs: 15 * 60 * 1000,
+      absoluteTtlMs: 60 * 60 * 1000,
+    });
+
+    const session = store.create();
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+
+    const touched = store.touch(session.sessionId);
+
+    expect(touched).not.toBeNull();
+    expect(touched?.lastSeenAt).toBe(Date.parse('2026-04-18T00:10:00.000Z'));
+    expect(touched?.expiresAt).toBe(session.expiresAt);
+
+    vi.advanceTimersByTime(14 * 60 * 1000 + 59 * 1000);
+
+    expect(store.get(session.sessionId)).not.toBeNull();
+
+    vi.setSystemTime(new Date('2026-04-18T01:00:00.001Z'));
+
+    expect(store.get(session.sessionId)).toBeNull();
+  });
+});

--- a/packages/memento-server/src/server/auth/session-store.ts
+++ b/packages/memento-server/src/server/auth/session-store.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto';
+
+export type SessionRecord = {
+  sessionId: string;
+  createdAt: number;
+  lastSeenAt: number;
+  expiresAt: number;
+};
+
+export type SessionStore = {
+  create(): SessionRecord;
+  get(sessionId: string): SessionRecord | null;
+  touch(sessionId: string): SessionRecord | null;
+  delete(sessionId: string): void;
+};
+
+export type SessionStoreConfig = {
+  idleTtlMs: number;
+  absoluteTtlMs: number;
+};
+
+export function createSessionStore(config: SessionStoreConfig): SessionStore {
+  const sessions = new Map<string, SessionRecord>();
+
+  const isExpired = (session: SessionRecord, now: number): boolean => {
+    return now - session.lastSeenAt > config.idleTtlMs || now > session.expiresAt;
+  };
+
+  const store: SessionStore = {
+    create(): SessionRecord {
+      const now = Date.now();
+      const session: SessionRecord = {
+        sessionId: randomUUID(),
+        createdAt: now,
+        lastSeenAt: now,
+        expiresAt: now + config.absoluteTtlMs,
+      };
+
+      sessions.set(session.sessionId, session);
+      return session;
+    },
+
+    get(sessionId: string): SessionRecord | null {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        return null;
+      }
+
+      if (isExpired(session, Date.now())) {
+        sessions.delete(sessionId);
+        return null;
+      }
+
+      return session;
+    },
+
+    touch(sessionId: string): SessionRecord | null {
+      const session = store.get(sessionId);
+      if (!session) {
+        return null;
+      }
+
+      session.lastSeenAt = Date.now();
+      sessions.set(sessionId, session);
+      return session;
+    },
+
+    delete(sessionId: string): void {
+      sessions.delete(sessionId);
+    },
+  };
+
+  return store;
+}

--- a/packages/memento-server/src/server/auth/session-store.ts
+++ b/packages/memento-server/src/server/auth/session-store.ts
@@ -26,9 +26,19 @@ export function createSessionStore(config: SessionStoreConfig): SessionStore {
     return now - session.lastSeenAt > config.idleTtlMs || now > session.expiresAt;
   };
 
+  const cleanupExpiredSessions = (now: number): void => {
+    for (const [sessionId, session] of sessions.entries()) {
+      if (isExpired(session, now)) {
+        sessions.delete(sessionId);
+      }
+    }
+  };
+
   const store: SessionStore = {
     create(): SessionRecord {
       const now = Date.now();
+      cleanupExpiredSessions(now);
+
       const session: SessionRecord = {
         sessionId: randomUUID(),
         createdAt: now,
@@ -41,12 +51,15 @@ export function createSessionStore(config: SessionStoreConfig): SessionStore {
     },
 
     get(sessionId: string): SessionRecord | null {
+      const now = Date.now();
+      cleanupExpiredSessions(now);
+
       const session = sessions.get(sessionId);
       if (!session) {
         return null;
       }
 
-      if (isExpired(session, Date.now())) {
+      if (isExpired(session, now)) {
         sessions.delete(sessionId);
         return null;
       }
@@ -55,12 +68,20 @@ export function createSessionStore(config: SessionStoreConfig): SessionStore {
     },
 
     touch(sessionId: string): SessionRecord | null {
-      const session = store.get(sessionId);
+      const now = Date.now();
+      cleanupExpiredSessions(now);
+
+      const session = sessions.get(sessionId);
       if (!session) {
         return null;
       }
 
-      session.lastSeenAt = Date.now();
+      if (isExpired(session, now)) {
+        sessions.delete(sessionId);
+        return null;
+      }
+
+      session.lastSeenAt = now;
       sessions.set(sessionId, session);
       return session;
     },


### PR DESCRIPTION
## 요약
[이슈 #163](https://github.com/jee1/memento/issues/163): `embedding-migration-service.ts`의 `execute()` / `rollback()`를 private 메서드로 분리해 복잡도·가독성을 개선합니다.

## 변경 사항
- `resolveEffectiveMonitor`, `processMigrationRow`, `runMigrationBatchLoop`, `finalizeMigrationExecution` 추가
- `applyRollbackDelete` / `applyRollbackRestore`로 롤백 분기 정리
- 소스 제공자 행이 0건일 때 동작을 고정하는 회귀 테스트 추가
- `better-sqlite3` `Statement` 타입으로 prepared statement 명시

## 문서
- `docs/superpowers/specs/2026-04-18-issue-163-embedding-migration-refactor-design.md`
- `docs/superpowers/plans/2026-04-18-issue-163-embedding-migration-refactor.md`

## 검증
- `npm run type-check` 통과
- `embedding-migration-service.spec.ts` (11 tests) 통과


Made with [Cursor](https://cursor.com)