### PR TITLE
fix: CLI DB 직접 접근 제거 및 HTTP 클라이언트 전환 (issue #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- CLI(`memento remember` 등)가 HTTP/stdio MCP 서버와 동시에 실행될 때 발생하던 WAL 체크포인트 충돌 및 DB 손상 버그 수정 (#160)
+
+### Changed
+- CLI가 DB를 직접 열지 않고 실행 중인 서버의 HTTP 관리 포트로 요청을 위임하도록 아키텍처 전환
+- stdio MCP 서버가 CLI 통신을 위한 localhost-only HTTP 관리 포트를 함께 기동
+- `--db-path`, `--env-file` CLI 옵션 deprecated (무시됨)
+
 ### Added
 
 - Docker instability 분석을 위한 runtime diagnostics 모드 추가: `/app/logs/diagnostics` JSONL 로그, background service feature flags, Docker 외부 관측 스크립트(`scripts/collect-docker-diagnostics.sh`) 및 운영 가이드 포함

--- a/packages/memento-server/src/cli.ts
+++ b/packages/memento-server/src/cli.ts
@@ -4,15 +4,8 @@
  * 명세: REQ-CLI-1, REQ-OPT-1~3, REQ-CFG-1, REQ-IO-4, AC8. 서브커맨드: recall, remember, forget, memory_injection
  */
 
-// 서드파티(onnxruntime, transformers 등) stderr 억제: core import 전에 stderr 래핑 (AC8)
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
-process.stderr.write = function (chunk: unknown, encoding?: unknown, callback?: unknown): boolean {
-  if (process.env.MEMENTO_CLI_QUIET === '1') {
-    if (typeof callback === 'function') (callback as () => void)();
-    return true;
-  }
-  return originalStderrWrite(chunk as any, encoding as any, callback as any);
-};
+import os from 'os';
+import path from 'path';
 
 function writeStdout(message: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -28,7 +21,7 @@ function writeStdout(message: string): Promise<void> {
 
 function writeStderr(message: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    originalStderrWrite(message, undefined, (error?: Error | null) => {
+    process.stderr.write(message, (error) => {
       if (error) {
         reject(error);
         return;
@@ -45,7 +38,6 @@ import {
   forgetParams,
   memoryInjectionParams
 } from './cli/option-map.js';
-import type { ServerServices } from '@memento/core';
 
 const TOOL_SUBCOMMANDS = new Set(['recall', 'remember', 'forget', 'memory_injection']);
 
@@ -127,23 +119,9 @@ function parseCli(argv: string[]): {
 const preOptions = parseCli(process.argv);
 loadEnv({ envFile: preOptions.envFile, configDir: preOptions.configDir });
 
-// CLI 모드 로그 억제 (REQ-IO-4, AC8). core import 전에 설정.
-process.env.MEMENTO_CLI_QUIET = '1';
-process.env.BATCH_SCHEDULER_ENABLED = 'false';
-process.env.WAL_CHECKPOINT_ENABLED = 'false';
-process.env.DB_LOCK_MONITOR_ENABLED = 'false';
+// 2) server-info import (env 로드 이후)
+const { readServerInfo, isServerAlive, callToolViaHttp, deleteServerInfo } = await import('./server/server-info.js');
 
-// 2) core import는 env 로드 이후 (mementoConfig가 이미 env 반영)
-const {
-  mementoConfig,
-  createMementoCore,
-  closeDatabase,
-  createToolContext,
-  executeTool,
-  getBatchScheduler
-} = await import('@memento/core');
-
-const dbPath = preOptions.dbPath ?? process.env.DB_PATH ?? mementoConfig.dbPath;
 const subcommand = preOptions.subcommand;
 const subIdx = preOptions.subIdx;
 const commandToken = preOptions.commandToken;
@@ -159,8 +137,8 @@ async function main(): Promise<number> {
     await writeStderr('  forget              기억을 삭제합니다 (소프트/하드)\n');
     await writeStderr('  memory_injection    관련 기억을 요약하여 프롬프트에 주입\n\n');
     await writeStderr('Global options (서브커맨드 앞·뒤 모두 가능):\n');
-    await writeStderr('  --db-path <path>    DB 파일 경로\n');
-    await writeStderr('  --env-file <path>   .env 파일 경로\n');
+    await writeStderr('  --db-path <path>    (deprecated) DB 파일 경로\n');
+    await writeStderr('  --env-file <path>   (deprecated) .env 파일 경로\n');
     await writeStderr('  --config-dir <path> 설정 디렉터리 (~/.memento 대체)\n');
     await writeStderr('  --help, -h           이 도움말\n');
     return 0;
@@ -176,72 +154,35 @@ async function main(): Promise<number> {
     return 1;
   }
 
-  let db: import('better-sqlite3').Database | null = null;
-  let coreServices: ServerServices | null = null;
-  let isCleaningUp = false;
+  // configDir 결정
+  const configDir =
+    preOptions.configDir ??
+    process.env.MEMENTO_CONFIG_DIR ??
+    path.join(os.homedir(), '.memento');
 
-  const cleanup = async (): Promise<void> => {
-    if (isCleaningUp) {
-      return;
+  // deprecated 옵션 경고
+  if (preOptions.dbPath) {
+    await writeStderr('[deprecated] --db-path 옵션은 더 이상 사용되지 않습니다. 서버가 DB를 관리합니다.\n');
+  }
+  if (preOptions.envFile) {
+    await writeStderr('[deprecated] --env-file 옵션은 더 이상 사용되지 않습니다.\n');
+  }
+
+  // 서버 발견
+  const serverInfo = await readServerInfo(configDir);
+  const serverAlive = serverInfo ? await isServerAlive(serverInfo) : false;
+  if (!serverInfo || !serverAlive) {
+    if (serverInfo && !serverAlive) {
+      await deleteServerInfo(configDir);
     }
-
-    isCleaningUp = true;
-
-    if (coreServices?.runtimeDiagnosticsSamplerCleanup) {
-      try {
-        await coreServices.runtimeDiagnosticsSamplerCleanup();
-      } catch (_) {}
-    }
-
-    try {
-      await coreServices?.walCheckpointScheduler.stop();
-    } catch (_) {}
-
-    try {
-      coreServices?.databaseLockMonitor.stop();
-    } catch (_) {}
-
-    try {
-      await coreServices?.writeCoalescingManager?.flush();
-      await coreServices?.writeCoalescingManager?.destroy();
-    } catch (_) {}
-
-    try {
-      await getBatchScheduler().stop();
-    } catch (_) {}
-
-    if (db) {
-      try {
-        closeDatabase(db);
-      } catch (_) {}
-      db = null;
-    }
-
-    coreServices = null;
-    isCleaningUp = false;
-  };
-
-  process.on('exit', (code) => {
-    void cleanup();
-  });
-  process.on('uncaughtException', async () => {
-    await cleanup();
-    process.exit(1);
-  });
-  process.on('SIGINT', async () => {
-    await cleanup();
-    process.exit(130);
-  });
-  process.on('SIGTERM', async () => {
-    await cleanup();
-    process.exit(143);
-  });
+    await writeStderr(
+      'Memento 서버가 실행 중이지 않습니다.\n' +
+      'npm run dev 또는 npm run dev:http 로 먼저 서버를 실행하세요.\n'
+    );
+    return 1;
+  }
 
   try {
-    const core = await createMementoCore({ dbPath });
-    db = core.db;
-    coreServices = core.services;
-    const context = createToolContext(db, core.services);
     const cmdArgv =
       subIdx !== undefined ? subcommandArgvFrom(process.argv, subIdx) : process.argv.slice(3);
 
@@ -251,7 +192,7 @@ async function main(): Promise<number> {
         await writeStderr('recall requires --query <string>.\n');
         return 1;
       }
-      const result = await executeTool('recall', params, context);
+      const result = await callToolViaHttp(serverInfo.port, 'recall', params as Record<string, unknown>);
       await writeStdout(JSON.stringify(result) + '\n');
       return 0;
     }
@@ -262,7 +203,7 @@ async function main(): Promise<number> {
         await writeStderr('remember requires --content <string>.\n');
         return 1;
       }
-      const result = await executeTool('remember', params, context);
+      const result = await callToolViaHttp(serverInfo.port, 'remember', params as Record<string, unknown>);
       await writeStdout(JSON.stringify(result) + '\n');
       return 0;
     }
@@ -273,7 +214,7 @@ async function main(): Promise<number> {
         await writeStderr('forget requires --id <memory_id> or --batch <id1,id2,...>.\n');
         return 1;
       }
-      const result = await executeTool('forget', params, context);
+      const result = await callToolViaHttp(serverInfo.port, 'forget', params as Record<string, unknown>);
       await writeStdout(JSON.stringify(result) + '\n');
       return 0;
     }
@@ -284,7 +225,7 @@ async function main(): Promise<number> {
         await writeStderr('memory_injection requires --query <string>.\n');
         return 1;
       }
-      const result = await executeTool('memory_injection', params, context);
+      const result = await callToolViaHttp(serverInfo.port, 'memory_injection', params as Record<string, unknown>);
       await writeStdout(JSON.stringify(result) + '\n');
       return 0;
     }
@@ -294,8 +235,6 @@ async function main(): Promise<number> {
     const msg = err instanceof Error ? err.message : String(err);
     await writeStderr(msg + '\n');
     return 1;
-  } finally {
-    await cleanup();
   }
 }
 

--- a/packages/memento-server/src/cli.ts
+++ b/packages/memento-server/src/cli.ts
@@ -154,12 +154,6 @@ async function main(): Promise<number> {
     return 1;
   }
 
-  // configDir 결정
-  const configDir =
-    preOptions.configDir ??
-    process.env.MEMENTO_CONFIG_DIR ??
-    path.join(os.homedir(), '.memento');
-
   // deprecated 옵션 경고
   if (preOptions.dbPath) {
     await writeStderr('[deprecated] --db-path 옵션은 더 이상 사용되지 않습니다. 서버가 DB를 관리합니다.\n');
@@ -167,6 +161,49 @@ async function main(): Promise<number> {
   if (preOptions.envFile) {
     await writeStderr('[deprecated] --env-file 옵션은 더 이상 사용되지 않습니다.\n');
   }
+
+  // 인자 검증 (서버 체크 이전: 필수 인자 누락 시 서버 오류보다 명확한 메시지 제공)
+  const cmdArgv =
+    subIdx !== undefined ? subcommandArgvFrom(process.argv, subIdx) : process.argv.slice(3);
+
+  let toolParams: Record<string, unknown>;
+  if (subcommand === 'recall') {
+    const params = recallParams(cmdArgv);
+    if (typeof params.query !== 'string' || !String(params.query).trim()) {
+      await writeStderr('recall requires --query <string>.\n');
+      return 1;
+    }
+    toolParams = params as Record<string, unknown>;
+  } else if (subcommand === 'remember') {
+    const params = rememberParams(cmdArgv);
+    if (typeof params.content !== 'string' || !String(params.content).trim()) {
+      await writeStderr('remember requires --content <string>.\n');
+      return 1;
+    }
+    toolParams = params as Record<string, unknown>;
+  } else if (subcommand === 'forget') {
+    const params = forgetParams(cmdArgv);
+    if (params.id === undefined && (!Array.isArray(params.batch) || params.batch.length === 0)) {
+      await writeStderr('forget requires --id <memory_id> or --batch <id1,id2,...>.\n');
+      return 1;
+    }
+    toolParams = params as Record<string, unknown>;
+  } else if (subcommand === 'memory_injection') {
+    const params = memoryInjectionParams(cmdArgv);
+    if (typeof params.query !== 'string' || !String(params.query).trim()) {
+      await writeStderr('memory_injection requires --query <string>.\n');
+      return 1;
+    }
+    toolParams = params as Record<string, unknown>;
+  } else {
+    return 0;
+  }
+
+  // configDir 결정
+  const configDir =
+    preOptions.configDir ??
+    process.env.MEMENTO_CONFIG_DIR ??
+    path.join(os.homedir(), '.memento');
 
   // 서버 발견
   const serverInfo = await readServerInfo(configDir);
@@ -183,53 +220,8 @@ async function main(): Promise<number> {
   }
 
   try {
-    const cmdArgv =
-      subIdx !== undefined ? subcommandArgvFrom(process.argv, subIdx) : process.argv.slice(3);
-
-    if (subcommand === 'recall') {
-      const params = recallParams(cmdArgv);
-      if (typeof params.query !== 'string' || !String(params.query).trim()) {
-        await writeStderr('recall requires --query <string>.\n');
-        return 1;
-      }
-      const result = await callToolViaHttp(serverInfo.port, 'recall', params as Record<string, unknown>);
-      await writeStdout(JSON.stringify(result) + '\n');
-      return 0;
-    }
-
-    if (subcommand === 'remember') {
-      const params = rememberParams(cmdArgv);
-      if (typeof params.content !== 'string' || !String(params.content).trim()) {
-        await writeStderr('remember requires --content <string>.\n');
-        return 1;
-      }
-      const result = await callToolViaHttp(serverInfo.port, 'remember', params as Record<string, unknown>);
-      await writeStdout(JSON.stringify(result) + '\n');
-      return 0;
-    }
-
-    if (subcommand === 'forget') {
-      const params = forgetParams(cmdArgv);
-      if (params.id === undefined && (!Array.isArray(params.batch) || params.batch.length === 0)) {
-        await writeStderr('forget requires --id <memory_id> or --batch <id1,id2,...>.\n');
-        return 1;
-      }
-      const result = await callToolViaHttp(serverInfo.port, 'forget', params as Record<string, unknown>);
-      await writeStdout(JSON.stringify(result) + '\n');
-      return 0;
-    }
-
-    if (subcommand === 'memory_injection') {
-      const params = memoryInjectionParams(cmdArgv);
-      if (typeof params.query !== 'string' || !String(params.query).trim()) {
-        await writeStderr('memory_injection requires --query <string>.\n');
-        return 1;
-      }
-      const result = await callToolViaHttp(serverInfo.port, 'memory_injection', params as Record<string, unknown>);
-      await writeStdout(JSON.stringify(result) + '\n');
-      return 0;
-    }
-
+    const result = await callToolViaHttp(serverInfo.port, subcommand, toolParams);
+    await writeStdout(JSON.stringify(result) + '\n');
     return 0;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
+++ b/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
@@ -62,17 +62,14 @@ function runCli(
 }
 
 describe.skipIf(!cliBuilt || !supportsCapturedChildIo)('CLI AC5/AC6', () => {
-  it('AC5: --db-path 지정 시 해당 DB 사용 (recall 호출 시 exit 0, JSON stdout)', async () => {
+  it('AC5: --db-path 지정 시 deprecated 경고 출력 후 exit 1 (서버 미실행)', async () => {
     const dbPath = path.join(os.tmpdir(), `memento-cli-ac5-${Date.now()}.db`);
-    const { stdout, code } = await runCli([
+    const { stderr, code } = await runCli([
       '--db-path', dbPath,
       'recall', '--query', 'test', '--limit', '1'
     ]);
-    expect(code).toBe(0);
-    const parsed = JSON.parse(stdout.trim());
-    const hasItems = parsed.items !== undefined && Array.isArray(parsed.items);
-    const hasContent = Array.isArray(parsed.content) && parsed.content.length > 0;
-    expect(hasItems || hasContent).toBe(true);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/deprecated/);
     try { fs.unlinkSync(dbPath); } catch (_) {}
   }, 15000);
 
@@ -86,24 +83,19 @@ describe.skipIf(!cliBuilt || !supportsCapturedChildIo)('CLI AC5/AC6', () => {
     expect(out).toContain('memory_injection');
   });
 
-  it('AC6/AC9: cwd에 .env 없고 ~/.memento/.env에만 DB_PATH 있을 때 해당 DB 사용', async () => {
+  it('AC6/AC9: 서버 미실행 시 exit 1 및 서버 실행 안내 메시지 출력', async () => {
     const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-cli-ac6-cwd-'));
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-cli-home-'));
-    const dbPath = path.join(os.tmpdir(), `memento-cli-ac6-db-${Date.now()}.db`);
     try {
       fs.mkdirSync(path.join(fakeHome, '.memento'), { recursive: true });
-      fs.writeFileSync(path.join(fakeHome, '.memento', '.env'), `DB_PATH=${dbPath.replace(/\\/g, '/')}\n`);
-      // DB_PATH를 제거한 env를 명시적으로 전달해야 CLI가 ~/.memento/.env를 읽는 경로로 진입함
-      // runCli에 env를 명시하면 process.env를 병합하지 않으므로 DB_PATH가 주입되지 않음
+      // server.json 없는 configDir → 서버 미실행 상태
       const { DB_PATH: _omit, ...baseEnv } = process.env;
-      const { stdout, code } = await runCli(['recall', '--query', 'test', '--limit', '1'], { env: { ...baseEnv, HOME: fakeHome }, cwd: tmpCwd });
-      expect(code).toBe(0);
-      const parsed = JSON.parse(stdout.trim());
-      expect(parsed.items !== undefined && Array.isArray(parsed.items) || Array.isArray(parsed.content)).toBe(true);
+      const { stderr, code } = await runCli(['recall', '--query', 'test', '--limit', '1'], { env: { ...baseEnv, HOME: fakeHome }, cwd: tmpCwd });
+      expect(code).not.toBe(0);
+      expect(stderr).toMatch(/서버/);
     } finally {
       try { fs.rmSync(tmpCwd, { recursive: true }); } catch (_) {}
       try { fs.rmSync(fakeHome, { recursive: true }); } catch (_) {}
-      try { fs.unlinkSync(dbPath); } catch (_) {}
     }
   }, 15000);
 

--- a/packages/memento-server/src/server/cli-integration.spec.ts
+++ b/packages/memento-server/src/server/cli-integration.spec.ts
@@ -39,7 +39,7 @@ describe('CLI 통합 (server-info + callToolViaHttp)', () => {
         const result = await executeTool(req.params.name, req.body, context);
         let actual: unknown = result;
         if (Array.isArray(result.content) && result.content[0]?.text) {
-          try { actual = JSON.parse(result.content[0].text); } catch {}
+          try { actual = JSON.parse(result.content[0].text); } catch { /* ignore parse error */ }
         }
         res.json({ result: actual, tool: req.params.name, timestamp: new Date().toISOString() });
       } catch (err) {

--- a/packages/memento-server/src/server/cli-integration.spec.ts
+++ b/packages/memento-server/src/server/cli-integration.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import express from 'express';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import {
+  writeServerInfo,
+  readServerInfo,
+  isServerAlive,
+  callToolViaHttp,
+  deleteServerInfo,
+} from './server-info.js';
+import {
+  setupTestDatabase,
+  cleanupTestDatabase,
+  type TestDatabaseContext,
+} from './test/helpers/test-database.js';
+import { createToolContext, executeTool } from '@memento/core';
+
+describe('CLI 통합 (server-info + callToolViaHttp)', () => {
+  let tmpDir: string;
+  let ctx: TestDatabaseContext;
+  let httpServer: ReturnType<typeof createServer>;
+  let port: number;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'memento-cli-int-'));
+    ctx = await setupTestDatabase();
+
+    // lightweight test HTTP server mimicking management server
+    const app = express();
+    app.use(express.json({ limit: '1mb' }));
+    app.get('/health', (_req, res) => res.json({ status: 'healthy' }));
+    app.post('/tools/:name', async (req, res) => {
+      try {
+        const context = createToolContext(ctx.db, ctx.services);
+        const result = await executeTool(req.params.name, req.body, context);
+        let actual: unknown = result;
+        if (Array.isArray(result.content) && result.content[0]?.text) {
+          try { actual = JSON.parse(result.content[0].text); } catch {}
+        }
+        res.json({ result: actual, tool: req.params.name, timestamp: new Date().toISOString() });
+      } catch (err) {
+        res.status(500).json({ error: String(err) });
+      }
+    });
+
+    httpServer = createServer(app);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        port = (httpServer.address() as AddressInfo).port;
+        resolve();
+      });
+    });
+    await writeServerInfo(tmpDir, port);
+  }, 30_000);
+
+  afterAll(async () => {
+    await cleanupTestDatabase(ctx);
+    await deleteServerInfo(tmpDir);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('server.json이 없으면 readServerInfo는 null을 반환한다', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'memento-empty-'));
+    try {
+      const info = await readServerInfo(emptyDir);
+      expect(info).toBeNull();
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('isServerAlive는 실행 중인 서버에 대해 true를 반환한다', async () => {
+    const info = await readServerInfo(tmpDir);
+    expect(info).not.toBeNull();
+    const alive = await isServerAlive(info!);
+    expect(alive).toBe(true);
+  });
+
+  it('isServerAlive는 존재하지 않는 PID에 대해 false를 반환한다', async () => {
+    const fakeInfo = { port, pid: 999999999, startedAt: new Date().toISOString() };
+    const alive = await isServerAlive(fakeInfo);
+    expect(alive).toBe(false);
+  });
+
+  it('callToolViaHttp로 remember 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'remember', {
+      content: '통합 테스트용 기억',
+      type: 'semantic',
+      tags: ['test'],
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('callToolViaHttp로 recall 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'recall', {
+      query: '통합 테스트용 기억',
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('callToolViaHttp로 forget 호출이 성공한다', async () => {
+    const remembered = await callToolViaHttp(port, 'remember', {
+      content: 'forget 테스트용 기억',
+      type: 'semantic',
+      tags: ['forget-test'],
+    }) as { id?: string };
+    expect(remembered).toBeDefined();
+    if (remembered?.id) {
+      const result = await callToolViaHttp(port, 'forget', { id: remembered.id });
+      expect(result).toBeDefined();
+    }
+  });
+
+  it('callToolViaHttp로 memory_injection 호출이 성공한다', async () => {
+    const result = await callToolViaHttp(port, 'memory_injection', {
+      query: '통합 테스트',
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('동시성: N회 병렬 호출 후 DB 무결성이 유지된다', async () => {
+    const N = 10;
+    const calls = Array.from({ length: N }, (_, i) =>
+      callToolViaHttp(port, 'remember', {
+        content: `동시성 테스트 ${i}`,
+        type: 'semantic',
+        tags: ['concurrency-test'],
+      })
+    );
+    const results = await Promise.all(calls);
+    expect(results).toHaveLength(N);
+    results.forEach((r) => expect(r).toBeDefined());
+
+    const recallResult = await callToolViaHttp(port, 'recall', {
+      query: '동시성 테스트',
+    });
+    expect(recallResult).toBeDefined();
+  });
+});

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -6,7 +6,9 @@
 
 import express from 'express';
 import { existsSync } from 'fs';
+import { homedir } from 'os';
 import { join } from 'path';
+import { writeServerInfo, deleteServerInfo } from './server-info.js';
 import { WebSocketServer } from 'ws';
 import type { WebSocket } from 'ws';
 import cors from 'cors';
@@ -295,8 +297,14 @@ async function cleanup() {
   }
   
   isCleaningUp = true;
-  
+
   try {
+    // delete server.json on shutdown
+    const configDirForCleanup = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+    try {
+      await deleteServerInfo(configDirForCleanup);
+    } catch (_) {}
+
     await writeRuntimeDiagnosticsEvent('server_cleanup_start');
 
     // WAL 체크포인트 스케줄러 및 데이터베이스 락 모니터 중지
@@ -611,6 +619,9 @@ async function startServer() {
     const address = server.address();
     if (address && typeof address === 'object') {
       logger.info('서버 바인딩 완료', { address: address.address, port: address.port });
+      // write server.json for CLI discovery
+      const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+      void writeServerInfo(configDir, address.port);
     }
   });
 }

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -303,7 +303,9 @@ async function cleanup() {
     const configDirForCleanup = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
     try {
       await deleteServerInfo(configDirForCleanup);
-    } catch (_) {}
+    } catch {
+      // ignore cleanup errors
+    }
 
     await writeRuntimeDiagnosticsEvent('server_cleanup_start');
 
@@ -576,6 +578,7 @@ async function startServer() {
     logger.warn(
       'ADMIN_API_KEY is not configured: all admin/API/quality endpoints are disabled and will return 401. Set ADMIN_API_KEY environment variable to enable admin access.'
     );
+  // eslint-disable-next-line no-control-regex
   } else if (!/^[\x00-\x7F]+$/.test(adminKey)) {
     logger.warn(
       'ADMIN_API_KEY contains non-ASCII characters: browser-based graph/dashboard may fail to send Authorization (use ASCII-only keys, e.g. hex or base64url).'

--- a/packages/memento-server/src/server/index.ts
+++ b/packages/memento-server/src/server/index.ts
@@ -136,6 +136,7 @@ function setupConsoleErrorOverride(): void {
     return;
   }
   
+  // eslint-disable-next-line no-console
   console.error = (...args: any[]) => {
     const isInitialized = serverState.isMcpServerInitialized();
     
@@ -155,11 +156,16 @@ function setupConsoleErrorOverride(): void {
 }
 
 // console 메서드 오버라이드 (중복 등록 방지)
+// eslint-disable-next-line no-console
 if (!serverState.isConsoleOverridden()) {
+  // eslint-disable-next-line no-console
   console.log = () => {};
   setupConsoleErrorOverride();
+  // eslint-disable-next-line no-console
   console.warn = () => {};
+  // eslint-disable-next-line no-console
   console.info = () => {};
+  // eslint-disable-next-line no-console
   console.debug = () => {};
   serverState.setConsoleOverridden(true);
 }
@@ -566,7 +572,7 @@ async function startMgmtHttpServer(): Promise<void> {
       const result = await executeTool(name, req.body as Record<string, unknown>, context);
       let actual: unknown = result;
       if (Array.isArray(result.content) && result.content[0]?.text) {
-        try { actual = JSON.parse(result.content[0].text as string); } catch {}
+        try { actual = JSON.parse(result.content[0].text as string); } catch { /* ignore parse error */ }
       }
       res.json({ result: actual, tool: name, timestamp: new Date().toISOString() });
     } catch (err) {
@@ -705,7 +711,9 @@ async function cleanup() {
     const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
     try {
       await deleteServerInfo(configDir);
-    } catch (_) {}
+    } catch {
+      // ignore cleanup errors
+    }
     await new Promise<void>((resolveClose) => mgmtHttpServer!.close(() => resolveClose()));
     mgmtHttpServer = null;
   }

--- a/packages/memento-server/src/server/index.ts
+++ b/packages/memento-server/src/server/index.ts
@@ -35,6 +35,11 @@ import {
 import { mcpLogger } from './mcp-logger.js';
 import { ServerState } from './server-state.js';
 import Database from 'better-sqlite3';
+import express from 'express';
+import { createServer as createHttpServer } from 'http';
+import type { AddressInfo } from 'net';
+import { homedir } from 'os';
+import { writeServerInfo, deleteServerInfo } from './server-info.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 /**
@@ -65,6 +70,7 @@ let server: Server;
 let db: Database.Database | null = null;
 // core에서 반환된 서비스 (ToolContext 생성 시 사용)
 let serverServices: ServerServices | null = null;
+let mgmtHttpServer: ReturnType<typeof createHttpServer> | null = null;
 
 type TestDependencies = {
   database: Database.Database | null;
@@ -540,6 +546,57 @@ function registerHandlers() {
     });
 }
 
+// 관리 HTTP 서버 기동 (CLI 통신용)
+async function startMgmtHttpServer(): Promise<void> {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'healthy', transport: 'stdio' });
+  });
+
+  app.post('/tools/:name', async (req, res) => {
+    if (!db || !serverServices) {
+      res.status(503).json({ error: '서버 초기화 중입니다. 잠시 후 다시 시도하세요.' });
+      return;
+    }
+    const { name } = req.params;
+    try {
+      const context = createToolContext(db, serverServices);
+      const result = await executeTool(name, req.body as Record<string, unknown>, context);
+      let actual: unknown = result;
+      if (Array.isArray(result.content) && result.content[0]?.text) {
+        try { actual = JSON.parse(result.content[0].text as string); } catch {}
+      }
+      res.json({ result: actual, tool: name, timestamp: new Date().toISOString() });
+    } catch (err) {
+      res.status(500).json({
+        error: 'Tool execution failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  mgmtHttpServer = createHttpServer(app);
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    mgmtHttpServer!.once('error', rejectPromise);
+    mgmtHttpServer!.listen(0, '127.0.0.1', async () => {
+      const addr = mgmtHttpServer!.address() as AddressInfo;
+      const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+      try {
+        await writeServerInfo(configDir, addr.port);
+      } catch (err) {
+        mcpLogger.logServer('error', `server.json 기록 실패: ${err}`);
+        rejectPromise(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      mcpLogger.logServer('info', `관리 HTTP 서버 기동 완료 (port: ${addr.port})`);
+      resolvePromise();
+    });
+  });
+}
+
 // 서버 시작
 async function startServer() {
   try {
@@ -571,6 +628,9 @@ async function startServer() {
     // transport를 먼저 연결해 Cursor가 7초 내에 Initialize 응답을 받도록 함
     const transport = new StdioServerTransport();
     await server.connect(transport);
+
+    // 관리 HTTP 서버 기동 (CLI 통신용)
+    await startMgmtHttpServer();
 
     serverState.setMcpTransportConnected(true);
     serverState.setMcpServerInitialized(true);
@@ -639,7 +699,17 @@ async function cleanup() {
   }
   
   isCleaningUp = true;
-  
+
+  // server.json 삭제 및 관리 HTTP 서버 종료
+  if (mgmtHttpServer) {
+    const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+    try {
+      await deleteServerInfo(configDir);
+    } catch (_) {}
+    await new Promise<void>((resolveClose) => mgmtHttpServer!.close(() => resolveClose()));
+    mgmtHttpServer = null;
+  }
+
   mcpLogger.logServer('info', '서버 정리 시작...');
   await writeRuntimeDiagnosticsEvent('server_cleanup_start');
   
@@ -787,7 +857,7 @@ async function main() {
 // 팩토리 패턴을 사용하지 않는 경우를 위해 기존 startServer도 유지
 // NPM 패키지로 실행할 때도 작동하도록 강화된 체크
 import { fileURLToPath } from 'url';
-import { basename, resolve } from 'path';
+import { basename, join, resolve } from 'path';
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentFileName = basename(currentFile);

--- a/packages/memento-server/src/server/server-info.spec.ts
+++ b/packages/memento-server/src/server/server-info.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  writeServerInfo,
+  readServerInfo,
+  deleteServerInfo,
+  type ServerInfo,
+} from './server-info.js';
+
+describe('server-info', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'memento-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writeServerInfo는 server.json을 생성한다', async () => {
+    await writeServerInfo(tmpDir, 51764);
+    const info = await readServerInfo(tmpDir);
+    expect(info).not.toBeNull();
+    expect(info!.port).toBe(51764);
+    expect(info!.pid).toBe(process.pid);
+    expect(info!.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('readServerInfo는 파일이 없으면 null을 반환한다', async () => {
+    const info = await readServerInfo(tmpDir);
+    expect(info).toBeNull();
+  });
+
+  it('deleteServerInfo는 server.json을 삭제한다', async () => {
+    await writeServerInfo(tmpDir, 51764);
+    await deleteServerInfo(tmpDir);
+    const info = await readServerInfo(tmpDir);
+    expect(info).toBeNull();
+  });
+
+  it('deleteServerInfo는 파일이 없어도 에러를 던지지 않는다', async () => {
+    await expect(deleteServerInfo(tmpDir)).resolves.not.toThrow();
+  });
+});

--- a/packages/memento-server/src/server/server-info.spec.ts
+++ b/packages/memento-server/src/server/server-info.spec.ts
@@ -6,7 +6,6 @@ import {
   writeServerInfo,
   readServerInfo,
   deleteServerInfo,
-  type ServerInfo,
 } from './server-info.js';
 
 describe('server-info', () => {

--- a/packages/memento-server/src/server/server-info.ts
+++ b/packages/memento-server/src/server/server-info.ts
@@ -23,7 +23,15 @@ export async function readServerInfo(configDir: string): Promise<ServerInfo | nu
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const raw = await readFile(serverInfoPath(configDir), 'utf-8');
-    return JSON.parse(raw) as ServerInfo;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      typeof parsed.port !== 'number' ||
+      typeof parsed.pid !== 'number' ||
+      typeof parsed.startedAt !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as unknown as ServerInfo;
   } catch {
     return null;
   }
@@ -47,7 +55,7 @@ export async function isServerAlive(info: ServerInfo): Promise<boolean> {
   }
   // Step 2: HTTP /health check (prevents PID reuse false positives)
   try {
-    const res = await fetch(`http://localhost:${info.port}/health`, {
+    const res = await fetch(`http://127.0.0.1:${info.port}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     return res.ok;

--- a/packages/memento-server/src/server/server-info.ts
+++ b/packages/memento-server/src/server/server-info.ts
@@ -12,13 +12,16 @@ function serverInfoPath(configDir: string): string {
 }
 
 export async function writeServerInfo(configDir: string, port: number): Promise<void> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   await mkdir(configDir, { recursive: true });
   const info: ServerInfo = { port, pid: process.pid, startedAt: new Date().toISOString() };
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   await writeFile(serverInfoPath(configDir), JSON.stringify(info, null, 2), 'utf-8');
 }
 
 export async function readServerInfo(configDir: string): Promise<ServerInfo | null> {
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const raw = await readFile(serverInfoPath(configDir), 'utf-8');
     return JSON.parse(raw) as ServerInfo;
   } catch {
@@ -28,6 +31,7 @@ export async function readServerInfo(configDir: string): Promise<ServerInfo | nu
 
 export async function deleteServerInfo(configDir: string): Promise<void> {
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     await unlink(serverInfoPath(configDir));
   } catch {
     // ignore if file doesn't exist

--- a/packages/memento-server/src/server/server-info.ts
+++ b/packages/memento-server/src/server/server-info.ts
@@ -1,0 +1,77 @@
+import { readFile, writeFile, unlink, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+export interface ServerInfo {
+  port: number;
+  pid: number;
+  startedAt: string;
+}
+
+function serverInfoPath(configDir: string): string {
+  return join(configDir, 'server.json');
+}
+
+export async function writeServerInfo(configDir: string, port: number): Promise<void> {
+  await mkdir(configDir, { recursive: true });
+  const info: ServerInfo = { port, pid: process.pid, startedAt: new Date().toISOString() };
+  await writeFile(serverInfoPath(configDir), JSON.stringify(info, null, 2), 'utf-8');
+}
+
+export async function readServerInfo(configDir: string): Promise<ServerInfo | null> {
+  try {
+    const raw = await readFile(serverInfoPath(configDir), 'utf-8');
+    return JSON.parse(raw) as ServerInfo;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteServerInfo(configDir: string): Promise<void> {
+  try {
+    await unlink(serverInfoPath(configDir));
+  } catch {
+    // ignore if file doesn't exist
+  }
+}
+
+export async function isServerAlive(info: ServerInfo): Promise<boolean> {
+  // Step 1: PID existence check
+  try {
+    process.kill(info.pid, 0);
+  } catch {
+    return false;
+  }
+  // Step 2: HTTP /health check (prevents PID reuse false positives)
+  try {
+    const res = await fetch(`http://localhost:${info.port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function callToolViaHttp(
+  port: number,
+  toolName: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await fetch(`http://localhost:${port}/tools/${toolName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const body = await res.json() as Record<string, unknown>;
+
+  if (!res.ok) {
+    throw new Error(
+      (typeof body.message === 'string' ? body.message : null) ??
+      `HTTP ${res.status}: Tool ${toolName} failed`,
+    );
+  }
+
+  return body.result;
+}


### PR DESCRIPTION
## Summary

- CLI(`memento remember`, `recall` 등)가 `createMementoCore()`로 DB를 직접 열어 WAL 체크포인트 경합·DB 손상을 유발하던 문제 해결
- CLI를 순수 HTTP 클라이언트로 전환: `server.json`으로 서버를 발견하고 `POST /tools/:name`으로 요청
- HTTP 서버·stdio MCP 서버 모두 기동 시 `~/.memento/server.json` 기록, 종료 시 삭제
- stdio 서버에 경량 관리용 HTTP 서버(`:0` 자동 포트) 추가하여 CLI 발견 가능

## Changes

- **`server-info.ts`** (신규): `writeServerInfo`, `readServerInfo`, `deleteServerInfo`, `isServerAlive`, `callToolViaHttp` 유틸
- **`http-server.ts`**: `listen` 완료 시 `server.json` 기록, `cleanup()` 시 삭제
- **`server/index.ts`** (stdio): 관리용 Express HTTP 서버 병행 기동, `server.json` 기록/삭제
- **`cli.ts`**: DB 초기화 코드 전체 제거, HTTP 클라이언트로 교체; `--db-path`·`--env-file` deprecated 처리

## Test Plan

- [ ] `server-info.ts` 유닛 테스트: 읽기/쓰기/삭제/PID 검증/stale file 자동 삭제
- [ ] CLI 통합 테스트: 서버 없을 때 에러 메시지 검증
- [ ] CLI 통합 테스트: 실제 HTTP 서버 기동 후 `remember`/`recall`/`forget`/`memory_injection` 왕복 테스트
- [ ] 동시성 통합 테스트: CLI N=10 병렬 호출 → 정상 완료 검증
- [ ] 기존 289개 테스트 파일 전체 통과

Closes #160

🤖 Generated with [Claude Code](https://claude.ai/claude-code)