### PR TITLE
fix(server): MCP stdio guards — slop-detector Critical 제거 (#179)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-issue-179-slop-index.md
+++ b/docs/superpowers/plans/2026-04-18-issue-179-slop-index.md
@@ -1,0 +1,199 @@
+# Issue 179 — `index.ts` slop-detector Critical 제거 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `packages/memento-server/src/server/index.ts`에서 `any`·익명 빈 함수 패턴을 제거하고, MCP stdio 제약을 **타입·주석·이름 있는 no-op**으로 명시하여 `ai-slop-detector --js` Critical를 없앤다.
+
+**Architecture:** 동작은 유지한다(회귀 방지). `process.stderr.write` 래퍼는 첫 인자를 `unknown`으로 받아 런타임의 비정상 호출을 그대로 처리하고, 내부에서 기존과 같이 문자열로 정규화한 뒤 바인딩된 원본에 전달한다. `console.error`는 `unknown[]`. `log`/`warn`/`info`/`debug`는 단일 `silenceConsoleForMcpStdio` 함수로 묶는다.
+
+**Tech Stack:** TypeScript 5.x, Node.js 20+, Vitest, `@types/node`
+
+**Spec:** [docs/superpowers/specs/2026-04-18-issue-179-slop-index-design.md](../specs/2026-04-18-issue-179-slop-index-design.md)
+
+---
+
+## File Structure
+
+| File | 역할 |
+|------|------|
+| `packages/memento-server/src/server/index.ts` | stderr 래핑, console 오버라이드, no-op 헬퍼 및 주석 |
+| `packages/memento-server/src/server/index.spec.ts` | stdio 가드 동작 특성화 테스트(선택적이지만 권장) |
+
+---
+
+### Task 1: 특성화 테스트 추가 (회귀 방지)
+
+**Files:**
+- Modify: `packages/memento-server/src/server/index.spec.ts`
+
+**Note:** `index.ts`는 import 시 부수효과로 래핑이 설치된다. 기존 스펙이 이미 `./index.js`를 로드하므로, 같은 `describe` 트리 안 또는 새 `describe('MCP stdio guards')`에 아래를 추가한다.
+
+- [ ] **Step 1: 테스트 블록 추가**
+
+`index.spec.ts` 적절한 위치(파일 하단 `describe` 근처 또는 새 섹션)에 추가:
+
+```typescript
+describe('MCP stdio guards (Issue #179)', () => {
+  it('stderr.write는 undefined/null 청크를 삼키고 true를 반환해야 한다', () => {
+    const write = process.stderr.write.bind(process.stderr);
+    expect(write(undefined as unknown as string)).toBe(true);
+    expect(write(null as unknown as string)).toBe(true);
+  });
+
+  it('stderr.write는 문자열 "undefined"만 있는 청크를 삼켜야 한다', () => {
+    const write = process.stderr.write.bind(process.stderr);
+    expect(write('undefined')).toBe(true);
+    expect(write('  undefined  ')).toBe(true);
+  });
+
+  it('console.log은 no-op이어야 한다 (stdout 오염 방지)', () => {
+    expect(console.log).toBeDefined();
+    expect(() => console.log('must not throw')).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행**
+
+Run: `npx vitest run packages/memento-server/src/server/index.spec.ts`
+
+Expected: **PASS** (현재 구현 기준)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/memento-server/src/server/index.spec.ts
+git commit -m "test(server): add MCP stdio guard characterization tests (#179)"
+```
+
+---
+
+### Task 2: `index.ts` — 타입·no-op·주석
+
+**Files:**
+- Modify: `packages/memento-server/src/server/index.ts` (대략 L53–61, L127–158)
+
+- [ ] **Step 1: `stderr.write` 래퍼 교체**
+
+기존 L55–61 블록을 아래로 교체한다 (`any` 제거, 동작 동일).
+
+```typescript
+const _stderrWrite = process.stderr.write.bind(process.stderr);
+
+process.stderr.write = function (chunk: unknown, ...rest: unknown[]): boolean {
+  if (chunk === undefined || chunk === null) return true;
+  const s = typeof chunk === 'string' ? chunk : String(chunk);
+  if (s === 'undefined' || s.trim() === 'undefined') return true;
+  return (_stderrWrite as (first: string | Uint8Array, ...args: unknown[]) => boolean)(
+    s,
+    ...rest
+  );
+} as typeof process.stderr.write;
+```
+
+- [ ] **Step 2: `silenceConsoleForMcpStdio` 헬퍼 추가 및 console 무력화 블록 정리**
+
+`setupConsoleErrorOverride` **위**(또는 `console` 오버라이드 직전)에 헬퍼와 블록 주석을 둔다. 아래는 **한 덩어리**로 맞춘 예시(기존 주석 L104–108과 통합·정리 가능).
+
+```typescript
+/**
+ * MCP stdio 전송 시 stdout에는 JSON-RPC 메시지만 있어야 한다.
+ * 모듈 로드 시점부터 `console.log` 등 기본 경로의 stdout 출력을 막는다.
+ * `console.error`는 `setupConsoleErrorOverride`에서 stderr/mcpLogger로 우회한다.
+ * @see https://github.com/jee1/memento/issues/179
+ */
+function silenceConsoleForMcpStdio(..._args: unknown[]): void {
+  // intentionally empty
+}
+```
+
+`console.error` 오버라이드 내부:
+
+```typescript
+  console.error = (...args: unknown[]) => {
+```
+
+`if (!serverState.isConsoleOverridden()) { ... }` 블록을 다음과 같이 바꾼다:
+
+```typescript
+if (!serverState.isConsoleOverridden()) {
+  console.log = silenceConsoleForMcpStdio;
+  setupConsoleErrorOverride();
+  console.warn = silenceConsoleForMcpStdio;
+  console.info = silenceConsoleForMcpStdio;
+  console.debug = silenceConsoleForMcpStdio;
+  serverState.setConsoleOverridden(true);
+}
+```
+
+- [ ] **Step 3: 타입 검사 및 테스트**
+
+Run:
+
+```bash
+npm run type-check
+npx vitest run packages/memento-server/src/server/index.spec.ts
+```
+
+Expected: **PASS**, 타입 에러 없음
+
+- [ ] **Step 4: Lint**
+
+Run: `npm run lint`
+
+Expected: **PASS** (필요 시 `npm run lint -- --fix`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/memento-server/src/server/index.ts
+git commit -m "fix(server): tighten types for stdio guards in MCP index (#179)"
+```
+
+---
+
+### Task 3: 품질 게이트 및 slop-detector
+
+- [ ] **Step 1: 워크스페이스 테스트 (서버 패키지 또는 전체)**
+
+Run: `npm test`
+
+Expected: **PASS** (또는 기존 CI와 동일한 스킵 규칙)
+
+- [ ] **Step 2: slop-detector (로컬에 도구가 있을 때)**
+
+```bash
+slop-detector --project packages/memento-server/src --js
+```
+
+Expected: **`[JS/TS Analysis]`** 구간에서 **Critical 0** (Suspicious는 허용)
+
+도구 미설치 시: `pip install ai-slop-detector` 후 재실행.
+
+- [ ] **Step 3: (선택) 최종 커밋 없음 — Task 2에서 이미 커밋했다면 생략**
+
+---
+
+## Spec coverage (self-review)
+
+| Spec 요구 | Task |
+|-----------|------|
+| `any` 제거/축소 | Task 2 (`unknown`, `as typeof process.stderr.write`) |
+| 의도적 no-op 명시 | Task 2 (`silenceConsoleForMcpStdio`, 블록 주석, Issue 링크) |
+| 비목표: 라우트·CI·`.slopconfig` | 본 플랜에 작업 없음 ✓ |
+| 검증: lint, type-check, 테스트, slop | Task 2–3 |
+
+## Placeholder scan
+
+- TBD/TODO 없음.
+- 모든 코드 블록은 구현 가능한 완전한 형태.
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-issue-179-slop-index.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — 태스크마다 새 서브에이전트, 태스크 사이 리뷰
+
+**2. Inline Execution** — 이 세션에서 `executing-plans` 스킬로 순차 실행
+
+원하는 방식을 알려 주세요.

--- a/docs/superpowers/specs/2026-04-18-issue-179-slop-index-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-179-slop-index-design.md
@@ -1,0 +1,77 @@
+# 설계: 이슈 #179 — memento-server `slop-detector` Critical (`index.ts`)
+
+**상태**: 브레인스토밍 확정 (구현 전)  
+**날짜**: 2026-04-18  
+**이슈**: [GitHub #179](https://github.com/jee1/memento/issues/179) — `ai-slop-detector --js` 스캔 결과 추적 (Critical: `src/server/index.ts`)
+
+---
+
+## 1. 배경·문제 정의
+
+`ai-slop-detector --project packages/memento-server/src --js` 실행 시 **Critical 1건**이 `packages/memento-server/src/server/index.ts`에 집중된다. 보고된 패턴은 대략 다음과 같다.
+
+- `process.stderr.write` 래핑에서 `any` 사용
+- `console.error` 오버라이드에서 `any[]`
+- MCP stdio 준수를 위한 **의도적** `console.log` / `warn` / `info` / `debug` 무력화(빈 함수)
+
+도구 점수만 맞추면 설정으로 누르는 방법도 있으나, 본 설계의 우선순위는 **타입 안전성과 “왜 이렇게 하는지”의 코드 내 명시**다(브레인스토밍에서 선택한 목표 **B**).
+
+---
+
+## 2. 목표·비목표
+
+### 2.1 목표
+
+- Critical 구간에서 **`any`를 제거하거나 의미 있게 좁힌다** (`unknown`, Node typings, `Parameters<>` 등).
+- MCP stdio에서 **stdout 오염 방지**를 위해 `console.*` 일부를 막는 동작을 **이름 있는 no-op/헬퍼 + 블록 주석**으로 읽기 쉽게 만든다.
+- 변경 후 **로컬에서 `slop-detector` 재실행**하여 Critical가 사라졌는지 확인한다(점수·Suspicious는 부차 지표).
+
+### 2.2 비목표 (동일 PR·동일 스펙 범위에서 하지 않음)
+
+- `mcp.routes.ts`, `admin.routes.ts`, `http-server.ts` 등 **Suspicious만 있는 파일**의 일괄 리팩터.
+- `*.spec.ts`에 대한 `.slopconfig` 정책 정리(필요 시 **후속 이슈**).
+- CI에 `slop-detector --ci-mode hard` **게이트 도입**(이슈 제안 3단계 — **후속**).
+
+---
+
+## 3. 설계 방침
+
+### 3.1 타입
+
+- `process.stderr.write` 대입: **Node.js 공식 타입과 동일한 인자·반환**을 따른다. 과도하게 좁히면 런타임과 어긋날 수 있으므로, 모호하면 `unknown` + 안전한 분기로 처리한다.
+- `console.error` 오버라이드: 가변 인자는 `unknown[]`(또는 동등한 안전한 타입)로 두고, 기존처럼 `String(a)` 등으로 직렬화한다.
+
+### 3.2 의도적 console 무력화
+
+- **복제된 익명 `() => {}` 네 개** 대신, 공통 **no-op 헬퍼 하나**(`void` 반환)를 두고 `log` / `warn` / `info` / `debug`에 동일 참조를 할당하는 방식을 우선한다.
+- 해당 블록 위에 **짧은 블록 주석**: MCP stdio 전송 시 stdout에는 JSON-RPC만 허용되므로, 모듈 로드 시점부터 `console` 기본 경로로의 출력을 막는다는 점을 명시한다.
+- 선택: 주석에 **Issue #179** 참조 한 줄을 두어 추적성을 높인다.
+
+### 3.3 도구 설정 (`.slopconfig`)
+
+- **원칙**: Critical는 **코드로 해소**한다. 설정 파일로 라인을 숨기는 것은 **B 목표와 상충**할 수 있다.
+- Suspicious·테스트 노이즈가 커질 때만 **후속**으로 `.slopconfig`의 `ignore` 등을 검토한다.
+
+---
+
+## 4. 검증
+
+- `npm run lint`
+- `npm run type-check`
+- `packages/memento-server` 관련 단위 테스트(기존 `index.spec.ts` 등)
+- 로컬: `slop-detector --project packages/memento-server/src --js` — **`[JS/TS Analysis]` 구간 기준 Critical 0**
+
+---
+
+## 5. 리스크·완화
+
+| 리스크 | 완화 |
+|--------|------|
+| `stderr.write` 시그니처 오타로 런타임 깨짐 | Node typings 준수, 테스트·수동 smoke |
+| no-op 리팩터로 diff만 커짐 | 동작 변경 없음을 유지, 한 파일·한 목적로 제한 |
+
+---
+
+## 6. 후속 작업 (이 스펙 외)
+
+- 이슈 본문 2·3단계: 프로덕션 위주 재스캔, 선택 CI 게이트 및 테스트 경로 정책.

--- a/packages/memento-server/src/server/index.spec.ts
+++ b/packages/memento-server/src/server/index.spec.ts
@@ -525,4 +525,23 @@ describe('MCP 서버 진입점', () => {
       }
     });
   });
+
+  describe('MCP stdio guards (Issue #179)', () => {
+    it('stderr.write는 undefined/null 청크를 삼키고 true를 반환해야 한다', () => {
+      const write = process.stderr.write.bind(process.stderr);
+      expect(write(undefined as unknown as string)).toBe(true);
+      expect(write(null as unknown as string)).toBe(true);
+    });
+
+    it('stderr.write는 문자열 "undefined"만 있는 청크를 삼켜야 한다', () => {
+      const write = process.stderr.write.bind(process.stderr);
+      expect(write('undefined')).toBe(true);
+      expect(write('  undefined  ')).toBe(true);
+    });
+
+    it('console.log은 no-op이어야 한다 (stdout 오염 방지)', () => {
+      expect(console.log).toBeDefined();
+      expect(() => console.log('must not throw')).not.toThrow();
+    });
+  });
 });

--- a/packages/memento-server/src/server/index.ts
+++ b/packages/memento-server/src/server/index.ts
@@ -55,14 +55,16 @@ const MEMENTO_SERVER_INSTRUCTIONS = `Memento MCP provides persistent memory for 
 - **Triples / knowledge graph**: Use \`extract_triples\` (MCP) to extract subject–predicate–object triples from conversation or body text and optionally persist to \`kg_triple\`. For Graphviz DOT output of **memory relation** graphs, use the HTTP admin \`visualize_relations\` endpoint with \`format: "dot"\` (relation tools are not exposed via MCP stdio in this build).
 - Prefer \`recall\` for general lookup and \`memory_injection\` when you need injected context for a specific query.`;
 
-// stderr.write 래핑: undefined/null 전달 및 "undefined" 문자열 출력 차단
-// (Cursor MCP 클라이언트가 stderr 라인마다 반환값을 표시할 때 undefined가 찍히는 현상 완화)
 const _stderrWrite = process.stderr.write.bind(process.stderr);
-process.stderr.write = function (chunk: any, ...args: any[]): boolean {
+
+process.stderr.write = function (chunk: unknown, ...rest: unknown[]): boolean {
   if (chunk === undefined || chunk === null) return true;
   const s = typeof chunk === 'string' ? chunk : String(chunk);
   if (s === 'undefined' || s.trim() === 'undefined') return true;
-  return _stderrWrite(s, ...args);
+  return (_stderrWrite as (first: string | Uint8Array, ...args: unknown[]) => boolean)(
+    s,
+    ...rest
+  );
 } as typeof process.stderr.write;
 
 // MCP 서버 인스턴스
@@ -121,6 +123,16 @@ const serverState = ServerState.getInstance();
 serverState.setMcpServerInitialized(false);
 
 /**
+ * MCP stdio 전송 시 stdout에는 JSON-RPC 메시지만 있어야 한다.
+ * 모듈 로드 시점부터 `console.log` 등 기본 경로의 stdout 출력을 막는다.
+ * `console.error`는 `setupConsoleErrorOverride`에서 stderr/mcpLogger로 우회한다.
+ * @see https://github.com/jee1/memento/issues/179
+ */
+function silenceConsoleForMcpStdio(..._args: unknown[]): void {
+  // intentionally empty
+}
+
+/**
  * console.error 오버라이드 함수
  * 초기화 상태에 따라 로깅 전략을 변경:
  * - 초기화 전: fallback logger (stderr 직접 출력)
@@ -137,7 +149,7 @@ function setupConsoleErrorOverride(): void {
   }
   
   // eslint-disable-next-line no-console
-  console.error = (...args: any[]) => {
+  console.error = (...args: unknown[]) => {
     const isInitialized = serverState.isMcpServerInitialized();
     
     if (isInitialized) {
@@ -159,14 +171,14 @@ function setupConsoleErrorOverride(): void {
 // eslint-disable-next-line no-console
 if (!serverState.isConsoleOverridden()) {
   // eslint-disable-next-line no-console
-  console.log = () => {};
+  console.log = silenceConsoleForMcpStdio;
   setupConsoleErrorOverride();
   // eslint-disable-next-line no-console
-  console.warn = () => {};
+  console.warn = silenceConsoleForMcpStdio;
   // eslint-disable-next-line no-console
-  console.info = () => {};
+  console.info = silenceConsoleForMcpStdio;
   // eslint-disable-next-line no-console
-  console.debug = () => {};
+  console.debug = silenceConsoleForMcpStdio;
   serverState.setConsoleOverridden(true);
 }
 


### PR DESCRIPTION
## 요약
[Issue #179](https://github.com/jee1/memento/issues/179): `packages/memento-server/src/server/index.ts`에서 `ai-slop-detector --js` **Critical** 항목을 코드로 해소합니다. 목표는 점수가 아니라 **타입 안전성과 MCP stdio 제약의 의도 명시**([설계 스펙](docs/superpowers/specs/2026-04-18-issue-179-slop-index-design.md)).

## 변경 사항
- **테스트**: `index.spec.ts`에 MCP stdio 가드 특성화 테스트 3개 (stderr 필터, `console.log` no-op).
- **구현**: `process.stderr.write` 래퍼에서 `any` 제거 (`unknown`), `console.error`는 `unknown[]`, `log/warn/info/debug`는 `silenceConsoleForMcpStdio` + 주석 + Issue 링크.
- **main 병합**: `origin/main`에 이미 있던 `eslint-disable-next-line no-console` 패턴을 유지하면서 위 변경을 적용 (리베이스 충돌 해결).

## 검증
- `npm run type-check`
- `npx vitest run packages/memento-server/src/server/index.spec.ts`
- `slop-detector --project packages/memento-server/src --js` → **[JS/TS Analysis] Critical: 0**

## 문서
- [설계](docs/superpowers/specs/2026-04-18-issue-179-slop-index-design.md)
- [플랜](docs/superpowers/plans/2026-04-18-issue-179-slop-index.md)


Made with [Cursor](https://cursor.com)