### PR TITLE
feat: add project-scoped memory (Issue #81)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-issue-81-project-scoped-memory.md
+++ b/docs/superpowers/plans/2026-04-18-issue-81-project-scoped-memory.md
@@ -1,0 +1,888 @@
+# Issue #81: Project-Scoped Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `project_id` support to `remember`, `recall`, and `memory_injection` MCP tools, plus HTTP admin endpoints for project stats and cleanup, so AI agents can store and retrieve memories scoped to a specific project.
+
+**Architecture:** A new `project_id TEXT` column is added to `memory_item` via migration 032. The three MCP tools (`remember`, `recall`, `memory_injection`) each get a `project_id` parameter; `recall` and `memory_injection` apply it as an in-memory post-filter (consistent with the existing `owner_id`/`process_id`/`session_id` pattern). Two HTTP admin endpoints handle project stats and bulk cleanup.
+
+**Tech Stack:** TypeScript, better-sqlite3, zod, vitest, Express 5.x (`@memento/core`, `memento-server`)
+
+**Spec:** `docs/superpowers/specs/2026-04-18-issue-81-project-scoped-memory-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts` | **Create** — migration class |
+| `packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts` | **Create** — migration tests |
+| `packages/memento-core/src/shared/types/index.ts` | **Modify** — add `project_id` to `MemoryItem` and `MemorySearchFilters` |
+| `packages/memento-core/src/domains/memory/tools/remember-tool.ts` | **Modify** — add `project_id` schema param + INSERT |
+| `packages/memento-core/src/domains/memory/tools/recall-tool.ts` | **Modify** — add `project_id` to `RecallSearchItem`, `AppliedFilters`, schema, in-memory filter |
+| `packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts` | **Modify** — add `project_id` schema param + in-memory filter |
+| `packages/memento-server/src/server/routes/admin.routes.ts` | **Modify** — add GET stats, GET preview, DELETE cleanup routes |
+
+---
+
+## Task 1: DB Migration 032 — Add `project_id` Column
+
+**Files:**
+- Create: `packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts`
+- Create: `packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `032-add-project-id.spec.ts`:
+
+```typescript
+/**
+ * Migration 032 테스트 — memory_item project_id 컬럼
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { AddProjectIdMigration } from './032-add-project-id.js';
+
+function createMemoryItemTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+function columnExists(db: Database.Database, tableName: string, columnName: string): boolean {
+  const columns = db.prepare(`PRAGMA table_info("${tableName}")`).all() as Array<{ name: string }>;
+  return columns.some(c => c.name === columnName);
+}
+
+function indexExists(db: Database.Database, indexName: string): boolean {
+  const row = db.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`
+  ).get(indexName) as { name: string } | undefined;
+  return !!row;
+}
+
+describe('Migration 032 - project_id column', () => {
+  let db: Database.Database;
+  let migration: AddProjectIdMigration;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMemoryItemTable(db);
+    migration = new AddProjectIdMigration();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('adds project_id column to memory_item', async () => {
+    expect(columnExists(db, 'memory_item', 'project_id')).toBe(false);
+    await migration.up(db);
+    expect(columnExists(db, 'memory_item', 'project_id')).toBe(true);
+  });
+
+  it('creates composite partial index on (project_id, type)', async () => {
+    await migration.up(db);
+    expect(indexExists(db, 'idx_memory_item_project_id_type')).toBe(true);
+  });
+
+  it('is idempotent — running up() twice does not throw', async () => {
+    await migration.up(db);
+    await expect(migration.up(db)).resolves.not.toThrow();
+  });
+
+  it('existing rows get NULL project_id after migration', async () => {
+    db.exec(`INSERT INTO memory_item (id, type, content) VALUES ('mem_1', 'episodic', 'test')`);
+    await migration.up(db);
+    const row = db.prepare(`SELECT project_id FROM memory_item WHERE id = 'mem_1'`).get() as { project_id: string | null };
+    expect(row.project_id).toBeNull();
+  });
+
+  it('validateAfter passes after up()', async () => {
+    await migration.up(db);
+    await expect(migration.validateAfter(db)).resolves.not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts
+```
+
+Expected: FAIL — `Cannot find module './032-add-project-id.js'`
+
+- [ ] **Step 3: Create the migration file**
+
+Create `032-add-project-id.ts`:
+
+```typescript
+/**
+ * Migration: 032 — memory_item project_id column
+ * Version: 32.0
+ */
+
+import type Database from 'better-sqlite3';
+import type { Migration } from '../types.js';
+
+export class AddProjectIdMigration implements Migration {
+  version = '32.0';
+  name = 'add-project-id';
+  description = 'Add project_id to memory_item for project-scoped memory (Issue #81)';
+
+  private columnExists(db: Database.Database, table: string, column: string): boolean {
+    const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    return rows.some(r => r.name === column);
+  }
+
+  private indexExists(db: Database.Database, indexName: string): boolean {
+    const row = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+      .get(indexName) as { name: string } | undefined;
+    return !!row;
+  }
+
+  async validateBefore(_db: Database.Database): Promise<void> {}
+
+  async up(db: Database.Database): Promise<void> {
+    if (!this.columnExists(db, 'memory_item', 'project_id')) {
+      db.exec(`ALTER TABLE memory_item ADD COLUMN project_id TEXT`);
+    }
+    if (!this.indexExists(db, 'idx_memory_item_project_id_type')) {
+      db.exec(`
+        CREATE INDEX idx_memory_item_project_id_type
+          ON memory_item(project_id, type)
+          WHERE project_id IS NOT NULL
+      `);
+    }
+  }
+
+  async down(db: Database.Database): Promise<void> {
+    db.exec('DROP INDEX IF EXISTS idx_memory_item_project_id_type');
+  }
+
+  async validateAfter(db: Database.Database): Promise<void> {
+    if (!this.columnExists(db, 'memory_item', 'project_id')) {
+      throw new Error('project_id column was not created');
+    }
+    if (!this.indexExists(db, 'idx_memory_item_project_id_type')) {
+      throw new Error('idx_memory_item_project_id_type was not created');
+    }
+  }
+}
+
+export default AddProjectIdMigration;
+```
+
+- [ ] **Step 4: Register the migration**
+
+Find where migrations are registered (look for `030-triple-extraction-fields` import) and add:
+
+```bash
+grep -rn "031-soft-delete-fields\|030-triple-extraction" packages/memento-core/src/infrastructure/database/ --include="*.ts" | grep "import" | head -5
+```
+
+Add the import and registration in the same file, following the existing pattern:
+```typescript
+import { AddProjectIdMigration } from './migrations/032-add-project-id.js';
+// ... add to the migrations array:
+new AddProjectIdMigration(),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npx vitest run packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts
+```
+
+Expected: All 5 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts
+git commit -m "feat(core): add migration 032 — project_id column on memory_item"
+```
+
+---
+
+## Task 2: Update Shared Types
+
+**Files:**
+- Modify: `packages/memento-core/src/shared/types/index.ts`
+
+- [ ] **Step 1: Add `project_id` to `MemoryItem`**
+
+In `packages/memento-core/src/shared/types/index.ts`, after `session_id?: string | null` (around line 53), add:
+
+```typescript
+  // Project-scoped memory (Issue #81)
+  project_id?: string | null;
+```
+
+- [ ] **Step 2: Add `project_id` to `MemorySearchFilters`**
+
+In the same file, after `session_id?: string | string[] | undefined` (around line 98), add:
+
+```typescript
+  // Project-scoped memory (Issue #81)
+  project_id?: string | undefined;
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+npm run type-check -w @memento/core 2>&1 | head -30
+```
+
+Expected: No new errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/memento-core/src/shared/types/index.ts
+git commit -m "feat(core): add project_id to MemoryItem and MemorySearchFilters types"
+```
+
+---
+
+## Task 3: Update `remember` Tool
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/memory/tools/remember-tool.ts`
+- Modify: `packages/memento-core/src/domains/memory/tools/__tests__/` or co-located spec
+
+- [ ] **Step 1: Write the failing test**
+
+Find the remember-tool spec file:
+```bash
+find packages/memento-core/src/domains/memory/tools -name "remember-tool.spec.ts" -o -name "remember*.spec.ts" | head -3
+```
+
+In the spec file, add a test for `project_id`:
+
+```typescript
+it('stores project_id when provided', async () => {
+  const result = await callTool('remember', {
+    content: 'PostgreSQL을 사용한다',
+    type: 'semantic',
+    project_id: 'test-project'
+  }, context);
+
+  expect(result.isError).toBe(false);
+  // Verify DB
+  const row = db.prepare(
+    `SELECT project_id FROM memory_item WHERE content = ?`
+  ).get('PostgreSQL을 사용한다') as { project_id: string | null } | undefined;
+  expect(row?.project_id).toBe('test-project');
+});
+
+it('stores NULL project_id when not provided', async () => {
+  const result = await callTool('remember', {
+    content: '프로젝트 없는 기억',
+    type: 'episodic'
+  }, context);
+
+  expect(result.isError).toBe(false);
+  const row = db.prepare(
+    `SELECT project_id FROM memory_item WHERE content = ?`
+  ).get('프로젝트 없는 기억') as { project_id: string | null } | undefined;
+  expect(row?.project_id).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ 2>&1 | grep -E "FAIL|PASS|project_id" | head -10
+```
+
+Expected: FAIL — `project_id` column does not exist yet (or test runs but assertion fails)
+
+- [ ] **Step 3: Add `project_id` to the schema**
+
+In `remember-tool.ts`, find `RememberSchema = z.object({` and add (near `session_id`):
+
+```typescript
+  // Project-scoped memory (Issue #81)
+  project_id: z.string().max(200).optional()
+    .describe('프로젝트 식별자. 동일 project_id로 저장한 기억끼리 recall/memory_injection 시 필터링 가능'),
+```
+
+- [ ] **Step 4: Destructure the new param**
+
+Find `RememberSchema.parse(params)` destructuring and add `project_id`:
+
+```typescript
+  project_id,
+} = RememberSchema.parse(params);
+```
+
+- [ ] **Step 5: Add to INSERT statement**
+
+Find the `INSERT INTO memory_item (` statement (around line 805). Add `project_id` to the column list and `project_id ?? null` to the values array, following the same position as `session_id`:
+
+Column list change:
+```
+..., owner_id, process_id, session_id, project_id,
+num_times, ...
+```
+
+Values array change (after `sessionId`):
+```typescript
+project_id ?? null,
+```
+
+Also add `?` to the VALUES placeholders count.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ 2>&1 | grep -E "FAIL|PASS" | head -10
+```
+
+Expected: All tests PASS including the new ones
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/tools/remember-tool.ts
+git commit -m "feat(core): add project_id param to remember tool"
+```
+
+---
+
+## Task 4: Update `recall` Tool
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/memory/tools/recall-tool.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Find recall-tool spec and add:
+
+```typescript
+it('filters results by project_id — excludes other projects', async () => {
+  // Setup: two memories in different projects
+  db.exec(`
+    INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+    VALUES
+      ('mem_proj_a', 'semantic', 'proj-a 결정', 0.8, 'proj-a', datetime('now')),
+      ('mem_proj_b', 'semantic', 'proj-b 결정', 0.8, 'proj-b', datetime('now'))
+  `);
+
+  const result = await callTool('recall', {
+    query: '결정',
+    project_id: 'proj-a'
+  }, context);
+
+  expect(result.isError).toBe(false);
+  const items = result.content[0]?.text ? JSON.parse(result.content[0].text) : [];
+  const ids = (items.memories ?? items).map((m: any) => m.memory_id ?? m.id);
+  expect(ids).toContain('mem_proj_a');
+  expect(ids).not.toContain('mem_proj_b');
+});
+
+it('returns all memories when project_id is not specified', async () => {
+  db.exec(`
+    INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+    VALUES
+      ('mem_a', 'semantic', '테스트 A', 0.8, 'proj-a', datetime('now')),
+      ('mem_b', 'semantic', '테스트 B', 0.8, NULL, datetime('now'))
+  `);
+
+  const result = await callTool('recall', { query: '테스트' }, context);
+  expect(result.isError).toBe(false);
+  // Both should be returned (no project filter)
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ -t "project_id" 2>&1 | head -20
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add `project_id` to `RecallSearchItem` interface**
+
+Around line 356 (after `session_id?: string | null`):
+
+```typescript
+  project_id?: string | null;
+```
+
+- [ ] **Step 4: Add `project_id` to `AppliedFilters` interface**
+
+Around line 398 (after `session_id?: string | string[]`):
+
+```typescript
+  project_id?: string;
+```
+
+- [ ] **Step 5: Add `project_id` to the zod schema**
+
+Find the recall schema (look for `owner_id: z.union(...)`) and add after `session_id`:
+
+```typescript
+  // Project-scoped memory (Issue #81)
+  project_id: z.string().max(200).optional()
+    .describe('이 project_id로 저장된 기억만 검색. 미지정 시 전체 검색'),
+```
+
+- [ ] **Step 6: Destructure and apply in-memory filter**
+
+In the `handle()` method, destructure `project_id` from parsed params.
+
+Then, after the `session_id` filter block (around line 1039), add:
+
+```typescript
+// Project-scoped memory (Issue #81): project_id 필터
+if (project_id && searchItems.length > 0) {
+  searchItems = searchItems.filter(
+    (i: RecallSearchItem) => i.project_id != null && i.project_id === project_id
+  );
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ 2>&1 | grep -E "FAIL|PASS" | head -10
+```
+
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/tools/recall-tool.ts
+git commit -m "feat(core): add project_id filter to recall tool"
+```
+
+---
+
+## Task 5: Update `memory_injection` Tool
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Find or create the memory-injection spec and add:
+
+```typescript
+it('injects only project memories when project_id is specified', async () => {
+  db.exec(`
+    INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+    VALUES
+      ('mem_mine', 'semantic', 'proj-x 전용 결정', 0.9, 'proj-x', datetime('now')),
+      ('mem_other', 'semantic', '다른 프로젝트 결정', 0.9, 'proj-y', datetime('now')),
+      ('mem_none', 'semantic', '프로젝트 없는 기억', 0.9, NULL, datetime('now'))
+  `);
+
+  const result = await callTool('memory_injection', {
+    query: '결정',
+    project_id: 'proj-x'
+  }, context);
+
+  expect(result.isError).toBe(false);
+  const text = result.content[0]?.text ?? '';
+  expect(text).toContain('proj-x 전용 결정');
+  expect(text).not.toContain('다른 프로젝트 결정');
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ -t "memory_injection" 2>&1 | head -20
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add `project_id` to `MemoryInjectionSchema`**
+
+In `memory-injection-prompt.ts`, find `const MemoryInjectionSchema = z.object({` and add:
+
+```typescript
+  // Project-scoped memory (Issue #81)
+  project_id: z.string().max(200).optional()
+    .describe('지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색'),
+```
+
+- [ ] **Step 4: Add to `super()` properties**
+
+In the `super(...)` call (the MCP schema definition), add after `importance_threshold`:
+
+```typescript
+          project_id: {
+            type: 'string',
+            description: '지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색',
+            maxLength: 200
+          }
+```
+
+- [ ] **Step 5: Destructure and apply filter**
+
+In `handle()`, add `project_id` to the destructuring from `MemoryInjectionSchema.parse(params)`.
+
+After `const memories = searchResult.items;`, add:
+
+```typescript
+// Project-scoped memory filter (Issue #81)
+const filteredMemories = project_id
+  ? memories.filter((m: any) => m.project_id != null && m.project_id === project_id)
+  : memories;
+```
+
+Replace all subsequent references to `memories` in this method with `filteredMemories`.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/tools/ 2>&1 | grep -E "FAIL|PASS" | head -10
+```
+
+Expected: All PASS
+
+- [ ] **Step 7: Type-check**
+
+```bash
+npm run type-check -w @memento/core 2>&1 | head -20
+```
+
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
+git commit -m "feat(core): add project_id filter to memory_injection tool"
+```
+
+---
+
+## Task 6: HTTP Admin Routes — Project Stats & Cleanup
+
+**Files:**
+- Modify: `packages/memento-server/src/server/routes/admin.routes.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Find `packages/memento-server/src/server/routes/admin.routes.spec.ts` and add:
+
+```typescript
+describe('Project admin routes', () => {
+  it('GET /admin/memory/project/:project_id/stats returns counts by type', async () => {
+    // Insert test data
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+      VALUES
+        ('m1', 'semantic', 'a', 0.5, 'proj-test', datetime('now')),
+        ('m2', 'episodic', 'b', 0.5, 'proj-test', datetime('now')),
+        ('m3', 'semantic', 'c', 0.5, 'other-proj', datetime('now'))
+    `);
+
+    const res = await request(app)
+      .get('/admin/memory/project/proj-test/stats')
+      .set('X-Admin-Key', TEST_ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.project_id).toBe('proj-test');
+    expect(res.body.total).toBe(2);
+    expect(res.body.by_type.semantic).toBe(1);
+    expect(res.body.by_type.episodic).toBe(1);
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns would_delete without deleting', async () => {
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+      VALUES ('old_mem', 'episodic', 'old content', 0.5, 'proj-x', '${old}')
+    `);
+
+    const res = await request(app)
+      .get('/admin/memory/project/proj-x/cleanup/preview?older_than_days=90')
+      .set('X-Admin-Key', TEST_ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.would_delete).toBe(1);
+    expect(res.body.items[0].id).toBe('old_mem');
+
+    // Verify nothing was deleted
+    const count = db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE id = 'old_mem'`).get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns 400 when older_than_days missing', async () => {
+    const res = await request(app)
+      .get('/admin/memory/project/proj-x/cleanup/preview')
+      .set('X-Admin-Key', TEST_ADMIN_KEY);
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns 400 when types includes core', async () => {
+    const res = await request(app)
+      .get('/admin/memory/project/proj-x/cleanup/preview?older_than_days=90&types=core')
+      .set('X-Admin-Key', TEST_ADMIN_KEY);
+    expect(res.status).toBe(400);
+  });
+
+  it('DELETE /admin/memory/project/:project_id/cleanup deletes old memories', async () => {
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+      VALUES ('del_mem', 'episodic', 'delete me', 0.5, 'proj-del', '${old}')
+    `);
+
+    const res = await request(app)
+      .delete('/admin/memory/project/proj-del/cleanup?older_than_days=90')
+      .set('X-Admin-Key', TEST_ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(1);
+
+    const count = db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE id = 'del_mem'`).get() as { c: number };
+    expect(count.c).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npx vitest run packages/memento-server/src/server/routes/admin.routes.spec.ts 2>&1 | head -20
+```
+
+Expected: FAIL — routes not found
+
+- [ ] **Step 3: Add the routes**
+
+In `admin.routes.ts`, after the existing routes (e.g., after the `/embeddings/migrate` route), add:
+
+```typescript
+  // Project stats (Issue #81)
+  router.get('/memory/project/:project_id/stats', async (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { project_id } = req.params;
+
+      const total = (db.prepare(
+        `SELECT COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0`
+      ).get(project_id) as { c: number }).c;
+
+      const byTypeRows = db.prepare(
+        `SELECT type, COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0 GROUP BY type`
+      ).all(project_id) as Array<{ type: string; c: number }>;
+      const by_type: Record<string, number> = {};
+      for (const row of byTypeRows) {
+        by_type[row.type] = row.c;
+      }
+
+      const dates = db.prepare(
+        `SELECT MIN(created_at) as oldest, MAX(created_at) as newest FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0`
+      ).get(project_id) as { oldest: string | null; newest: string | null };
+
+      return res.json({
+        project_id,
+        total,
+        by_type,
+        oldest_created_at: dates.oldest,
+        newest_created_at: dates.newest
+      });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 통계 조회 실패', message: String(error) });
+    }
+  });
+
+  // Helper: parse and validate cleanup query params
+  function parseCleanupParams(query: Record<string, unknown>): { olderThanDays: number; types: string[] } | { error: string; status: number } {
+    const olderThanDays = Number(query['older_than_days']);
+    if (!query['older_than_days'] || isNaN(olderThanDays) || olderThanDays <= 0) {
+      return { error: 'older_than_days 파라미터가 필요합니다 (양의 정수)', status: 400 };
+    }
+    const typesRaw = typeof query['types'] === 'string' ? query['types'] : 'episodic,working';
+    const types = typesRaw.split(',').map(t => t.trim()).filter(Boolean);
+    if (types.includes('core')) {
+      return { error: 'core 타입 기억은 삭제할 수 없습니다', status: 400 };
+    }
+    const allowedTypes = ['working', 'episodic', 'semantic', 'procedural', 'vault'];
+    const invalid = types.filter(t => !allowedTypes.includes(t));
+    if (invalid.length > 0) {
+      return { error: `허용되지 않는 타입: ${invalid.join(', ')}`, status: 400 };
+    }
+    return { olderThanDays, types };
+  }
+
+  // Project cleanup preview (Issue #81)
+  router.get('/memory/project/:project_id/cleanup/preview', async (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { project_id } = req.params;
+      const parsed = parseCleanupParams(req.query as Record<string, unknown>);
+      if ('error' in parsed) {
+        return res.status(parsed.status).json({ error: parsed.error });
+      }
+      const { olderThanDays, types } = parsed;
+
+      const placeholders = types.map(() => '?').join(', ');
+      const rows = db.prepare(
+        `SELECT id, content, type, created_at FROM memory_item
+         WHERE project_id = ?
+           AND type IN (${placeholders})
+           AND created_at < datetime('now', '-${olderThanDays} days')
+           AND COALESCE(is_deleted, 0) = 0`
+      ).all(project_id, ...types) as Array<{ id: string; content: string; type: string; created_at: string }>;
+
+      return res.json({
+        would_delete: rows.length,
+        items: rows
+      });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 정리 미리보기 실패', message: String(error) });
+    }
+  });
+
+  // Project cleanup delete (Issue #81)
+  router.delete('/memory/project/:project_id/cleanup', async (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { project_id } = req.params;
+      const parsed = parseCleanupParams(req.query as Record<string, unknown>);
+      if ('error' in parsed) {
+        return res.status(parsed.status).json({ error: parsed.error });
+      }
+      const { olderThanDays, types } = parsed;
+
+      const placeholders = types.map(() => '?').join(', ');
+      const result = db.prepare(
+        `DELETE FROM memory_item
+         WHERE project_id = ?
+           AND type IN (${placeholders})
+           AND created_at < datetime('now', '-${olderThanDays} days')
+           AND COALESCE(is_deleted, 0) = 0`
+      ).run(project_id, ...types);
+
+      return res.json({ deleted: result.changes });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 정리 실패', message: String(error) });
+    }
+  });
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npx vitest run packages/memento-server/src/server/routes/admin.routes.spec.ts 2>&1 | grep -E "FAIL|PASS|project" | head -20
+```
+
+Expected: All PASS
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check -w memento-server 2>&1 | head -20
+```
+
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/memento-server/src/server/routes/admin.routes.ts packages/memento-server/src/server/routes/admin.routes.spec.ts
+git commit -m "feat(server): add project stats and cleanup admin routes (Issue #81)"
+```
+
+---
+
+## Task 7: Full Quality Gate
+
+- [ ] **Step 1: Run full lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors. If there are auto-fixable issues run `npm run lint -- --fix`.
+
+- [ ] **Step 2: Run full type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: No errors
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: All tests PASS (or only pre-existing failures)
+
+- [ ] **Step 4: Run the migration smoke test**
+
+```bash
+npm run db:migrate -w @memento/core
+```
+
+Expected: Migration 032 applied successfully
+
+- [ ] **Step 5: Final commit (if any lint/format fixes applied)**
+
+```bash
+git add -p  # review and stage only relevant changes
+git commit -m "chore: lint and type fixes for project-scoped memory feature"
+```
+
+---
+
+## Integration Scenario (Manual Verification)
+
+After all tasks complete, verify the end-to-end workflow:
+
+```bash
+# Start the server
+npm run dev:http
+
+# 1. Store a project decision
+curl -X POST http://localhost:7860/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"tool":"remember","params":{"content":"이 프로젝트는 PostgreSQL 사용","type":"semantic","project_id":"my-project","importance":0.9}}'
+
+# 2. Verify isolation — store something in a different project
+curl -X POST http://localhost:7860/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"tool":"remember","params":{"content":"다른 프로젝트 결정","type":"semantic","project_id":"other-project","importance":0.9}}'
+
+# 3. Recall — should only return my-project memory
+curl -X POST http://localhost:7860/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"tool":"recall","params":{"query":"프로젝트 기술 스택","project_id":"my-project"}}'
+
+# 4. Check stats
+curl http://localhost:7860/admin/memory/project/my-project/stats \
+  -H "X-Admin-Key: $ADMIN_KEY"
+
+# 5. Preview cleanup (dry run)
+curl "http://localhost:7860/admin/memory/project/my-project/cleanup/preview?older_than_days=90" \
+  -H "X-Admin-Key: $ADMIN_KEY"
+```

--- a/docs/superpowers/plans/2026-04-18-issue-81-project-scoped-memory.md
+++ b/docs/superpowers/plans/2026-04-18-issue-81-project-scoped-memory.md
@@ -183,20 +183,15 @@ export class AddProjectIdMigration implements Migration {
 export default AddProjectIdMigration;
 ```
 
-- [ ] **Step 4: Register the migration**
+- [ ] **Step 4: Confirm auto-discovery (no manual registration needed)**
 
-Find where migrations are registered (look for `030-triple-extraction-fields` import) and add:
+This project uses `MigrationDetector` which automatically scans the `migrations/` directory for files matching `/^\d{3}-/`. Since the file is named `032-add-project-id.ts`, it will be discovered automatically. **No import or registration in a registry file is required.** Just verify the file exists:
 
 ```bash
-grep -rn "031-soft-delete-fields\|030-triple-extraction" packages/memento-core/src/infrastructure/database/ --include="*.ts" | grep "import" | head -5
+ls packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts
 ```
 
-Add the import and registration in the same file, following the existing pattern:
-```typescript
-import { AddProjectIdMigration } from './migrations/032-add-project-id.js';
-// ... add to the migrations array:
-new AddProjectIdMigration(),
-```
+Expected: file exists
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -306,7 +301,7 @@ it('stores NULL project_id when not provided', async () => {
 npx vitest run packages/memento-core/src/domains/memory/tools/ 2>&1 | grep -E "FAIL|PASS|project_id" | head -10
 ```
 
-Expected: FAIL — `project_id` column does not exist yet (or test runs but assertion fails)
+Expected: FAIL — zod strips the unknown `project_id` param (not yet in `RememberSchema`), so the INSERT never includes it and the assertion `expect(row?.project_id).toBe('test-project')` fails with `null`.
 
 - [ ] **Step 3: Add `project_id` to the schema**
 
@@ -709,8 +704,12 @@ In `admin.routes.ts`, after the existing routes (e.g., after the `/embeddings/mi
   });
 
   // Helper: parse and validate cleanup query params
+  // NOTE: Place this function OUTSIDE the router callback (at module scope or before createAdminRouter),
+  // not inside the router chain, to match the existing file's style.
   function parseCleanupParams(query: Record<string, unknown>): { olderThanDays: number; types: string[] } | { error: string; status: number } {
-    const olderThanDays = Number(query['older_than_days']);
+    const olderThanDays = Math.floor(Number(query['older_than_days']));
+    // Math.floor ensures integer — safe for SQL string interpolation below.
+    // better-sqlite3 does not support bind params inside datetime() modifiers.
     if (!query['older_than_days'] || isNaN(olderThanDays) || olderThanDays <= 0) {
       return { error: 'older_than_days 파라미터가 필요합니다 (양의 정수)', status: 400 };
     }

--- a/packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts
+++ b/packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts
@@ -24,7 +24,8 @@ export function applyConsolidationTestSchema(db: Database.Database): void {
       owner_id TEXT NULL,
       is_consolidated BOOLEAN DEFAULT FALSE,
       is_deleted INTEGER DEFAULT 0,
-      deleted_at TEXT
+      deleted_at TEXT,
+      project_id TEXT
     );
 
     CREATE TABLE IF NOT EXISTS memory_embedding (

--- a/packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts
@@ -435,6 +435,29 @@ describe('MemoryInjectionPrompt', () => {
     });
   });
 
+  describe('project_id 필터', () => {
+    it('injects only project memories when project_id is specified', async () => {
+      // Pre-insert memories with different project_ids
+      db.exec(`
+        INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+        VALUES
+          ('inj_mine', 'semantic', 'proj-x 전용 결정', 0.9, 'proj-x', datetime('now')),
+          ('inj_other', 'semantic', '다른 프로젝트 결정', 0.9, 'proj-y', datetime('now')),
+          ('inj_none', 'semantic', '프로젝트 없는 기억', 0.9, NULL, datetime('now'))
+      `);
+
+      const result = await tool.handle({
+        query: '결정',
+        project_id: 'proj-x'
+      }, context);
+
+      expect(result.isError).toBeFalsy();
+      const text = result.content?.[0]?.text ?? JSON.stringify(result);
+      expect(text).toContain('proj-x 전용 결정');
+      expect(text).not.toContain('다른 프로젝트 결정');
+    });
+  });
+
   describe('도구 메타데이터', () => {
     it('도구 이름을 올바르게 반환해야 함', () => {
       // When: 도구 정의 조회

--- a/packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts
@@ -774,6 +774,40 @@ describe('RecallTool', () => {
     });
   });
 
+  describe('project_id 필터 (Project-scoped Memory, Issue #81)', () => {
+    it('Given: project_id가 서로 다른 메모리 2건, When: recall에 project_id 제공 시, Then: 해당 project 메모리만 반환', async () => {
+      vi.spyOn(hybridSearchEngine, 'search').mockResolvedValue({
+        items: [
+          { id: 'mem-proj-a', content: 'proj-a 결정', type: 'semantic', importance: 0.8, created_at: new Date().toISOString(), project_id: 'proj-a', finalScore: 0.9 },
+          { id: 'mem-proj-b', content: 'proj-b 결정', type: 'semantic', importance: 0.8, created_at: new Date().toISOString(), project_id: 'proj-b', finalScore: 0.8 },
+        ],
+        total_count: 2,
+        query_time: 10,
+      });
+      const params = { query: '결정', type: 'semantic', project_id: 'proj-a' };
+      const result = await tool.handle(params, context);
+      const data = JSON.parse(result.content[0].text);
+      expect(data.items).toHaveLength(1);
+      expect(data.items[0].memory_id).toBe('mem-proj-a');
+      expect(data.items[0].project_id).toBe('proj-a');
+    });
+
+    it('Given: project_id 미지정, When: recall 호출 시, Then: 모든 project 메모리 반환', async () => {
+      vi.spyOn(hybridSearchEngine, 'search').mockResolvedValue({
+        items: [
+          { id: 'mem-a2', content: '테스트 A2', type: 'semantic', importance: 0.8, created_at: new Date().toISOString(), project_id: 'proj-a', finalScore: 0.9 },
+          { id: 'mem-b2', content: '테스트 B2', type: 'semantic', importance: 0.8, created_at: new Date().toISOString(), project_id: null, finalScore: 0.8 },
+        ],
+        total_count: 2,
+        query_time: 10,
+      });
+      const params = { query: '테스트', type: 'semantic' };
+      const result = await tool.handle(params, context);
+      const data = JSON.parse(result.content[0].text);
+      expect(data.items).toHaveLength(2);
+    });
+  });
+
   describe('recall profiling (recallProfileEnabled)', () => {
     it('Given: recallProfileEnabled=true, When: recall 성공 시, Then: logInfo에 recall_profile 및 total_ms 호출됨', async () => {
       const configRestore = mementoConfig.recallProfileEnabled;

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts
@@ -53,6 +53,7 @@ function initializeTestDatabase(db: Database.Database): void {
       owner_id TEXT NULL,
       process_id TEXT NULL,
       session_id TEXT NULL,
+      project_id TEXT,
       -- Fact metadata (Issue #88, migration 017)
       num_times INTEGER NOT NULL DEFAULT 1,
       last_mentioned_at TIMESTAMP,

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
@@ -62,7 +62,9 @@ function initializeTestDatabase(db: Database.Database): void {
       num_times INTEGER NOT NULL DEFAULT 1,
       last_mentioned_at TIMESTAMP,
       source_session_id TEXT,
-      confidence REAL
+      confidence REAL,
+      -- Project-scoped memory (Issue #81)
+      project_id TEXT NULL
     );
 
     CREATE INDEX IF NOT EXISTS idx_memory_item_last_accessed ON memory_item(last_accessed_at DESC);
@@ -1683,6 +1685,35 @@ describe('RememberTool', () => {
           expect(link).toBeDefined();
         });
       });
+    });
+  });
+
+  describe('project_id (Project-scoped Memory, Issue #81)', () => {
+    it('stores project_id when provided', async () => {
+      const result = await tool.handle({
+        content: 'PostgreSQL을 사용한다',
+        type: 'semantic',
+        project_id: 'test-project'
+      }, context);
+
+      expect(result.isError).toBeFalsy();
+      const row = db.prepare(
+        `SELECT project_id FROM memory_item WHERE content = ?`
+      ).get('PostgreSQL을 사용한다') as { project_id: string | null } | undefined;
+      expect(row?.project_id).toBe('test-project');
+    });
+
+    it('stores NULL project_id when not provided', async () => {
+      const result = await tool.handle({
+        content: '프로젝트 없는 기억',
+        type: 'episodic'
+      }, context);
+
+      expect(result.isError).toBeFalsy();
+      const row = db.prepare(
+        `SELECT project_id FROM memory_item WHERE content = ?`
+      ).get('프로젝트 없는 기억') as { project_id: string | null } | undefined;
+      expect(row?.project_id).toBeNull();
     });
   });
 

--- a/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
+++ b/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
@@ -21,7 +21,10 @@ const MemoryInjectionSchema = z.object({
   token_budget: z.number().optional().describe('토큰 예산 (기본값: 1000)'),
   max_memories: z.number().optional().describe('최대 기억 개수 (기본값: 5)'),
   memory_types: z.array(CommonSchemas.MemoryType).optional().describe('포함할 기억 타입들'),
-  importance_threshold: z.number().optional().describe('중요도 임계값 (기본값: 0.5)')
+  importance_threshold: z.number().optional().describe('중요도 임계값 (기본값: 0.5)'),
+  // Project-scoped memory (Issue #81)
+  project_id: z.string().max(200).optional()
+    .describe('지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색')
 });
 
 export class MemoryInjectionPrompt extends BaseTool {
@@ -55,10 +58,15 @@ export class MemoryInjectionPrompt extends BaseTool {
             description: '포함할 기억 타입들 (core/vault는 자동으로 제거됩니다)',
             default: ['working', 'episodic', 'semantic', 'procedural']
           },
-          importance_threshold: { 
-            type: 'number', 
+          importance_threshold: {
+            type: 'number',
             description: '중요도 임계값 (기본값: 0.5)',
             default: 0.5
+          },
+          project_id: {
+            type: 'string',
+            description: '지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색',
+            maxLength: 200
           }
         },
         required: ['query']
@@ -72,7 +80,8 @@ export class MemoryInjectionPrompt extends BaseTool {
       token_budget = 1000,
       max_memories = 5,
       memory_types = ['working', 'episodic', 'semantic', 'procedural'],
-      importance_threshold = 0.5
+      importance_threshold = 0.5,
+      project_id
     } = MemoryInjectionSchema.parse(params);
 
     try {
@@ -142,17 +151,22 @@ export class MemoryInjectionPrompt extends BaseTool {
         count: memories.length
       });
 
+      // Project-scoped memory filter (Issue #81)
+      const filteredMemories = project_id
+        ? memories.filter((m: any) => m.project_id != null && m.project_id === project_id)
+        : memories;
+
       // Consolidation Score System 업데이트 (기능 플래그 확인)
-      if (mementoConfig.consolidationScoreEnabled && context.services.consolidationScoreService && memories.length > 0) {
+      if (mementoConfig.consolidationScoreEnabled && context.services.consolidationScoreService && filteredMemories.length > 0) {
         await this.updateConsolidationScoreMetadata(
           context.db,
           context.services.consolidationScoreService,
           context.services.writeCoalescingManager,
-          memories
+          filteredMemories
         );
       }
 
-      if (memories.length === 0) {
+      if (filteredMemories.length === 0) {
         return this.createSuccessResult({
           message: '관련 기억을 찾을 수 없습니다.',
           memories_used: 0,
@@ -162,7 +176,7 @@ export class MemoryInjectionPrompt extends BaseTool {
       }
 
       // 2. 기억 요약 및 토큰 예산 관리
-      const summary = await this.summarizeMemories(memories, token_budget, max_memories);
+      const summary = await this.summarizeMemories(filteredMemories, token_budget, max_memories);
 
       // 3. 프롬프트 형식으로 포맷팅
       const formattedPrompt = this.formatMemoryPrompt(summary, query);

--- a/packages/memento-core/src/domains/memory/tools/recall-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/recall-tool.ts
@@ -300,6 +300,9 @@ const RecallSchema = z.object({
   process_id: z.union([z.string(), z.array(z.string())]).optional(),
   /** Memori Attribution: 세션 ID 필터 (Issue #87) */
   session_id: z.union([z.string(), z.array(z.string())]).optional(),
+  /** Project-scoped Memory: 프로젝트 ID 필터 (Issue #81) */
+  project_id: z.string().max(200).optional()
+    .describe('이 project_id로 저장된 기억만 검색. 미지정 시 전체 검색'),
   include_diff_with: z.string().optional(), // 'previous' 또는 비교할 메모리 id
   include_score_breakdown: z.boolean().optional().default(false)
 }).refine((data) => {
@@ -356,6 +359,7 @@ interface RecallSearchItem {
   owner_id?: string | null;
   process_id?: string | null;
   session_id?: string | null;
+  project_id?: string | null;
   last_accessed?: Date;
   pinned?: boolean;
   tags?: string[];
@@ -396,6 +400,7 @@ interface AppliedFilters extends Record<string, unknown> {
   owner_id?: string | string[];
   process_id?: string | string[];
   session_id?: string | string[];
+  project_id?: string;
 }
 
 /** Recall 내부 필터 (MemorySearchFilters + importance 범위) */
@@ -606,6 +611,10 @@ export class RecallTool extends BaseTool {
           session_id: {
             type: 'string',
             description: 'Memori Attribution: 세션 ID로 결과 필터 (Issue #87)'
+          },
+          project_id: {
+            type: 'string',
+            description: 'Project-scoped Memory: 프로젝트 ID로 결과 필터 (Issue #81). 미지정 시 전체 검색'
           }
         },
         required: [] // 조건부 필수는 런타임 검증 (RecallSchema.refine()에서 처리)
@@ -657,6 +666,7 @@ export class RecallTool extends BaseTool {
         owner_id: owner_id_filter,
         process_id: process_id_filter,
         session_id: session_id_filter,
+        project_id: project_id_filter,
         include_score_breakdown
       } = RecallSchema.parse(params);
       
@@ -1037,6 +1047,12 @@ export class RecallTool extends BaseTool {
             (i: RecallSearchItem) => i.session_id != null && sessionIds.includes(i.session_id)
           );
         }
+        // Project-scoped Memory (Issue #81): project_id 필터
+        if (project_id_filter && searchItems.length > 0) {
+          searchItems = searchItems.filter(
+            (i: RecallSearchItem) => i.project_id != null && i.project_id === project_id_filter
+          );
+        }
 
         // Procedural Version Management: version_chain·diff 보강 (procedural 항목만, db 필요)
         if ((include_version_chain || include_diff_with) && context.db && searchItems.length > 0) {
@@ -1380,6 +1396,7 @@ export class RecallTool extends BaseTool {
         if (item.owner_id !== undefined) processed.owner_id = item.owner_id;
         if (item.process_id !== undefined) processed.process_id = item.process_id;
         if (item.session_id !== undefined) processed.session_id = item.session_id;
+        if (item.project_id !== undefined) processed.project_id = item.project_id;
 
         // origin_source 필드 추가 (JSON 파싱)
         if (item.origin_source) {
@@ -1502,6 +1519,7 @@ export class RecallTool extends BaseTool {
     if (filters.owner_id !== undefined) applied.owner_id = filters.owner_id;
     if (filters.process_id !== undefined) applied.process_id = filters.process_id;
     if (filters.session_id !== undefined) applied.session_id = filters.session_id;
+    if (filters.project_id !== undefined) applied.project_id = filters.project_id;
     if (filters.include_diff_with) applied.include_diff_with = filters.include_diff_with;
 
     return applied;

--- a/packages/memento-core/src/domains/memory/tools/remember-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool.ts
@@ -78,6 +78,9 @@ const RememberSchema = z.object({
   // Memori Attribution (Issue #87)
   process_id: z.string().optional(),
   session_id: z.string().optional(),
+  // Project-scoped memory (Issue #81)
+  project_id: z.string().max(200).optional()
+    .describe('프로젝트 식별자. 동일 project_id로 저장한 기억끼리 recall/memory_injection 시 필터링 가능'),
   // Fact metadata (Issue #88): semantic 표준 메타
   num_times: z.number().int().min(1).optional(),
   last_mentioned_at: z.string().datetime().optional(),
@@ -390,6 +393,7 @@ export class RememberTool extends BaseTool {
         owner_id: owner_id_param,
         process_id: process_id_param,
         session_id: session_id_param,
+        project_id: project_id_param,
         num_times: num_times_param,
         last_mentioned_at: last_mentioned_at_param,
         source_session_id: source_session_id_param,
@@ -803,22 +807,22 @@ export class RememberTool extends BaseTool {
             // INSERT 쿼리
             await DatabaseUtils.run(context.db!, `
               INSERT INTO memory_item (
-                id, type, content, importance, privacy_scope, tags, source, origin_source, 
-                task_goal, steps, reflection_notes, 
+                id, type, content, importance, privacy_scope, tags, source, origin_source,
+                task_goal, steps, reflection_notes,
                 workflow_name, skill_name, trigger_conditions,
                 created_at,
                 recall_count, last_accessed_at, g_value, consolidation_score,
-                version, version_series_id, owner_id, process_id, session_id,
+                version, version_series_id, owner_id, process_id, session_id, project_id,
                 num_times, last_mentioned_at, source_session_id, confidence
               )
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             `, [
-              id, 
-              type, 
-              content, 
-              importance, 
-              privacy_scope, 
-              tags ? JSON.stringify(tags) : null, 
+              id,
+              type,
+              content,
+              importance,
+              privacy_scope,
+              tags ? JSON.stringify(tags) : null,
               source || null,
               origin_source,
               task_goal || null,
@@ -837,6 +841,7 @@ export class RememberTool extends BaseTool {
               ownerId,
               processId,
               sessionId,
+              project_id_param ?? null,
               numTimes,
               lastMentionedAt,
               sourceSessionId,

--- a/packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts
+++ b/packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts
@@ -502,7 +502,8 @@ describe('HybridSearchEngine', () => {
           confidence REAL,
           is_consolidated BOOLEAN DEFAULT FALSE,
           is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
-          deleted_at TEXT
+          deleted_at TEXT,
+          project_id TEXT
         );
       `);
 
@@ -2155,7 +2156,8 @@ describe('IProceduralMemoryMatcher 인터페이스', () => {
           confidence REAL,
           is_consolidated BOOLEAN DEFAULT FALSE,
           is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
-          deleted_at TEXT
+          deleted_at TEXT,
+          project_id TEXT
         );
       `);
 

--- a/packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts
+++ b/packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts
@@ -52,7 +52,8 @@ function initializeTestDatabase(db: Database.Database): void {
       confidence REAL,
       is_consolidated BOOLEAN DEFAULT FALSE,
       is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
-      deleted_at TEXT
+      deleted_at TEXT,
+      project_id TEXT
     );
   `);
 

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -318,6 +318,8 @@ export interface HybridSearchResult {
     confidence: number;
   }>;
   score_breakdown?: ScoreBreakdown;
+  // Project-scoped memory (Issue #81)
+  project_id?: string | null;
 }
 
 export class HybridSearchEngine {

--- a/packages/memento-core/src/domains/search/algorithms/search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-engine.ts
@@ -53,6 +53,7 @@ type SearchEngineRow = {
   session_id?: string | null;
   num_times?: number | string | null;
   last_mentioned_at?: Date | string | null;
+  project_id?: string | null;
 } & Record<string, unknown>;
 
 export class SearchEngine {
@@ -104,7 +105,7 @@ export class SearchEngine {
               m.workflow_name, m.skill_name, m.trigger_conditions,
               m.version, m.version_series_id,
               m.privacy_scope, m.origin_source, m.owner_id, m.process_id, m.session_id,
-              m.num_times, m.last_mentioned_at,
+              m.num_times, m.last_mentioned_at, m.project_id,
               0 as fts_rank
             FROM memory_item m
           `;
@@ -118,7 +119,7 @@ export class SearchEngine {
               m.workflow_name, m.skill_name, m.trigger_conditions,
               m.version, m.version_series_id,
               m.privacy_scope, m.origin_source, m.owner_id, m.process_id, m.session_id,
-              m.num_times, m.last_mentioned_at,
+              m.num_times, m.last_mentioned_at, m.project_id,
               memory_item_fts.rank as fts_rank
             FROM memory_item_fts
             JOIN memory_item m ON memory_item_fts.rowid = m.rowid
@@ -522,6 +523,7 @@ export class SearchEngine {
         if (row.owner_id !== undefined) result.owner_id = row.owner_id;
         if (row.process_id !== undefined) result.process_id = row.process_id;
         if (row.session_id !== undefined) result.session_id = row.session_id;
+        if (row.project_id !== undefined) result.project_id = row.project_id;
         if (row.num_times != null) result.num_times = Number(row.num_times);
         if (row.last_mentioned_at != null) {
           result.last_mentioned_at =

--- a/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
@@ -34,7 +34,7 @@ export class SearchResultCombiner implements ISearchResultCombiner {
     // 텍스트 검색 결과를 먼저 추가하여 기본 점수를 설정합니다.
     textResults.forEach(result => {
       const textScore = typeof result.score === 'number' ? result.score : HYBRID_SEARCH.DEFAULT_TEXT_WEIGHT * 0; // 0
-      resultMap.set(result.id, {
+      const entry: HybridSearchResult = {
         id: result.id,
         content: result.content,
         type: result.type,
@@ -47,7 +47,14 @@ export class SearchResultCombiner implements ISearchResultCombiner {
         vectorScore: 0,
         finalScore: textScore * textWeight,
         recall_reason: result.recall_reason || '텍스트 검색 결과',
-      });
+      };
+      // Project-scoped memory (Issue #81): project_id 전달
+      if (result.project_id !== undefined) entry.project_id = result.project_id;
+      // 기타 extended 필드 전달
+      if (result.owner_id !== undefined) (entry as any).owner_id = result.owner_id;
+      if (result.process_id !== undefined) (entry as any).process_id = result.process_id;
+      if (result.session_id !== undefined) (entry as any).session_id = result.session_id;
+      resultMap.set(result.id, entry);
     });
 
     // 벡터 검색 결과를 추가하거나 기존 텍스트 결과와 결합하여 하이브리드 점수를 계산합니다.

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration 032 테스트 — memory_item project_id 컬럼
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { AddProjectIdMigration } from './032-add-project-id.js';
+
+function createMemoryItemTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+function columnExists(db: Database.Database, tableName: string, columnName: string): boolean {
+  const columns = db.prepare(`PRAGMA table_info("${tableName}")`).all() as Array<{ name: string }>;
+  return columns.some(c => c.name === columnName);
+}
+
+function indexExists(db: Database.Database, indexName: string): boolean {
+  const row = db.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`
+  ).get(indexName) as { name: string } | undefined;
+  return !!row;
+}
+
+describe('Migration 032 - project_id column', () => {
+  let db: Database.Database;
+  let migration: AddProjectIdMigration;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMemoryItemTable(db);
+    migration = new AddProjectIdMigration();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('adds project_id column to memory_item', async () => {
+    expect(columnExists(db, 'memory_item', 'project_id')).toBe(false);
+    await migration.up(db);
+    expect(columnExists(db, 'memory_item', 'project_id')).toBe(true);
+  });
+
+  it('creates composite partial index on (project_id, type)', async () => {
+    await migration.up(db);
+    expect(indexExists(db, 'idx_memory_item_project_id_type')).toBe(true);
+  });
+
+  it('is idempotent — running up() twice does not throw', async () => {
+    await migration.up(db);
+    await expect(migration.up(db)).resolves.not.toThrow();
+  });
+
+  it('existing rows get NULL project_id after migration', async () => {
+    db.exec(`INSERT INTO memory_item (id, type, content) VALUES ('mem_1', 'episodic', 'test')`);
+    await migration.up(db);
+    const row = db.prepare(`SELECT project_id FROM memory_item WHERE id = 'mem_1'`).get() as { project_id: string | null };
+    expect(row.project_id).toBeNull();
+  });
+
+  it('validateAfter passes after up()', async () => {
+    await migration.up(db);
+    await expect(migration.validateAfter(db)).resolves.not.toThrow();
+  });
+});

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts
@@ -1,0 +1,54 @@
+/**
+ * Migration: 032 — memory_item project_id column
+ * Version: 32.0
+ */
+import type Database from 'better-sqlite3';
+import type { Migration } from '../types.js';
+
+export class AddProjectIdMigration implements Migration {
+  version = '32.0';
+  name = 'add-project-id';
+  description = 'Add project_id to memory_item for project-scoped memory (Issue #81)';
+
+  private columnExists(db: Database.Database, table: string, column: string): boolean {
+    const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    return rows.some(r => r.name === column);
+  }
+
+  private indexExists(db: Database.Database, indexName: string): boolean {
+    const row = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+      .get(indexName) as { name: string } | undefined;
+    return !!row;
+  }
+
+  async validateBefore(_db: Database.Database): Promise<void> {}
+
+  async up(db: Database.Database): Promise<void> {
+    if (!this.columnExists(db, 'memory_item', 'project_id')) {
+      db.exec(`ALTER TABLE memory_item ADD COLUMN project_id TEXT`);
+    }
+    if (!this.indexExists(db, 'idx_memory_item_project_id_type')) {
+      db.exec(`
+        CREATE INDEX idx_memory_item_project_id_type
+          ON memory_item(project_id, type)
+          WHERE project_id IS NOT NULL
+      `);
+    }
+  }
+
+  async down(db: Database.Database): Promise<void> {
+    db.exec('DROP INDEX IF EXISTS idx_memory_item_project_id_type');
+  }
+
+  async validateAfter(db: Database.Database): Promise<void> {
+    if (!this.columnExists(db, 'memory_item', 'project_id')) {
+      throw new Error('project_id column was not created');
+    }
+    if (!this.indexExists(db, 'idx_memory_item_project_id_type')) {
+      throw new Error('idx_memory_item_project_id_type was not created');
+    }
+  }
+}
+
+export default AddProjectIdMigration;

--- a/packages/memento-core/src/infrastructure/database/database/schema.sql
+++ b/packages/memento-core/src/infrastructure/database/database/schema.sql
@@ -52,7 +52,9 @@ CREATE TABLE IF NOT EXISTS memory_item (
   triple_extracted_status TEXT,
   triple_extraction_metadata TEXT,
   is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
-  deleted_at TEXT
+  deleted_at TEXT,
+  -- Project-scoped memory (Issue #81, migration 032)
+  project_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_memory_item_triple_extracted_episodic
   ON memory_item(triple_extracted)
@@ -63,6 +65,9 @@ CREATE INDEX IF NOT EXISTS idx_memory_item_triple_extracted_status_episodic
 CREATE INDEX IF NOT EXISTS idx_memory_item_is_deleted_active
   ON memory_item(is_deleted)
   WHERE COALESCE(is_deleted, 0) = 0;
+CREATE INDEX IF NOT EXISTS idx_memory_item_project_id_type
+  ON memory_item(project_id, type)
+  WHERE project_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memory_item_triple ON memory_item(subject, predicate, object)
 WHERE type='semantic' AND subject IS NOT NULL AND predicate IS NOT NULL AND object IS NOT NULL;
 

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -198,6 +198,8 @@ export interface MemorySearchResult {
   session_id?: string | null;
   num_times?: number;
   last_mentioned_at?: Date;
+  // Project-scoped memory (Issue #81)
+  project_id?: string | null;
 }
 
 export interface SearchRankingWeights {

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -51,6 +51,8 @@ export interface MemoryItem {
   // Memori Attribution (Issue #87)
   process_id?: string | null;
   session_id?: string | null;
+  // Project-scoped memory (Issue #81)
+  project_id?: string | null;
   // Fact metadata (Issue #88): semantic/Fact 표준 메타
   num_times?: number;
   last_mentioned_at?: Date | string | null;
@@ -96,6 +98,8 @@ export interface MemorySearchFilters {
   // Memori Attribution (Issue #87)
   process_id?: string | string[] | undefined;
   session_id?: string | string[] | undefined;
+  // Project-scoped memory (Issue #81)
+  project_id?: string | undefined;
 }
 
 // 관계 추출 타입 재export

--- a/packages/memento-core/src/test/helpers/consolidation-test-data.ts
+++ b/packages/memento-core/src/test/helpers/consolidation-test-data.ts
@@ -73,7 +73,8 @@ export function initializeTestDatabase(db: Database.Database): void {
       confidence REAL,
       is_consolidated BOOLEAN DEFAULT FALSE,
       is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
-      deleted_at TEXT
+      deleted_at TEXT,
+      project_id TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_memory_item_type ON memory_item(type);

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -93,6 +93,32 @@ function getAdmin(port: number, path: string): Promise<{ statusCode: number; bod
   });
 }
 
+function deleteAdmin(port: number, path: string): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method: 'DELETE',
+        headers: { Connection: 'close' }
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8')
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 describe('admin.routes consolidation', () => {
   let db: Database.Database;
 
@@ -755,6 +781,117 @@ describe('admin.routes graph', () => {
       expect(res.statusCode).toBe(400);
       const body = JSON.parse(res.body) as { error: string };
       expect(body.error).toBe('잘못된 파라미터');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});
+
+// ============================================================
+// Project memory admin routes (Issue #81)
+// ============================================================
+
+describe('Project memory admin routes', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_item (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL DEFAULT 'working',
+        content TEXT NOT NULL,
+        importance REAL DEFAULT 0.5,
+        project_id TEXT,
+        created_at TEXT DEFAULT (datetime('now')),
+        is_deleted INTEGER DEFAULT 0
+      )
+    `);
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch { /* ignore */ }
+    vi.restoreAllMocks();
+  });
+
+  function makeApp(database: Database.Database) {
+    const app = express();
+    app.use(express.json());
+    app.use('/admin', createAdminRouter(database, null));
+    return app;
+  }
+
+  it('GET /admin/memory/project/:project_id/stats returns counts', async () => {
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, project_id, created_at, is_deleted)
+      VALUES
+        ('ps1', 'semantic', 'a', 0.5, 'proj-test', datetime('now'), 0),
+        ('ps2', 'episodic', 'b', 0.5, 'proj-test', datetime('now'), 0),
+        ('ps3', 'semantic', 'c', 0.5, 'other-proj', datetime('now'), 0)
+    `);
+
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/project/proj-test/stats');
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { project_id: string; total: number };
+      expect(body.project_id).toBe('proj-test');
+      expect(body.total).toBe(2);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns 400 when older_than_days missing', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/project/proj-x/cleanup/preview');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns 400 when types includes core', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/project/proj-x/cleanup/preview?older_than_days=90&types=core');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns would_delete without deleting', async () => {
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    db.exec(`INSERT INTO memory_item (id, type, content, importance, project_id, created_at, is_deleted) VALUES ('old1', 'episodic', 'old', 0.5, 'proj-preview', '${old}', 0)`);
+
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/project/proj-preview/cleanup/preview?older_than_days=90');
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { would_delete: number };
+      expect(body.would_delete).toBe(1);
+      // Verify not deleted
+      const count = db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE id = 'old1'`).get() as { c: number };
+      expect(count.c).toBe(1);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('DELETE /admin/memory/project/:project_id/cleanup deletes old memories', async () => {
+    const old = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    db.exec(`INSERT INTO memory_item (id, type, content, importance, project_id, created_at, is_deleted) VALUES ('del1', 'episodic', 'del', 0.5, 'proj-del', '${old}', 0)`);
+
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await deleteAdmin(port, '/admin/memory/project/proj-del/cleanup?older_than_days=90');
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { deleted: number };
+      expect(body.deleted).toBe(1);
+      const count = db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE id = 'del1'`).get() as { c: number };
+      expect(count.c).toBe(0);
     } finally {
       await new Promise<void>(r => server.close(() => r()));
     }

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -896,4 +896,35 @@ describe('Project memory admin routes', () => {
       await new Promise<void>(r => server.close(() => r()));
     }
   });
+
+  it('GET /admin/memory/project/:project_id/cleanup/preview returns 400 when older_than_days > 3650', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/project/proj-x/cleanup/preview?older_than_days=3651');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('DELETE /admin/memory/project/:project_id/cleanup returns 400 when older_than_days > 3650', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await deleteAdmin(port, '/admin/memory/project/proj-x/cleanup?older_than_days=9999999');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/project/:project_id/stats returns 400 when project_id exceeds 200 chars', async () => {
+    const longId = 'a'.repeat(201);
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, `/admin/memory/project/${longId}/stats`);
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
 });

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -25,6 +25,28 @@ import { registerAdminEmbeddingMapRoute } from './admin/admin-embedding-map.rout
 export type { GraphNode, GraphEdge, GraphFilter, GraphResponse } from './admin/admin-graph-response.js';
 
 /**
+ * cleanup 파라미터 파싱 헬퍼 (Issue #81)
+ * Math.floor를 사용해 정수 보장 — better-sqlite3의 datetime() modifier에 안전하게 사용 가능
+ */
+function parseCleanupParams(query: Record<string, unknown>): { olderThanDays: number; types: string[] } | { error: string; status: number } {
+  const olderThanDays = Math.floor(Number(query['older_than_days']));
+  if (!query['older_than_days'] || isNaN(olderThanDays) || olderThanDays <= 0) {
+    return { error: 'older_than_days 파라미터가 필요합니다 (양의 정수)', status: 400 };
+  }
+  const typesRaw = typeof query['types'] === 'string' ? query['types'] : 'episodic,working';
+  const types = typesRaw.split(',').map(t => t.trim()).filter(Boolean);
+  if (types.includes('core')) {
+    return { error: 'core 타입 기억은 삭제할 수 없습니다', status: 400 };
+  }
+  const allowedTypes = ['working', 'episodic', 'semantic', 'procedural', 'vault'];
+  const invalid = types.filter(t => !allowedTypes.includes(t));
+  if (invalid.length > 0) {
+    return { error: `허용되지 않는 타입: ${invalid.join(', ')}`, status: 400 };
+  }
+  return { olderThanDays, types };
+}
+
+/**
  * Admin 라우터 생성
  */
 export function createAdminRouter(
@@ -628,6 +650,58 @@ export function createAdminRouter(
         error: '메타 메모리 통계 조회 실패',
         message: error instanceof Error ? error.message : 'Unknown error'
       });
+    }
+  });
+
+  // Project stats (Issue #81)
+  router.get('/memory/project/:project_id/stats', async (req, res) => {
+    try {
+      if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      const { project_id } = req.params;
+      const total = (db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0`).get(project_id) as { c: number }).c;
+      const byTypeRows = db.prepare(`SELECT type, COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0 GROUP BY type`).all(project_id) as Array<{ type: string; c: number }>;
+      const by_type: Record<string, number> = {};
+      for (const row of byTypeRows) { by_type[row.type] = row.c; }
+      const dates = db.prepare(`SELECT MIN(created_at) as oldest, MAX(created_at) as newest FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0`).get(project_id) as { oldest: string | null; newest: string | null };
+      return res.json({ project_id, total, by_type, oldest_created_at: dates.oldest, newest_created_at: dates.newest });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 통계 조회 실패', message: String(error) });
+    }
+  });
+
+  // Project cleanup preview (Issue #81)
+  router.get('/memory/project/:project_id/cleanup/preview', async (req, res) => {
+    try {
+      if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      const { project_id } = req.params;
+      const parsed = parseCleanupParams(req.query as Record<string, unknown>);
+      if ('error' in parsed) return res.status(parsed.status).json({ error: parsed.error });
+      const { olderThanDays, types } = parsed;
+      const placeholders = types.map(() => '?').join(', ');
+      const rows = db.prepare(
+        `SELECT id, content, type, created_at FROM memory_item WHERE project_id = ? AND type IN (${placeholders}) AND created_at < datetime('now', '-${olderThanDays} days') AND COALESCE(is_deleted, 0) = 0`
+      ).all(project_id, ...types) as Array<{ id: string; content: string; type: string; created_at: string }>;
+      return res.json({ would_delete: rows.length, items: rows });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 정리 미리보기 실패', message: String(error) });
+    }
+  });
+
+  // Project cleanup delete (Issue #81)
+  router.delete('/memory/project/:project_id/cleanup', async (req, res) => {
+    try {
+      if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      const { project_id } = req.params;
+      const parsed = parseCleanupParams(req.query as Record<string, unknown>);
+      if ('error' in parsed) return res.status(parsed.status).json({ error: parsed.error });
+      const { olderThanDays, types } = parsed;
+      const placeholders = types.map(() => '?').join(', ');
+      const result = db.prepare(
+        `DELETE FROM memory_item WHERE project_id = ? AND type IN (${placeholders}) AND created_at < datetime('now', '-${olderThanDays} days') AND COALESCE(is_deleted, 0) = 0`
+      ).run(project_id, ...types);
+      return res.json({ deleted: result.changes });
+    } catch (error) {
+      return res.status(500).json({ error: '프로젝트 정리 실패', message: String(error) });
     }
   });
 

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -33,6 +33,9 @@ function parseCleanupParams(query: Record<string, unknown>): { olderThanDays: nu
   if (!query['older_than_days'] || isNaN(olderThanDays) || olderThanDays <= 0) {
     return { error: 'older_than_days 파라미터가 필요합니다 (양의 정수)', status: 400 };
   }
+  if (olderThanDays > 3650) {
+    return { error: 'older_than_days는 최대 3650일(10년)입니다', status: 400 };
+  }
   const typesRaw = typeof query['types'] === 'string' ? query['types'] : 'episodic,working';
   const types = typesRaw.split(',').map(t => t.trim()).filter(Boolean);
   if (types.includes('core')) {
@@ -658,6 +661,9 @@ export function createAdminRouter(
     try {
       if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
       const { project_id } = req.params;
+      if (!project_id || project_id.length > 200) {
+        return res.status(400).json({ error: 'project_id는 1~200자여야 합니다' });
+      }
       const total = (db.prepare(`SELECT COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0`).get(project_id) as { c: number }).c;
       const byTypeRows = db.prepare(`SELECT type, COUNT(*) as c FROM memory_item WHERE project_id = ? AND COALESCE(is_deleted, 0) = 0 GROUP BY type`).all(project_id) as Array<{ type: string; c: number }>;
       const by_type: Record<string, number> = {};
@@ -674,6 +680,9 @@ export function createAdminRouter(
     try {
       if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
       const { project_id } = req.params;
+      if (!project_id || project_id.length > 200) {
+        return res.status(400).json({ error: 'project_id는 1~200자여야 합니다' });
+      }
       const parsed = parseCleanupParams(req.query as Record<string, unknown>);
       if ('error' in parsed) return res.status(parsed.status).json({ error: parsed.error });
       const { olderThanDays, types } = parsed;
@@ -692,6 +701,9 @@ export function createAdminRouter(
     try {
       if (!db) return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
       const { project_id } = req.params;
+      if (!project_id || project_id.length > 200) {
+        return res.status(400).json({ error: 'project_id는 1~200자여야 합니다' });
+      }
       const parsed = parseCleanupParams(req.query as Record<string, unknown>);
       if ('error' in parsed) return res.status(parsed.status).json({ error: parsed.error });
       const { olderThanDays, types } = parsed;

--- a/src/test/test-meta-memory-e2e.spec.ts
+++ b/src/test/test-meta-memory-e2e.spec.ts
@@ -44,7 +44,12 @@ describe('Meta-Memory 통합 E2E 테스트', () => {
     } catch (error) {
       // 이미 존재하는 경우 무시
     }
-    
+    try {
+      DatabaseUtils.run(db, 'ALTER TABLE memory_item ADD COLUMN project_id TEXT');
+    } catch (error) {
+      // 이미 존재하는 경우 무시
+    }
+
     // meta_memory_stats 테이블 마이그레이션 실행
     const migrationSQL = `
       CREATE TABLE IF NOT EXISTS meta_memory_stats (

--- a/src/test/test-reflexion-e2e.spec.ts
+++ b/src/test/test-reflexion-e2e.spec.ts
@@ -55,7 +55,12 @@ async function testReflexionE2E() {
     } catch (error) {
       // 이미 존재하는 경우 무시
     }
-    
+    try {
+      DatabaseUtils.run(testDb, 'ALTER TABLE memory_item ADD COLUMN project_id TEXT');
+    } catch (error) {
+      // 이미 존재하는 경우 무시
+    }
+
     // FTS5 마이그레이션 상태 테이블 생성
     initializeMigrationStatusTable(testDb);
     setMigrationStatus(testDb, 'in_progress');


### PR DESCRIPTION
## Summary

- Adds `project_id` optional parameter to `remember`, `recall`, and `memory_injection` MCP tools so AI agents can scope memories to a specific project
- New DB migration (032) adds `project_id TEXT NULL` column + partial composite index on `memory_item`
- New HTTP admin endpoints: `GET/DELETE /admin/memory/project/:project_id/cleanup` and `GET /admin/memory/project/:project_id/stats`

## Changes

- `packages/memento-core` — Migration 032, shared types, remember/recall/memory_injection tools updated
- `packages/memento-server` — 3 new project admin routes with input validation (project_id length, older_than_days 1–3650)
- `docs/superpowers/` — Design spec and implementation plan

## Test Plan

- [x] `remember` stores `project_id` in DB (2 new tests)
- [x] `recall` post-filters by `project_id` (new tests)
- [x] Admin routes: stats, preview, delete — all 30 tests passing
- [x] `older_than_days > 3650` → 400, `project_id > 200 chars` → 400
- [x] Full test suite: 4175 passing, 11 pre-existing failures unchanged

## Notes

`project_id` filtering in recall/memory_injection uses in-memory post-filter (same pattern as `owner_id`/`process_id`/`session_id`). This is a documented MVP trade-off — may return fewer results than `limit` when project memories are sparse. SQL-level filtering is a future optimization path.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)