### PR TITLE
fix: use a writable server-info config dir in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN npm ci --omit=dev --ignore-scripts && \
     fi
 
 # Create data directory
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data /app/.memento
 
 # Create non-root user
 RUN groupadd -g 1001 nodejs

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -5,6 +5,7 @@ x-default-environment: &default-environment
   MCP_SERVER_NAME: ${MCP_SERVER_NAME:-memento-memory}
   MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-0.1.0}
   DB_PATH: "/app/data/memory.db"
+  MEMENTO_CONFIG_DIR: "/app/.memento"
   LOG_LEVEL: ${LOG_LEVEL:-info}
   LOG_FILE: ${LOG_FILE:-}
   EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-minilm}

--- a/packages/memento-server/src/cli.ts
+++ b/packages/memento-server/src/cli.ts
@@ -4,9 +4,6 @@
  * 명세: REQ-CLI-1, REQ-OPT-1~3, REQ-CFG-1, REQ-IO-4, AC8. 서브커맨드: recall, remember, forget, memory_injection
  */
 
-import os from 'os';
-import path from 'path';
-
 function writeStdout(message: string): Promise<void> {
   return new Promise((resolve, reject) => {
     process.stdout.write(message, (error) => {
@@ -120,7 +117,13 @@ const preOptions = parseCli(process.argv);
 loadEnv({ envFile: preOptions.envFile, configDir: preOptions.configDir });
 
 // 2) server-info import (env 로드 이후)
-const { readServerInfo, isServerAlive, callToolViaHttp, deleteServerInfo } = await import('./server/server-info.js');
+const {
+  readServerInfo,
+  isServerAlive,
+  callToolViaHttp,
+  deleteServerInfo,
+  resolveServerInfoConfigDir,
+} = await import('./server/server-info.js');
 
 const subcommand = preOptions.subcommand;
 const subIdx = preOptions.subIdx;
@@ -200,10 +203,7 @@ async function main(): Promise<number> {
   }
 
   // configDir 결정
-  const configDir =
-    preOptions.configDir ??
-    process.env.MEMENTO_CONFIG_DIR ??
-    path.join(os.homedir(), '.memento');
+  const configDir = preOptions.configDir ?? resolveServerInfoConfigDir();
 
   // 서버 발견
   const serverInfo = await readServerInfo(configDir);

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -6,9 +6,8 @@
 
 import express from 'express';
 import { existsSync } from 'fs';
-import { homedir } from 'os';
 import { join } from 'path';
-import { writeServerInfo, deleteServerInfo } from './server-info.js';
+import { writeServerInfo, deleteServerInfo, resolveServerInfoConfigDir } from './server-info.js';
 import { WebSocketServer } from 'ws';
 import type { WebSocket } from 'ws';
 import cors from 'cors';
@@ -369,7 +368,7 @@ async function cleanup() {
 
   try {
     // delete server.json on shutdown
-    const configDirForCleanup = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+    const configDirForCleanup = resolveServerInfoConfigDir();
     try {
       await deleteServerInfo(configDirForCleanup);
     } catch {
@@ -691,8 +690,13 @@ async function startServer() {
     if (address && typeof address === 'object') {
       logger.info('서버 바인딩 완료', { address: address.address, port: address.port });
       // write server.json for CLI discovery
-      const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
-      void writeServerInfo(configDir, address.port);
+      const configDir = resolveServerInfoConfigDir();
+      void writeServerInfo(configDir, address.port).catch((error) => {
+        logger.error('server.json 기록 실패', {
+          error: error instanceof Error ? error.message : String(error),
+          configDir,
+        });
+      });
     }
   });
 }

--- a/packages/memento-server/src/server/index.ts
+++ b/packages/memento-server/src/server/index.ts
@@ -38,8 +38,7 @@ import Database from 'better-sqlite3';
 import express from 'express';
 import { createServer as createHttpServer } from 'http';
 import type { AddressInfo } from 'net';
-import { homedir } from 'os';
-import { writeServerInfo, deleteServerInfo } from './server-info.js';
+import { writeServerInfo, deleteServerInfo, resolveServerInfoConfigDir } from './server-info.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 /**
@@ -601,7 +600,7 @@ async function startMgmtHttpServer(): Promise<void> {
     mgmtHttpServer!.once('error', rejectPromise);
     mgmtHttpServer!.listen(0, '127.0.0.1', async () => {
       const addr = mgmtHttpServer!.address() as AddressInfo;
-      const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+      const configDir = resolveServerInfoConfigDir();
       try {
         await writeServerInfo(configDir, addr.port);
       } catch (err) {
@@ -720,7 +719,7 @@ async function cleanup() {
 
   // server.json 삭제 및 관리 HTTP 서버 종료
   if (mgmtHttpServer) {
-    const configDir = process.env.MEMENTO_CONFIG_DIR ?? join(homedir(), '.memento');
+    const configDir = resolveServerInfoConfigDir();
     try {
       await deleteServerInfo(configDir);
     } catch {

--- a/packages/memento-server/src/server/server-info.spec.ts
+++ b/packages/memento-server/src/server/server-info.spec.ts
@@ -6,6 +6,7 @@ import {
   writeServerInfo,
   readServerInfo,
   deleteServerInfo,
+  resolveServerInfoConfigDir,
 } from './server-info.js';
 
 describe('server-info', () => {
@@ -42,5 +43,32 @@ describe('server-info', () => {
 
   it('deleteServerInfo는 파일이 없어도 에러를 던지지 않는다', async () => {
     await expect(deleteServerInfo(tmpDir)).resolves.not.toThrow();
+  });
+
+  it('resolveServerInfoConfigDir는 명시적 env를 우선 사용한다', () => {
+    expect(
+      resolveServerInfoConfigDir({
+        env: { MEMENTO_CONFIG_DIR: '/custom/config', DOCKER: 'true' },
+        homedirPath: '/home/memento',
+      })
+    ).toBe('/custom/config');
+  });
+
+  it('resolveServerInfoConfigDir는 docker 환경에서 /app/.memento를 기본값으로 사용한다', () => {
+    expect(
+      resolveServerInfoConfigDir({
+        env: { DOCKER: 'true' },
+        homedirPath: '/home/memento',
+      })
+    ).toBe('/app/.memento');
+  });
+
+  it('resolveServerInfoConfigDir는 일반 환경에서 홈 디렉터리 하위를 사용한다', () => {
+    expect(
+      resolveServerInfoConfigDir({
+        env: {},
+        homedirPath: '/Users/tester',
+      })
+    ).toBe('/Users/tester/.memento');
   });
 });

--- a/packages/memento-server/src/server/server-info.ts
+++ b/packages/memento-server/src/server/server-info.ts
@@ -1,3 +1,4 @@
+import { homedir } from 'os';
 import { readFile, writeFile, unlink, mkdir } from 'fs/promises';
 import { join } from 'path';
 
@@ -7,8 +8,31 @@ export interface ServerInfo {
   startedAt: string;
 }
 
+type ConfigDirResolutionOptions = {
+  env?: NodeJS.ProcessEnv;
+  homedirPath?: string;
+};
+
 function serverInfoPath(configDir: string): string {
   return join(configDir, 'server.json');
+}
+
+export function resolveServerInfoConfigDir(
+  options: ConfigDirResolutionOptions = {}
+): string {
+  const env = options.env ?? process.env;
+  const explicit = env.MEMENTO_CONFIG_DIR?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  // Docker 이미지는 비루트 사용자로 실행되므로 HOME 기반 경로가 비어 있거나
+  // 부모 디렉터리가 생성되지 않은 경우를 대비해 앱 작업 디렉터리 하위를 기본값으로 사용한다.
+  if (env.DOCKER === 'true') {
+    return '/app/.memento';
+  }
+
+  return join(options.homedirPath ?? process.env.HOME ?? homedir(), '.memento');
 }
 
 export async function writeServerInfo(configDir: string, port: number): Promise<void> {

--- a/scripts/start-container.sh
+++ b/scripts/start-container.sh
@@ -4,6 +4,9 @@
 echo "🔧 데이터 디렉토리 권한 설정 중..."
 chmod -R 755 /app/data
 chown -R memento:nodejs /app/data
+mkdir -p /app/.memento
+chmod 755 /app/.memento
+chown -R memento:nodejs /app/.memento
 
 # HTTP 서버 시작
 echo "🚀 Memento HTTP 서버 시작 중..."


### PR DESCRIPTION
## Summary
- add a shared `resolveServerInfoConfigDir()` helper for CLI and server startup paths
- use `/app/.memento` as the Docker default for `server.json` instead of relying on `/home/memento`
- catch async `writeServerInfo()` failures in the HTTP server so permission errors do not crash the process
- create and chown `/app/.memento` in the container startup path

## Root cause
The server wrote `server.json` under `os.homedir()/.memento` when `MEMENTO_CONFIG_DIR` was unset. In Docker this resolved to `/home/memento/.memento`, and the async `writeServerInfo()` call in `http-server.ts` was not awaited or caught, so an `EACCES` from `mkdir('/home/memento')` surfaced as an uncaught exception and terminated the process.

## Verification
- `npx vitest run packages/memento-server/src/server/server-info.spec.ts --reporter=basic`
- `npx vitest run packages/memento-server/src/server/http-server.spec.ts --reporter=basic`