### PR TITLE
refactor: hybrid-search 복잡도 감소 (issue #172)

### DIFF
--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -1518,13 +1518,13 @@ export class HybridSearchEngine {
         }
       }
       
-      // Step 4: 중복 제거 (방어적 프로그래밍)
+      // Step 3: 중복 제거 (방어적 프로그래밍)
       const deduplicatedResults = this.deduplicateResults(combinedResults);
-      
-      // Step 5: finalScore 기준 내림차순 정렬
+
+      // Step 4: finalScore 기준 내림차순 정렬
       const sortedResults = this.sortByFinalScore(deduplicatedResults);
-      
-      // Step 6: 제한 개수만큼 반환
+
+      // Step 5: 제한 개수만큼 반환
       return sortedResults.slice(0, limit);
     } catch (error) {
       throw new SearchError(

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -1625,8 +1625,9 @@ export class HybridSearchEngine {
       const feedbackRepo = new FeedbackRepository(db);
       return feedbackRepo.getNetScores(memoryIds, 90);
     } catch (err) {
+      const maskedError = err instanceof Error ? PIIMasker.maskError(err) : { message: String(err), name: 'Error' };
       logger.warn('피드백 순합 조회 실패 — 피드백 없이 진행', {
-        error: err instanceof Error ? err.message : String(err),
+        error: maskedError.message,
       });
       return new Map();
     }

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -1492,76 +1492,27 @@ export class HybridSearchEngine {
         weights
       );
       
-      // Step 2: 관계 그래프와 통합 점수를 활용하여 더 정교한 관련성 평가를 수행합니다.
+      // Step 2: 랭킹 컨텍스트 조회 및 점수 정규화
       if (db) {
         const memoryIds = combinedResults.map(r => r.id);
         if (memoryIds.length > 0) {
-          // 관계 그래프를 기반으로 관계 가중치와 관계 정보를 계산하여 관련성 점수에 반영합니다.
-          const relationData = await this.fetchRelationWeights(db, memoryIds);
-          const relationWeights = relationData.weights;
-          const relationInfo = relationData.relations;
-          
-          // 통합 점수 기능이 활성화된 경우 추가적인 관련성 지표를 조회합니다.
-          let consolidationScores: Map<string, number> = new Map();
-          if (mementoConfig.consolidationScoreEnabled) {
-            consolidationScores = this.fetchConsolidationScores(db, memoryIds);
-          }
-          
-          // Procedural Memory 특화 가중치를 위한 매칭 정보 조회
-          const proceduralMemoryMatches = this.proceduralMemoryMatcher.fetchProceduralMemoryMatches(db, memoryIds, query);
-          
-          // Process Attribute 적합도 (Issue #91): process_id로 검색 시 process별 주제/속성 반영
-          let processAttributes: ProcessAttribute | null = null;
-          let memoryDetailsMap: Map<string, { tags?: string[]; workflow_name?: string | null; skill_name?: string | null }> = new Map();
-          const processId = query?.filters?.process_id != null
-            ? (Array.isArray(query.filters.process_id) ? query.filters.process_id[0] : query.filters.process_id)
-            : undefined;
-          if (processId) {
-            const attrRepo = new ProcessAttributeRepository(db);
-            processAttributes = attrRepo.getByProcessId(processId);
-            const placeholders = memoryIds.map(() => '?').join(',');
-            const rows = db.prepare(
-              `SELECT id, tags, workflow_name, skill_name FROM memory_item WHERE id IN (${placeholders})`
-            ).all(...memoryIds) as Array<{ id: string; tags: string | null; workflow_name: string | null; skill_name: string | null }>;
-            for (const row of rows) {
-              let tags: string[] = [];
-              if (row.tags) {
-                try {
-                  const parsed = JSON.parse(row.tags);
-                  tags = Array.isArray(parsed) ? parsed : [];
-                } catch {
-                  tags = [];
-                }
-              }
-              memoryDetailsMap.set(row.id, {
-                tags,
-                workflow_name: row.workflow_name ?? null,
-                skill_name: row.skill_name ?? null
-              });
-            }
-          }
-          
-          let feedbackNetByMemory = new Map<string, number>();
-          try {
-            const feedbackRepo = new FeedbackRepository(db);
-            feedbackNetByMemory = feedbackRepo.getNetScores(memoryIds, 90);
-          } catch (err) {
-            logger.warn('피드백 순합 조회 실패 — 피드백 없이 진행', {
-              error: err instanceof Error ? err.message : String(err),
-            });
-          }
-
-          // Step 3: 점수 정규화 (관계 가중치와 통합 점수를 반영하여 각 결과의 최종 점수를 재계산)
+          const processId =
+            query?.filters?.process_id != null
+              ? Array.isArray(query.filters.process_id)
+                ? query.filters.process_id[0]
+                : query.filters.process_id
+              : undefined;
+          const ctx = await this.buildRankingContext(db, memoryIds, processId, query);
           this.normalizeScores(
             combinedResults,
-            relationWeights,
-            relationInfo,
-            consolidationScores,
-            proceduralMemoryMatches,
+            ctx.relationWeights,
+            ctx.relationInfo,
+            ctx.consolidationScores,
+            ctx.proceduralMatches,
             includeRelations,
-            processAttributes,
-            memoryDetailsMap,
-            feedbackNetByMemory,
+            ctx.processAttributes,
+            ctx.memoryDetailsMap,
+            ctx.feedbackScores,
             query?.include_score_breakdown === true
           );
         }
@@ -1680,6 +1631,52 @@ export class HybridSearchEngine {
       }
     }
     return { processAttributes, memoryDetailsMap };
+  }
+
+  private async buildRankingContext(
+    db: Database.Database,
+    memoryIds: string[],
+    processId: string | undefined,
+    query?: HybridSearchQuery
+  ): Promise<{
+    relationWeights: Map<string, number>;
+    relationInfo: Map<string, RelationInfoRow[]>;
+    consolidationScores: Map<string, number>;
+    proceduralMatches: Map<string, ProceduralMemoryMatch>;
+    processAttributes: ProcessAttribute | null;
+    memoryDetailsMap: Map<string, { tags?: string[]; workflow_name?: string | null; skill_name?: string | null }>;
+    feedbackScores: Map<string, number>;
+  }> {
+    const relationData = await this.fetchRelationWeights(db, memoryIds);
+
+    let consolidationScores: Map<string, number> = new Map();
+    if (mementoConfig.consolidationScoreEnabled) {
+      consolidationScores = this.fetchConsolidationScores(db, memoryIds);
+    }
+
+    const proceduralMatches = this.proceduralMemoryMatcher.fetchProceduralMemoryMatches(
+      db,
+      memoryIds,
+      query
+    );
+
+    const { processAttributes, memoryDetailsMap } = this.fetchProcessAttributeContext(
+      db,
+      memoryIds,
+      processId
+    );
+
+    const feedbackScores = this.fetchFeedbackScores(db, memoryIds);
+
+    return {
+      relationWeights: relationData.weights,
+      relationInfo: relationData.relations,
+      consolidationScores,
+      proceduralMatches,
+      processAttributes,
+      memoryDetailsMap,
+      feedbackScores,
+    };
   }
 
   // fetchProceduralMemoryMatches 메서드는 ProceduralMemoryMatcher 클래스로 분리됨

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -1617,6 +1617,70 @@ export class HybridSearchEngine {
     return scores;
   }
 
+  private fetchFeedbackScores(
+    db: Database.Database,
+    memoryIds: string[]
+  ): Map<string, number> {
+    try {
+      const feedbackRepo = new FeedbackRepository(db);
+      return feedbackRepo.getNetScores(memoryIds, 90);
+    } catch (err) {
+      logger.warn('피드백 순합 조회 실패 — 피드백 없이 진행', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Map();
+    }
+  }
+
+  private fetchProcessAttributeContext(
+    db: Database.Database,
+    memoryIds: string[],
+    processId: string | undefined
+  ): {
+    processAttributes: ProcessAttribute | null;
+    memoryDetailsMap: Map<string, { tags?: string[]; workflow_name?: string | null; skill_name?: string | null }>;
+  } {
+    if (!processId) {
+      return { processAttributes: null, memoryDetailsMap: new Map() };
+    }
+    const attrRepo = new ProcessAttributeRepository(db);
+    const processAttributes = attrRepo.getByProcessId(processId);
+    const memoryDetailsMap = new Map<
+      string,
+      { tags?: string[]; workflow_name?: string | null; skill_name?: string | null }
+    >();
+    if (memoryIds.length > 0) {
+      const placeholders = memoryIds.map(() => '?').join(',');
+      const rows = db
+        .prepare(
+          `SELECT id, tags, workflow_name, skill_name FROM memory_item WHERE id IN (${placeholders})`
+        )
+        .all(...memoryIds) as Array<{
+        id: string;
+        tags: string | null;
+        workflow_name: string | null;
+        skill_name: string | null;
+      }>;
+      for (const row of rows) {
+        let tags: string[] = [];
+        if (row.tags) {
+          try {
+            const parsed = JSON.parse(row.tags);
+            tags = Array.isArray(parsed) ? parsed : [];
+          } catch {
+            tags = [];
+          }
+        }
+        memoryDetailsMap.set(row.id, {
+          tags,
+          workflow_name: row.workflow_name ?? null,
+          skill_name: row.skill_name ?? null,
+        });
+      }
+    }
+    return { processAttributes, memoryDetailsMap };
+  }
+
   // fetchProceduralMemoryMatches 메서드는 ProceduralMemoryMatcher 클래스로 분리됨
 
   /**

--- a/packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts
+++ b/packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts
@@ -3,54 +3,53 @@
  * 의존성 주입 및 객체 생성 관리
  */
 
-import { HybridSearchEngine, resolveQueryUnifiedEmbeddingForHybridSearch } from '../algorithms/hybrid-search-engine.js';
+import {
+  HybridSearchEngine,
+  AdaptiveWeightCalculator,
+  resolveQueryUnifiedEmbeddingForHybridSearch,
+} from '../algorithms/hybrid-search-engine.js';
+import type {
+  ITextSearchEngine,
+  IEmbeddingService,
+  IVectorSearchEngine,
+  ISearchResultCombiner,
+  IAdaptiveWeightCalculator,
+  ISearchLogger,
+  HybridSearchQuery,
+} from '../algorithms/hybrid-search-engine.js';
 import { SearchEngine } from '../algorithms/search-engine.js';
+import { SearchResultCombiner } from '../algorithms/search-result-combiner.js';
 import { MemoryEmbeddingService } from '../../memory/services/memory-embedding-service.js';
 import { VectorSearchEngine } from '../algorithms/vector-search-engine.js';
 import { logger } from '../../../shared/utils/logger.js';
 import type { Database } from 'better-sqlite3';
 
-// Mock implementations for missing services
-class MockSearchResultCombiner {
-  combine(textResults: any[], vectorResults: any[], textWeight: number, vectorWeight: number): any[] {
-    return [...vectorResults, ...textResults];
+class DefaultSearchLogger implements ISearchLogger {
+  logSearchStart(searchId: string, query: HybridSearchQuery): void {
+    logger.debug('하이브리드 검색 시작', { searchId, query: query.query });
   }
-}
 
-class MockAdaptiveWeightCalculator {
-  calculateWeights(query: string, vectorWeight: number, textWeight: number): { vectorWeight: number, textWeight: number } {
-    return { vectorWeight: 0.6, textWeight: 0.4 };
+  logSearchStep(searchId: string, step: string, data: unknown): void {
+    logger.debug(`하이브리드 검색 단계: ${step}`, { searchId, data });
   }
-}
 
-class MockSearchLogger {
-  logSearchStart(query: string): void {
-    logger.info('검색 시작', { query });
-  }
-  
-  logSearchStep(step: string, details?: any): void {
-    logger.debug('검색 단계', { step, details });
-  }
-  
-  logSearchComplete(searchId: string, result: { items: unknown[]; total_count: number }, queryTime: number): void {
-    logger.info('검색 완료', {
+  logSearchComplete(
+    searchId: string,
+    result: { items: unknown[]; total_count: number },
+    queryTime: number
+  ): void {
+    logger.info('하이브리드 검색 완료', {
       searchId,
       resultCount: result.total_count,
-      duration: queryTime
+      queryTime,
     });
   }
-  
-  logSearchError(query: string, error: Error): void {
-    logger.error('검색 에러', {
-      query,
-      error: error.message
-    });
+
+  logSearchError(searchId: string, error: unknown, query: HybridSearchQuery): void {
+    logger.error('하이브리드 검색 오류', { searchId, error, query: query.query });
   }
 }
 
-/**
- * 하이브리드 검색 엔진 팩토리
- */
 export interface CreateDefaultHybridEngineOptions {
   /** 지정 시 해당 TOML에서 랭킹 가중치 로드 (미지정 시 기본 config/ranking-weights.toml 등) */
   rankingWeightsPath?: string;
@@ -68,9 +67,9 @@ export class HybridSearchFactory {
     const textSearchEngine = new SearchEngine();
     const emb = embeddingService ?? new MemoryEmbeddingService();
     const vectorSearchEngine = new VectorSearchEngine();
-    const resultCombiner = new MockSearchResultCombiner();
-    const weightCalculator = new MockAdaptiveWeightCalculator();
-    const logger = new MockSearchLogger();
+    const resultCombiner = new SearchResultCombiner();
+    const weightCalculator = new AdaptiveWeightCalculator();
+    const searchLogger = new DefaultSearchLogger();
 
     return new HybridSearchEngine(
       textSearchEngine,
@@ -78,7 +77,7 @@ export class HybridSearchFactory {
       vectorSearchEngine,
       resultCombiner,
       weightCalculator,
-      logger,
+      searchLogger,
       resolveQueryUnifiedEmbeddingForHybridSearch(emb),
       undefined,
       undefined,
@@ -90,12 +89,12 @@ export class HybridSearchFactory {
    * 의존성 주입으로 하이브리드 검색 엔진 생성
    */
   static createEngine(
-    textSearchEngine: any,
-    embeddingService: any,
-    vectorSearchEngine: any,
-    resultCombiner: any,
-    weightCalculator: any,
-    logger: any
+    textSearchEngine: ITextSearchEngine,
+    embeddingService: IEmbeddingService,
+    vectorSearchEngine: IVectorSearchEngine,
+    resultCombiner: ISearchResultCombiner,
+    weightCalculator: IAdaptiveWeightCalculator,
+    searchLogger: ISearchLogger
   ): HybridSearchEngine {
     const queryUnified = resolveQueryUnifiedEmbeddingForHybridSearch(embeddingService);
     return new HybridSearchEngine(
@@ -104,7 +103,7 @@ export class HybridSearchFactory {
       vectorSearchEngine,
       resultCombiner,
       weightCalculator,
-      logger,
+      searchLogger,
       queryUnified
     );
   }


### PR DESCRIPTION
## Summary

- `HybridSearchFactory`의 Mock 클래스 3개 제거 → 실제 구현체(`SearchResultCombiner`, `AdaptiveWeightCalculator`) 사용
- `MockSearchLogger` 대신 `ISearchLogger`를 올바르게 구현한 `DefaultSearchLogger` 인라인 추가
- `createEngine()` 파라미터 `any` × 6 → 타입 인터페이스로 교체
- `combineAndSortResults` 내 ~50줄 DB 조회 블록을 `buildRankingContext` private 메서드로 추출
- `fetchProcessAttributeContext`, `fetchFeedbackScores` private 메서드 추가

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm test` 전체 4196개 green

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)