### PR TITLE
fix(docker): inject OPENAI_LLM_MODEL and LLM_PROVIDER to prevent silent fallback

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -11,6 +11,11 @@ x-default-environment: &default-environment
   EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-minilm}
   OPENAI_API_KEY: ${OPENAI_API_KEY:-}
   OPENAI_MODEL: ${OPENAI_MODEL:-text-embedding-3-small}
+  # LLM 제공자 및 모델 설정 (임베딩과 분리)
+  # OPENAI_MODEL  → 임베딩 전용 (text-embedding-*)
+  # OPENAI_LLM_MODEL → 추출·요약 등 LLM 호출 전용 (gpt-4o, gpt-4o-mini 등)
+  LLM_PROVIDER: ${LLM_PROVIDER:-auto}
+  OPENAI_LLM_MODEL: ${OPENAI_LLM_MODEL:-gpt-4o-mini}
   GEMINI_API_KEY: ${GEMINI_API_KEY:-}
   GEMINI_MODEL: ${GEMINI_MODEL:-text-embedding-004}
   SEARCH_DEFAULT_LIMIT: ${SEARCH_DEFAULT_LIMIT:-10}

--- a/env.example
+++ b/env.example
@@ -33,7 +33,7 @@ LOG_FILE=
 EMBEDDING_PROVIDER=minilm   # Options: tfidf, lightweight, minilm, openai, gemini
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=text-embedding-3-large  # 임베딩 모델 (text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002)
-OPENAI_LLM_MODEL=  # LLM 채팅 모델 (필요 시 명시, 예: gpt-4o-mini)
+OPENAI_LLM_MODEL=gpt-4o-mini  # LLM 채팅 모델 (추출·요약용; 임베딩용 OPENAI_MODEL과 구분)
 GEMINI_API_KEY=your_gemini_api_key_here
 GEMINI_MODEL=text-embedding-004
 # EMBEDDING_DIMENSIONS를 지정하지 않으면 제공자 기본값을 사용

--- a/packages/memento-core/src/shared/services/llm-client-initializer.ts
+++ b/packages/memento-core/src/shared/services/llm-client-initializer.ts
@@ -97,6 +97,20 @@ export class LLMClientInitializer {
       selectedProvider
     );
 
+    const llmModel =
+      result.preferredProvider === 'openai'
+        ? (mementoConfig.openaiLlmModel ?? 'gpt-4o-mini')
+        : result.preferredProvider === 'ollama'
+          ? (mementoConfig.ollamaModel ?? 'unknown')
+          : result.preferredProvider === 'gemini'
+            ? 'gemini (API key only)'
+            : 'none';
+    logger.info('LLM provider initialized', {
+      preferredProvider: result.preferredProvider,
+      llmModel,
+      initializedProviders: result.initializedProviders,
+    });
+
     return result;
   }
 

--- a/packages/memento-core/src/shared/services/llm-client-initializer.ts
+++ b/packages/memento-core/src/shared/services/llm-client-initializer.ts
@@ -97,17 +97,9 @@ export class LLMClientInitializer {
       selectedProvider
     );
 
-    const llmModel =
-      result.preferredProvider === 'openai'
-        ? (mementoConfig.openaiLlmModel ?? 'gpt-4o-mini')
-        : result.preferredProvider === 'ollama'
-          ? (mementoConfig.ollamaModel ?? 'unknown')
-          : result.preferredProvider === 'gemini'
-            ? 'gemini (API key only)'
-            : 'none';
     logger.info('LLM provider initialized', {
       preferredProvider: result.preferredProvider,
-      llmModel,
+      llmModel: this.resolveLlmModelLabel(result.preferredProvider),
       initializedProviders: result.initializedProviders,
     });
 
@@ -126,9 +118,16 @@ export class LLMClientInitializer {
     };
   }
 
+  private resolveLlmModelLabel(provider: LLMClientInitializationResult['preferredProvider']): string {
+    if (provider === 'openai') return mementoConfig.openaiLlmModel ?? 'gpt-4o-mini';
+    if (provider === 'ollama') return mementoConfig.ollamaModel;
+    if (provider === 'gemini') return 'gemini (API key only)';
+    return 'none';
+  }
+
   /**
    * 환경 변수 우선순위에 따라 provider 선택
-   * 
+   *
    * @returns 선택된 provider
    */
   private getSelectedProvider(): LLMProvider {


### PR DESCRIPTION
## Summary

- `docker-compose.base.yml`에 `LLM_PROVIDER`와 `OPENAI_LLM_MODEL` 환경변수를 명시적으로 주입
- `env.example`의 `OPENAI_LLM_MODEL` 기본값을 `gpt-4o-mini`로 설정하여 Docker 기본값과 일치
- `LLMClientInitializer.initialize()` 완료 시 선택된 provider와 모델을 startup 로그로 기록

## 변경 동기

Docker 런타임에서 `OPENAI_API_KEY`만 있고 `LLM_PROVIDER`/`OPENAI_LLM_MODEL`이 주입되지 않으면, LLM auto-select 경로가 silent fallback으로 `gpt-4o-mini`를 사용했습니다. 운영자가 `docker inspect`를 실행하기 전에는 어떤 모델이 사용되는지 알 수 없었습니다.

## 수락 기준 달성

- [x] Docker runtime이 `OPENAI_LLM_MODEL`을 기본 노출
- [x] `docker compose up` 시 숨겨진 서비스 레벨 fallback 없음
- [x] docker-compose.base.yml 주석 및 env.example로 embedding vs LLM 변수 분리 명시
- [x] Startup 로그로 선택된 LLM provider/model 확인 가능

## 참고

- `resolveLlmModelLabel()` 헬퍼 메서드로 중첩 ternary 리팩터
- Gemini LLM 모델 명은 현재 config에 없음 — 별도 이슈로 추적 예정

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)