### PR TITLE
fix baseline cache test and client workspace path drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,10 +111,10 @@
     "docker:prod": "docker-compose -f docker-compose.prod.yml up -d",
     "docker:dev:logs": "docker-compose -f docker-compose.dev.yml logs -f",
     "docker:prod:logs": "docker-compose -f docker-compose.prod.yml logs -f",
-    "build:client": "cd packages/mcp-client && npm run build",
-    "dev:client": "cd packages/mcp-client && npm run dev",
-    "clean:client": "cd packages/mcp-client && npm run clean",
-    "publish:client": "cd packages/mcp-client && npm publish"
+    "build:client": "npm run build -w @memento/client",
+    "dev:client": "npm run dev -w @memento/client",
+    "clean:client": "npm run clean -w @memento/client",
+    "publish:client": "npm publish --workspace @memento/client"
   },
   "keywords": [
     "mcp",

--- a/packages/mcp-client/package.json
+++ b/packages/mcp-client/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@memento/client",
+  "name": "@memento/client-legacy",
   "version": "0.1.0",
-  "description": "Memento MCP Server client library for AI Agents",
+  "description": "Legacy client package kept only as a migration reference",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -52,7 +52,5 @@
   "peerDependencies": {
     "typescript": ">=5.0.0"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts
@@ -823,50 +823,82 @@ describe('TripleExtractionBatchJob', () => {
       // Given: 동일한 content를 가진 여러 Episodic Memory 생성
       const memoryCount = 10;
       const sameContent = 'Alice works at Microsoft. She is a data scientist.';
-      
-      for (let i = 0; i < memoryCount; i++) {
-        const memoryId = generateId();
-        DatabaseUtils.run(db, `
-          INSERT INTO memory_item (id, type, content, importance, triple_extracted, triple_extracted_status)
-          VALUES (?, ?, ?, ?, ?, ?)
-        `, [memoryId, 'episodic', sameContent, 0.5, null, null]);
+      const previousAllowLlmInTests = process.env.MEMENTO_ALLOW_LLM_IN_TESTS;
+      let extractWithLLMSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+      try {
+        process.env.MEMENTO_ALLOW_LLM_IN_TESTS = 'true';
+
+        extractWithLLMSpy = vi.spyOn(
+          tripleExtractionService as unknown as {
+            extractWithLLM: (
+              observation: string,
+              provider: 'openai' | 'gemini' | 'ollama' | 'auto',
+              options: Record<string, unknown>
+            ) => Promise<unknown>;
+          },
+          'extractWithLLM'
+        ).mockResolvedValue({
+          result: {
+            triples: [
+              {
+                subject: 'Alice',
+                predicate: 'works_at',
+                object: 'Microsoft'
+              }
+            ],
+            extractionInfo: {
+              steps: {
+                canonicalization: false,
+                entityLinking: false
+              }
+            }
+          },
+          rawLLMOutput: '[{"subject":"Alice","predicate":"works_at","object":"Microsoft"}]'
+        });
+
+        for (let i = 0; i < memoryCount; i++) {
+          const memoryId = generateId();
+          DatabaseUtils.run(db, `
+            INSERT INTO memory_item (id, type, content, importance, triple_extracted, triple_extracted_status)
+            VALUES (?, ?, ?, ?, ?, ?)
+          `, [memoryId, 'episodic', sameContent, 0.5, null, null]);
+        }
+
+        // When: 첫 번째 배치 실행 (첫 번째 메모리만 캐시 미스)
+        const result1 = await batchJob.execute(db);
+
+        // Then: 첫 번째 배치에서는 실제 추출 경로가 1회만 호출되어야 함
+        expect(result1).toBeDefined();
+        expect(result1.details.processed).toBe(memoryCount);
+        expect(result1.details.success).toBe(memoryCount);
+        expect(extractWithLLMSpy).toHaveBeenCalledTimes(1);
+
+        // 캐시가 채워진 상태에서 두 번째 배치 실행 (캐시 히트)
+        for (let i = 0; i < memoryCount; i++) {
+          const memoryId = generateId();
+          DatabaseUtils.run(db, `
+            INSERT INTO memory_item (id, type, content, importance, triple_extracted, triple_extracted_status)
+            VALUES (?, ?, ?, ?, ?, ?)
+          `, [memoryId, 'episodic', sameContent, 0.5, null, null]);
+        }
+
+        const result2 = await batchJob.execute(db);
+
+        // Then: 두 번째 배치에서는 캐시 히트로 추가 LLM 호출이 없어야 함
+        expect(result2).toBeDefined();
+        expect(result2.details.processed).toBe(memoryCount);
+        expect(result2.details.success).toBe(memoryCount);
+        expect(extractWithLLMSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        extractWithLLMSpy?.mockRestore();
+
+        if (previousAllowLlmInTests === undefined) {
+          delete process.env.MEMENTO_ALLOW_LLM_IN_TESTS;
+        } else {
+          process.env.MEMENTO_ALLOW_LLM_IN_TESTS = previousAllowLlmInTests;
+        }
       }
-
-      // When: 첫 번째 배치 실행 (캐시 미스)
-      const startTime1 = Date.now();
-      const result1 = await batchJob.execute(db);
-      const endTime1 = Date.now();
-      const duration1 = endTime1 - startTime1;
-
-      // 캐시가 채워진 상태에서 두 번째 배치 실행 (캐시 히트)
-      // 동일한 content를 가진 새로운 메모리 생성
-      for (let i = 0; i < memoryCount; i++) {
-        const memoryId = generateId();
-        DatabaseUtils.run(db, `
-          INSERT INTO memory_item (id, type, content, importance, triple_extracted, triple_extracted_status)
-          VALUES (?, ?, ?, ?, ?, ?)
-        `, [memoryId, 'episodic', sameContent, 0.5, null, null]);
-      }
-
-      const startTime2 = Date.now();
-      const result2 = await batchJob.execute(db);
-      const endTime2 = Date.now();
-      const duration2 = endTime2 - startTime2;
-
-      // Then: 캐시 히트로 인한 성능 향상 확인
-      expect(result1).toBeDefined();
-      expect(result2).toBeDefined();
-      
-      // 캐시 히트 시 더 빠른 처리 시간 (LLM 호출 생략)
-      // 주의: 실제 LLM 호출 시간에 따라 다를 수 있음
-      console.log('\n📊 캐시 성능 비교:');
-      console.log(`  - 첫 번째 배치 (캐시 미스): ${duration1}ms`);
-      console.log(`  - 두 번째 배치 (캐시 히트): ${duration2}ms`);
-      console.log(`  - 성능 향상: ${((duration1 - duration2) / duration1 * 100).toFixed(1)}%`);
-      
-      // 캐시 히트 시 더 빠르거나 비슷한 시간이어야 함 (LLM 호출이 없으므로 더 빠를 것으로 예상)
-      // CI/스케줄링 변동을 고려하여 3배 이내 오차 허용
-      expect(duration2).toBeLessThanOrEqual(Math.max(duration1 * 3, 20));
     });
 
     it('배치 크기에 따른 성능 비교', async () => {

--- a/tests/workspace-client-paths.spec.ts
+++ b/tests/workspace-client-paths.spec.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  name?: string;
+  private?: boolean;
+  scripts?: Record<string, string>;
+};
+
+function readJson(relativePath: string): PackageJson {
+  return JSON.parse(readFileSync(join(process.cwd(), relativePath), 'utf-8')) as PackageJson;
+}
+
+describe('workspace client path contracts', () => {
+  it('root client scripts should target the official @memento/client workspace', () => {
+    const root = readJson('package.json');
+
+    expect(root.scripts?.['build:client']).toBe('npm run build -w @memento/client');
+    expect(root.scripts?.['dev:client']).toBe('npm run dev -w @memento/client');
+    expect(root.scripts?.['clean:client']).toBe('npm run clean -w @memento/client');
+    expect(root.scripts?.['publish:client']).toBe('npm publish --workspace @memento/client');
+  });
+
+  it('legacy packages/mcp-client should not claim the official package name', () => {
+    const legacy = readJson('packages/mcp-client/package.json');
+
+    expect(legacy.name).toBe('@memento/client-legacy');
+    expect(legacy.private).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the flaky triple extraction cache timing assertion with a deterministic cache-hit test so the baseline suite stops depending on wall-clock noise
- point root client scripts at the official `@memento/client` workspace and mark `packages/mcp-client` as a private legacy package to prevent release-path drift
- add a contract test that locks the workspace client script paths and legacy package metadata in place

## Test plan
- [x] `npx vitest run tests/workspace-client-paths.spec.ts tests/npm-publish-bin.spec.ts`
- [x] `npx vitest run packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts -t "캐시 히트 시 성능 향상 확인"`


Made with [Cursor](https://cursor.com)