### PR TITLE
refactor: complete remaining AGENTS compliance remediation

### DIFF
--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -32,6 +32,7 @@ import { getVectorSearchEngine } from './domains/search/algorithms/vector-search
 import { getBatchScheduler } from './infrastructure/scheduler/batch-scheduler.js';
 import { SleepConsolidationService } from './domains/consolidation/services/sleep-consolidation-service.js';
 import { createRelationGraph } from './infrastructure/relation-graph-factory.js';
+import type { RelationGraphPort } from './domains/relation/ports/relation-graph.port.js';
 import { logger } from './shared/utils/logger.js';
 import { WalCheckpointScheduler } from './infrastructure/database/wal-checkpoint-scheduler.js';
 import { DatabaseLockMonitor } from './infrastructure/database/database-lock-monitor.js';
@@ -55,6 +56,7 @@ export interface ServerServices {
   writeCoalescingManager: WriteCoalescingManager;
   metaMemoryService: MetaMemoryService;
   anchorManager: AnchorManager;
+  relationGraph: RelationGraphPort;
   failureDetector: FailureDetector;
   reflexionWorker?: IReflexionWorker;
   walCheckpointScheduler: WalCheckpointScheduler;
@@ -203,8 +205,9 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
     batchScheduler.setTelemetryCleanupRepository(telemetryRepository);
     const telemetryService = new TelemetryService(telemetryRepository, () => getBatchScheduler());
     batchScheduler.setIntrospectionScanCache(introspectionScanCache);
+    const relationGraph = createRelationGraph(db);
     const sleepConsolidationService = new SleepConsolidationService(db, {
-      relationGraph: createRelationGraph(db),
+      relationGraph: relationGraph,
       memoryEmbeddingService: embeddingService,
       telemetryService
     });
@@ -316,6 +319,7 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       writeCoalescingManager,
       metaMemoryService,
       anchorManager,
+      relationGraph,
       failureDetector,
       reflexionWorker,
       walCheckpointScheduler,

--- a/packages/memento-core/src/context.ts
+++ b/packages/memento-core/src/context.ts
@@ -50,6 +50,7 @@ function createToolContextFromServerContext(serverContext: ServerContext): ToolC
       consolidationScoreService: serverContext.services.consolidationScoreService,
       writeCoalescingManager: serverContext.services.writeCoalescingManager,
       anchorManager: serverContext.services.anchorManager,
+      relationGraph: serverContext.services.relationGraph,
       failureDetector: serverContext.services.failureDetector,
       reflexionWorker: serverContext.services.reflexionWorker,
       metaMemoryService: serverContext.services.metaMemoryService,

--- a/packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts
+++ b/packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts
@@ -15,7 +15,7 @@ import type { ExtractionInfo,Triple,TripleExtractionResult } from '../../../../s
 import { DatabaseUtils } from '../../../../shared/utils/database.js';
 import { logger } from '../../../../shared/utils/logger.js';
 import { UnifiedEmbeddingService } from '../../../embedding/services/unified-embedding-service.js';
-import type { RelationGraph } from '../../../relation/services/relation-graph.js';
+import type { RelationGraphPort } from '../../../relation/ports/relation-graph.port.js';
 import { EntityLinker } from '../../../relation/services/triple-extraction/entity-linker.js';
 import { PredicateCanonicalizer } from '../../../relation/services/triple-extraction/predicate-canonicalizer.js';
 import { KgTripleRepository } from '../../repositories/kg-triple-repository.js';
@@ -75,7 +75,7 @@ export class SemanticMemoryUpdateService {
   private readonly canonicalizer: PredicateCanonicalizer;
   private readonly entityLinker: EntityLinker;
   private readonly embeddingService: UnifiedEmbeddingService;
-  private readonly relationGraph: RelationGraph;
+  private readonly relationGraph: RelationGraphPort;
   private readonly statistics: SemanticMemoryStatisticsService; // PRD 8.2: Semantic Memory 생성 통계 수집
   private readonly kgTripleRepo: KgTripleRepository; // Issue #90: KG 전용 저장소 dedupe
 
@@ -94,7 +94,7 @@ export class SemanticMemoryUpdateService {
 
   constructor(
     private db: Database.Database,
-    relationGraph: RelationGraph,
+    relationGraph: RelationGraphPort,
     embeddingService?: UnifiedEmbeddingService,
     kgTripleRepo?: KgTripleRepository
   ) {

--- a/packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts
@@ -10,6 +10,8 @@ import { ConvertEpisodicToSemanticTool } from '../convert-episodic-to-semantic-t
 import type { ToolContext } from '../../../tools/types.js';
 import { UnifiedEmbeddingService } from '../../../../domains/embedding/services/unified-embedding-service.js';
 import { createRelationGraph } from '../../../../infrastructure/relation-graph-factory.js';
+import { TripleExtractionService } from '../../../relation/services/triple-extraction/triple-extraction-service.js';
+import { SemanticMemoryUpdateService } from '../../services/semantic-memory/semantic-memory-update-service.js';
 /**
  * Memory ID 생성 유틸리티 (테스트용)
  */
@@ -243,6 +245,90 @@ describe('ConvertEpisodicToSemanticTool', () => {
       // Then: 에러 반환
       expect(resultData.error).toBe('MEMORY_NOT_FOUND');
       expect(resultData.message).toContain(nonExistentId);
+    });
+
+    it('should mark conversion as relation_graph_unavailable when triples exist but relationGraph is missing', async () => {
+      const episodicMemoryId = generateId('mem');
+      createTestEpisodicMemory(db, episodicMemoryId, 'Alice mentors Bob at Acme.', 0.8);
+
+      vi.spyOn(TripleExtractionService.prototype, 'extractTriples').mockResolvedValue({
+        triples: [
+          { subject: 'Alice', predicate: 'mentors', object: 'Bob' }
+        ],
+        extractionInfo: {
+          steps: { canonicalization: true, entityLinking: true }
+        }
+      });
+
+      const contextWithoutRelationGraph: ToolContext = {
+        db,
+        services: {}
+      };
+
+      const result = await tool.handle({ memory_id: episodicMemoryId }, contextWithoutRelationGraph);
+      const resultData = JSON.parse(result.content[0].text);
+
+      expect(resultData.total).toBe(1);
+      expect(resultData.success).toBe(0);
+      expect(resultData.failed).toBe(1);
+
+      const episodicMemory = DatabaseUtils.get(db, `
+        SELECT triple_extracted_status, triple_extraction_metadata
+        FROM memory_item WHERE id = ?
+      `, [episodicMemoryId]) as {
+        triple_extracted_status: string | null;
+        triple_extraction_metadata: string | null;
+      } | undefined;
+
+      const metadata = JSON.parse(episodicMemory?.triple_extraction_metadata ?? '{}');
+      expect(episodicMemory?.triple_extracted_status).toBe('failed');
+      expect(metadata.failureReason).toBe('relation_graph_unavailable');
+    });
+
+
+    it('should mark conversion as semantic_update_failed when semantic update crashes after extraction', async () => {
+      const episodicMemoryId = generateId('mem');
+      createTestEpisodicMemory(db, episodicMemoryId, 'Alice mentors Bob at Acme.', 0.8);
+
+      vi.spyOn(TripleExtractionService.prototype, 'extractTriples').mockResolvedValue({
+        triples: [
+          { subject: 'Alice', predicate: 'mentors', object: 'Bob' }
+        ],
+        extractionInfo: {
+          steps: { canonicalization: true, entityLinking: true }
+        }
+      });
+      const updateSemanticMemorySpy = vi
+        .spyOn(SemanticMemoryUpdateService.prototype, 'updateSemanticMemory')
+        .mockRejectedValue(new Error('semantic update exploded'));
+
+      const contextWithRelationGraphOnly: ToolContext = {
+        db,
+        services: {
+          relationGraph: createRelationGraph(db)
+        }
+      };
+
+      const result = await tool.handle({ memory_id: episodicMemoryId }, contextWithRelationGraphOnly);
+      const resultData = JSON.parse(result.content[0].text);
+
+      expect(resultData.total).toBe(1);
+      expect(resultData.success).toBe(0);
+      expect(resultData.failed).toBe(1);
+      expect(updateSemanticMemorySpy).toHaveBeenCalledOnce();
+
+      const episodicMemory = DatabaseUtils.get(db, `
+        SELECT triple_extracted_status, triple_extraction_metadata
+        FROM memory_item WHERE id = ?
+      `, [episodicMemoryId]) as {
+        triple_extracted_status: string | null;
+        triple_extraction_metadata: string | null;
+      } | undefined;
+
+      const metadata = JSON.parse(episodicMemory?.triple_extraction_metadata ?? '{}');
+      expect(episodicMemory?.triple_extracted_status).toBe('failed');
+      expect(metadata.failureReason).toBe('semantic_update_failed');
+      expect(metadata.failureReason).not.toBe('conversion_error');
     });
 
     it('should return error when memory_id is not episodic type', async () => {

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
@@ -11,6 +11,7 @@ import * as environmentCheck from '../../../../shared/utils/environment-check.js
 import { getBatchScheduler, resetBatchScheduler } from '../../../../infrastructure/scheduler/batch-scheduler.js';
 import { createRelationGraph } from '../../../../infrastructure/relation-graph-factory.js';
 import { TripleExtractionService } from '../../../relation/services/triple-extraction/triple-extraction-service.js';
+import { SemanticMemoryUpdateService } from '../../services/semantic-memory/semantic-memory-update-service.js';
 
 /**
  * 테스트용 데이터베이스 초기화
@@ -1983,6 +1984,128 @@ describe('RememberTool', () => {
 
       testEnvironmentSpy.mockRestore();
       extractTriplesSpy.mockRestore();
+    });
+
+    it('should record relation_graph_unavailable when semantic update needs relationGraph', async () => {
+      const extractTriplesSpy = vi.spyOn(TripleExtractionService.prototype, 'extractTriples').mockResolvedValue({
+        triples: [
+          { subject: 'Alice', predicate: 'works_at', object: 'Acme' }
+        ],
+        extractionInfo: {
+          steps: { canonicalization: true, entityLinking: true }
+        }
+      });
+
+      const contextWithoutRelationGraph: ToolContext = {
+        ...context,
+        services: {
+          hybridSearchEngine,
+          embeddingService,
+          batchScheduler: getBatchScheduler(),
+        }
+      };
+
+      const params = {
+        type: 'episodic',
+        content: 'Alice works at Acme.',
+        importance: 0.6,
+        enable_triple_extraction: true
+      };
+
+      const result = await tool.handle(params, contextWithoutRelationGraph);
+      const resultData = JSON.parse(result.content[0].text);
+      const memoryId = resultData.memory_id;
+
+      let metadata: Record<string, unknown> | null = null;
+      let status: string | null | undefined;
+      for (let attempt = 0; attempt < 20; attempt++) {
+        const row = DatabaseUtils.get(db, `
+          SELECT triple_extracted_status, triple_extraction_metadata
+          FROM memory_item WHERE id = ?
+        `, [memoryId]) as {
+          triple_extracted_status: string | null;
+          triple_extraction_metadata: string | null;
+        } | undefined;
+
+        status = row?.triple_extracted_status;
+        metadata = row?.triple_extraction_metadata ? JSON.parse(row.triple_extraction_metadata) : null;
+        if (status === 'failed' && metadata) {
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      expect(extractTriplesSpy).toHaveBeenCalledOnce();
+      expect(status).toBe('failed');
+      expect(metadata).toMatchObject({
+        failureReason: 'relation_graph_unavailable'
+      });
+      expect(metadata).not.toMatchObject({
+        failureReason: 'llm_api_error'
+      });
+    });
+
+
+    it('should record semantic_update_failed when semantic update crashes after extraction', async () => {
+      const extractTriplesSpy = vi.spyOn(TripleExtractionService.prototype, 'extractTriples').mockResolvedValue({
+        triples: [
+          { subject: 'Alice', predicate: 'works_at', object: 'Acme' }
+        ],
+        extractionInfo: {
+          steps: { canonicalization: true, entityLinking: true }
+        }
+      });
+      const updateSemanticMemorySpy = vi
+        .spyOn(SemanticMemoryUpdateService.prototype, 'updateSemanticMemory')
+        .mockRejectedValue(new Error('semantic update exploded'));
+
+      const contextWithScheduler: ToolContext = {
+        ...context,
+        services: {
+          ...context.services,
+          batchScheduler: getBatchScheduler(),
+        }
+      };
+
+      const params = {
+        type: 'episodic',
+        content: 'Alice works at Acme.',
+        importance: 0.6,
+        enable_triple_extraction: true
+      };
+
+      const result = await tool.handle(params, contextWithScheduler);
+      const resultData = JSON.parse(result.content[0].text);
+      const memoryId = resultData.memory_id;
+
+      let metadata: Record<string, unknown> | null = null;
+      let status: string | null | undefined;
+      for (let attempt = 0; attempt < 20; attempt++) {
+        const row = DatabaseUtils.get(db, `
+          SELECT triple_extracted_status, triple_extraction_metadata
+          FROM memory_item WHERE id = ?
+        `, [memoryId]) as {
+          triple_extracted_status: string | null;
+          triple_extraction_metadata: string | null;
+        } | undefined;
+
+        status = row?.triple_extracted_status;
+        metadata = row?.triple_extraction_metadata ? JSON.parse(row.triple_extraction_metadata) : null;
+        if (status === 'failed' && metadata) {
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      expect(extractTriplesSpy).toHaveBeenCalledOnce();
+      expect(updateSemanticMemorySpy).toHaveBeenCalledOnce();
+      expect(status).toBe('failed');
+      expect(metadata).toMatchObject({
+        failureReason: 'semantic_update_failed'
+      });
+      expect(metadata).not.toMatchObject({
+        failureReason: 'llm_api_error'
+      });
     });
 
     /**

--- a/packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts
@@ -13,11 +13,13 @@ import { TripleExtractionService } from '../../relation/services/triple-extracti
 import { SemanticMemoryUpdateService } from '../services/semantic-memory/semantic-memory-update-service.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { UnifiedEmbeddingService } from '../../../domains/embedding/services/unified-embedding-service.js';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 
 /**
  * Convert Episodic to Semantic 스키마
  */
+const RELATION_GRAPH_UNAVAILABLE_ERROR = 'relation_graph_unavailable';
+const SEMANTIC_UPDATE_FAILED_ERROR = 'semantic_update_failed';
+
 const ConvertEpisodicToSemanticSchema = z.object({
   memory_id: z.string().optional(), // 단일 Episodic Memory ID (선택)
   // 필터 조건 (memory_id가 없을 때 사용)
@@ -238,16 +240,23 @@ export class ConvertEpisodicToSemanticTool extends BaseTool {
           const episodicMemory = batch[j];
           const extractionResult = extractionResults[j];
           if (!episodicMemory || !extractionResult) continue;
+          let semanticUpdateStarted = false;
           try {
 
           // Triple이 추출된 경우 Semantic Memory 생성/업데이트
           if (extractionResult.triples.length > 0) {
+            semanticUpdateStarted = true;
             const unifiedForSemantic: UnifiedEmbeddingService = context.services.embeddingService
               ? context.services.embeddingService.getUnifiedEmbeddingService()
               : new UnifiedEmbeddingService();
+            const relationGraph = context.services.relationGraph;
+            if (!relationGraph) {
+              throw new Error(RELATION_GRAPH_UNAVAILABLE_ERROR);
+            }
+
             const semanticMemoryUpdateService = new SemanticMemoryUpdateService(
               db,
-              context.services.relationGraph ?? createRelationGraph(db),
+              relationGraph,
               unifiedForSemantic
             );
 
@@ -358,6 +367,11 @@ export class ConvertEpisodicToSemanticTool extends BaseTool {
           }
         } catch (error) {
           results.failed++;
+          const failureReason = error instanceof Error && error.message === RELATION_GRAPH_UNAVAILABLE_ERROR
+            ? 'relation_graph_unavailable'
+            : semanticUpdateStarted
+              ? SEMANTIC_UPDATE_FAILED_ERROR
+              : 'conversion_error';
           
           // 에러 발생 시에도 상태 업데이트 (PRD 5.5, 5.5a, 5.6)
           try {
@@ -371,7 +385,7 @@ export class ConvertEpisodicToSemanticTool extends BaseTool {
               0, // SQLite에서는 boolean을 INTEGER로 변환
               'failed',
               JSON.stringify({
-                failureReason: 'conversion_error',
+                failureReason,
                 error: error instanceof Error ? error.message : String(error),
                 last_attempt: new Date().toISOString()
               }),
@@ -386,6 +400,7 @@ export class ConvertEpisodicToSemanticTool extends BaseTool {
           
           logger.error('Episodic Memory 변환 중 에러 발생', {
             episodic_memory_id: episodicMemory.id,
+            failure_reason: failureReason,
             error: error instanceof Error ? error.message : String(error)
           });
         }

--- a/packages/memento-core/src/domains/memory/tools/remember-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool.ts
@@ -30,7 +30,6 @@ import { KnowledgeVaultService } from '../services/knowledge-vault-service.js';
 import { MemoryNeighborService } from '../services/memory-neighbor-service.js';
 import { getNextVersionNumber } from '../services/procedural-versioning.js';
 // AriGraph Pipeline
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import type { TripleExtractionResult } from '../../../shared/types/triple-extraction.js';
 import { TripleExtractionService } from '../../relation/services/triple-extraction/triple-extraction-service.js';
 import { SemanticMemoryUpdateService } from '../services/semantic-memory/semantic-memory-update-service.js';
@@ -38,6 +37,9 @@ import { SemanticMemoryUpdateService } from '../services/semantic-memory/semanti
 /**
  * 기존 reflection_notes 조회 결과 타입
  */
+const RELATION_GRAPH_UNAVAILABLE_ERROR = 'relation_graph_unavailable';
+const SEMANTIC_UPDATE_FAILED_ERROR = 'semantic_update_failed';
+
 interface ExistingReflectionNotesResult {
   exists: boolean;
   type: 'null' | 'object' | 'array';
@@ -1052,6 +1054,7 @@ export class RememberTool extends BaseTool {
                   
                   // Triple 추출 작업 함수 정의
                   const tripleExtractionJob = async () => {
+                    let semanticUpdateStarted = false;
                     try {
                       // 데이터베이스 연결 재확인
                       let dbValid = false;
@@ -1151,13 +1154,19 @@ export class RememberTool extends BaseTool {
 
                         // Triple이 추출된 경우 Semantic Memory 생성/업데이트
                         if (extractionResult.triples.length > 0) {
+                          semanticUpdateStarted = true;
                           // MemoryEmbeddingService는 generateEmbedding을 노출하지 않음 — 내부 UnifiedEmbeddingService 사용
                           const unifiedEmbeddingService: UnifiedEmbeddingService = embeddingServiceRef
                             ? embeddingServiceRef.getUnifiedEmbeddingService()
                             : new UnifiedEmbeddingService();
+                          const relationGraph = context.services.relationGraph;
+                          if (!relationGraph) {
+                            throw new Error(RELATION_GRAPH_UNAVAILABLE_ERROR);
+                          }
+
                           const semanticMemoryUpdateService = new SemanticMemoryUpdateService(
                             dbRef,
-                            context.services.relationGraph ?? createRelationGraph(dbRef),
+                            relationGraph,
                             unifiedEmbeddingService
                           );
 
@@ -1269,9 +1278,19 @@ export class RememberTool extends BaseTool {
                         }
                       }
                     } catch (error) {
+                      const errorMessage = error instanceof Error ? error.message : String(error);
+                      const failureReason = errorMessage === RELATION_GRAPH_UNAVAILABLE_ERROR
+                        ? 'relation_graph_unavailable'
+                        : errorMessage.includes('database connection')
+                          ? 'db_connection_error'
+                          : semanticUpdateStarted
+                            ? SEMANTIC_UPDATE_FAILED_ERROR
+                            : 'llm_api_error';
+
                       // Triple 추출 실패해도 메모리 저장은 성공했으므로 경고만 출력
                       this.logWarning(`Triple 추출 실패 (${savedMemoryId})`, {
-                        error: error instanceof Error ? error.message : String(error)
+                        failure_reason: failureReason,
+                        error: errorMessage
                       });
                       
                       // PRD 5.5, 5.5a, 5.6: 에러 발생 시에도 상태 업데이트
@@ -1288,9 +1307,6 @@ export class RememberTool extends BaseTool {
                         });
                         
                         // 데이터베이스 연결이 유효하면 상태 업데이트
-                        const failureReason = error instanceof Error && error.message.includes('database connection')
-                          ? 'db_connection_error'
-                          : 'llm_api_error';
                         
                         // 기존 metadata에서 retry_count 가져오기 (있는 경우)
                         let retryCount = 0;

--- a/packages/memento-core/src/domains/relation/ports/relation-graph.port.ts
+++ b/packages/memento-core/src/domains/relation/ports/relation-graph.port.ts
@@ -1,0 +1,3 @@
+import type { IRelationGraph } from '../../../shared/types/relation-graph.js';
+
+export interface RelationGraphPort extends IRelationGraph {}

--- a/packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts
+++ b/packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts
@@ -401,7 +401,7 @@ describe('AddRelationTool', () => {
   });
 
   describe('RelationGraph 통합', () => {
-    it('context에 relationGraph가 없으면 새로 생성해야 함', async () => {
+    it('context에 relationGraph가 없으면 구성 오류를 반환해야 함', async () => {
       // Given: relationGraph가 없는 context
       const contextWithoutGraph: ToolContext = {
         db,
@@ -420,10 +420,12 @@ describe('AddRelationTool', () => {
       // When: 관계 추가
       const result = await tool.handle(params, contextWithoutGraph);
 
-      // Then: 에러 없이 완료 (내부에서 RelationGraph 생성)
+      // Then: 구성 오류 반환
       expect(result.content).toBeDefined();
       const data = JSON.parse(result.content[0].text);
-      expect(data.relation_id).toBeDefined();
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('RELATION_GRAPH_UNAVAILABLE');
+      expect(data.message).toContain('관계 그래프 서비스');
     });
 
     it('context에 relationGraph가 있으면 사용해야 함', async () => {

--- a/packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts
+++ b/packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts
@@ -318,7 +318,7 @@ describe('ExtractRelationsTool', () => {
   });
 
   describe('RelationGraph 통합', () => {
-    it('context에 relationGraph가 없으면 새로 생성해야 함', async () => {
+    it('context에 relationGraph가 없으면 구성 오류를 반환해야 함', async () => {
       // Given: relationGraph가 없는 context
       const contextWithoutGraph: ToolContext = {
         db,
@@ -327,6 +327,14 @@ describe('ExtractRelationsTool', () => {
 
       createTestMemory(db, 'mem1', 'Test memory 1');
       createTestMemory(db, 'mem2', 'Test memory 2');
+      vi.spyOn(RelationExtractor.prototype, 'extractRelations').mockResolvedValue([
+        {
+          source_id: 'mem1',
+          target_id: 'mem2',
+          relation_type: 'CAUSES',
+          confidence: 0.8
+        }
+      ]);
 
       const params = {
         memory_id: 'mem1'
@@ -335,10 +343,12 @@ describe('ExtractRelationsTool', () => {
       // When: 관계 추출 수행
       const result = await tool.handle(params, contextWithoutGraph);
 
-      // Then: 에러 없이 완료 (내부에서 RelationGraph 생성)
+      // Then: 구성 오류 반환
       expect(result.content).toBeDefined();
       const data = JSON.parse(result.content[0].text);
-      expect(data.extracted_count).toBeGreaterThanOrEqual(0);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('RELATION_GRAPH_UNAVAILABLE');
+      expect(data.message).toContain('관계 그래프 서비스');
     });
 
     it('context에 relationGraph가 있으면 사용해야 함', async () => {

--- a/packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts
+++ b/packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts
@@ -323,7 +323,7 @@ describe('GetRelationsTool', () => {
       expect(data.relations).toEqual([]);
     });
 
-    it('context에 relationGraph가 없으면 새로 생성해야 함', async () => {
+    it('context에 relationGraph가 없으면 구성 오류를 반환해야 함', async () => {
       // Given: relationGraph가 없는 context
       const contextWithoutGraph: ToolContext = {
         db,
@@ -341,10 +341,12 @@ describe('GetRelationsTool', () => {
       // When: 관계 조회
       const result = await tool.handle(params, contextWithoutGraph);
 
-      // Then: 에러 없이 완료 (내부에서 RelationGraph 생성)
+      // Then: 구성 오류 반환
       expect(result.content).toBeDefined();
       const data = JSON.parse(result.content[0].text);
-      expect(data.relation_count).toBeGreaterThanOrEqual(0);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('RELATION_GRAPH_UNAVAILABLE');
+      expect(data.message).toContain('관계 그래프 서비스');
     });
 
     it('관계 정보를 올바르게 반환해야 함', async () => {

--- a/packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts
+++ b/packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { RemoveRelationTool } from '../remove-relation-tool.js';
+import type { ToolContext } from '../../../../tools/types.js';
+
+describe('RemoveRelationTool', () => {
+  it('relationGraph가 없으면 구성 오류를 반환해야 함', async () => {
+    const db = new Database(':memory:');
+    const tool = new RemoveRelationTool();
+    const context: ToolContext = {
+      db,
+      services: {}
+    };
+
+    try {
+      const result = await tool.handle({ relation_id: 1 }, context);
+      const data = JSON.parse(result.content[0].text);
+
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('RELATION_GRAPH_UNAVAILABLE');
+      expect(data.message).toContain('관계 그래프 서비스');
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts
+++ b/packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts
@@ -103,6 +103,27 @@ describe('VisualizeRelationsTool', () => {
     expect(data.visualization).toContain('REFERENCES');
   });
 
+
+  it('relationGraph가 없으면 구성 오류를 반환해야 함', async () => {
+    createTestMemory(db, 'mem1', 'Test memory 1');
+
+    const result = await tool.handle(
+      {
+        memory_id: 'mem1',
+        format: 'dot',
+      },
+      {
+        db,
+        services: {},
+      }
+    );
+
+    const data = JSON.parse(result.content![0].text);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('RELATION_GRAPH_UNAVAILABLE');
+    expect(data.message).toContain('관계 그래프 서비스');
+  });
+
   it('관계가 없을 때 dot 형식은 빈 그래프 주석을 포함할 수 있음', async () => {
     createTestMemory(db, 'mem1', 'Test memory 1');
 

--- a/packages/memento-core/src/domains/relation/tools/add-relation-tool.ts
+++ b/packages/memento-core/src/domains/relation/tools/add-relation-tool.ts
@@ -4,7 +4,6 @@
  */
 
 import { z } from 'zod';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
 import { BaseTool } from '../../../tools/base-tool.js';
 import type { ToolContext,ToolResult } from '../../../tools/types.js';
@@ -109,8 +108,19 @@ export class AddRelationTool extends BaseTool {
         };
       }
 
-      // RelationGraph 인스턴스 생성 (context에 없으면 새로 생성)
-      const relationGraph = context.services.relationGraph || createRelationGraph(db);
+      const relationGraph = context.services.relationGraph;
+      if (!relationGraph) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              error: 'RELATION_GRAPH_UNAVAILABLE',
+              message: '관계 그래프 서비스가 구성되지 않았습니다'
+            }, null, 2)
+          }]
+        };
+      }
 
       // When: 관계 추가 수행
       try {

--- a/packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts
+++ b/packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts
@@ -4,7 +4,6 @@
  */
 
 import { z } from 'zod';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { convertMemoryRowToItem,isMemoryRow } from '../../../shared/utils/type-guards.js';
@@ -132,9 +131,20 @@ export class ExtractRelationsTool extends BaseTool {
       // 추출된 관계를 RelationGraph에 저장
       let savedCount = 0;
       if (candidates.length > 0) {
-        // RelationGraph 인스턴스 생성 (context에 없으면 새로 생성)
-        const relationGraph = context.services.relationGraph || createRelationGraph(db);
-        
+        const relationGraph = context.services.relationGraph;
+        if (!relationGraph) {
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: false,
+                error: 'RELATION_GRAPH_UNAVAILABLE',
+                message: '관계 그래프 서비스가 구성되지 않았습니다'
+              }, null, 2)
+            }]
+          };
+        }
+
         for (const candidate of candidates) {
           try {
             await relationGraph.addRelation(

--- a/packages/memento-core/src/domains/relation/tools/get-relations-tool.ts
+++ b/packages/memento-core/src/domains/relation/tools/get-relations-tool.ts
@@ -4,7 +4,6 @@
  */
 
 import { z } from 'zod';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import type { GetRelationsOptions,MemoryRelation } from '../../../shared/types/relation-graph.js';
 import type { RelationType } from '../../../shared/types/relation.js';
 import { RELATION_TYPE_CATEGORY_MAP } from '../../../shared/types/relation.js';
@@ -81,8 +80,19 @@ export class GetRelationsTool extends BaseTool {
         };
       }
 
-      // RelationGraph 인스턴스 생성 (context에 없으면 새로 생성)
-      const relationGraph = context.services.relationGraph || createRelationGraph(db);
+      const relationGraph = context.services.relationGraph;
+      if (!relationGraph) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              error: 'RELATION_GRAPH_UNAVAILABLE',
+              message: '관계 그래프 서비스가 구성되지 않았습니다'
+            }, null, 2)
+          }]
+        };
+      }
 
       // When: 관계 조회 수행
       const options: GetRelationsOptions = {

--- a/packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts
+++ b/packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts
@@ -8,7 +8,6 @@ import { z } from 'zod';
 import { BaseTool } from '../../../tools/base-tool.js';
 import type { ToolContext, ToolResult } from '../../../tools/types.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import type { RelationType } from '../../../shared/types/relation.js';
 
 const RemoveRelationSchema = z.object({
@@ -69,8 +68,19 @@ export class RemoveRelationTool extends BaseTool {
     const db = context.db;
 
     try {
-      // RelationGraph 인스턴스 생성 (context에 없으면 새로 생성)
-      const relationGraph = context.services.relationGraph || createRelationGraph(db);
+      const relationGraph = context.services.relationGraph;
+      if (!relationGraph) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              error: 'RELATION_GRAPH_UNAVAILABLE',
+              message: '관계 그래프 서비스가 구성되지 않았습니다'
+            }, null, 2)
+          }]
+        };
+      }
 
       let deleted = false;
       let relationInfo: { source_id: string; target_id: string; relation_type: RelationType } | null = null;

--- a/packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts
+++ b/packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts
@@ -7,7 +7,6 @@ import { z } from 'zod';
 import { BaseTool } from '../../../tools/base-tool.js';
 import type { ToolContext, ToolResult } from '../../../tools/types.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
-import { createRelationGraph } from '../../../infrastructure/relation-graph-factory.js';
 import { RelationVisualizer, type VisualizationOptions } from '../../../shared/utils/relation-visualizer.js';
 
 const VisualizeRelationsSchema = z.object({
@@ -109,8 +108,19 @@ export class VisualizeRelationsTool extends BaseTool {
         };
       }
 
-      // RelationGraph 인스턴스 생성 (context에 없으면 새로 생성)
-      const relationGraph = context.services.relationGraph || createRelationGraph(db);
+      const relationGraph = context.services.relationGraph;
+      if (!relationGraph) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              error: 'RELATION_GRAPH_UNAVAILABLE',
+              message: '관계 그래프 서비스가 구성되지 않았습니다'
+            }, null, 2)
+          }]
+        };
+      }
 
       // When: 관계 조회
       const relations = await relationGraph.getRelations(parsed.memory_id, {

--- a/packages/memento-core/src/shared/types/triple-extraction.ts
+++ b/packages/memento-core/src/shared/types/triple-extraction.ts
@@ -16,11 +16,15 @@ export interface Triple {
  * Triple 추출 실패 사유
  */
 export type TripleExtractionFailureReason =
-  | 'no_triple'           // 트리플이 추출되지 않음
-  | 'ambiguous_structure' // 구조가 모호함
-  | 'llm_parse_fail'      // LLM 응답 파싱 실패
-  | 'llm_api_error'       // LLM API 호출 실패
-  | 'llm_unavailable';    // LLM 서비스 사용 불가능 (초기화 실패 등)
+  | 'no_triple'                // 트리플이 추출되지 않음
+  | 'ambiguous_structure'      // 구조가 모호함
+  | 'llm_parse_fail'           // LLM 응답 파싱 실패
+  | 'llm_api_error'            // LLM API 호출 실패
+  | 'llm_unavailable'          // LLM 서비스 사용 불가능 (초기화 실패 등)
+  | 'db_connection_error'      // 후처리 중 DB 연결 문제
+  | 'relation_graph_unavailable' // Semantic 업데이트에 필요한 relation graph 미구성
+  | 'semantic_update_failed'   // Semantic update 단계 런타임 실패
+  | 'conversion_error';        // 수동 semantic 변환 중 기타 처리 오류
 
 /**
  * Triple 추출 단계별 성공 여부

--- a/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
+++ b/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(currentDir, '..', '..');
+const domainsRoot = path.join(srcRoot, 'domains');
+const ALLOWED_CONCRETE_RELATION_GRAPH_IMPORTS = [
+  'domains/anchor/services/anchor/anchor-search-service.ts',
+  'domains/anchor/services/anchor/n-hop-search-service.ts',
+  'domains/search/algorithms/hybrid-search-engine.ts',
+] as const;
+
+async function readSource(relativePath: string): Promise<string> {
+  return await readFile(path.join(srcRoot, relativePath), 'utf8');
+}
+
+async function collectDomainProductionFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') {
+        return [];
+      }
+      return await collectDomainProductionFiles(entryPath);
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.endsWith('.spec.ts')) {
+      return [];
+    }
+    return [path.relative(srcRoot, entryPath)];
+  }));
+
+  return files.flat().sort();
+}
+
+describe('dependency boundaries', () => {
+  it('keeps relation graph factory imports and fallbacks out of domain production files', async () => {
+    const domainFiles = await collectDomainProductionFiles(domainsRoot);
+    const offenders: string[] = [];
+
+    for (const relativePath of domainFiles) {
+      const source = await readSource(relativePath);
+      const hasFactoryImport = /^\s*import\s+.*relation-graph-factory\.js['"];?$/m.test(source);
+      const hasFallback = /relationGraph\s*(?:\?\?|\|\|)\s*createRelationGraph\s*\(/m.test(source);
+
+      if (hasFactoryImport || hasFallback) {
+        offenders.push(relativePath);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps concrete RelationGraph imports pinned to an explicit allowlist', async () => {
+    const domainFiles = await collectDomainProductionFiles(domainsRoot);
+    const offenders: string[] = [];
+
+    for (const relativePath of domainFiles) {
+      const source = await readSource(relativePath);
+      const hasConcreteRelationGraphImport = /import\s+(?:type\s+)?\{?\s*RelationGraph\s*\}?\s+from\s+['"].*relation\/services\/relation-graph\.js['"]/m.test(source);
+
+      if (hasConcreteRelationGraphImport) {
+        offenders.push(relativePath);
+      }
+    }
+
+    expect(offenders).toEqual([...ALLOWED_CONCRETE_RELATION_GRAPH_IMPORTS]);
+  });
+
+  it('wires relationGraph through the domain port from bootstrap to tool context', async () => {
+    const [portSource, toolTypesSource, bootstrapSource, contextSource] = await Promise.all([
+      readSource('domains/relation/ports/relation-graph.port.ts'),
+      readSource('tools/types.ts'),
+      readSource('bootstrap.ts'),
+      readSource('context.ts'),
+    ]);
+
+    expect(portSource).toContain('RelationGraphPort');
+    expect(toolTypesSource).toContain('relationGraph?: RelationGraphPort;');
+    expect(toolTypesSource).not.toContain('services/relation-graph.js');
+    expect(bootstrapSource).toContain('relationGraph: RelationGraphPort;');
+    expect(bootstrapSource).toContain('const relationGraph = createRelationGraph(db);');
+    expect(bootstrapSource).toContain('relationGraph: relationGraph,');
+    expect(contextSource).toContain('relationGraph: serverContext.services.relationGraph');
+  });
+});

--- a/packages/memento-core/src/tools/types.ts
+++ b/packages/memento-core/src/tools/types.ts
@@ -12,7 +12,7 @@ import type { ErrorLoggingService } from '../domains/monitoring/services/error-l
 import type { PerformanceAlertService } from '../domains/monitoring/services/performance-alert-service.js';
 import type { WriteCoalescingManager } from '../shared/utils/write-coalescing.js';
 import type { AnchorManager } from '../domains/anchor/services/anchor/anchor-manager.js';
-import type { RelationGraph } from '../domains/relation/services/relation-graph.js';
+import type { RelationGraphPort } from '../domains/relation/ports/relation-graph.port.js';
 import type { VectorSearchEngine } from '../domains/search/algorithms/vector-search-engine.js';
 import type { FailureDetector } from '../domains/monitoring/services/failure-detector.js';
 import type { IBatchScheduler } from '../shared/interfaces/batch-scheduler.interface.js';
@@ -76,7 +76,7 @@ export interface ToolContext {
     /** 앵커 관리자 서비스 */
     anchorManager?: AnchorManager;
     /** 관계 그래프 서비스 */
-    relationGraph?: RelationGraph;
+    relationGraph?: RelationGraphPort;
     /** 실패 감지 서비스 (Phase 2) */
     failureDetector?: FailureDetector;
     /** Reflexion Worker 서비스 (Phase 2) */

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -23,7 +23,7 @@
 
 .m-button--primary {
   background: var(--color-brand-primary);
-  color: white;
+  color: var(--color-text-inverse);
 }
 
 .m-button--primary:hover:not(:disabled) {
@@ -31,13 +31,13 @@
 }
 
 .m-button--secondary {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: var(--color-button-secondary-surface);
+  color: var(--color-text-inverse);
+  border: 1px solid var(--color-button-secondary-border);
 }
 
 .m-button--secondary:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--color-button-secondary-hover);
 }
 
 .m-button--ghost {
@@ -78,7 +78,7 @@
 /* --- Header --- */
 .m-header {
   background: var(--color-brand-gradient);
-  color: white;
+  color: var(--color-text-inverse);
   padding: var(--spacing-md) var(--spacing-lg);
   box-shadow: var(--shadow-md);
 }
@@ -98,8 +98,8 @@
   display: flex;
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: #e8eaf6;
-  border-bottom: 1px solid #c5cae9;
+  background: var(--color-tab-surface);
+  border-bottom: 1px solid var(--color-tab-border);
 }
 
 .m-tab-btn {
@@ -116,7 +116,7 @@
 
 .m-tab-btn.active {
   background: var(--color-bg-card);
-  border-color: #c5cae9;
+  border-color: var(--color-tab-border);
   border-bottom-color: var(--color-bg-card);
   color: var(--color-text-main);
   margin-bottom: -1px;

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -50,7 +50,7 @@ body {
 
 .dashboard-subtitle {
   font-size: var(--font-size-sm);
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--color-dashboard-text-on-brand);
 }
 
 .dashboard-auth-panel {
@@ -58,8 +58,8 @@ body {
   max-width: 32rem;
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-lg);
-  background: rgba(15, 23, 42, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--color-dashboard-auth-panel-bg);
+  border: 1px solid var(--color-dashboard-auth-panel-border);
   backdrop-filter: blur(6px);
 }
 
@@ -86,11 +86,11 @@ body {
   min-height: 1.25rem;
   margin-top: var(--spacing-xs);
   font-size: var(--font-size-xs);
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--color-dashboard-text-on-brand);
 }
 
 .dashboard-auth-message[data-tone='error'] {
-  color: #fee2e2;
+  color: var(--color-dashboard-auth-error);
 }
 
 .header-controls {
@@ -191,6 +191,16 @@ body {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   word-break: break-all;
+}
+
+.anchor-item-preview {
+  margin-top: var(--spacing-xs);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.anchor-change-btn {
+  margin-top: var(--spacing-md);
 }
 
 /* Memory Details */
@@ -320,7 +330,7 @@ body {
 .node.highlighted {
   stroke: var(--color-success) !important;
   stroke-width: 4px !important;
-  filter: drop-shadow(0 0 8px rgba(16, 185, 129, 0.6));
+  filter: drop-shadow(0 0 8px var(--color-anchor-highlight-glow));
   animation: pulse 2s ease-in-out infinite;
 }
 
@@ -421,8 +431,8 @@ body {
   display: flex;
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: #e8eaf6;
-  border-bottom: 1px solid #c5cae9;
+  background: var(--color-tab-surface);
+  border-bottom: 1px solid var(--color-tab-border);
   flex-shrink: 0;
 }
 
@@ -439,12 +449,12 @@ body {
 }
 
 .m-tab-btn:hover {
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--color-tab-hover);
 }
 
 .m-tab-btn.active {
   background: var(--color-bg-card);
-  border-color: #c5cae9;
+  border-color: var(--color-tab-border);
   border-bottom-color: var(--color-bg-card);
   margin-bottom: -1px;
   color: var(--color-text-main);
@@ -511,7 +521,7 @@ body {
   line-height: 1.45;
   color: var(--color-text-muted);
   background: var(--color-bg-card);
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .em-color-legend strong {
@@ -524,7 +534,7 @@ body {
   border: none;
   border-radius: var(--radius-sm);
   background: var(--color-brand-gradient);
-  color: #fff;
+  color: var(--color-text-inverse);
   font-weight: 600;
   cursor: pointer;
 }
@@ -542,21 +552,21 @@ body {
 }
 
 .em-loading {
-  background: #fff8e1;
-  color: #795548;
+  background: var(--color-status-loading-bg);
+  color: var(--color-status-loading-text);
 }
 
 .em-error {
-  background: #ffebee;
-  color: #c62828;
+  background: var(--color-status-error-bg);
+  color: var(--color-status-error-text);
 }
 
 .em-error .em-retry-btn {
   margin-top: var(--spacing-sm);
   padding: 0.35rem 0.75rem;
   border-radius: var(--radius-sm);
-  border: 1px solid #c62828;
-  background: #fff;
+  border: 1px solid var(--color-status-error-border);
+  background: var(--color-bg-card);
   cursor: pointer;
 }
 

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -25,15 +25,44 @@
   --color-bg-graph: #0f1117;
   --color-text-graph: #e2e8f0;
   --color-border-graph: #2d3748;
+  --color-graph-surface: #1a1d2e;
+  --color-graph-surface-elevated: #1e293b;
+  --color-graph-title: #a78bfa;
+  --color-graph-text-muted: #94a3b8;
+  --color-graph-text-subtle: #64748b;
+  --color-graph-link: #c4b5fd;
+  --color-graph-error: #f87171;
+  --color-graph-auth-error: #fca5a5;
+  --color-graph-auth-required-border: #312e81;
+  --color-graph-auth-required-bg: rgba(49, 46, 129, 0.18);
+  --color-graph-detail-text: #cbd5e1;
+  --color-graph-tag-bg: #312e81;
+  --color-graph-tag-text: #a5b4fc;
+  --color-graph-legend-bg: rgba(26, 29, 46, 0.92);
+  --color-graph-edge-default: #475569;
+  --color-graph-badge-episodic-bg: #312e81;
+  --color-graph-badge-episodic-text: #a5b4fc;
+  --color-graph-badge-semantic-bg: #064e3b;
+  --color-graph-badge-semantic-text: #6ee7b7;
+  --color-graph-badge-procedural-bg: #451a03;
+  --color-graph-badge-procedural-text: #fdba74;
+  --color-graph-badge-working-bg: #1e293b;
+  --color-graph-badge-working-text: #94a3b8;
+  --color-graph-badge-default-bg: var(--color-graph-surface-elevated);
+  --color-graph-badge-default-text: var(--color-graph-text-muted);
 
   /* Colors - Anchor Slots */
   --color-anchor-a: #ef4444;
+  --color-anchor-a-stroke: #dc2626;
   --color-anchor-a-bg: #fee2e2;
   --color-anchor-b: #f59e0b;
+  --color-anchor-b-stroke: #d97706;
   --color-anchor-b-bg: #fef3c7;
   --color-anchor-c: #3b82f6;
+  --color-anchor-c-stroke: #2563eb;
   --color-anchor-c-bg: #dbeafe;
   --color-memory-neutral: #9ca3af;
+  --color-memory-neutral-stroke: #6b7280;
   --color-memory-neutral-bg: #e5e7eb;
 
   /* Colors - Memory Types */
@@ -41,6 +70,26 @@
   --color-memory-semantic: var(--color-success);
   --color-memory-procedural: var(--color-warning);
   --color-memory-working: var(--color-memory-neutral);
+
+  /* Colors - Shared UI Surfaces */
+  --color-tab-surface: #e8eaf6;
+  --color-tab-border: #c5cae9;
+  --color-border-subtle: #eeeeee;
+  --color-text-inverse: #ffffff;
+  --color-status-loading-bg: #fff8e1;
+  --color-status-loading-text: #795548;
+  --color-status-error-bg: #ffebee;
+  --color-status-error-text: #c62828;
+  --color-status-error-border: #c62828;
+  --color-anchor-highlight-glow: rgba(16, 185, 129, 0.6);
+  --color-dashboard-text-on-brand: rgba(255, 255, 255, 0.88);
+  --color-dashboard-auth-panel-bg: rgba(15, 23, 42, 0.18);
+  --color-dashboard-auth-panel-border: rgba(255, 255, 255, 0.18);
+  --color-dashboard-auth-error: #fee2e2;
+  --color-tab-hover: rgba(255, 255, 255, 0.6);
+  --color-button-secondary-surface: rgba(255, 255, 255, 0.2);
+  --color-button-secondary-border: rgba(255, 255, 255, 0.3);
+  --color-button-secondary-hover: rgba(255, 255, 255, 0.3);
 
   /* Spacing */
   --spacing-xs: 0.25rem;  /* 4px */

--- a/static/graph.html
+++ b/static/graph.html
@@ -23,7 +23,7 @@
     }
 
     header {
-      background: #1a1d2e;
+      background: var(--color-graph-surface);
       border-bottom: 1px solid var(--color-border-graph);
       padding: var(--spacing-sm) var(--spacing-md);
       display: flex;
@@ -40,7 +40,7 @@
     header h1 {
       font-size: var(--font-size-sm);
       font-weight: 600;
-      color: #a78bfa;
+      color: var(--color-graph-title);
       white-space: nowrap;
     }
 
@@ -66,11 +66,15 @@
     .graph-auth-message,
     .graph-auth-hint {
       font-size: var(--font-size-xs);
-      color: #94a3b8;
+      color: var(--color-graph-text-muted);
     }
 
     .graph-auth-input {
       width: 200px;
+    }
+
+    .graph-action-button {
+      padding: 4px 10px;
     }
 
     .graph-auth-btn-secondary {
@@ -78,26 +82,26 @@
     }
 
     .graph-auth-message[data-tone="error"] {
-      color: #fca5a5;
+      color: var(--color-graph-auth-error);
     }
 
     .graph-auth-hint a {
-      color: #c4b5fd;
+      color: var(--color-graph-link);
     }
 
     .graph-auth-required {
       display: none;
       margin: var(--spacing-md);
       padding: var(--spacing-md) var(--spacing-lg);
-      border: 1px solid #312e81;
+      border: 1px solid var(--color-graph-auth-required-border);
       border-radius: var(--radius-lg);
-      background: rgba(49, 46, 129, 0.18);
-      color: #cbd5e1;
+      background: var(--color-graph-auth-required-bg);
+      color: var(--color-graph-detail-text);
       line-height: 1.5;
     }
 
     .graph-auth-required strong {
-      color: #e2e8f0;
+      color: var(--color-text-graph);
     }
 
     .graph-session-only {
@@ -128,7 +132,7 @@
 
     .filter-group label {
       font-size: var(--font-size-xs);
-      color: #94a3b8;
+      color: var(--color-graph-text-muted);
       white-space: nowrap;
     }
 
@@ -161,7 +165,7 @@
 
     #importance-val {
       font-size: var(--font-size-xs);
-      color: #94a3b8;
+      color: var(--color-graph-text-muted);
       min-width: 28px;
     }
 
@@ -190,7 +194,7 @@
       left: 50%;
       transform: translate(-50%, -50%);
       text-align: center;
-      color: #64748b;
+      color: var(--color-graph-text-subtle);
     }
 
     #empty-msg .icon { font-size: 40px; margin-bottom: var(--spacing-sm); }
@@ -203,7 +207,7 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      color: #94a3b8;
+      color: var(--color-graph-text-muted);
       font-size: var(--font-size-sm);
     }
 
@@ -215,14 +219,14 @@
       left: 50%;
       transform: translate(-50%, -50%);
       text-align: center;
-      color: #f87171;
+      color: var(--color-graph-error);
       font-size: var(--font-size-sm);
     }
 
     /* 툴팁 */
     #tooltip {
       position: fixed;
-      background: #1e293b;
+      background: var(--color-graph-surface-elevated);
       border: 1px solid var(--color-border-graph);
       border-radius: var(--radius-md);
       padding: var(--spacing-sm) var(--spacing-md);
@@ -238,7 +242,7 @@
     /* 상세 패널 */
     #detail-panel {
       width: 300px;
-      background: #1a1d2e;
+      background: var(--color-graph-surface);
       border-left: 1px solid var(--color-border-graph);
       padding: var(--spacing-md);
       overflow-y: auto;
@@ -248,7 +252,7 @@
 
     #detail-panel h3 {
       font-size: var(--font-size-sm);
-      color: #a78bfa;
+      color: var(--color-graph-title);
       margin-bottom: var(--spacing-md);
       border-bottom: 1px solid var(--color-border-graph);
       padding-bottom: var(--spacing-xs);
@@ -260,7 +264,7 @@
 
     .detail-label {
       font-size: var(--font-size-xs);
-      color: #64748b;
+      color: var(--color-graph-text-subtle);
       text-transform: uppercase;
       letter-spacing: 0.05em;
       margin-bottom: 2px;
@@ -268,11 +272,21 @@
 
     .detail-value {
       font-size: var(--font-size-xs);
-      color: #cbd5e1;
+      color: var(--color-graph-detail-text);
       word-break: break-word;
       max-height: 150px;
       overflow-y: auto;
       line-height: 1.5;
+    }
+
+    .detail-value--mono {
+      color: var(--color-graph-text-subtle);
+      font-family: monospace;
+      font-size: 10px;
+    }
+
+    .detail-empty {
+      color: var(--color-graph-edge-default);
     }
 
     .tag-list {
@@ -282,8 +296,8 @@
     }
 
     .tag {
-      background: #312e81;
-      color: #a5b4fc;
+      background: var(--color-graph-tag-bg);
+      color: var(--color-graph-tag-text);
       border-radius: var(--radius-sm);
       padding: 1px 6px;
       font-size: 11px;
@@ -297,12 +311,37 @@
       font-weight: 600;
     }
 
+    .type-badge--episodic {
+      background: var(--color-graph-badge-episodic-bg);
+      color: var(--color-graph-badge-episodic-text);
+    }
+
+    .type-badge--semantic {
+      background: var(--color-graph-badge-semantic-bg);
+      color: var(--color-graph-badge-semantic-text);
+    }
+
+    .type-badge--procedural {
+      background: var(--color-graph-badge-procedural-bg);
+      color: var(--color-graph-badge-procedural-text);
+    }
+
+    .type-badge--working {
+      background: var(--color-graph-badge-working-bg);
+      color: var(--color-graph-badge-working-text);
+    }
+
+    .type-badge--default {
+      background: var(--color-graph-badge-default-bg);
+      color: var(--color-graph-badge-default-text);
+    }
+
     /* 범례 */
     #legend {
       position: absolute;
       bottom: var(--spacing-md);
       left: var(--spacing-md);
-      background: rgba(26,29,46,0.92);
+      background: var(--color-graph-legend-bg);
       border: 1px solid var(--color-border-graph);
       border-radius: var(--radius-md);
       padding: var(--spacing-sm) var(--spacing-md);
@@ -310,7 +349,7 @@
     }
 
     #legend .legend-title {
-      color: #64748b;
+      color: var(--color-graph-text-subtle);
       margin-bottom: var(--spacing-xs);
       font-size: 11px;
       text-transform: uppercase;
@@ -322,7 +361,7 @@
       align-items: center;
       gap: var(--spacing-sm);
       margin-bottom: 3px;
-      color: #94a3b8;
+      color: var(--color-graph-text-muted);
     }
 
     .legend-dot {
@@ -330,6 +369,22 @@
       height: 10px;
       border-radius: var(--radius-full);
       flex-shrink: 0;
+    }
+
+    .legend-dot--episodic {
+      background: var(--color-memory-episodic);
+    }
+
+    .legend-dot--semantic {
+      background: var(--color-memory-semantic);
+    }
+
+    .legend-dot--procedural {
+      background: var(--color-memory-procedural);
+    }
+
+    .legend-dot--working {
+      background: var(--color-memory-working);
     }
 
     /* 노드 스타일 */
@@ -343,7 +398,7 @@
 
     .node text {
       font-size: 10px;
-      fill: #94a3b8;
+      fill: var(--color-graph-text-muted);
       pointer-events: none;
       user-select: none;
     }
@@ -374,8 +429,8 @@
         <span id="importance-val">0.0</span>
       </div>
     </div>
-    <button id="apply-btn" class="graph-session-only m-button m-button--primary" style="padding: 4px 10px;">필터 적용</button>
-    <button id="reset-btn" class="graph-session-only m-button m-button--secondary" style="padding: 4px 10px;">초기화</button>
+    <button id="apply-btn" class="graph-session-only graph-action-button m-button m-button--primary">필터 적용</button>
+    <button id="reset-btn" class="graph-session-only graph-action-button m-button m-button--secondary">초기화</button>
     <div class="header-spacer"></div>
     <section class="graph-auth-panel" aria-label="Graph session">
       <form id="graph-auth-form" class="graph-auth-form">
@@ -387,11 +442,11 @@
           placeholder="Enter key for /auth/session"
           autocomplete="current-password"
         >
-        <button type="submit" id="graph-sign-in-btn" class="m-button m-button--primary" style="padding: 4px 10px;">Sign in</button>
+        <button type="submit" id="graph-sign-in-btn" class="graph-action-button m-button m-button--primary">Sign in</button>
       </form>
       <div id="graph-auth-session" class="graph-auth-session" hidden>
         <span id="graph-auth-status" class="graph-auth-status">Session active</span>
-        <button type="button" id="graph-sign-out-btn" class="m-button m-button--secondary" style="padding: 4px 10px;">Sign out</button>
+        <button type="button" id="graph-sign-out-btn" class="graph-action-button m-button m-button--secondary">Sign out</button>
       </div>
       <p id="graph-auth-message" class="graph-auth-message" aria-live="polite"></p>
       <p class="graph-auth-hint">Full admin UI is available in <a href="/dashboard">/dashboard</a>.</p>
@@ -417,10 +472,10 @@
 
       <div id="legend">
         <div class="legend-title">노드 타입</div>
-        <div class="legend-item"><span class="legend-dot" style="background:#818cf8"></span>Episodic</div>
-        <div class="legend-item"><span class="legend-dot" style="background:#10b981"></span>Semantic</div>
-        <div class="legend-item"><span class="legend-dot" style="background:#f59e0b"></span>Procedural</div>
-        <div class="legend-item"><span class="legend-dot" style="background:#9ca3af"></span>Working</div>
+        <div class="legend-item"><span class="legend-dot legend-dot--episodic"></span>Episodic</div>
+        <div class="legend-item"><span class="legend-dot legend-dot--semantic"></span>Semantic</div>
+        <div class="legend-item"><span class="legend-dot legend-dot--procedural"></span>Procedural</div>
+        <div class="legend-item"><span class="legend-dot legend-dot--working"></span>Working</div>
       </div>
     </div>
 

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -13,12 +13,37 @@ const highlightedNodeIds = new Set(); // 하이라이트된 노드 ID 집합
 let autoRefreshInterval = null; // 자동 새로고침 인터벌
 let websocket = null; // WebSocket 연결
 
-// 슬롯별 색상 정의
-const slotColors = {
-  'A': { fill: '#ef4444', stroke: '#dc2626' },
-  'B': { fill: '#f59e0b', stroke: '#d97706' },
-  'C': { fill: '#3b82f6', stroke: '#2563eb' }
+// 슬롯별 색상 토큰 정의
+const slotColorTokens = {
+  'A': { fill: '--color-anchor-a', stroke: '--color-anchor-a-stroke' },
+  'B': { fill: '--color-anchor-b', stroke: '--color-anchor-b-stroke' },
+  'C': { fill: '--color-anchor-c', stroke: '--color-anchor-c-stroke' }
 };
+
+function readAnchorMapToken(name, fallback = '') {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  if (value) {
+    return value;
+  }
+  if (fallback) {
+    return fallback;
+  }
+  throw new Error(`Missing CSS token: ${name}`);
+}
+
+function getAnchorMapPalette() {
+  return {
+    slotColors: Object.fromEntries(
+      Object.entries(slotColorTokens).map(([slot, tokenNames]) => [slot, {
+        fill: readAnchorMapToken(tokenNames.fill),
+        stroke: readAnchorMapToken(tokenNames.stroke),
+      }])
+    ),
+    memoryFill: readAnchorMapToken('--color-memory-neutral'),
+    memoryStroke: readAnchorMapToken('--color-memory-neutral-stroke'),
+    labelFill: readAnchorMapToken('--color-text-main'),
+  };
+}
 
 /** XSS 방지: HTML 특수문자 이스케이프 */
 function escapeHtml(str) {
@@ -37,7 +62,9 @@ function debugAnchorMap(eventName, detail) {
     return;
   }
 
-  document.body?.dispatchEvent(new CustomEvent('memento:debug', {
+  document.dispatchEvent(new CustomEvent('memento:debug', {
+    bubbles: true,
+    composed: true,
     detail: { scope: 'anchor-map', eventName, detail },
   }));
 }
@@ -196,6 +223,8 @@ function renderMap() {
   const g = svg.select('g');
   g.selectAll('*').remove();
 
+  const palette = getAnchorMapPalette();
+
   // 노드와 링크 데이터 준비
   nodes = mapData.nodes.map(d => ({
     ...d,
@@ -236,15 +265,15 @@ function renderMap() {
     .attr('r', d => d.radius)
     .attr('fill', d => {
       if (d.type === 'anchor' && d.slot) {
-        return slotColors[d.slot].fill;
+        return palette.slotColors[d.slot].fill;
       }
-      return '#9ca3af';
+      return palette.memoryFill;
     })
     .attr('stroke', d => {
       if (d.type === 'anchor' && d.slot) {
-        return slotColors[d.slot].stroke;
+        return palette.slotColors[d.slot].stroke;
       }
-      return '#6b7280';
+      return palette.memoryStroke;
     })
     .attr('stroke-width', d => d.type === 'anchor' ? 3 : 2)
     .attr('opacity', 1.0)
@@ -270,7 +299,7 @@ function renderMap() {
       return d.content.substring(0, 20) + (d.content.length > 20 ? '...' : '');
     })
     .style('font-size', '12px')
-    .style('fill', '#333')
+    .style('fill', palette.labelFill)
     .style('pointer-events', 'none');
 
   // Tooltip 추가
@@ -431,7 +460,7 @@ function displayMemoryDetails(node) {
         <label>Created:</label>
         <div class="value">${created}</div>
       </div>
-      <button type="button" class="js-change-anchor" data-slot="${slot}" style="margin-top: 1rem; padding: 0.5rem 1rem; background: #667eea; color: white; border: none; border-radius: 4px; cursor: pointer;">
+      <button type="button" class="anchor-change-btn js-change-anchor m-button m-button--primary" data-slot="${slot}">
         Change Anchor
       </button>
     `;
@@ -498,7 +527,7 @@ function updateAnchorList() {
         <div class="anchor-item slot-${slotClass} js-select-anchor" data-memory-id="${memoryId}">
           <div class="slot-label">Slot ${slot}</div>
           <div class="memory-id">${memoryId}</div>
-          ${memory ? `<div style="font-size: 0.8rem; color: #666; margin-top: 0.25rem;">${contentPreview}</div>` : ''}
+          ${memory ? `<div class="anchor-item-preview">${contentPreview}</div>` : ''}
         </div>
       `;
     })

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -1,32 +1,49 @@
-    // ── 색상 맵 (tokens.css와 동기화) ──────────────────────────
-    const NODE_COLORS = {
-      episodic:   '#818cf8', // --color-memory-episodic
-      semantic:   '#10b981', // --color-success
-      procedural: '#f59e0b', // --color-warning
-      working:    '#9ca3af', // --color-memory-neutral
-    };
+    function readGraphToken(name, fallback = '') {
+      const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      if (value) {
+        return value;
+      }
+      if (fallback) {
+        return fallback;
+      }
+      throw new Error(`Missing CSS token: ${name}`);
+    }
 
-    const EDGE_COLORS = {
-      supports:        '#818cf8',
-      related_to:      '#10b981',
-      extracted_from:  '#f59e0b',
-      contradicts:     '#ef4444', // --color-error
-      default:         '#475569',
-    };
+    function getGraphPalette() {
+      return {
+        nodeColors: {
+          episodic: readGraphToken('--color-memory-episodic'),
+          semantic: readGraphToken('--color-memory-semantic'),
+          procedural: readGraphToken('--color-memory-procedural'),
+          working: readGraphToken('--color-memory-working'),
+          default: readGraphToken('--color-memory-neutral'),
+        },
+        edgeColors: {
+          supports: readGraphToken('--color-memory-episodic'),
+          related_to: readGraphToken('--color-memory-semantic'),
+          extracted_from: readGraphToken('--color-memory-procedural'),
+          contradicts: readGraphToken('--color-error'),
+          default: readGraphToken('--color-graph-edge-default'),
+        },
+      };
+    }
 
-    const TYPE_BG = {
-      episodic:   '#312e81',
-      semantic:   '#064e3b',
-      procedural: '#451a03',
-      working:    '#1e293b',
-    };
+    function getNodeFillColor(type, palette) {
+      return palette.nodeColors[type] ?? palette.nodeColors.default;
+    }
 
-    const TYPE_FG = {
-      episodic:   '#a5b4fc',
-      semantic:   '#6ee7b7',
-      procedural: '#fdba74',
-      working:    '#94a3b8',
-    };
+    function getNodeStrokeColor(type, palette) {
+      const fill = getNodeFillColor(type, palette);
+      const color = d3.color(fill);
+      return color ? color.darker(0.5).formatHex() : fill;
+    }
+
+    function getTypeBadgeClass(type) {
+      const normalizedType = String(type ?? '').toLowerCase();
+      return ['episodic', 'semantic', 'procedural', 'working'].includes(normalizedType)
+        ? `type-badge--${normalizedType}`
+        : 'type-badge--default';
+    }
 
     // ── DOM refs ──────────────────────────────────────────────
     const svgEl      = document.getElementById('graph');
@@ -72,6 +89,7 @@
       const container = document.getElementById('graph-container');
       const W = container.clientWidth;
       const H = container.clientHeight;
+      const palette = getGraphPalette();
 
       d3.select(svgEl).selectAll('*').remove();
 
@@ -120,7 +138,7 @@
         .data(edges)
         .enter().append('line')
         .attr('class', 'link')
-        .attr('stroke', d => EDGE_COLORS[d.relation_type] ?? EDGE_COLORS.default)
+        .attr('stroke', d => palette.edgeColors[d.relation_type] ?? palette.edgeColors.default)
         .attr('stroke-width', d => Math.max(1, (d.confidence ?? 1) * 3));
 
       // 노드 그룹 (T013)
@@ -148,8 +166,8 @@
 
       node.append('circle')
         .attr('r', d => rScale(d.importance))
-        .attr('fill', d => NODE_COLORS[d.type] ?? '#94a3b8')
-        .attr('stroke', d => d3.color(NODE_COLORS[d.type] ?? '#94a3b8').darker(0.5))
+        .attr('fill', d => getNodeFillColor(d.type, palette))
+        .attr('stroke', d => getNodeStrokeColor(d.type, palette))
         // 마우스오버 툴팁 (T018)
         .on('mouseover', (event, d) => {
           tooltip.style.display = 'block';
@@ -186,17 +204,16 @@
 
     // ── 상세 패널 (T019, T020) ────────────────────────────────
     function showDetail(d) {
-      const typeBg = TYPE_BG[d.type] ?? '#1e293b';
-      const typeFg = TYPE_FG[d.type] ?? '#94a3b8';
+      const badgeClass = getTypeBadgeClass(d.type);
       const tagsHtml = (d.tags ?? []).length > 0
         ? `<div class="tag-list">${d.tags.map(t => `<span class="tag">${escHtml(t)}</span>`).join('')}</div>`
-        : '<span style="color:#475569">없음</span>';
+        : '<span class="detail-empty">없음</span>';
 
       detailContent.innerHTML = `
         <div class="detail-row">
           <div class="detail-label">타입</div>
           <div class="detail-value">
-            <span class="type-badge" style="background:${typeBg};color:${typeFg}">${escHtml(d.type)}</span>
+            <span class="type-badge ${badgeClass}">${escHtml(d.type)}</span>
           </div>
         </div>
         <div class="detail-row">
@@ -221,7 +238,7 @@
         </div>
         <div class="detail-row">
           <div class="detail-label">ID</div>
-          <div class="detail-value" style="font-family:monospace;font-size:10px;color:#64748b">${escHtml(d.id)}</div>
+          <div class="detail-value detail-value--mono">${escHtml(d.id)}</div>
         </div>
       `;
       detailPanel.style.display = 'block';
@@ -280,7 +297,8 @@
 
       } catch (err) {
         showLoading(false);
-        showError(err.message ?? '알 수 없는 오류');
+        const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류';
+        showError(errorMessage);
       }
     }
 

--- a/tests/static-design-contracts.spec.ts
+++ b/tests/static-design-contracts.spec.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readStaticFile(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), 'utf-8');
+}
+
+describe('static design contracts', () => {
+  it('anchor-map.js avoids console calls, hex colors, and inline html styles', () => {
+    const source = readStaticFile('static/js/anchor-map.js');
+
+    expect(source).not.toContain('console.');
+    expect(source).not.toMatch(/#[0-9A-Fa-f]{3,8}(?![0-9A-Za-z_-])/);
+    expect(source).not.toMatch(/style\s*=/);
+  });
+
+  it('anchor-map.js emits observable debug events for document-level listeners', () => {
+    const source = readStaticFile('static/js/anchor-map.js');
+
+    expect(source).toMatch(/document\.dispatchEvent\(new CustomEvent\('memento:debug', \{/);
+    expect(source).toMatch(/bubbles:\s*true/);
+    expect(source).toMatch(/composed:\s*true/);
+  });
+
+  it('token readers fail in a bounded way when a required token is missing', () => {
+    const anchorMapSource = readStaticFile('static/js/anchor-map.js');
+    const graphSource = readStaticFile('static/js/graph.js');
+
+    expect(anchorMapSource).toMatch(/function readAnchorMapToken\(name, fallback = ''\)/);
+    expect(anchorMapSource).toMatch(/throw new Error\(`Missing CSS token: \$\{name\}`\);/);
+    expect(graphSource).toMatch(/function readGraphToken\(name, fallback = ''\)/);
+    expect(graphSource).toMatch(/throw new Error\(`Missing CSS token: \$\{name\}`\);/);
+  });
+
+  it('graph.js reads colors from tokens instead of hardcoded hex or inline styles', () => {
+    const source = readStaticFile('static/js/graph.js');
+
+    expect(source).not.toMatch(/#[0-9A-Fa-f]{3,8}(?![0-9A-Za-z_-])/);
+    expect(source).not.toMatch(/style\s*=/);
+  });
+
+  it('graph.html avoids inline color/background styles and hardcoded hex colors', () => {
+    const source = readStaticFile('static/graph.html');
+
+    expect(source).not.toMatch(/style\s*=\s*['"][^'"]*(?:color|background)/);
+    expect(source).not.toMatch(/#[0-9A-Fa-f]{3,8}(?![0-9A-Za-z_-])/);
+  });
+
+  it('dashboard.css uses tokens for tab hover and auth messaging colors', () => {
+    const source = readStaticFile('static/css/dashboard.css');
+
+    expect(source).not.toContain('rgba(255, 255, 255, 0.6)');
+    expect(source).not.toContain('rgba(255, 255, 255, 0.88)');
+    expect(source).not.toContain('#fee2e2');
+  });
+
+  it('components.css uses tokens instead of direct white/rgba color literals', () => {
+    const source = readStaticFile('static/css/components.css');
+
+    expect(source).not.toContain('color: white;');
+    expect(source).not.toContain('background: rgba(');
+    expect(source).not.toContain('border: 1px solid rgba(');
+  });
+});


### PR DESCRIPTION
## Summary
This closes the remaining AGENTS compliance work by removing domain-level relation graph factory fallbacks in `@memento/core` and making the dashboard static assets token-first with no direct console usage.

The core changes route relation graph access through bootstrap-provided services and architecture contracts so new domain code cannot quietly instantiate infrastructure dependencies again. The static changes move graph and anchor map styling onto shared tokens, remove inline color/background styles, and add contract tests that lock in the no-console and token-first rules.

These ship together because they were the last two open tasks in the same remediation plan, and both exist to turn the updated AGENTS guidance into enforceable code and tests rather than documentation-only expectations.

## What Changed
- add `RelationGraphPort`, wire `relationGraph` through `bootstrap` and tool context, and remove direct `relation-graph-factory` fallbacks from remember/relation conversion paths
- add architecture and behavior regression tests for relation graph boundaries, missing service handling, and semantic update failure taxonomy
- add `tests/static-design-contracts.spec.ts` and refactor `static/js/anchor-map.js`, `static/js/graph.js`, `static/graph.html`, and related CSS files to consume shared design tokens instead of hard-coded colors or inline styles
- replace direct dashboard debug logging with an event-based debug channel that keeps `static/js` compliant with `no-console`

## Test Plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npx vitest run packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts`
- [x] `npx vitest run tests/static-design-contracts.spec.ts tests/anchor-map-search-highlight.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/GPT_5.4-1f6feb)

Made with [Cursor](https://cursor.com)