### PR TITLE
refactor(core): isolate relation cache and retry boundaries

### DIFF
--- a/packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts
+++ b/packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts
@@ -88,7 +88,7 @@ vi.mock('../../../embedding/services/unified-embedding-service.js', () => {
 import { LLMBasedRelationExtractor } from '../llm-based-relation-extractor.js';
 import type { MemoryItem, RelationType } from '../../../shared/types/index.js';
 import { UnifiedEmbeddingService } from '../../../embedding/services/unified-embedding-service.js';
-import { CacheService } from '../../../../infrastructure/cache/cache-service.js';
+import { RelationCache } from '../relation-cache.js';
 import { LLMClientInitializer } from '../../../../shared/services/llm-client-initializer.js';
 import type { LLMClientInitializationResult } from '../../../../shared/services/llm-client-initializer.js';
 import { logger } from '../../../../shared/utils/logger.js';
@@ -232,13 +232,13 @@ describe('LLMBasedRelationExtractor', () => {
       get searchSimilar() { return mockSearchSimilar; }
     };
 
-    // CacheService 모킹
+    // RelationCache 모킹
     mockCacheService = {
       get: vi.fn(),
       set: vi.fn()
     };
-    vi.spyOn(CacheService.prototype, 'get').mockImplementation(mockCacheService.get);
-    vi.spyOn(CacheService.prototype, 'set').mockImplementation(mockCacheService.set);
+    vi.spyOn(RelationCache.prototype, 'get').mockImplementation(mockCacheService.get);
+    vi.spyOn(RelationCache.prototype, 'set').mockImplementation(mockCacheService.set);
 
     // 모킹 초기화 (안전 체크)
     if (mockOpenAICreate && typeof mockOpenAICreate.mockClear === 'function') {

--- a/packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts
+++ b/packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts
@@ -16,7 +16,7 @@ import { RuleBasedRelationExtractor } from '../rule-based-relation-extractor.js'
 import { LLMBasedRelationExtractor } from '../llm-based-relation-extractor.js';
 import type { MemoryItem, RelationType } from '../../../shared/types/index.js';
 import { UnifiedEmbeddingService } from '../../../embedding/services/unified-embedding-service.js';
-import { CacheService } from '../../../../infrastructure/cache/cache-service.js';
+import { RelationCache } from '../relation-cache.js';
 
 // mementoConfig 모킹
 vi.mock('../config/index.js', () => {
@@ -123,13 +123,13 @@ describe('RelationExtractor', () => {
       mockEmbeddingService.searchSimilar
     );
 
-    // CacheService 모킹
+    // RelationCache 모킹
     mockCacheService = {
       get: vi.fn(),
       set: vi.fn()
     };
-    vi.spyOn(CacheService.prototype, 'get').mockImplementation(mockCacheService.get);
-    vi.spyOn(CacheService.prototype, 'set').mockImplementation(mockCacheService.set);
+    vi.spyOn(RelationCache.prototype, 'get').mockImplementation(mockCacheService.get);
+    vi.spyOn(RelationCache.prototype, 'set').mockImplementation(mockCacheService.set);
 
     extractor = new RelationExtractor();
 

--- a/packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts
+++ b/packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts
@@ -14,9 +14,8 @@
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import OpenAI from 'openai';
-import { CacheService } from '../../../infrastructure/cache/cache-service.js';
-import type { RetryConfig } from '../../../infrastructure/scheduler/retry-manager.js';
-import { RetryManager } from '../../../infrastructure/scheduler/retry-manager.js';
+import type { ICacheService } from '../../../shared/interfaces/cache.interface.js';
+import type { IRetryManager } from '../../../shared/interfaces/retry-manager.interface.js';
 import { mementoConfig } from '../../../shared/config/index.js';
 import { getRetryOptions } from '../../../shared/config/retry-options-loader.js';
 import { CACHE,CONFIDENCE,LIMITS,LLM_COST,RATE_LIMITER,TIME } from '../../../shared/constants/relation-constants.js';
@@ -33,6 +32,8 @@ import { ALL_RELATION_TYPES,isApplicableRelationType,MEMORY_TYPE_RELATION_MAP } 
 import { CacheKeyGenerator } from '../../../shared/utils/cache-key-generator.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { UnifiedEmbeddingService } from '../../embedding/services/unified-embedding-service.js';
+import { RelationCache } from './relation-cache.js';
+import { RelationRetryManager } from './relation-retry-manager.js';
 
 /**
  * LLM 응답 파싱 결과 (레거시 호환성을 위해 유지)
@@ -153,16 +154,20 @@ export class LLMBasedRelationExtractor implements IRelationExtractor {
   private readonly initializationPromise: Promise<void>;
   private initializationCompleted = false;
   private readonly embeddingService: UnifiedEmbeddingService;
-  private readonly cache: CacheService<RelationCandidate[]>; // 7일 TTL
+  private readonly cache: ICacheService<RelationCandidate[]>; // 7일 TTL
   private readonly rateLimiter: TokenBucketRateLimiter;
   private readonly costMetrics: LLMCostMetrics;
-  private readonly retryManager: RetryManager;
+  private readonly retryManager: IRetryManager;
 
-  constructor(embeddingService?: UnifiedEmbeddingService) {
+  constructor(
+    embeddingService?: UnifiedEmbeddingService,
+    cache?: ICacheService<RelationCandidate[]>,
+    retryManager?: IRetryManager,
+  ) {
     // 초기화 지연: preferredProvider는 null로 시작하고, initializationPromise를 통해 비동기 초기화
     this.preferredProvider = null;
     this.embeddingService = embeddingService || new UnifiedEmbeddingService();
-    this.cache = new CacheService<RelationCandidate[]>(CACHE.EXTRACTION_SIZE, CACHE.EXTRACTION_TTL_MS);
+    this.cache = cache ?? new RelationCache<RelationCandidate[]>(CACHE.EXTRACTION_SIZE, CACHE.EXTRACTION_TTL_MS);
     this.rateLimiter = new TokenBucketRateLimiter(RATE_LIMITER.CAPACITY, RATE_LIMITER.REFILL_RATE);
     this.costMetrics = {
       totalCalls: 0,
@@ -173,11 +178,10 @@ export class LLMBasedRelationExtractor implements IRelationExtractor {
     
     // RetryManager 초기화 (external_api 설정 사용)
     const retryOptions = getRetryOptions();
-    const retryConfig: RetryConfig = {
-      ...retryOptions.external_api,
-      maxErrorCount: retryOptions.default.maxErrorCount
-    };
-    this.retryManager = new RetryManager(retryConfig);
+    this.retryManager = retryManager ?? new RelationRetryManager({
+      maxAttempts: retryOptions.external_api.maxAttempts,
+      baseDelay: retryOptions.external_api.baseDelay,
+    });
     
     // 비동기 초기화: initializeClients()를 호출하고 결과를 설정
     this.initializationPromise = this.initializeClients().then((provider) => {

--- a/packages/memento-core/src/domains/relation/services/relation-cache.ts
+++ b/packages/memento-core/src/domains/relation/services/relation-cache.ts
@@ -1,0 +1,82 @@
+import type { ICacheService } from '../../../shared/interfaces/cache.interface.js';
+
+type CacheEntry<T> = {
+  data: T;
+  timestamp: number;
+  ttl: number;
+  lastAccessed: number;
+};
+
+export class RelationCache<T> implements ICacheService<T> {
+  private readonly cache = new Map<string, CacheEntry<T>>();
+
+  constructor(
+    private readonly maxSize: number = 1000,
+    private readonly defaultTTL: number = 300000,
+  ) {}
+
+  get(key: string): T | null {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (Date.now() - entry.timestamp > entry.ttl) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    entry.lastAccessed = Date.now();
+    return entry.data;
+  }
+
+  set(key: string, data: T, ttl: number = this.defaultTTL): void {
+    const now = Date.now();
+    const existingEntry = this.cache.get(key);
+
+    if (!existingEntry && this.cache.size >= this.maxSize) {
+      this.evictLeastRecentlyUsed();
+    }
+
+    this.cache.set(key, {
+      data,
+      timestamp: now,
+      ttl,
+      lastAccessed: now,
+    });
+  }
+
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  keys(): string[] {
+    this.pruneExpired();
+    return [...this.cache.keys()];
+  }
+
+  private evictLeastRecentlyUsed(): void {
+    let oldestKey: string | undefined;
+    let oldestAccess = Number.POSITIVE_INFINITY;
+
+    for (const [key, entry] of this.cache.entries()) {
+      if (entry.lastAccessed < oldestAccess) {
+        oldestAccess = entry.lastAccessed;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey !== undefined) {
+      this.cache.delete(oldestKey);
+    }
+  }
+
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (now - entry.timestamp > entry.ttl) {
+        this.cache.delete(key);
+      }
+    }
+  }
+}

--- a/packages/memento-core/src/domains/relation/services/relation-extractor.ts
+++ b/packages/memento-core/src/domains/relation/services/relation-extractor.ts
@@ -18,10 +18,11 @@ import { isApplicableRelationType, MEMORY_TYPE_RELATION_MAP } from '../../../sha
 import type { MemoryType, MemoryItem } from '../../../shared/types/index.js';
 import { RuleBasedRelationExtractor } from './rule-based-relation-extractor.js';
 import { LLMBasedRelationExtractor } from './llm-based-relation-extractor.js';
-import { CacheService } from '../../../infrastructure/cache/cache-service.js';
+import type { ICacheService } from '../../../shared/interfaces/cache.interface.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { CacheKeyGenerator } from '../../../shared/utils/cache-key-generator.js';
 import { CONFIDENCE, LIMITS, CACHE } from '../../../shared/constants/relation-constants.js';
+import { RelationCache } from './relation-cache.js';
 
 /**
  * 관계 추출 메인 서비스
@@ -29,16 +30,17 @@ import { CONFIDENCE, LIMITS, CACHE } from '../../../shared/constants/relation-co
 export class RelationExtractor implements IRelationExtractor {
   private readonly ruleExtractor: RuleBasedRelationExtractor;
   private readonly llmExtractor: LLMBasedRelationExtractor;
-  private readonly cache: CacheService<RelationCandidate[]>;
+  private readonly cache: ICacheService<RelationCandidate[]>;
 
   constructor(
     ruleExtractor?: RuleBasedRelationExtractor,
-    llmExtractor?: LLMBasedRelationExtractor
+    llmExtractor?: LLMBasedRelationExtractor,
+    cache?: ICacheService<RelationCandidate[]>,
   ) {
     this.ruleExtractor = ruleExtractor ?? new RuleBasedRelationExtractor();
     this.llmExtractor = llmExtractor ?? new LLMBasedRelationExtractor();
     // 캐시: 1000개 항목, 7일 TTL
-    this.cache = new CacheService<RelationCandidate[]>(CACHE.EXTRACTION_SIZE, CACHE.EXTRACTION_TTL_MS);
+    this.cache = cache ?? new RelationCache<RelationCandidate[]>(CACHE.EXTRACTION_SIZE, CACHE.EXTRACTION_TTL_MS);
   }
 
   /**

--- a/packages/memento-core/src/domains/relation/services/relation-retry-manager.ts
+++ b/packages/memento-core/src/domains/relation/services/relation-retry-manager.ts
@@ -1,0 +1,36 @@
+import type { IRetryManager, IRetryOptions } from '../../../shared/interfaces/retry-manager.interface.js';
+
+type RetryConfig = {
+  maxAttempts: number;
+  baseDelay: number;
+};
+
+export class RelationRetryManager implements IRetryManager {
+  constructor(private readonly config: RetryConfig) {}
+
+  async retry<T>(fn: () => Promise<T>, options: IRetryOptions = {}): Promise<T> {
+    const maxAttempts = options.maxAttempts ?? this.config.maxAttempts;
+    const baseDelay = options.baseDelay ?? this.config.baseDelay;
+    const shouldRetry = options.shouldRetry ?? (() => true);
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        if (!shouldRetry(lastError) || attempt === maxAttempts - 1) {
+          throw lastError;
+        }
+
+        const delay = baseDelay * Math.pow(2, attempt);
+        options.onRetry?.(lastError, attempt + 1, delay);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    throw lastError ?? new Error('Retry attempts exhausted');
+  }
+}

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts
@@ -15,7 +15,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import OpenAI from 'openai';
 import { tripleExtractionLogger } from '../../../../infrastructure/logging/triple-extraction-logger.js';
-import { RetryManager } from '../../../../infrastructure/scheduler/retry-manager.js';
+import type { IRetryManager } from '../../../../shared/interfaces/retry-manager.interface.js';
 import { mementoConfig } from '../../../../shared/config/index.js';
 import { getRetryOptions } from '../../../../shared/config/retry-options-loader.js';
 import type { LLMClientInitializationResult } from '../../../../shared/services/llm-client-initializer.js';
@@ -36,6 +36,7 @@ import { PredicateCanonicalizer } from './predicate-canonicalizer.js';
 import { TripleExtractionStatisticsService } from './triple-extraction-statistics.js';
 import { TripleNormalizer } from './triple-normalizer.js';
 import { TripleParser } from './triple-parser.js';
+import { RelationRetryManager } from '../relation-retry-manager.js';
 
 /**
  * 토큰 버킷 Rate Limiter
@@ -117,7 +118,7 @@ export class TripleExtractionService {
   private readonly parser: TripleParser;
   private readonly normalizer: TripleNormalizer;
   private readonly statistics: TripleExtractionStatisticsService; // PRD 8.1: Triple 추출 통계 수집
-  private readonly retryManager: RetryManager;
+  private readonly retryManager: IRetryManager;
   private initializationPromise: Promise<void> | null = null;
 
   // 기본 설정
@@ -131,7 +132,7 @@ export class TripleExtractionService {
   // 로깅 설정
   private readonly SUCCESS_SAMPLING_RATE = 0.1; // 성공 케이스 10% 샘플링
 
-  constructor() {
+  constructor(retryManager?: IRetryManager) {
     // PRD 6.11: Triple 추출 결과 캐싱 구현
     // PRD 6.12: 캐시 키 생성 로직 구현 (content_hash 기반)
     // PRD 6.13: 캐시 TTL 기반 자동 무효화 구현
@@ -154,10 +155,9 @@ export class TripleExtractionService {
     this.statistics = new TripleExtractionStatisticsService();
     // RetryManager 초기화 (외부 API 호출 재시도용)
     const retryOptions = getRetryOptions();
-    this.retryManager = new RetryManager({
+    this.retryManager = retryManager ?? new RelationRetryManager({
       maxAttempts: retryOptions.external_api.maxAttempts,
       baseDelay: retryOptions.external_api.baseDelay,
-      maxErrorCount: retryOptions.default.maxErrorCount
     });
     
     // 비동기 초기화 시작 (constructor에서 Promise 저장)

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts
@@ -12,12 +12,13 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { mementoConfig } from '../../../../shared/config/index.js';
 import { PromptTemplateLoader } from '../../../../shared/utils/prompt-template-loader.js';
 import { logger } from '../../../../shared/utils/logger.js';
-import { RetryManager } from '../../../../infrastructure/scheduler/retry-manager.js';
+import type { IRetryManager } from '../../../../shared/interfaces/retry-manager.interface.js';
 import { getRetryOptions } from '../../../../shared/config/retry-options-loader.js';
 import { LLMClientInitializer } from '../../../../shared/services/llm-client-initializer.js';
 import type { LLMClientInitializationResult } from '../../../../shared/services/llm-client-initializer.js';
 import type { ITripleExtractor } from './interfaces.js';
 import type { Triple, TripleExtractionOptions } from '../../../../shared/types/triple-extraction.js';
+import { RelationRetryManager } from '../relation-retry-manager.js';
 
 /**
  * Triple 추출기 클래스
@@ -28,7 +29,7 @@ export class TripleExtractor implements ITripleExtractor {
   private geminiClient: GoogleGenerativeAI | null = null;
   private preferredProvider: 'openai' | 'gemini' | 'ollama' | null = null;
   private initializedProviders: ('openai' | 'gemini' | 'ollama')[] = [];
-  private readonly retryManager: RetryManager;
+  private readonly retryManager: IRetryManager;
   private initializationPromise: Promise<void> | null = null;
 
   // 기본 설정
@@ -36,13 +37,12 @@ export class TripleExtractor implements ITripleExtractor {
   private readonly DEFAULT_MAX_TOKENS = 2000;
   private readonly SYSTEM_MESSAGE = 'You are a knowledge graph extractor. Extract triples (subject, predicate, object) from observations and return JSON format only.';
 
-  constructor() {
+  constructor(retryManager?: IRetryManager) {
     this.initializationPromise = this.initializeClients();
     const retryOptions = getRetryOptions();
-    this.retryManager = new RetryManager({
+    this.retryManager = retryManager ?? new RelationRetryManager({
       maxAttempts: retryOptions.external_api.maxAttempts,
       baseDelay: retryOptions.external_api.baseDelay,
-      maxErrorCount: retryOptions.default.maxErrorCount
     });
   }
 

--- a/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
+++ b/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
@@ -36,6 +36,24 @@ async function collectDomainProductionFiles(dir: string): Promise<string[]> {
 }
 
 describe('dependency boundaries', () => {
+  it('keeps infrastructure cache and retry-manager imports out of relation service production files', async () => {
+    const relationServicesRoot = path.join(domainsRoot, 'relation', 'services');
+    const relationServiceFiles = await collectDomainProductionFiles(relationServicesRoot);
+    const offenders: string[] = [];
+
+    for (const relativePath of relationServiceFiles) {
+      const source = await readSource(relativePath);
+      const hasConcreteCacheImport = /import\s+.*['"].*infrastructure\/cache\/cache-service\.js['"]/m.test(source);
+      const hasConcreteRetryImport = /import\s+.*['"].*infrastructure\/scheduler\/retry-manager\.js['"]/m.test(source);
+
+      if (hasConcreteCacheImport || hasConcreteRetryImport) {
+        offenders.push(relativePath);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it('keeps relation graph factory imports and fallbacks out of domain production files', async () => {
     const domainFiles = await collectDomainProductionFiles(domainsRoot);
     const offenders: string[] = [];


### PR DESCRIPTION
## Summary
- route relation extraction and triple extraction services through relation-scoped cache and retry adapters so the domain layer no longer imports concrete infrastructure implementations directly
- preserve existing caching and retry behavior while updating constructors and unit tests to depend on shared ports instead of infrastructure classes
- add an architecture contract test that blocks future direct imports of `infrastructure/cache/cache-service` and `infrastructure/scheduler/retry-manager` from `domains/relation/services`

## Test plan
- [x] `npx vitest run packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts`
- [x] `npm run type-check`
- [x] `npm test`


Made with [Cursor](https://cursor.com)