### PR TITLE
fix: resolve npm publish verify-bin failure for workspace build outputs

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,25 @@
+# Memento × External AI Assistants
+
+이 디렉터리는 **이미 존재하는 단일-사용자 개인 AI 비서**가 Memento를 공유 장기 기억 백엔드로 사용하도록 안내합니다. 새 비서를 만들지 않고, 기존 비서에 memento를 *그냥 또 하나의 MCP 서버*로 등록하는 방식입니다.
+
+## 어떤 비서를 쓰시나요?
+
+- [OpenClaw](./openclaw.md) — Node.js 게이트웨이 + 멀티채널
+- [NanoClaw](./nanoclaw.md) — 컨테이너 격리 + Claude Agent SDK
+- [ZeroClaw](./zeroclaw.md) — Rust 단일 바이너리
+
+## 트랙 결정
+
+- 단일 머신만 사용 → [stdio 트랙](./_shared/transports.md#stdio-트랙) (5분 셋업)
+- 여러 디바이스/홈서버 → [HTTP 트랙](./_shared/transports.md#http-트랙) (멀티 디바이스 기억 공유)
+
+## 공통 가이드
+
+- [Transport 결정 + 셋업](./_shared/transports.md)
+- [인증 / 토큰 관리](./_shared/auth.md)
+- [권장 시스템 프롬프트 패턴](./_shared/system-prompt.md)
+- [트러블슈팅](./_shared/troubleshooting.md)
+
+## 더 깊은 통합 (옵션)
+
+베어 MCP만으로 부족하면 `@memento/assistant` SDK를 사용해 *결정론적 자동 회상/저장*을 얻을 수 있습니다. v0.2에서 별도 가이드 추가 예정.

--- a/docs/integrations/_shared/auth.md
+++ b/docs/integrations/_shared/auth.md
@@ -1,0 +1,3 @@
+# Authentication
+
+> TODO: 이 문서는 Task 4에서 작성됩니다.

--- a/docs/integrations/_shared/system-prompt.md
+++ b/docs/integrations/_shared/system-prompt.md
@@ -1,0 +1,3 @@
+# System Prompt Pattern
+
+> TODO: 이 문서는 Task 5에서 작성됩니다.

--- a/docs/integrations/_shared/transports.md
+++ b/docs/integrations/_shared/transports.md
@@ -1,0 +1,3 @@
+# Transports
+
+> TODO: 이 문서는 Task 3에서 작성됩니다.

--- a/docs/integrations/_shared/troubleshooting.md
+++ b/docs/integrations/_shared/troubleshooting.md
@@ -1,0 +1,3 @@
+# Troubleshooting
+
+> TODO: 이 문서는 Task 6에서 작성됩니다.

--- a/docs/integrations/nanoclaw.md
+++ b/docs/integrations/nanoclaw.md
@@ -1,0 +1,3 @@
+# NanoClaw × Memento
+
+> TODO: 이 문서는 Task 8에서 작성됩니다.

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,0 +1,3 @@
+# OpenClaw × Memento
+
+> TODO: 이 문서는 Task 9에서 작성됩니다.

--- a/docs/integrations/zeroclaw.md
+++ b/docs/integrations/zeroclaw.md
@@ -1,0 +1,3 @@
+# ZeroClaw × Memento
+
+> TODO: 이 문서는 Task 7에서 작성됩니다.

--- a/docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md
+++ b/docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md
@@ -33,6 +33,29 @@
 
 ---
 
+## Task 0: 작업 브랜치 생성
+
+**Files:** (없음 — git 작업)
+
+### 배경
+
+이 저장소의 글로벌 규칙: **main 직접 커밋 금지, 항상 브랜치 → PR**. 모든 후속 task는 이 브랜치에서 수행한다.
+
+> **Note:** 본 plan 문서 자체가 이미 `docs/external-assistant-integration-design` 브랜치에 커밋되어 있다면 그 브랜치를 그대로 이어 쓰면 된다. 새로 시작하는 경우에만 아래 명령 실행.
+
+- [ ] **Step 1: 브랜치 확인 / 생성**
+
+```bash
+git branch --show-current
+# 결과가 'main'이면 새 브랜치 생성:
+git checkout -b docs/external-assistant-integration-design
+# 결과가 이미 'docs/external-assistant-integration-design'이면 skip
+```
+
+기대 결과: 작업 브랜치 `docs/external-assistant-integration-design`에 위치.
+
+---
+
 ## Task 1: memento-agent 아카이브
 
 **Files:**
@@ -43,14 +66,32 @@
 
 `packages/memento-agent/`는 이슈 #100의 자체 비서 빌드 산출물(설계 + 일부 스캐폴드). 외부 비서 통합으로 방향 전환했으므로 active 패키지에서 제외한다. 루트 `package.json`의 `workspaces` 배열에 이미 포함되어 있지 않아 빌드/테스트 영향 없음 — 그래도 `packages/` 아래에 있으면 혼란을 줄 수 있어 `_archived/`로 격리.
 
-- [ ] **Step 1: 아카이브 디렉터리 생성 및 이동**
+- [ ] **Step 1: 현재 git 상태 확인**
 
+```bash
+git status -s packages/memento-agent
+```
+
+결과 해석:
+- 라인이 `??`로 시작 → **untracked**. `git mv` 사용 불가. Step 2의 폴백 경로 사용.
+- 라인이 비어있거나 `M`/`A` 등으로 시작 → **tracked**. `git mv` 사용 가능.
+
+- [ ] **Step 2: 아카이브 디렉터리 생성 및 이동**
+
+tracked인 경우:
 ```bash
 mkdir -p packages/_archived
 git mv packages/memento-agent packages/_archived/memento-agent-issue-100
 ```
 
-- [ ] **Step 2: 아카이브 README 작성**
+untracked인 경우 (폴백):
+```bash
+mkdir -p packages/_archived
+mv packages/memento-agent packages/_archived/memento-agent-issue-100
+# 새 위치를 git이 인식하도록 (Step 5 commit에서 자동 staged됨)
+```
+
+- [ ] **Step 3: 아카이브 README 작성**
 
 ```markdown
 # _archived
@@ -69,7 +110,7 @@ git mv packages/memento-agent packages/_archived/memento-agent-issue-100
 
 저장: `packages/_archived/README.md`
 
-- [ ] **Step 3: 빌드 깨지지 않음 확인**
+- [ ] **Step 4: 빌드 깨지지 않음 확인**
 
 ```bash
 npm install
@@ -78,7 +119,7 @@ npm run build
 
 기대 결과: 둘 다 성공. `packages/memento-agent`가 `workspaces`에 없었으므로 영향 없어야 함.
 
-- [ ] **Step 4: 테스트 통과 확인**
+- [ ] **Step 5: 테스트 통과 확인**
 
 ```bash
 npm test
@@ -86,7 +127,7 @@ npm test
 
 기대 결과: 모든 테스트 PASS.
 
-- [ ] **Step 5: 커밋**
+- [ ] **Step 6: 커밋**
 
 ```bash
 git add packages/_archived
@@ -553,7 +594,11 @@ npx vitest run tests/integrations/smoke.spec.ts
 
 - [ ] **Step 3: vitest 설정 확인**
 
-`vitest.config.ts`에서 `tests/integrations/`가 include 되는지 확인. 안 되면 추가:
+```bash
+grep -n "include" vitest.config.ts
+```
+
+`tests/integrations/`나 `tests/**/*.spec.ts`가 include 패턴에 들어있는지 확인. 안 되면 추가:
 
 ```typescript
 test: {

--- a/docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md
+++ b/docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md
@@ -1,0 +1,648 @@
+# External Assistant Integration — L1 Guides Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Phase 0 (memento-agent 아카이브) + Phase 1 (외부 비서 통합 가이드 docs) 완료. v0.1 스펙의 L1 단계로, 사용자가 OpenClaw / NanoClaw / ZeroClaw에서 베어 MCP로 memento를 즉시 사용할 수 있게 한다.
+
+**Architecture:** 모든 가이드 docs는 `docs/integrations/` 아래에 모이고, 90% 공통 내용은 `_shared/`로 추출, 10% 비서별 차이만 비서 파일에 둔다. T3 트랙(stdio + HTTP)을 둘 다 안내. 코드 변경은 Phase 0 아카이브 이동 한 건뿐.
+
+**Tech Stack:** Markdown, JSON/TOML config 스니펫, Node.js (스모크 테스트), Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md`
+
+---
+
+## 파일 구조
+
+| 파일 | 유형 | 역할 |
+|---|---|---|
+| `packages/_archived/memento-agent-issue-100/**` | 이동 | 기존 `packages/memento-agent/` 전체를 아카이브 |
+| `packages/_archived/README.md` | 신규 | 아카이브 정책 노트 |
+| `docs/integrations/README.md` | 신규 | 통합 허브, 비서 선택 + 트랙 결정 가이드 진입점 |
+| `docs/integrations/_shared/transports.md` | 신규 | T3: stdio vs HTTP 트랙 결정 + 셋업 |
+| `docs/integrations/_shared/auth.md` | 신규 | 토큰 발급, 회전, 폐기, secret store 가이드 |
+| `docs/integrations/_shared/system-prompt.md` | 신규 | recall-first 시스템 프롬프트 패턴, ExtractedItem 추출 가이드 |
+| `docs/integrations/_shared/troubleshooting.md` | 신규 | 공통 이슈 (응답 없음, 빈 결과, 401 등) |
+| `docs/integrations/openclaw.md` | 신규 | OpenClaw 고유 셋업 + 식별자 매핑 |
+| `docs/integrations/nanoclaw.md` | 신규 | NanoClaw 고유 (호스트 memento + 컨테이너 HTTP 접근) |
+| `docs/integrations/zeroclaw.md` | 신규 | ZeroClaw 고유 (Rust `[[mcp.servers]]` config) |
+| `README.md` | 수정 | "External Assistants" 섹션 + 허브 링크 |
+| `README.en.md` | 수정 | 영문 동일 |
+| `tests/integrations/smoke.spec.ts` | 신규 | L1 가이드 스니펫 drift 방지 스모크 (최소형) |
+| `vitest.config.ts` | 수정 (필요 시) | tests/integrations/ include |
+
+---
+
+## Task 1: memento-agent 아카이브
+
+**Files:**
+- Move: `packages/memento-agent/` → `packages/_archived/memento-agent-issue-100/`
+- Create: `packages/_archived/README.md`
+
+### 배경
+
+`packages/memento-agent/`는 이슈 #100의 자체 비서 빌드 산출물(설계 + 일부 스캐폴드). 외부 비서 통합으로 방향 전환했으므로 active 패키지에서 제외한다. 루트 `package.json`의 `workspaces` 배열에 이미 포함되어 있지 않아 빌드/테스트 영향 없음 — 그래도 `packages/` 아래에 있으면 혼란을 줄 수 있어 `_archived/`로 격리.
+
+- [ ] **Step 1: 아카이브 디렉터리 생성 및 이동**
+
+```bash
+mkdir -p packages/_archived
+git mv packages/memento-agent packages/_archived/memento-agent-issue-100
+```
+
+- [ ] **Step 2: 아카이브 README 작성**
+
+```markdown
+# _archived
+
+이 디렉터리는 **참고용으로만** 보존되는 보류된 패키지를 담는다. 빌드·테스트·배포에 포함되지 않는다.
+
+## memento-agent-issue-100
+
+이슈 #100 ("자체 Memento Agent 빌드")의 산출물. 2026-04-27 외부 비서 통합(OpenClaw / NanoClaw / ZeroClaw) 방향으로 전환되면서 active 개발이 중단되었다.
+
+- 설계: `docs/superpowers/specs/2026-04-25-memento-agent-design.md`
+- 새 방향: `docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md`
+
+코드와 설계는 향후 reminder/scheduled-recall 같은 코어 기능 도입 시 참고할 가치가 있어 보존.
+```
+
+저장: `packages/_archived/README.md`
+
+- [ ] **Step 3: 빌드 깨지지 않음 확인**
+
+```bash
+npm install
+npm run build
+```
+
+기대 결과: 둘 다 성공. `packages/memento-agent`가 `workspaces`에 없었으므로 영향 없어야 함.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+npm test
+```
+
+기대 결과: 모든 테스트 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/_archived
+git commit -m "chore: archive memento-agent (issue #100 superseded by external assistant integration)"
+```
+
+---
+
+## Task 2: `docs/integrations/` 스켈레톤
+
+**Files:**
+- Create: `docs/integrations/README.md`
+- Create: `docs/integrations/_shared/transports.md` (placeholder)
+- Create: `docs/integrations/_shared/auth.md` (placeholder)
+- Create: `docs/integrations/_shared/system-prompt.md` (placeholder)
+- Create: `docs/integrations/_shared/troubleshooting.md` (placeholder)
+- Create: `docs/integrations/openclaw.md` (placeholder)
+- Create: `docs/integrations/nanoclaw.md` (placeholder)
+- Create: `docs/integrations/zeroclaw.md` (placeholder)
+
+### 배경
+
+먼저 빈 골격을 만들어 후속 태스크가 각 파일을 채운다. 빈 placeholder는 `> TODO: filled in Task N` 한 줄만 둔다 — drift는 후속 task에서 잡힘.
+
+- [ ] **Step 1: 디렉터리와 placeholder 파일 생성**
+
+각 파일 내용:
+```markdown
+# <파일 제목>
+
+> TODO: 이 문서는 Task N에서 작성됩니다.
+```
+
+- [ ] **Step 2: integrations/README.md 허브 골격**
+
+```markdown
+# Memento × External AI Assistants
+
+이 디렉터리는 **이미 존재하는 단일-사용자 개인 AI 비서**가 Memento를 공유 장기 기억 백엔드로 사용하도록 안내합니다. 새 비서를 만들지 않고, 기존 비서에 memento를 *그냥 또 하나의 MCP 서버*로 등록하는 방식입니다.
+
+## 어떤 비서를 쓰시나요?
+
+- [OpenClaw](./openclaw.md) — Node.js 게이트웨이 + 멀티채널
+- [NanoClaw](./nanoclaw.md) — 컨테이너 격리 + Claude Agent SDK
+- [ZeroClaw](./zeroclaw.md) — Rust 단일 바이너리
+
+## 트랙 결정
+
+- 단일 머신만 사용 → [stdio 트랙](./_shared/transports.md#stdio-트랙) (5분 셋업)
+- 여러 디바이스/홈서버 → [HTTP 트랙](./_shared/transports.md#http-트랙) (멀티 디바이스 기억 공유)
+
+## 공통 가이드
+
+- [Transport 결정 + 셋업](./_shared/transports.md)
+- [인증 / 토큰 관리](./_shared/auth.md)
+- [권장 시스템 프롬프트 패턴](./_shared/system-prompt.md)
+- [트러블슈팅](./_shared/troubleshooting.md)
+
+## 더 깊은 통합 (옵션)
+
+베어 MCP만으로 부족하면 `@memento/assistant` SDK를 사용해 *결정론적 자동 회상/저장*을 얻을 수 있습니다. v0.2에서 별도 가이드 추가 예정.
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/integrations/
+git commit -m "docs(integrations): scaffold external assistant integration guides"
+```
+
+---
+
+## Task 3: `_shared/transports.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/_shared/transports.md`
+
+### 배경
+
+T3 핵심 문서. stdio vs HTTP 결정 가이드, 각 트랙의 셋업 절차, 트랙 전환 시 주의사항.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- 결정 매트릭스 (단일/멀티 머신, 멀티채널 우선순위, 보안 요구)
+- stdio 트랙 셋업: `npx memento-mcp-server@latest setup` 한 줄, 트러블슈팅 링크
+- HTTP 트랙 셋업: `docker compose -f docker-compose.prod.yml up -d`, base URL 확인, `/auth/session` 흐름
+- 트랙 전환: 같은 owner_id로 같은 SQLite 파일을 보면 stdio/HTTP가 같은 데이터를 본다는 점, 마이그레이션 절차
+
+저장 위치: `docs/integrations/_shared/transports.md`
+
+- [ ] **Step 2: 내부 링크 검증**
+
+```bash
+npm run docs:audit-links
+```
+
+기대 결과: 새 링크 모두 OK.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/integrations/_shared/transports.md
+git commit -m "docs(integrations): write _shared/transports.md"
+```
+
+---
+
+## Task 4: `_shared/auth.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/_shared/auth.md`
+
+### 배경
+
+HTTP 트랙 사용자가 봐야 할 인증 흐름. 토큰 발급, 회전, 폐기, secret store 권장.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- Bearer 토큰 발급: 어드민 페이지에서 발급, 또는 CLI 발급 명령
+- 토큰 종류 (X-API-Key vs Bearer 비교 표 — `docs/reference/ko/security.md` 참조)
+- 회전 절차: 새 토큰 발급 → 비서 config 갱신 → 옛 토큰 폐기
+- 폐기: 어드민 UI 또는 API 호출
+- secret store 권장 (비서별 위치 명시 — OpenClaw env, NanoClaw `.env.local`, ZeroClaw Vault, OS keychain 등)
+- TLS 검증: 자체 서명 인증서 사용 시 주의 (개발 모드 옵트인)
+
+- [ ] **Step 2: 링크 검증**
+
+```bash
+npm run docs:audit-links
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/integrations/_shared/auth.md
+git commit -m "docs(integrations): write _shared/auth.md"
+```
+
+---
+
+## Task 5: `_shared/system-prompt.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/_shared/system-prompt.md`
+
+### 배경
+
+베어 MCP 모드에서 LLM이 `recall`/`remember`를 부지런히 호출하도록 만드는 권장 시스템 프롬프트. v0.2에서 SDK가 자동화하지만, v0.1 베어 MCP는 LLM 의지에 의존.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- 권장 프롬프트 블록 (그대로 복붙 가능):
+
+```text
+[Memento Memory]
+이 어시스턴트는 memento MCP 서버에 장기 기억을 저장합니다. 다음 규칙을 따릅니다:
+
+1. 사용자가 새 주제를 꺼내거나 과거 사실/대화를 참조할 때, 우선 `memento.recall(query)`를 호출하여 관련 기억을 가져옵니다.
+2. 사용자가 사실, 선호, 약속, 결정사항을 알려주면 응답을 마치기 전 `memento.remember`로 저장합니다. type 매핑:
+   - 사실/지식 → `semantic`
+   - 사건/대화/약속 → `episodic` (미래 약속은 tags에 'commitment' 추가)
+   - 임시 컨텍스트 → `working` (48h)
+3. 모든 저장은 다음 tags를 자동 부여: ["channel:<현재_채널>", "user:<현재_사용자>"]
+4. recall 결과는 출처(memory_id, type, importance)를 응답에 명시하지 않아도 되지만, 사용자가 "어떻게 알았어?"라고 물으면 출처를 노출할 수 있습니다.
+
+memento가 응답하지 않으면 **그냥 진행**하세요. 메모리는 augmentation이지 dependency가 아닙니다.
+```
+
+- ExtractedItem 추출 가이드 (LLM이 직접 추출하는 경우 — 베어 MCP에서는 LLM 책임):
+  - fact / preference / event 형태 예시
+  - "commitment"는 event + tags에 'commitment'로 표현
+
+- 비서별 channel/user 토큰 자리에 무엇을 넣을지 — 비서 가이드 본문에서 다시 안내
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add docs/integrations/_shared/system-prompt.md
+git commit -m "docs(integrations): write _shared/system-prompt.md"
+```
+
+---
+
+## Task 6: `_shared/troubleshooting.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/_shared/troubleshooting.md`
+
+### 배경
+
+흔한 이슈와 진단 단계.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- "memento MCP가 응답이 없음": stdio 자식 프로세스 로그 확인 위치 (비서별 링크), `npx memento-mcp-server health-check` 명령
+- "recall 결과가 비어있음": 임베딩 프로바이더 확인 (`/admin/providers`), TF-IDF 폴백 동작 여부, 데이터 파일 위치 (`~/.memento/memento.db`)
+- "401 Unauthorized": 토큰 만료/회전 절차 → `auth.md` 링크
+- "TLS 인증서 오류": 자체 서명 시 옵션 + 권장 (Let's Encrypt)
+- "두 디바이스가 같은 기억을 못 봄": HTTP 트랙으로 전환했는지, 같은 base URL인지, owner_id 일치 여부
+- 디버그 로그 활성화: `MEMENTO_LOG=debug` (단, 토큰이 로그에 나오지 않도록 주의 안내)
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add docs/integrations/_shared/troubleshooting.md
+git commit -m "docs(integrations): write _shared/troubleshooting.md"
+```
+
+---
+
+## Task 7: `zeroclaw.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/zeroclaw.md`
+
+### 배경
+
+ZeroClaw는 Rust 바이너리. config가 TOML, MCP 서버는 `[[mcp.servers]]` 블록.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- 사전 조건: `agent-runtime` feature 필요 (소스 빌드 시 `--features agent-runtime`)
+- stdio 트랙 config 스니펫:
+
+```toml
+# ~/.config/zeroclaw/config.toml 또는 워크스페이스 config.toml
+[[mcp.servers]]
+name    = "memento"
+command = "npx"
+args    = ["-y", "memento-mcp-server@latest", "start", "--stdio"]
+```
+
+- HTTP 트랙 config 스니펫:
+
+```toml
+[[mcp.servers]]
+name      = "memento"
+transport = "http"
+url       = "http://your-home-server:9001/mcp"
+
+[mcp.servers.headers]
+authorization = "Bearer ${MEMENTO_TOKEN}"
+```
+
+- 식별자 매핑: ZeroClaw `actor.id` → memento `owner_id`, channel kind → tag
+- 시스템 프롬프트 적용 위치: `_shared/system-prompt.md` 블록을 ZeroClaw의 system prompt slot에 붙여넣기. `<현재_채널>` 자리에 ZeroClaw 채널 변수
+- 검증: ZeroClaw에서 `/list-tools` 같은 명령으로 memento 도구가 노출됐는지 확인
+
+- [ ] **Step 2: 링크 검증**
+
+```bash
+npm run docs:audit-links
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add docs/integrations/zeroclaw.md
+git commit -m "docs(integrations): write zeroclaw guide"
+```
+
+---
+
+## Task 8: `nanoclaw.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/nanoclaw.md`
+
+### 배경
+
+NanoClaw는 컨테이너 격리. **결정사항: 호스트에서 memento 실행 + 컨테이너 → HTTP 접근**. stdio는 컨테이너 격리 모델과 충돌하므로 비권장.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- 권장 트랙: HTTP only (stdio는 컨테이너 안에서 SQLite 파일까지 마운트하면 가능하지만 maintenance 부담 ↑)
+- 호스트 셋업: `docker compose -f docker-compose.prod.yml up -d` (memento 자체 컨테이너), 토큰 발급
+- NanoClaw fork에 추가할 mcp config (`mcp.json` 또는 agent CLAUDE.md):
+
+```json
+{
+  "mcpServers": {
+    "memento": {
+      "transport": "http",
+      "url": "http://host.docker.internal:9001/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MEMENTO_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+- 토큰을 컨테이너에 주입: NanoClaw `.env.local`에 `MEMENTO_TOKEN=...`, agent group의 mount 정책 명시
+- 식별자 매핑: NanoClaw agent group 이름 → owner_id 권장 형식, channel 모듈 이름 → tag
+- 옵션: stdio를 굳이 쓰고 싶을 때 — SQLite 파일 + npx 바이너리를 컨테이너에 마운트하는 방법 + 비권장 이유
+
+- [ ] **Step 2: 링크 검증 + 커밋**
+
+```bash
+npm run docs:audit-links
+git add docs/integrations/nanoclaw.md
+git commit -m "docs(integrations): write nanoclaw guide"
+```
+
+---
+
+## Task 9: `openclaw.md` 작성
+
+**Files:**
+- Modify: `docs/integrations/openclaw.md`
+
+### 배경
+
+OpenClaw는 Node.js 게이트웨이 + skill 시스템. MCP 등록은 게이트웨이 config에.
+
+- [ ] **Step 1: 콘텐츠 작성**
+
+내용 골격:
+- stdio 트랙 config 스니펫 (게이트웨이 config 또는 skill MCP 등록):
+
+```json
+{
+  "mcp": {
+    "memento": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "memento-mcp-server@latest", "start", "--stdio"]
+    }
+  }
+}
+```
+
+- HTTP 트랙 config 스니펫
+- 식별자 매핑: OpenClaw gateway user → owner_id, channel 어댑터 이름(telegram/slack 등) → tag
+- skill loading 메커니즘 안내: 어떤 skill 컨텍스트에서 memento를 노출할지, 사용자별 분리 시 가이드
+- 시스템 프롬프트 적용 위치
+
+- [ ] **Step 2: 링크 검증 + 커밋**
+
+```bash
+npm run docs:audit-links
+git add docs/integrations/openclaw.md
+git commit -m "docs(integrations): write openclaw guide"
+```
+
+---
+
+## Task 10: 루트 README에 External Assistants 섹션 추가
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.en.md`
+
+### 배경
+
+루트 README에서 통합 허브로 진입하는 링크 추가. 기존 README 구조 유지.
+
+- [ ] **Step 1: README.md에 섹션 추가**
+
+기존 "주요 기능" 또는 "설치" 섹션 근처에 다음 블록 추가:
+
+```markdown
+## 🔗 외부 AI 비서와 함께 쓰기
+
+OpenClaw / NanoClaw / ZeroClaw 같은 개인 AI 비서가 Memento를 공유 장기 기억 백엔드로 사용할 수 있습니다. 가이드: [docs/integrations/](./docs/integrations/README.md)
+```
+
+- [ ] **Step 2: README.en.md에 영문 동일 섹션 추가**
+
+```markdown
+## 🔗 Use Memento with External AI Assistants
+
+Personal AI assistants like OpenClaw, NanoClaw, and ZeroClaw can use Memento as a shared long-term memory backend. Guide: [docs/integrations/](./docs/integrations/README.md)
+```
+
+- [ ] **Step 3: 링크 검증**
+
+```bash
+npm run docs:audit-links
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add README.md README.en.md
+git commit -m "docs: link external assistant integration hub from root README"
+```
+
+---
+
+## Task 11: L1 가이드 스모크 테스트 (최소형)
+
+**Files:**
+- Create: `tests/integrations/smoke.spec.ts`
+- Modify: `vitest.config.ts` (필요 시 include 패턴 확장)
+
+### 배경
+
+스펙 §9에 따라 가이드 스니펫 drift 방지용 스모크 테스트. v0.1 Phase 1 범위에서는 **스니펫 *추출* + *형식 검증*** 까지만. 실제 spawn/HTTP 호출은 L3 SDK 통합 테스트가 더 효율적이라 v0.2에서 확장.
+
+검증 범위 (이번 task):
+- 각 비서 가이드(.md)에서 첫 번째 ```json 또는 ```toml 블록을 추출
+- JSON/TOML로 파싱 가능한지 (= 문법 깨짐 없음)
+- stdio 블록은 `command`/`args` 키 또는 `command`/`args`에 해당하는 TOML 키가 있는지
+- HTTP 블록은 `url`이 있고 `Authorization` 헤더 패턴이 있는지
+
+이 정도만으로도 가이드를 무심코 깨뜨리는 PR을 잡아낼 수 있다.
+
+- [ ] **Step 1: 실패 테스트 작성 (TDD)**
+
+```typescript
+// tests/integrations/smoke.spec.ts
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const guides = ['openclaw', 'nanoclaw', 'zeroclaw'];
+
+function extractFencedBlocks(md: string, lang: 'json' | 'toml'): string[] {
+  const re = new RegExp('```' + lang + '\\n([\\s\\S]*?)```', 'g');
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(md)) !== null) out.push(m[1]);
+  return out;
+}
+
+describe('docs/integrations smoke', () => {
+  for (const name of guides) {
+    it(`${name}.md: stdio config block parses and references memento-mcp-server`, async () => {
+      const path = join(ROOT, 'docs/integrations', `${name}.md`);
+      const md = await readFile(path, 'utf8');
+      const blocks = [...extractFencedBlocks(md, 'json'), ...extractFencedBlocks(md, 'toml')];
+      const stdio = blocks.find(b => b.includes('--stdio'));
+      expect(stdio, `no stdio config block found in ${name}.md`).toBeTruthy();
+      expect(stdio).toMatch(/memento-mcp-server/);
+    });
+
+    it(`${name}.md: HTTP config block contains url and Authorization`, async () => {
+      const path = join(ROOT, 'docs/integrations', `${name}.md`);
+      const md = await readFile(path, 'utf8');
+      const blocks = [...extractFencedBlocks(md, 'json'), ...extractFencedBlocks(md, 'toml')];
+      const http = blocks.find(b => /url\s*[:=]/.test(b) && /Authorization|authorization/.test(b));
+      expect(http, `no HTTP config block found in ${name}.md`).toBeTruthy();
+      expect(http).toMatch(/(Bearer|MEMENTO_TOKEN)/);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: 실행해 실패 확인**
+
+```bash
+npx vitest run tests/integrations/smoke.spec.ts
+```
+
+기대: Task 7-9에서 가이드를 작성했으므로 **이미 통과**할 가능성이 높다. 통과하면 그대로 OK. 만약 실패하면 가이드 본문에 누락된 블록을 추가하고 다시 실행.
+
+- [ ] **Step 3: vitest 설정 확인**
+
+`vitest.config.ts`에서 `tests/integrations/`가 include 되는지 확인. 안 되면 추가:
+
+```typescript
+test: {
+  include: ['packages/**/*.spec.ts', 'tests/**/*.spec.ts'],
+  // ...
+}
+```
+
+- [ ] **Step 4: 전체 테스트 실행**
+
+```bash
+npm test
+```
+
+기대: 전체 PASS, 새 스모크 테스트 6개 (3 비서 × 2 케이스) 포함.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add tests/integrations/smoke.spec.ts vitest.config.ts
+git commit -m "test(integrations): add L1 guide snippet smoke tests"
+```
+
+---
+
+## Task 12: PR 생성 및 이슈 #100 정리
+
+**Files:** (코드 변경 없음 — 외부 작업)
+
+### 배경
+
+지금까지의 모든 변경(Task 1-11)을 하나의 PR로 묶어 main에 병합 요청. 이슈 #100에 결정 노트 코멘트 + close.
+
+- [ ] **Step 1: 브랜치 push 및 PR 생성**
+
+```bash
+git push -u origin docs/external-assistant-integration-design
+gh pr create --title "docs+chore: external assistant integration v0.1 — L1 guides + memento-agent archive" --body "$(cat <<'EOF'
+## Summary
+- Phase 0: archive `packages/memento-agent/` (issue #100 superseded)
+- Phase 1: external assistant integration guides under `docs/integrations/`
+  - `_shared/` 공통 가이드 (transports, auth, system-prompt, troubleshooting)
+  - per-assistant guides (openclaw, nanoclaw, zeroclaw)
+  - root README linkage
+  - L1 guide snippet smoke tests
+
+Spec: `docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md`
+Plan: `docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md`
+
+## Test plan
+- [ ] `npm test` 전체 통과
+- [ ] `npm run docs:audit-links` 통과
+- [ ] `npm run lint` / `npm run type-check` 통과
+- [ ] OpenClaw / NanoClaw / ZeroClaw 가이드의 stdio 스니펫을 실제 비서 한 곳에서 시도 (수동 검증, 수용 기준)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: 이슈 #100 코멘트 + close**
+
+```bash
+gh issue comment 100 --body "$(cat <<'EOF'
+방향 전환 결정. 자체 비서 빌드(memento-agent) 대신 **외부 비서 통합**(OpenClaw / NanoClaw / ZeroClaw)으로 전환합니다.
+
+- 새 스펙: docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md
+- L1 plan: docs/superpowers/plans/2026-04-27-external-assistant-l1-guides.md
+- packages/memento-agent → packages/_archived/memento-agent-issue-100 (참고용 보존)
+
+이 이슈를 close하고, 외부 통합 작업은 별도 PR/이슈로 트랙합니다.
+EOF
+)"
+gh issue close 100
+```
+
+(주의: 이 단계는 외부 가시성 영향 — PR/이슈에 대한 사용자 권한 확인 후 진행)
+
+---
+
+## 완료 기준
+
+- [ ] 모든 Task 1-12 완료
+- [ ] PR이 main에 머지됨
+- [ ] `docs/integrations/`에서 출발해 사용자가 자기 비서를 골라 5분 안에 stdio 트랙으로 memento에 연결 가능
+- [ ] HTTP 트랙도 docs만 따라 구성 가능
+- [ ] L1 스모크 테스트가 CI에서 통과
+
+## 후속 (이 plan 범위 밖)
+
+- Plan 2: `docs/superpowers/plans/2026-04-27-external-assistant-l3-sdk.md` (Phase 2 + Phase 3)
+- v0.2: L2 (NanoClaw / ZeroClaw / OpenClaw 업스트림 PR)

--- a/docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md
+++ b/docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md
@@ -1,0 +1,598 @@
+# External Personal Assistant Integration — Design Spec
+
+**Date:** 2026-04-27
+**Related Issue:** #100 (방향 전환 — 자체 비서 빌드 보류)
+**Status:** Draft v1
+**Author:** brainstorming session 산출물
+
+---
+
+## 1. 목적
+
+OpenClaw / NanoClaw / ZeroClaw 같은 **이미 존재하는 단일-사용자 개인 AI 비서**가 Memento를 *공유 장기 기억 백엔드*로 사용할 수 있게 한다. **새 비서 런타임을 만들지 않는다** (= 이슈 #100 `memento-agent` 방향과 결별).
+
+### 핵심 장면
+사용자는 노트북(ZeroClaw)과 홈서버(OpenClaw)에서 같은 비서 페르소나를 쓰고, Telegram·Discord·iMessage를 오가며 대화한다. 어디서 말해도 **같은 기억**을 본다.
+
+---
+
+## 2. 범위
+
+### v0.1 = L1 + L3
+
+**Phase 1 (L1) — 가이드:**
+- 세 비서별 통합 가이드: `docs/integrations/{openclaw,nanoclaw,zeroclaw}.md`
+  - stdio 트랙 (5분 셋업, 단일 머신)
+  - HTTP 트랙 (멀티 디바이스, 토큰 발급)
+- 권장 시스템 프롬프트 스니펫 (recall-first 패턴)
+- 트러블슈팅 / 보안 / 채널 식별 매핑
+
+**Phase 2 (L3) — SDK:**
+- `@memento/assistant` 패키지 신설 (현재 비어있는 `packages/memento-assistant/` 채움)
+- Transport 추상화 (stdio / HTTP 둘 다 투명 지원 — T3)
+- 대화 라이프사이클 훅: `beforeUserTurn` / `afterAssistantTurn`
+- 채널 스코핑 헬퍼
+- proactive 자동 recall + 자동 remember (옵트인 기본값 ON)
+- 폴백 / 저하 모드 (memento 다운 시 비서 멈추지 않음)
+
+### v0.1 제외 (이후)
+- **L2** (외부 비서 저장소에 PR 기여): `/add-memento` 스킬, ZeroClaw 플러그인, OpenClaw 스킬
+- 비서 측 UI (memento `/dashboard`로 충분)
+- 멀티 사용자 / 팀 공유 (단일-사용자 비서 타깃)
+
+### 비-목표
+- 비서 런타임을 새로 만들지 않는다
+- Memento 코어 도메인 변경 없음 (이 작업은 통합 레이어만 다룸)
+- LLM 호출 / 에이전트 루프를 SDK에 포함하지 않는다 (= `memento-agent`와의 명확한 차별점)
+
+---
+
+## 3. 아키텍처 개요
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                  사용자의 머신 (또는 홈서버)                          │
+│                                                                    │
+│  ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐   │
+│  │   OpenClaw      │   │   NanoClaw      │   │   ZeroClaw      │   │
+│  │ (Node + Skill)  │   │ (Container +    │   │ (Rust binary)   │   │
+│  │                 │   │  Claude SDK)    │   │                 │   │
+│  └────────┬────────┘   └────────┬────────┘   └────────┬────────┘   │
+│           │                     │                     │            │
+│           │  (1) MCP 도구 등록 — L1 가이드            │            │
+│           │       stdio 또는 HTTP                     │            │
+│           │                     │                     │            │
+│           │ ┌───────────────────┴───────────────────┐ │            │
+│           ├─┤  @memento/assistant  (L3, 옵션)       ├─┤            │
+│           │ │  - Transport 추상화                   │ │            │
+│           │ │  - beforeUserTurn / afterAssistantTurn│ │            │
+│           │ │  - 채널 스코핑                         │ │            │
+│           │ │  - proactive recall/remember          │ │            │
+│           │ └───────────────────┬───────────────────┘ │            │
+│           ▼                     ▼                     ▼            │
+│  ┌────────────────────────────────────────────────────────┐        │
+│  │                    Memento 서버                         │        │
+│  │  ┌──────────────┐    또는    ┌──────────────────────┐  │        │
+│  │  │ stdio MCP    │             │ HTTP MCP + REST     │  │        │
+│  │  └──────┬───────┘             └─────────┬────────────┘  │        │
+│  │         └───────────┬─────────────────────┘             │        │
+│  │                     ▼                                   │        │
+│  │            @memento/core (도메인 로직)                  │        │
+│  │           SQLite + FTS5 + sqlite-vec                    │        │
+│  └────────────────────────────────────────────────────────┘        │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 두 개의 통합 채널 (의도적 이중성)
+
+**채널 A — "베어 MCP"** (L1 단독, 모든 비서에서 가능)
+- 비서가 memento를 그냥 또 하나의 MCP 서버로 등록
+- LLM이 스스로 `recall`/`remember`를 도구로 호출
+- 우리 쪽 코드 변경 0, 가이드 + 시스템 프롬프트 권장 패턴만 제공
+- 장점: 즉시 동작, 위험도 0, 세 비서 모두 호환
+- 단점: 자동 회상 품질이 LLM의 "도구 호출 의지"에 종속
+
+**채널 B — "memento-assistant SDK"** (L3, 옵션)
+- 비서가 자기 메시지 파이프라인 안에서 SDK를 호출
+- 매 사용자 발화 *앞*에 `beforeUserTurn(msg)` → 관련 기억 자동 주입
+- 매 비서 응답 *뒤*에 `afterAssistantTurn(reply)` → 자동 저장
+- 장점: LLM의 도구 호출 의지와 무관한 결정론적 동작
+- 단점: 비서 측 코드 한 군데 수정 필요 (그래서 옵션)
+
+### 핵심 설계 원칙
+
+1. **두 채널은 독립적이고 상호 배타적이지 않다.** A로 시작 → 필요할 때 B로 업그레이드. 같은 memento 인스턴스에 둘 다 붙어도 정합성 안 깨짐.
+2. **Transport는 SDK 내부 구현 디테일.** 사용자/비서는 stdio든 HTTP든 같은 `MementoAssistant` API만 본다. URL/토큰만 환경변수로 바꾸면 전환됨.
+3. **비서가 죽지 않는다.** memento 다운 시 SDK는 빈 컨텍스트를 반환하고 경고만 로그. 절대 throw하지 않음 (§7).
+4. **메모리 코어를 건드리지 않는다.** 모든 작업은 `@memento/client` + `@memento/assistant` 신설 패키지에 한정.
+
+---
+
+## 4. L1: 비서별 통합 가이드
+
+### 산출물 위치
+
+```
+docs/integrations/
+  README.md                # 통합 허브
+  _shared/
+    transports.md          # T3: stdio vs HTTP 트랙 결정 가이드
+    auth.md                # 토큰 발급, 회전, 폐기
+    system-prompt.md       # recall-first 권장 패턴
+    troubleshooting.md
+  openclaw.md
+  nanoclaw.md
+  zeroclaw.md
+```
+
+### 비서 가이드 공통 골격 (90% 동일)
+
+**4.1 5분 셋업 (stdio 트랙)**
+- `npx memento-mcp-server@latest setup`
+- 비서별 MCP 등록 스니펫 (예시는 가이드 본문에)
+
+**4.2 멀티 디바이스 셋업 (HTTP 트랙)**
+- `docker compose -f docker-compose.prod.yml up -d`
+- `/auth/session` 또는 `/admin`에서 Bearer 토큰 발급
+- HTTP MCP 등록 스니펫 + `Authorization` 헤더 위치
+- 토큰을 비서별 secret store에 저장하라는 보안 노트
+
+**4.3 권장 시스템 프롬프트 (`_shared/system-prompt.md` import)**
+- "사용자가 새 주제를 꺼내거나 과거를 참조하면 먼저 `memento.recall`을 호출하라. 사실/선호/약속/결정사항이 나오면 끝나기 전 `memento.remember`로 저장하라."
+- 비서별 채널 컨텍스트를 `tags`에 넣는 패턴 예시
+
+**4.4 채널 스코핑 권장**
+- §5 모델을 가이드 코드 스니펫에 그대로 반영
+
+**4.5 트러블슈팅**
+- "memento가 응답이 없음", "검색 결과 비어있음", "토큰 401" 등
+
+### 비서별 *고유* 부분 (10%)
+
+| 비서 | 고유 이슈 |
+|---|---|
+| OpenClaw | 게이트웨이의 skill loading 메커니즘, MCP 등록 컨텍스트 |
+| NanoClaw | **호스트에서 memento 실행 + 컨테이너에서 HTTP 접근 권장** (stdio는 컨테이너 격리 모델과 충돌). mount 정책 명시 |
+| ZeroClaw | Rust 바이너리의 `[[mcp.servers]]` config 위치, 필요 feature flag |
+
+### 무엇을 *하지 않는*가
+- 각 비서 저장소에 PR 보내지 않는다 (= L2). v0.1은 memento 쪽 docs만.
+
+---
+
+## 5. 멀티채널 스코핑 모델
+
+### 결정: owner_id = 사용자, tags로 채널 구분, 기본 검색은 사용자 전체
+
+```
+owner_id   = "user:<userId>"
+tags       = ["channel:telegram", "channel:discord", ...]
+project_id = (비활용 — 향후 "워크스페이스" 도입 시)
+```
+
+### 의미
+
+| 시나리오 | 동작 |
+|---|---|
+| Telegram에서 "내 생일 5/10" 저장 → Discord에서 "내 생일 언제?" | 회상됨 (owner_id만으로) |
+| 채널별로만 회상하고 싶을 때 | `recall(query, { tags: ['channel:telegram'] })` 명시 |
+
+### `@memento/assistant` 자동 적용
+
+```ts
+const memory = MementoAssistant.fromEnv({
+  ownerId: 'user:jee1lee',
+  channel: 'telegram',
+  policy: { crossChannelRecall: 'on' }
+});
+// remember 시: tags = [...userTags, 'channel:telegram'], owner_id = 'user:jee1lee'
+// recall 시:   crossChannelRecall='on'  → tags 필터 없음
+//              crossChannelRecall='off' → tags ⊇ ['channel:telegram']
+//              crossChannelRecall='sameContext' → 향후 (work/personal 컨텍스트 도입 시)
+```
+
+기본값 `'on'`. 프라이버시 우려 있는 사용자는 `'off'`로 끔.
+
+### 비서별 사용자/채널 식별 매핑
+
+| 비서 | userId 소스 | channel 소스 |
+|---|---|---|
+| OpenClaw | gateway의 user 객체 | channel 어댑터 이름 |
+| NanoClaw | agent group 이름 | channel 모듈 이름 |
+| ZeroClaw | config의 actor.id | channel kind |
+
+### 명시적 비-결정
+- 채널별 별도 owner_id 부여 안 함 (멀티채널 가치 무력화)
+- conversation_id 기반 격리 안 함 (working TTL 48h로 자연 격리)
+- project_id 미사용 (개인 비서엔 과함, 빈자리 유지)
+
+---
+
+## 6. `@memento/assistant` SDK 표면
+
+### 패키지 구조
+
+```
+packages/memento-assistant/
+  src/
+    index.ts                  # 공개 API export
+    assistant.ts              # MementoAssistant 클래스
+    transport/
+      transport.ts            # interface Transport
+      stdio-transport.ts
+      http-transport.ts       # @memento/client 위에 thin wrapper
+      factory.ts              # env/옵션 → Transport 인스턴스
+    scoping/
+      channel-scope.ts
+    lifecycle/
+      before-user-turn.ts
+      after-assistant-turn.ts
+    policy/
+      auto-recall-policy.ts
+      auto-remember-policy.ts
+    fallback/
+      degraded-mode.ts
+      circuit-breaker.ts
+    types.ts
+  README.md
+  package.json
+  tsconfig.json
+  vitest.config.ts
+```
+
+### 핵심 API
+
+```ts
+import { MementoAssistant } from '@memento/assistant';
+
+const memory = MementoAssistant.fromEnv({
+  channel: 'telegram',
+  ownerId: 'user:jee1lee',
+  policy: {
+    autoRecall: 'always',           // 'always' | 'heuristic' | 'off'
+    autoRemember: 'turn',           // 'turn' | 'decision' | 'off'
+    crossChannelRecall: 'on',       // 'on' | 'off' | 'sameContext'
+    tokenBudget: 1200,
+    recallLimit: 8,
+    recallTimeoutMs: 1500,
+    degradeOnError: true,
+  },
+});
+
+// 매 사용자 발화 직전
+const ctx = await memory.beforeUserTurn({ userMessage, conversationId });
+// ctx.systemContext (포맷된 텍스트, 시스템 프롬프트에 합성)
+// ctx.references    (메타데이터 배열, UI 출처 표시 옵션)
+// ctx.degraded      (boolean)
+
+// 매 비서 응답 직후
+await memory.afterAssistantTurn({
+  userMessage,
+  assistantReply,
+  conversationId,
+  extracted: [{ kind: 'preference', content: '...' }],  // 옵션
+});
+
+// 명시 호출 (선택)
+await memory.remember({ content: '...', type: 'semantic', tags: [...] });
+const hits = await memory.recall('지난번 그 식당 이름이 뭐였지?');
+```
+
+### `MementoAssistant.fromEnv()`
+- 환경변수만으로 stdio/HTTP 자동 결정 (T3 핵심)
+- `MEMENTO_TRANSPORT=stdio` (기본) → 자식 프로세스 spawn
+- `MEMENTO_TRANSPORT=http MEMENTO_URL=… MEMENTO_TOKEN=…` → HTTP
+
+### 라이프사이클 훅
+
+| 훅 | 입력 | 출력 | 부수효과 |
+|---|---|---|---|
+| `beforeUserTurn` | userMessage + conversationId | `{ systemContext, references, degraded }` | 없음 (read-only) |
+| `afterAssistantTurn` | userMessage + assistantReply + extracted? | void | working memory 저장, 필요 시 episodic/semantic 승급 |
+| `recall` / `remember` | client passthrough | client 결과 | client와 동일 |
+
+**Invariant**: `beforeUserTurn`/`afterAssistantTurn` 은 절대 throw하지 않는다. memento 다운이어도 `degraded:true` 빈 번들 반환. 비서는 그냥 계속 응답함.
+
+### `extracted` 형태
+
+```ts
+type ExtractedItem =
+  | { kind: 'fact';        content: string; tags?: string[] }                // → semantic
+  | { kind: 'preference';  content: string; tags?: string[] }                // → semantic, importance 0.7
+  | { kind: 'event';       content: string; at?: string; tags?: string[] };  // → episodic
+```
+
+`'commitment'`는 v0.1에서 제외 — 미래 약속은 `{ kind: 'event', at: '<future ISO>', tags: ['commitment'] }`로 표현. v0.2에서 reminder 도메인과 함께 재검토.
+
+### 기본값 (Just Works)
+
+| 옵션 | 기본 |
+|---|---|
+| `autoRecall` | `'always'` |
+| `autoRemember` | `'turn'` |
+| `crossChannelRecall` | `'on'` |
+| `tokenBudget` | `1200` |
+| `recallLimit` | `8` |
+| `recallTimeoutMs` | `1500` |
+| `degradeOnError` | `true` |
+
+### 비-목표
+- 자동 요약/consolidation은 memento-core의 sleep-consolidation에 위임 (이미 존재)
+- 비서별 메시지 큐/스케줄링 — 각 비서가 잘함, SDK는 stateless
+- 직접 LLM 호출 — SDK는 LLM과 무관
+
+---
+
+## 7. 자동 recall / remember 의미론
+
+### Recall — `beforeUserTurn`
+
+```
+userMessage
+  → autoRecall 정책 체크
+     'always'    → 항상 1회 recall
+     'heuristic' → 길이/물음표/대명사 휴리스틱
+     'off'       → skip
+  → scoping 적용
+     owner_id = ownerId
+     tags filter:
+       crossChannelRecall='on'          → 필터 없음
+       crossChannelRecall='off'         → tags ⊇ ['channel:<current>']
+       crossChannelRecall='sameContext' → 향후
+  → client.recall (token budget 처리)
+  → 실패 → degraded:true, 빈 systemContext (절대 throw 안 함)
+  → systemContext 포맷팅: "<memento>...</memento>" 펜스로 일반 컨텍스트와 구분
+```
+
+### Remember — `afterAssistantTurn`
+
+```
+턴 종료 (userMessage + assistantReply)
+  → autoRemember 정책 체크
+     'turn'     → working memory 저장 (user/assistant 페어)
+     'decision' → 'turn' + extracted 항목을 type별 저장
+     'off'      → skip
+
+  case 'turn':
+    type    = 'working'
+    content = `User: ${userMessage}\nAssistant: ${assistantReply}`
+    ttl     = 48h (memento working 기본)
+    tags    = ['channel:<current>', 'conv:<id>', ...userTags]
+
+  case 'decision' AND extracted.length > 0:
+    각 항목 → 적절한 type 매핑
+      kind:'fact'       → semantic
+      kind:'preference' → semantic, importance 0.7
+      kind:'event'      → episodic
+    + 'turn' 동작도 함께 (working 백업)
+
+  중복 회피:
+    extracted 항목은 저장 직전 client.recall(content, limit:1, tags) 로
+    유사도 0.85+ 결과 있으면 updateExisting 사용
+    'turn' working은 중복 체크 안 함 (TTL로 자연 소멸)
+
+  fire-and-forget:
+    저장은 비동기. 실패해도 로그만, 비서에 영향 없음
+```
+
+### Working → Episodic 승급
+SDK는 working을 그대로 둠. memento-core의 sleep-consolidation 서비스가 알아서 episodic/semantic으로 증류함 (이미 존재). SDK 책임은 *입력만 정확히*.
+
+---
+
+## 8. 오류 처리 / 저하 모드
+
+### 핵심 원칙
+**비서는 절대 memento 때문에 멈추지 않는다.** 메모리는 augmentation이지 dependency가 아니다.
+
+### 실패 모드별 동작
+
+| 시점 | 실패 종류 | SDK 동작 | 비서가 보는 결과 |
+|---|---|---|---|
+| `beforeUserTurn` | 네트워크/타임아웃 | `degraded:true`, 빈 systemContext | 메모리 없이 응답 진행 |
+| `beforeUserTurn` | 401/403 | 같음 + 1회 경고 로그 (rate-limited) | 동일 |
+| `beforeUserTurn` | 5xx | 같음 | 동일 |
+| `beforeUserTurn` | stdio child 사망 | 같음 + spawn 재시도 (백오프) | 동일 |
+| `afterAssistantTurn` | 모든 실패 | 큐 적재 + 백그라운드 재시도, 최종 실패 시 **drop** + WARN | 영향 없음 |
+| 명시 `recall`/`remember` | 모든 실패 | 정상 throw (호출자 책임) | LLM이 도구 호출 결과로 인지 |
+
+비대칭 의도: 자동 동작은 absorb, 명시 호출은 propagate.
+
+### 타임아웃 / 백오프
+
+```
+beforeUserTurn:  recallTimeoutMs = 1500 (사용자 응답 지연 = UX 손상)
+afterAssistantTurn 재시도: 1s → 2s → 4s, 최대 3회, 최종 drop
+                          큐 cap 1000건, 초과 시 oldest drop (메모리 누수 방지)
+stdio: child 사망 → 5s 쿨다운 후 1회 재spawn, 연속 3회 실패 → 다음 startup까지 비활성
+       env에 HTTP URL도 있으면 자동 fallback 시도
+```
+
+### Circuit Breaker
+연속 5회 실패 → 30s open → half-open probe → closed 복귀. 작은 inline 구현.
+
+### 로깅
+- 사용자에게 노출 안 함 (비서 로그에만)
+- 첫 실패 WARN 1줄, 같은 종류 반복은 1분에 1회 rate-limit
+- 정상 복귀 INFO 1줄
+- `MEMENTO_LOG=debug` 시 모든 호출 trace
+
+### `degraded` 시그널
+비서가 사용하든 무시하든 자유. 옵션으로 시스템 프롬프트에 "(memory unavailable)" 추가하면 LLM이 자연스럽게 응답 가능.
+
+### 명시적 비-목표
+- 디스크 WAL/큐 (in-process only — 손실 무방)
+- 자동 토큰 갱신 (보안 위험, 가이드에 회전 절차만)
+- 헬스체크 endpoint 폴링 (circuit breaker가 자연 헬스 신호)
+
+### Dependency invariant
+SDK는 비서 측에 추가 데몬/사이드카를 요구하지 않는다. 단순 in-process 라이브러리.
+
+---
+
+## 9. 테스트 전략
+
+### 패키지별 책임
+
+| 영역 | 위치 | 도구 |
+|---|---|---|
+| `@memento/assistant` 단위 | `packages/memento-assistant/src/**/*.spec.ts` | Vitest + MockTransport |
+| Transport 통합 | `packages/memento-assistant/**/*.integration.spec.ts` | 실제 stdio child + 실제 HTTP fixture |
+| End-to-end | `packages/memento-assistant/test/e2e/` | 실제 memento-server + in-memory SQLite |
+| L1 가이드 smoke | `tests/integrations/{openclaw,nanoclaw,zeroclaw}.smoke.spec.ts` | 가이드 스니펫을 그대로 사용 |
+
+### 단위 테스트 핵심 케이스
+
+```
+beforeUserTurn:
+  ✓ autoRecall='always' — 항상 호출
+  ✓ autoRecall='off'    — 호출 안 함
+  ✓ autoRecall='heuristic' + 짧은 인사 — 호출 안 함
+  ✓ autoRecall='heuristic' + 물음표 — 호출함
+  ✓ crossChannelRecall='off' — channel tag 필터 적용
+  ✓ recall throw → degraded:true
+  ✓ recall timeout 1500ms → degraded:true
+
+afterAssistantTurn:
+  ✓ autoRemember='turn' — working 1건 저장
+  ✓ autoRemember='decision' + fact → semantic
+  ✓ autoRemember='decision' + preference → semantic, importance 0.7
+  ✓ autoRemember='decision' + event(future at) → episodic
+  ✓ remember 실패 → drop, 호출자에 throw 안 함
+  ✓ retry 1→2→4s 후 drop
+  ✓ 유사도 0.85+ 시 updateExisting
+
+scoping:
+  ✓ 자동 tags 부여 (channel/conv)
+  ✓ ownerId 항상 전파
+  ✓ user-supplied + 자동 tags 머지
+
+circuit breaker:
+  ✓ closed → 5회 실패 → open
+  ✓ open 동안 즉시 degraded
+  ✓ 30s 후 half-open probe → closed
+```
+
+### 통합 테스트 (Transport)
+
+```
+stdio:
+  ✓ child spawn → recall 응답
+  ✓ child kill → 5s 후 재spawn
+  ✓ 연속 3회 실패 → HTTP fallback (env에 URL 있으면)
+  ✓ 종료 시 child cleanup (좀비 방지)
+
+http:
+  ✓ Bearer 헤더 부착
+  ✓ 401 → degraded
+  ✓ MCP-over-HTTP 응답 파싱
+  ✓ self-signed TLS 거부 (개발 모드 옵트인)
+```
+
+### E2E 시나리오 (5개)
+
+1. **Cross-channel recall**: Telegram에서 fact 저장 → Discord에서 질의 → 회상 (`crossChannelRecall='on'`)
+2. **Channel isolation**: 같은 흐름 + `crossChannelRecall='off'` → 회상 안 됨
+3. **Degraded fallback**: memento 강제 종료 → beforeUserTurn 즉시 degraded → 비서 응답 정상
+4. **Working → episodic 승격**: 같은 사실 5턴 반복 → sleep-consolidation 후 semantic 승급 (입력 정확성 검증)
+5. **stdio → http 전환**: env 바꿔 재시작 → 같은 owner_id로 같은 기억 회상 (T3 약속 검증)
+
+### L1 가이드 smoke 테스트
+
+문서 스니펫이 *진짜* 동작하는지. 비서 자체는 설치 안 함 — config 스니펫의 명령어/URL/auth 형식만 검증. 가이드 drift 방지.
+
+### Mocking 정책
+- LLM은 항상 mock (echo 등). SDK는 LLM과 무관.
+- Embedding provider는 통합/E2E에서 TF-IDF만 (외부 API 의존 0)
+- 시간은 vitest fake timers (TTL/백오프 검증)
+
+### CI 게이트
+- `npm test` / `npm run lint` / `npm run type-check` 통과
+- 신규 패키지 커버리지 ≥85% (CI 리포트만, 빌드 게이트 아님)
+
+### 비-목표
+- L2 어댑터 테스트 (v0.1에 없음)
+- 부하 / 카오스 테스트 (단일-사용자 비서 타깃)
+
+---
+
+## 10. 롤아웃 / 단계
+
+### Phase 0 — 정리 (PR 1개)
+- `packages/memento-agent/` → `packages/_archived/memento-agent-issue-100/` 이동, 루트 workspaces에서 제외
+- 이슈 #100에 결정 노트 + close
+
+### Phase 1 — L1 가이드 (PR 2~3개, ~1주)
+- `docs/integrations/_shared/{transports,auth,system-prompt,troubleshooting}.md`
+- `docs/integrations/{openclaw,nanoclaw,zeroclaw}.md`
+- `docs/integrations/README.md` (허브)
+- README.md / README.en.md "External Assistants" 섹션
+- L1만으로도 사용자가 베어 MCP로 시작 가능 — 가치 출시 빠름
+
+### Phase 2 — L3 SDK (PR 5~7개, ~2주)
+1. 패키지 스캐폴드 + Transport 인터페이스 + MockTransport
+2. stdio transport
+3. http transport (`@memento/client` 위에)
+4. `MementoAssistant` + `fromEnv` + `beforeUserTurn`
+5. `afterAssistantTurn` + 정책 + extracted 처리
+6. 채널 스코핑 + crossChannelRecall + circuit breaker
+7. README, examples, 단위/통합/E2E 테스트
+
+### Phase 3 — 가이드 업그레이드 (PR 1~2개, ~3일)
+L3 안정화 후 L1 가이드에 "한 단계 더: `@memento/assistant` 사용" 섹션 추가. 두 트랙 병기.
+
+### Phase 4 — L2 (외부 PR, v0.2 이후, 별도 일정)
+- NanoClaw `/add-memento` 스킬 → 업스트림 PR
+- ZeroClaw 플러그인 → 업스트림 PR
+- OpenClaw 스킬 → 업스트림 PR
+- 메인테이너 수용 의지에 의존. 거절돼도 L1 가이드(fork 사용)는 유효.
+
+### 마이그레이션 / 호환성
+- Memento 코어 변경 없음 → 기존 사용자 영향 0
+- `memento-agent` 아카이브: 외부 의존 거의 없을 것. published라면 deprecate 1릴리스 후 제거.
+
+### 성공 기준 (v0.1 출시 시점)
+- ZeroClaw에서 5분 안에 stdio MCP로 등록 → 회상 동작
+- HTTP 트랙으로 노트북 ZeroClaw + 홈서버 OpenClaw 기억 공유
+- `@memento/assistant` 사용 시 LLM 도구 호출 없이도 자동 회상/저장
+- memento 강제 종료 → 비서 응답 계속
+
+### 위험 / 완화
+
+| 위험 | 완화 |
+|---|---|
+| 세 비서 plugin 모델 변경 → 가이드 drift | smoke 테스트 + `_shared/` 추출 |
+| 사용자가 토큰 평문 저장 → 유출 | 가이드에 비서별 secret store 위치 명시 |
+| HTTP 트랙 셋업 복잡 → 채택률 저조 | `docker compose up`만으로 시작하는 quickstart |
+| L3 SDK가 LLM 가정에 의존 | `extracted`는 옵션, 'turn' 모드만으로도 가치 |
+| 무한 retry 메모리 누수 | in-process 큐 cap 1000건 |
+
+### 출시 후 측정
+memento 텔레메트리에서:
+- `memento-assistant/<v>` user-agent 별 호출량
+- recall p95 latency
+- circuit breaker open 빈도
+- → v0.2 우선순위 입력
+
+---
+
+## Appendix A — 결정 요약
+
+| 항목 | 결정 | 대안 (기각) |
+|---|---|---|
+| 통합 깊이 | L1 + L3 (L2는 v0.2 이후) | L1만 / L1+L2 / L3만 |
+| 배포 토폴로지 | T3 (stdio + HTTP 둘 다 지원) | T1 stdio only / T2 HTTP only |
+| 채널 스코핑 | owner_id=user, tags=channel | 채널별 owner_id (멀티채널 가치 무력화) |
+| 자동 회상 기본값 | `autoRecall='always'` | `'heuristic'` (정확도 ↓) |
+| 자동 저장 기본값 | `autoRemember='turn'` | `'decision'` (extracted 의존 ↑) |
+| 채널 간 회상 | 옵션 (기본 'on', 'off' 가능) | 항상 통합 (프라이버시) / 항상 격리 (가치 ↓) |
+| ExtractedItem.kind | fact / preference / event | + commitment (v0.2 reminder와 함께 재검토) |
+| 실패 시 손실 | drop 허용 (in-process queue only) | 디스크 WAL (단순함 손해) |
+| `memento-agent` 패키지 | 아카이브 (`packages/_archived/`) | 삭제 / 유지 |
+
+## Appendix B — 용어
+
+- **L1 / L2 / L3**: 통합 깊이 단계. L1=가이드만, L2=외부 비서에 PR 기여, L3=memento쪽 SDK
+- **T1 / T2 / T3**: 배포 토폴로지. T1=stdio, T2=HTTP, T3=둘 다
+- **베어 MCP**: SDK 없이 비서가 memento를 그냥 MCP 서버로 등록한 상태
+- **degraded mode**: memento 호출 실패 시 빈 컨텍스트로 응답 진행하는 폴백 모드

--- a/docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md
+++ b/docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md
@@ -183,13 +183,17 @@ project_id = (비활용 — 향후 "워크스페이스" 도입 시)
 const memory = MementoAssistant.fromEnv({
   ownerId: 'user:jee1lee',
   channel: 'telegram',
+  userTags: ['persona:assistant-v1'],   // 사용자가 SDK 생성 시 옵션으로 주는 베이스 태그 (선택)
   policy: { crossChannelRecall: 'on' }
 });
 // remember 시: tags = [...userTags, 'channel:telegram'], owner_id = 'user:jee1lee'
 // recall 시:   crossChannelRecall='on'  → tags 필터 없음
 //              crossChannelRecall='off' → tags ⊇ ['channel:telegram']
-//              crossChannelRecall='sameContext' → 향후 (work/personal 컨텍스트 도입 시)
+//              crossChannelRecall='sameContext' → v0.2 예약. v0.1에서 이 값을 받으면
+//                                                 WARN 로그 1회 + 'on'으로 fallback (throw 안 함)
 ```
+
+`userTags`는 SDK 생성 시 사용자가 모든 remember에 자동 부여하고 싶은 베이스 태그 배열(선택, 기본 `[]`). 비서/페르소나/배포 환경 식별 등에 활용. ownerId 기반이 아니라 사용자가 직접 지정.
 
 기본값 `'on'`. 프라이버시 우려 있는 사용자는 `'off'`로 끔.
 
@@ -280,8 +284,18 @@ const hits = await memory.recall('지난번 그 식당 이름이 뭐였지?');
 
 ### `MementoAssistant.fromEnv()`
 - 환경변수만으로 stdio/HTTP 자동 결정 (T3 핵심)
-- `MEMENTO_TRANSPORT=stdio` (기본) → 자식 프로세스 spawn
-- `MEMENTO_TRANSPORT=http MEMENTO_URL=… MEMENTO_TOKEN=…` → HTTP
+
+| 환경변수 | 의미 | 기본 |
+|---|---|---|
+| `MEMENTO_TRANSPORT` | `stdio` \| `http` | `stdio` |
+| `MEMENTO_URL` | HTTP 트랙의 base URL | (HTTP일 때 필수) |
+| `MEMENTO_TOKEN` | HTTP 트랙의 Bearer 토큰 | (HTTP일 때 필수) |
+| `MEMENTO_STDIO_COMMAND` | stdio 트랙에서 spawn할 명령 | `npx -y memento-mcp-server@latest start --stdio` |
+| `MEMENTO_OWNER_ID` | 옵션이 없을 때의 기본 ownerId | `default` |
+| `MEMENTO_CHANNEL` | 옵션이 없을 때의 기본 channel | (없음, tag 미부여) |
+| `MEMENTO_LOG` | `error` \| `warn` \| `info` \| `debug` | `warn` |
+
+생성자 옵션이 환경변수보다 우선. 옵션 미지정 + 환경변수도 미지정이면 위 기본값 적용.
 
 ### 라이프사이클 훅
 
@@ -427,6 +441,9 @@ stdio: child 사망 → 5s 쿨다운 후 1회 재spawn, 연속 3회 실패 → �
 
 ### Dependency invariant
 SDK는 비서 측에 추가 데몬/사이드카를 요구하지 않는다. 단순 in-process 라이브러리.
+
+### 프로세스 종료 시 큐 처리
+`afterAssistantTurn`의 retry 큐는 in-process이며 **프로세스 종료 시 그대로 손실된다**(SIGTERM/SIGINT/crash 모두). graceful shutdown 시 큐를 flush하려는 시도도 하지 않는다 — 비서 종료를 지연시키지 않기 위함. 손실되는 항목은 working memory tier(48h TTL)이므로 무방하다는 §7 결정의 직접적 귀결.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "memento-dev": "packages/memento-server/dist/server/http-server.js",
-        "memento-mcp": "packages/memento-server/dist/server/index.js",
-        "memento-mcp-server": "packages/memento-server/dist/server/index.js",
+        "memento-dev": "dist/server/http-server.js",
+        "memento-mcp": "dist/server/index.js",
+        "memento-mcp-server": "dist/server/index.js",
         "memento-setup": "scripts/auto-setup.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "apps/*"
   ],
   "bin": {
-    "memento-mcp-server": "./packages/memento-server/dist/server/index.js",
-    "memento-dev": "./packages/memento-server/dist/server/http-server.js",
-    "memento-mcp": "./packages/memento-server/dist/server/index.js",
+    "memento-mcp-server": "./dist/server/index.js",
+    "memento-dev": "./dist/server/http-server.js",
+    "memento-mcp": "./dist/server/index.js",
     "memento-setup": "./scripts/auto-setup.js"
   },
   "scripts": {
@@ -21,7 +21,7 @@
     "dev:http": "npm run dev:http -w memento-server",
     "dev:http-v2": "npm run dev:http-v2 -w memento-server",
     "build": "npm run build:packages",
-    "build:packages": "npm run build -w @memento/core && npm run build -w memento-server && npm run build -w @memento/client",
+    "build:packages": "npm run build -w @memento/core && npm run build -w memento-server && npm run build -w @memento/client && npm run sync:root-server-dist",
     "copy:assets": "npm run copy:assets -w @memento/core",
     "docs:audit-links": "node scripts/audit-markdown-links.mjs",
     "start": "npm run start -w memento-server",
@@ -114,7 +114,9 @@
     "publish:client": "npm publish --workspace @memento/client",
     "test:prepare": "npm run build -w @memento/core && npm run build -w memento-server",
     "lint:ts": "eslint \"{packages,apps,tests,scripts}/**/*.ts\"",
-    "lint:js": "eslint \"static/js/**/*.js\""
+    "lint:js": "eslint \"static/js/**/*.js\"",
+    "sync:root-server-dist": "node scripts/sync-root-server-dist.js",
+    "build:root": "npm run build -w memento-server && npm run sync:root-server-dist"
   },
   "keywords": [
     "mcp",

--- a/packages/_archived/README.md
+++ b/packages/_archived/README.md
@@ -1,0 +1,12 @@
+# _archived
+
+이 디렉터리는 **참고용으로만** 보존되는 보류된 패키지를 담는다. 빌드·테스트·배포에 포함되지 않는다.
+
+## memento-agent-issue-100
+
+이슈 #100 ("자체 Memento Agent 빌드")의 산출물. 2026-04-27 외부 비서 통합(OpenClaw / NanoClaw / ZeroClaw) 방향으로 전환되면서 active 개발이 중단되었다.
+
+- 설계: `docs/superpowers/specs/2026-04-25-memento-agent-design.md`
+- 새 방향: `docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md`
+
+코드와 설계는 향후 reminder/scheduled-recall 같은 코어 기능 도입 시 참고할 가치가 있어 보존.

--- a/packages/_archived/memento-agent-issue-100/package.json
+++ b/packages/_archived/memento-agent-issue-100/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "memento-agent",
+  "version": "1.17.0",
+  "description": "Memento Agent - AI agent with Memento integration",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@memento/core": "1.17.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/_archived/memento-agent-issue-100/src/core/types.ts
+++ b/packages/_archived/memento-agent-issue-100/src/core/types.ts
@@ -1,0 +1,34 @@
+import type { MemorySearchResult } from '@memento/client';
+
+export interface Message {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export interface AskResult {
+  answer: string;
+  usedMemories: MemorySearchResult[];
+  searchResults: SearchResult[];
+}
+
+export interface AgentConfig {
+  mementoBaseUrl: string;
+  recallLimit: number;
+  llmTimeoutMs: number;
+  searchTimeoutMs: number;
+}
+
+export function loadAgentConfig(): AgentConfig {
+  return {
+    mementoBaseUrl: process.env.MEMENTO_BASE_URL ?? 'http://localhost:3000',
+    recallLimit: parseInt(process.env.MEMENTO_AGENT_RECALL_LIMIT ?? '10', 10),
+    llmTimeoutMs: parseInt(process.env.MEMENTO_AGENT_LLM_TIMEOUT_MS ?? '30000', 10),
+    searchTimeoutMs: parseInt(process.env.MEMENTO_AGENT_SEARCH_TIMEOUT_MS ?? '10000', 10),
+  };
+}

--- a/packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts
+++ b/packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts
@@ -1,0 +1,11 @@
+export const SYSTEM_PROMPT_TEMPLATE = `당신은 Memento 기억 시스템과 연결된 개인 AI 어시스턴트입니다.
+
+사용자의 질문에 답할 때:
+1. 제공된 과거 기억(memories)을 먼저 참고하세요
+2. 웹 검색 결과(search results)가 있으면 기억과 결합하세요
+3. 불확실한 내용은 추측하지 말고 모른다고 답하세요
+4. 어떤 기억/검색 결과를 근거로 답했는지 간략히 밝히세요
+
+{{memories}}
+
+{{searchResults}}`;

--- a/packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'Hello from Claude' }],
+  }),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: mockCreate };
+  },
+}));
+
+import { ClaudeProvider } from './claude-provider.js';
+
+describe('ClaudeProvider', () => {
+  it('returns text from API response', async () => {
+    const provider = new ClaudeProvider('fake-key');
+    const result = await provider.complete([
+      { role: 'user', content: 'Hello' },
+    ]);
+    expect(result).toBe('Hello from Claude');
+  });
+});

--- a/packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts
@@ -1,0 +1,9 @@
+import type { Message } from '../../core/types.js';
+
+export interface LLMOptions {
+  timeoutMs?: number;
+}
+
+export interface LLMProvider {
+  complete(messages: Message[], options?: LLMOptions): Promise<string>;
+}

--- a/packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { BraveSearchProvider } from './brave-search-provider.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('BraveSearchProvider', () => {
+  it('returns empty array when API key is missing', async () => {
+    const provider = new BraveSearchProvider('');
+    const results = await provider.search('test query');
+    expect(results).toEqual([]);
+  });
+
+  it('maps API response to SearchResult[]', async () => {
+    const provider = new BraveSearchProvider('fake-key');
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        web: {
+          results: [
+            { title: 'Title 1', url: 'https://a.com', description: 'Desc 1' },
+          ],
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const results = await provider.search('test query');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      title: 'Title 1',
+      url: 'https://a.com',
+      snippet: 'Desc 1',
+    });
+  });
+});

--- a/packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts
@@ -1,0 +1,42 @@
+import type { SearchProvider } from './search-provider.js';
+import type { SearchResult } from '../../core/types.js';
+
+export class BraveSearchProvider implements SearchProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async search(query: string, timeoutMs = 10000): Promise<SearchResult[]> {
+    if (!this.apiKey) return [];
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(
+        `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=5`,
+        {
+          headers: {
+            'Accept': 'application/json',
+            'X-Subscription-Token': this.apiKey,
+          },
+          signal: controller.signal,
+        }
+      );
+
+      if (!response.ok) return [];
+
+      const data = await response.json() as {
+        web?: { results?: Array<{ title: string; url: string; description: string }> };
+      };
+
+      return (data.web?.results ?? []).map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.description,
+      }));
+    } catch {
+      return [];
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts
@@ -1,0 +1,8 @@
+import type { SearchProvider } from './search-provider.js';
+import type { SearchResult } from '../../core/types.js';
+
+export class NoopSearchProvider implements SearchProvider {
+  async search(_query: string): Promise<SearchResult[]> {
+    return [];
+  }
+}

--- a/packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts
@@ -1,0 +1,15 @@
+import type { SearchProvider } from './search-provider.js';
+import { NoopSearchProvider } from './noop-search-provider.js';
+import { BraveSearchProvider } from './brave-search-provider.js';
+
+export function createSearchProvider(): SearchProvider {
+  const name = process.env.MEMENTO_AGENT_SEARCH ?? 'none';
+  switch (name) {
+    case 'brave':
+      return new BraveSearchProvider(process.env.BRAVE_API_KEY ?? '');
+    case 'playwright':
+      throw new Error('playwright not installed. Run: npm install playwright');
+    default:
+      return new NoopSearchProvider();
+  }
+}

--- a/packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts
+++ b/packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts
@@ -1,0 +1,5 @@
+import type { SearchResult } from '../../core/types.js';
+
+export interface SearchProvider {
+  search(query: string, timeoutMs?: number): Promise<SearchResult[]>;
+}

--- a/packages/_archived/memento-agent-issue-100/tsconfig.json
+++ b/packages/_archived/memento-agent-issue-100/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/_archived/memento-agent-issue-100/vitest.config.ts
+++ b/packages/_archived/memento-agent-issue-100/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    exclude: ['node_modules', 'dist'],
+  },
+});

--- a/scripts/sync-root-server-dist.js
+++ b/scripts/sync-root-server-dist.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * npm publish용 루트 `dist/`에 memento-server 빌드 산출물을 복사한다.
+ * - 루트 package.json `bin`은 `./dist/server/*.js`를 가리켜야 하며(verify-bin),
+ * - `prepack-bundle-core.js`도 동일 경로를 전제로 한다.
+ */
+import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const src = join(root, 'packages/memento-server/dist');
+const dest = join(root, 'dist');
+
+if (!existsSync(join(src, 'server/index.js'))) {
+  console.error(
+    '[sync-root-server-dist] packages/memento-server/dist/server/index.js 가 없습니다. 먼저 `npm run build -w memento-server` 를 실행하세요.'
+  );
+  process.exit(1);
+}
+
+rmSync(dest, { recursive: true, force: true });
+mkdirSync(dest, { recursive: true });
+cpSync(src, dest, { recursive: true });
+console.log('[sync-root-server-dist] Copied packages/memento-server/dist → dist/');


### PR DESCRIPTION
## Summary
- Align root package `bin` paths to publish-safe `./dist/server/*` targets so `verify-bin` no longer rejects workspace-internal paths.
- Add `scripts/sync-root-server-dist.js` to copy `packages/memento-server/dist` into root `dist/` after workspace builds.
- Wire `build:packages` to run the sync step and add `build:root` fallback expected by prepack verification scripts.

## Test plan
- [x] `npm run verify-bin`
- [x] `npm run verify-pack-bundle`
- [x] `npm run prepublishOnly`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run type-check`

Made with [Cursor](https://cursor.com)