### PR TITLE
refactor(core): Wave 1 bootstrap split (#214)

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-214-wave1-bootstrap.md
+++ b/docs/superpowers/plans/2026-05-01-issue-214-wave1-bootstrap.md
@@ -1,0 +1,174 @@
+# Issue #214 Wave 1 — Core bootstrap split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `packages/memento-core/src/bootstrap.ts` `initializeServices` into named modules under `packages/memento-core/src/bootstrap/` without changing runtime behavior or the `ServerServices` contract.
+
+**Architecture:** Thin `bootstrap.ts` re-exports `ServerServices` and `initializeServices`; helper modules own vertical slices (anchors, failure/reflexion, monitoring/WAL/lock, write path, batch/telemetry/relation/sleep, runtime diagnostics sampler). No new package-level imports for consumers.
+
+**Tech Stack:** TypeScript 5.x, Node ≥20, Vitest, existing `@memento/core` patterns (`.js` import suffixes in TS sources).
+
+**Note:** This is a behavior-preserving refactor. Verification is the **existing** test suite (`npm test`), not greenfield TDD with new failing tests.
+
+---
+
+## File map (target end state)
+
+| Path | Responsibility |
+|------|------------------|
+| `packages/memento-core/src/bootstrap.ts` | `ServerServices`, `initializeServices` orchestration only; re-import from `bootstrap/*.js` |
+| `packages/memento-core/src/bootstrap/search-and-embedding.ts` | `SearchEngine`, embedding pair, `HybridSearchFactory.createDefaultEngine`, `ForgettingPolicyService`, `DatabaseOptimizer` construction |
+| `packages/memento-core/src/bootstrap/anchor-stack.ts` | `AnchorCacheService`, `AnchorSearchService`, `AnchorManager`, `getVectorSearchEngine`, `restoreCacheFromDB` |
+| `packages/memento-core/src/bootstrap/failure-reflexion.ts` | `AsyncTaskQueue`, `FailureDetector.startQueue`, `ReflexionWorker` start |
+| `packages/memento-core/src/bootstrap/monitoring-schedulers.ts` | `getPerformanceMonitor().initialize`, `RuntimeDiagnosticsLogger`, `WalCheckpointScheduler`, `DatabaseLockMonitor`, conditional `start()` + log lines |
+| `packages/memento-core/src/bootstrap/write-and-meta.ts` | `WriteCoalescingManager` flush callback body (unchanged logic), optional `ConsolidationScoreService`, `MetaMemoryService` |
+| `packages/memento-core/src/bootstrap/batch-telemetry-relation.ts` | `IntrospectionScanCache`, `TelemetryRepository`, `getBatchScheduler()` wiring, `TelemetryService`, `createRelationGraph`, `SleepConsolidationService`, conditional `batchScheduler.start` |
+| `packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts` | Entire `diagnosticsEnabled` block (lines 218–307 in pre-refactor `bootstrap.ts`): timer, in-flight promise, `writeSample`, cleanup function |
+
+Exact filenames may be shortened (for example `write-path.ts`) as long as each file has one responsibility; merge two modules if a circular import appears.
+
+---
+
+### Task 1: Scaffold `bootstrap/` and move search/embedding/optimizer slice
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/search-and-embedding.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Add `search-and-embedding.ts` with a function such as `createSearchEmbeddingAndOptimizerServices(db: Database.Database)` returning `{ searchEngine, embeddingService, queryEmbeddingService, hybridSearchEngine, forgettingPolicyService, databaseOptimizer }` using the same constructors and comments as current `bootstrap.ts` lines 80–86.
+- [ ] **Step 2:** In `bootstrap.ts`, remove duplicated lines 80–86 and call the new function; preserve variable names used downstream.
+- [ ] **Step 3:** Run `npm run type-check` — expect PASS.
+- [ ] **Step 4:** Run `npm test` — expect PASS.
+- [ ] **Step 5:** Commit
+
+```bash
+git add packages/memento-core/src/bootstrap.ts packages/memento-core/src/bootstrap/search-and-embedding.ts
+git commit -m "refactor(core): extract search/embedding bootstrap slice (#214)"
+```
+
+---
+
+### Task 2: Extract anchor stack
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/anchor-stack.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Add `createAnchorStack(db, embeddingService, hybridSearchEngine, errorLoggingService)` returning `{ vectorSearchEngine, anchorCacheService, anchorSearchService, anchorManager }` matching lines 89–100; keep `await anchorCacheService.restoreCacheFromDB(db)` in the same relative order as today (inside helper or immediately after the call).
+- [ ] **Step 2:** Replace inlined anchor block in `bootstrap.ts`.
+- [ ] **Step 3:** `npm run type-check` then `npm test` — PASS.
+- [ ] **Step 4:** Commit `refactor(core): extract anchor bootstrap stack (#214)`
+
+---
+
+### Task 3: Extract failure detector + reflexion worker
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/failure-reflexion.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Move lines 101–105 logic into `startFailureAndReflexion(db)` returning `{ failureDetector, reflexionWorker }`.
+- [ ] **Step 2:** Wire from `initializeServices`.
+- [ ] **Step 3:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 4:** Commit `refactor(core): extract failure/reflexion bootstrap (#214)`
+
+---
+
+### Task 4: Extract monitoring + WAL + lock monitors
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/monitoring-schedulers.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Move construction of `performanceMonitor`, `runtimeDiagnosticsLogger`, `bootstrap_start` event, `walCheckpointScheduler`, `databaseLockMonitor`, and the two `if (mementoConfig...)` start blocks into one function taking `db` and returning `{ performanceMonitor, runtimeDiagnosticsLogger, walCheckpointScheduler, databaseLockMonitor }`.
+- [ ] **Step 2:** Verify log strings unchanged (`WAL 체크포인트`, `데이터베이스 락 모니터`).
+- [ ] **Step 3:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 4:** Commit `refactor(core): extract monitoring and WAL/lock bootstrap (#214)`
+
+---
+
+### Task 5: Extract write coalescing, consolidation score, meta memory
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/write-and-meta.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Move `WriteCoalescingManager` instantiation and its flush callback verbatim (including `mementoConfig.consolidationScoreEnabled` branches and SQL update loop).
+- [ ] **Step 2:** Move `consolidationScoreService` conditional and `MetaMemoryService` plus log line `MetaMemoryService 초기화 완료`.
+- [ ] **Step 3:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 4:** Commit `refactor(core): extract write coalescing and meta memory bootstrap (#214)`
+
+---
+
+### Task 6: Extract batch scheduler, telemetry, relation graph, sleep consolidation
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/batch-telemetry-relation.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Move lines 201–217 into a function that accepts `db`, `embeddingService`, `runtimeDiagnosticsLogger`, `reflexionWorker` and returns `{ introspectionScanCache, telemetryRepository, batchScheduler, telemetryService, relationGraph, sleepConsolidationService }`, preserving `getBatchScheduler()` and setter call order.
+- [ ] **Step 2:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 3:** Commit `refactor(core): extract batch/telemetry/relation bootstrap (#214)`
+
+---
+
+### Task 7: Extract runtime diagnostics sampler
+
+**Files:**
+
+- Create: `packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts`
+- Modify: `packages/memento-core/src/bootstrap.ts`
+
+- [ ] **Step 1:** Move the full `if (mementoConfig.diagnosticsEnabled) { ... }` block into `createRuntimeDiagnosticsSampler({ mementoConfig, batchScheduler, runtimeDiagnosticsLogger })` returning `{ runtimeDiagnosticsSamplerCleanup } | undefined`.
+- [ ] **Step 2:** Ensure `unref`, in-flight await, and `scheduleRuntimeDiagnosticsSampler` recursion match pre-refactor behavior.
+- [ ] **Step 3:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 4:** Commit `refactor(core): extract runtime diagnostics sampler (#214)`
+
+---
+
+### Task 8: Final cleanup and quality gate
+
+**Files:**
+
+- Modify: `packages/memento-core/src/bootstrap.ts` (imports only, ensure no dead imports)
+
+- [ ] **Step 1:** `npm run lint` — fix unused imports or order issues.
+- [ ] **Step 2:** `npm run type-check` and `npm test` — PASS.
+- [ ] **Step 3:** Confirm `packages/memento-core/src/index.ts` still imports `./bootstrap.js` and exports unchanged.
+- [ ] **Step 4:** No code change expected in `packages/memento-server/src/server/bootstrap.ts`.
+- [ ] **Step 5:** Final commit only if cleanup remains.
+
+```bash
+git add packages/memento-core/src/bootstrap.ts
+git commit -m "refactor(core): tidy bootstrap imports after split (#214)"
+```
+
+---
+
+## Plan self-review
+
+| Spec section (#214 design) | Tasks covering it |
+|----------------------------|-------------------|
+| `bootstrap/` modules, thin orchestrator | Tasks 1–7 |
+| No behavior/API change | Each task: verbatim move + full suite |
+| Server bootstrap unchanged | Task 8 note |
+| Lint/type/test | Task 8 |
+
+Placeholder scan: none.
+
+---
+
+## Execution handoff
+
+Plan saved to `docs/superpowers/plans/2026-05-01-issue-214-wave1-bootstrap.md`.
+
+1. **Subagent-Driven (recommended)** — Fresh subagent per task, review between tasks.
+2. **Inline Execution** — Execute tasks in this session using executing-plans with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-01-issue-214-wave1-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-214-wave1-bootstrap-design.md
@@ -1,0 +1,61 @@
+# 설계: 이슈 #214 — memento-core Wave 1 부트스트랩 조립 분리
+
+**상태**: 승인됨 (브레인스토밍 2026-05-01)  
+**날짜**: 2026-05-01  
+**관련**: [GitHub #214](https://github.com/jee1/memento/issues/214), 부모 [#180](https://github.com/jee1/memento/issues/180), 로드맵 `docs/superpowers/specs/2026-05-01-issue-180-refactor-roadmap-design.md`
+
+---
+
+## 1. 목적
+
+`packages/memento-core/src/bootstrap.ts`의 `initializeServices`에 집중된 **과도한 중첩·단일 파일 부담**을 줄인다. **런타임 동작·공개 계약은 변경하지 않는다** (리팩터만).
+
+---
+
+## 2. 범위
+
+| 포함 | 제외 |
+|------|------|
+| `packages/memento-core/src/bootstrap.ts` 및 분리를 위해 추가하는 `packages/memento-core/src/bootstrap/**/*.ts` | Wave 2(거대 spec 분할), Wave 3(`any` 정리) |
+| `ServerServices` 타입과 `initializeServices`의 반환 필드·초기화 순서 **동일 유지** | DB 스키마·마이그레이션·`initializeDatabase` 로직 변경 (`infrastructure/database/database/init.ts`는 대상 아님) |
+| `packages/memento-server/src/server/bootstrap.ts`는 **읽기 점검만** (현재는 `@memento/core` 재수출만 존재 → 코드 변경 없음) | 기능 추가, 설정 키 추가 |
+
+---
+
+## 3. 아키텍처 방향
+
+- **권장 구조**: `packages/memento-core/src/bootstrap/` 하위에 **이름 있는 단위**(앵커 스택, 실패/리플렉션, 모니터링·WAL·락, 쓰기 병합·메타, 배치·텔레메트리·관계·슬립, 런타임 진단 샘플러 등)로 분리한다.
+- 루트 `bootstrap.ts`는 **공개 API**(`ServerServices`, `initializeServices`)와 얇은 오케스트레이션만 남긴다.
+- `@memento/core` 패키지 **외부로의 import 경로**는 기존과 동일하게 유지한다 (`./bootstrap.js` 경유 re-export는 `index.ts` 등 기존과 동일).
+
+---
+
+## 4. 데이터 흐름·계약
+
+- `createMementoCore` (`packages/memento-core/src/index.ts`)는 계속 `initializeDatabase` 후 `initializeServices(db)`를 호출한다.
+- `initializeServices`는 단일 `Database.Database` 인스턴스를 받아, 기존과 동일한 순서로 부수 효과(큐 시작, `restoreCacheFromDB`, 스케줄러 `start`, 배치 스케줄러 `start` 등)를 수행한다.
+- 새 전역 싱글톤을 도입하지 않는다.
+
+---
+
+## 5. 오류 처리
+
+- 최상위 `try/catch`에서 `서비스 초기화 실패: …` 메시지로 래핑하는 **기존 패턴을 유지**한다.
+- 진단 샘플러 등 best-effort 경로는 기존과 같이 부트스트랩 중단을 유발하지 않는다.
+
+---
+
+## 6. 검증
+
+- `npm run lint`
+- `npm run type-check`
+- `npm test`
+- (선택) 해당 패키지 스모크: 이슈 완료 조건에 부합하는 한 **CI와 동일한 명령으로 충분**하다.
+
+---
+
+## 7. 스펙 자체 점검
+
+- **Placeholder**: 없음.
+- **모호성**: `initializeDatabase`는 본 웨이브 대상이 아님을 본 문서 §2에 명시함.
+- **범위**: 단일 PR·단일 웨이브에 적합.

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -17,6 +17,7 @@ import { PerformanceAlertService } from './domains/monitoring/services/performan
 import { WriteCoalescingManager, type CoalescedWrite } from './shared/utils/write-coalescing.js';
 import { DatabaseUtils } from './shared/utils/database.js';
 import { createAnchorStack } from './bootstrap/anchor-stack.js';
+import { createMonitoringAndSchedulers } from './bootstrap/monitoring-schedulers.js';
 import { startFailureAndReflexion } from './bootstrap/failure-reflexion.js';
 import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
 import type { FailureDetector } from './domains/monitoring/services/failure-detector.js';
@@ -90,52 +91,12 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       errorLoggingService
     );
     const { failureDetector, reflexionWorker } = await startFailureAndReflexion(db);
-    const performanceMonitor = getPerformanceMonitor();
-    performanceMonitor.initialize(db);
-    const runtimeDiagnosticsLogger = new RuntimeDiagnosticsLogger(
-      mementoConfig.diagnosticsEnabled,
-      mementoConfig.diagnosticsLogDir
-    );
-    await runtimeDiagnosticsLogger.writeEvent({
-      type: 'bootstrap_start',
-      timestamp: new Date().toISOString(),
-      diagnosticsEnabled: mementoConfig.diagnosticsEnabled
-    });
-    const walCheckpointScheduler = new WalCheckpointScheduler(
-      db,
-      {
-        intervalMs: mementoConfig.walCheckpointIntervalMs,
-        walSizeWarningThreshold: mementoConfig.walSizeWarningThreshold,
-        walSizeDangerThreshold: mementoConfig.walSizeDangerThreshold,
-        useDedicatedConnection: mementoConfig.walCheckpointUseDedicatedConnection,
-        maxRetries: mementoConfig.walCheckpointMaxRetries,
-        retryBackoffMs: mementoConfig.walCheckpointRetryBackoffMs
-      },
-      logger,
+    const {
       performanceMonitor,
-      runtimeDiagnosticsLogger
-    );
-    const databaseLockMonitor = new DatabaseLockMonitor(
-      db,
-      {
-        intervalMs: mementoConfig.lockMonitorIntervalMs,
-        warningThresholdMs: mementoConfig.lockMonitorWarningThresholdMs,
-        dangerThresholdMs: mementoConfig.lockMonitorDangerThresholdMs,
-        criticalThresholdMs: mementoConfig.lockMonitorCriticalThresholdMs
-      },
-      logger,
-      performanceMonitor,
+      runtimeDiagnosticsLogger,
       walCheckpointScheduler,
-      runtimeDiagnosticsLogger
-    );
-    if (mementoConfig.walCheckpointEnabled) {
-      walCheckpointScheduler.start();
-      logger.info('WAL 체크포인트 스케줄러 시작됨');
-    }
-    if (mementoConfig.dbLockMonitorEnabled) {
-      databaseLockMonitor.start();
-      logger.info('데이터베이스 락 모니터 시작됨');
-    }
+      databaseLockMonitor
+    } = await createMonitoringAndSchedulers(db);
     let consolidationScoreService: ConsolidationScoreService | undefined;
     const writeCoalescingManager = new WriteCoalescingManager(
       1000,

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -18,6 +18,7 @@ import type { WriteCoalescingManager } from './shared/utils/write-coalescing.js'
 import { createAnchorStack } from './bootstrap/anchor-stack.js';
 import { createWriteCoalescingMetaAndScore } from './bootstrap/write-and-meta.js';
 import { createMonitoringAndSchedulers } from './bootstrap/monitoring-schedulers.js';
+import { createBatchTelemetryRelationAndSleep } from './bootstrap/batch-telemetry-relation.js';
 import { startFailureAndReflexion } from './bootstrap/failure-reflexion.js';
 import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
 import type { FailureDetector } from './domains/monitoring/services/failure-detector.js';
@@ -26,16 +27,13 @@ import type { IConsolidationScoreService } from './shared/interfaces/consolidati
 import type { IDatabaseOptimizer } from './shared/interfaces/database-optimizer.interface.js';
 import type { IReflexionWorker } from './shared/interfaces/reflexion-worker.interface.js';
 import { getVectorSearchEngine } from './domains/search/algorithms/vector-search-engine.js';
-import { getBatchScheduler } from './infrastructure/scheduler/batch-scheduler.js';
 import { SleepConsolidationService } from './domains/consolidation/services/sleep-consolidation-service.js';
-import { createRelationGraph } from './infrastructure/relation-graph-factory.js';
 import type { RelationGraphPort } from './domains/relation/ports/relation-graph.port.js';
 import { logger } from './shared/utils/logger.js';
 import { WalCheckpointScheduler } from './infrastructure/database/wal-checkpoint-scheduler.js';
 import { DatabaseLockMonitor } from './infrastructure/database/database-lock-monitor.js';
 import type { MetaMemoryService } from './domains/memory/services/meta-memory-service.js';
 import { IntrospectionScanCache } from './domains/memory/services/introspection-scan-cache.js';
-import { TelemetryRepository } from './domains/telemetry/repositories/telemetry-repository.js';
 import { TelemetryService } from './domains/telemetry/services/telemetry-service.js';
 import { RuntimeDiagnosticsLogger } from './domains/monitoring/services/runtime-diagnostics-logger.js';
 
@@ -97,23 +95,18 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
     } = await createMonitoringAndSchedulers(db);
     const { writeCoalescingManager, consolidationScoreService, metaMemoryService } =
       createWriteCoalescingMetaAndScore(db);
-    const introspectionScanCache = new IntrospectionScanCache();
-    const telemetryRepository = new TelemetryRepository(db);
-    const batchScheduler = getBatchScheduler();
-    batchScheduler.setDiagnosticsLogger(runtimeDiagnosticsLogger);
-    batchScheduler.setTelemetryCleanupRepository(telemetryRepository);
-    const telemetryService = new TelemetryService(telemetryRepository, () => getBatchScheduler());
-    batchScheduler.setIntrospectionScanCache(introspectionScanCache);
-    const relationGraph = createRelationGraph(db);
-    const sleepConsolidationService = new SleepConsolidationService(db, {
-      relationGraph: relationGraph,
-      memoryEmbeddingService: embeddingService,
-      telemetryService
-    });
-    batchScheduler.setSleepConsolidationService(sleepConsolidationService);
-    if (mementoConfig.batchSchedulerEnabled) {
-      await batchScheduler.start(db, reflexionWorker);
-    }
+    const {
+      introspectionScanCache,
+      batchScheduler,
+      telemetryService,
+      relationGraph,
+      sleepConsolidationService
+    } = await createBatchTelemetryRelationAndSleep(
+      db,
+      embeddingService,
+      runtimeDiagnosticsLogger,
+      reflexionWorker
+    );
     let runtimeDiagnosticsSamplerCleanup: (() => Promise<void>) | undefined;
     if (mementoConfig.diagnosticsEnabled) {
       let runtimeDiagnosticsSamplerStopped = false;

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -14,9 +14,9 @@ import { ForgettingPolicyService } from './domains/forgetting/services/forgettin
 import { getPerformanceMonitor } from './domains/monitoring/services/performance-monitor.js';
 import { ErrorLoggingService } from './domains/monitoring/services/error-logging-service.js';
 import { PerformanceAlertService } from './domains/monitoring/services/performance-alert-service.js';
-import { WriteCoalescingManager, type CoalescedWrite } from './shared/utils/write-coalescing.js';
-import { DatabaseUtils } from './shared/utils/database.js';
+import type { WriteCoalescingManager } from './shared/utils/write-coalescing.js';
 import { createAnchorStack } from './bootstrap/anchor-stack.js';
+import { createWriteCoalescingMetaAndScore } from './bootstrap/write-and-meta.js';
 import { createMonitoringAndSchedulers } from './bootstrap/monitoring-schedulers.js';
 import { startFailureAndReflexion } from './bootstrap/failure-reflexion.js';
 import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
@@ -25,7 +25,6 @@ import type { IBatchScheduler } from './shared/interfaces/batch-scheduler.interf
 import type { IConsolidationScoreService } from './shared/interfaces/consolidation-score.interface.js';
 import type { IDatabaseOptimizer } from './shared/interfaces/database-optimizer.interface.js';
 import type { IReflexionWorker } from './shared/interfaces/reflexion-worker.interface.js';
-import { ConsolidationScoreService } from './infrastructure/consolidation-score-service.js';
 import { getVectorSearchEngine } from './domains/search/algorithms/vector-search-engine.js';
 import { getBatchScheduler } from './infrastructure/scheduler/batch-scheduler.js';
 import { SleepConsolidationService } from './domains/consolidation/services/sleep-consolidation-service.js';
@@ -34,9 +33,8 @@ import type { RelationGraphPort } from './domains/relation/ports/relation-graph.
 import { logger } from './shared/utils/logger.js';
 import { WalCheckpointScheduler } from './infrastructure/database/wal-checkpoint-scheduler.js';
 import { DatabaseLockMonitor } from './infrastructure/database/database-lock-monitor.js';
-import { MetaMemoryService } from './domains/memory/services/meta-memory-service.js';
+import type { MetaMemoryService } from './domains/memory/services/meta-memory-service.js';
 import { IntrospectionScanCache } from './domains/memory/services/introspection-scan-cache.js';
-import type { SqlParam } from './shared/types/index.js';
 import { TelemetryRepository } from './domains/telemetry/repositories/telemetry-repository.js';
 import { TelemetryService } from './domains/telemetry/services/telemetry-service.js';
 import { RuntimeDiagnosticsLogger } from './domains/monitoring/services/runtime-diagnostics-logger.js';
@@ -97,55 +95,8 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       walCheckpointScheduler,
       databaseLockMonitor
     } = await createMonitoringAndSchedulers(db);
-    let consolidationScoreService: ConsolidationScoreService | undefined;
-    const writeCoalescingManager = new WriteCoalescingManager(
-      1000,
-      async (writes: CoalescedWrite[]) => {
-        if (!db || writes.length === 0) return;
-        const currentDb = db;
-        try {
-          await DatabaseUtils.runTransaction(currentDb, async () => {
-            for (const write of writes) {
-              const updates: string[] = [];
-              const params: SqlParam[] = [];
-              if (write.fields.recall_count !== undefined) {
-                updates.push('recall_count = ?');
-                params.push(write.fields.recall_count);
-              }
-              if (write.fields.last_accessed_at !== undefined) {
-                updates.push('last_accessed_at = ?');
-                params.push(write.fields.last_accessed_at);
-              }
-              if (mementoConfig.consolidationScoreEnabled) {
-                if (write.fields.g_value !== undefined) {
-                  updates.push('g_value = ?');
-                  params.push(write.fields.g_value);
-                }
-                if (write.fields.consolidation_score !== undefined) {
-                  updates.push('consolidation_score = ?');
-                  params.push(write.fields.consolidation_score);
-                }
-              }
-              if (updates.length > 0) {
-                params.push(write.memoryId);
-                DatabaseUtils.run(
-                  currentDb,
-                  `UPDATE memory_item SET ${updates.join(', ')} WHERE id = ?`,
-                  params
-                );
-              }
-            }
-          });
-        } catch (error) {
-          logger.error(`⚠️ Write coalescing flush 실패: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-    );
-    if (mementoConfig.consolidationScoreEnabled) {
-      consolidationScoreService = new ConsolidationScoreService();
-    }
-    const metaMemoryService = new MetaMemoryService(db, writeCoalescingManager);
-    logger.info('MetaMemoryService 초기화 완료');
+    const { writeCoalescingManager, consolidationScoreService, metaMemoryService } =
+      createWriteCoalescingMetaAndScore(db);
     const introspectionScanCache = new IntrospectionScanCache();
     const telemetryRepository = new TelemetryRepository(db);
     const batchScheduler = getBatchScheduler();

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -16,9 +16,8 @@ import { ErrorLoggingService } from './domains/monitoring/services/error-logging
 import { PerformanceAlertService } from './domains/monitoring/services/performance-alert-service.js';
 import { WriteCoalescingManager, type CoalescedWrite } from './shared/utils/write-coalescing.js';
 import { DatabaseUtils } from './shared/utils/database.js';
-import { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
-import { AnchorCacheService } from './domains/anchor/services/anchor/anchor-cache-service.js';
-import { AnchorSearchService } from './domains/anchor/services/anchor/anchor-search-service.js';
+import { createAnchorStack } from './bootstrap/anchor-stack.js';
+import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
 import { FailureDetector } from './domains/monitoring/services/failure-detector.js';
 import { AsyncTaskQueue } from './infrastructure/async-optimizer.js';
 import type { IBatchScheduler } from './shared/interfaces/batch-scheduler.interface.js';
@@ -85,18 +84,12 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
     } = createSearchEmbeddingAndOptimizerServices(db);
     const errorLoggingService = new ErrorLoggingService();
     const performanceAlertService = new PerformanceAlertService('./logs');
-    const anchorCacheService = new AnchorCacheService(db, embeddingService);
-    const vectorSearchEngine = getVectorSearchEngine();
-    const anchorSearchService = new AnchorSearchService(anchorCacheService, {
+    const { vectorSearchEngine, anchorManager } = await createAnchorStack(
       db,
+      embeddingService,
       hybridSearchEngine,
-      vectorSearchEngine
-    });
-    const anchorManager = new AnchorManager(anchorCacheService, anchorSearchService, {
-      db,
       errorLoggingService
-    });
-    await anchorCacheService.restoreCacheFromDB(db);
+    );
     const failureEventQueue = new AsyncTaskQueue(5);
     const failureDetector = new FailureDetector(failureEventQueue);
     await failureDetector.startQueue();

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -6,9 +6,9 @@
 
 import Database from 'better-sqlite3';
 import { mementoConfig } from './shared/config/index.js';
-import { SearchEngine } from './domains/search/algorithms/search-engine.js';
+import type { SearchEngine } from './domains/search/algorithms/search-engine.js';
 import { HybridSearchEngine } from './domains/search/algorithms/hybrid-search-engine.js';
-import { HybridSearchFactory } from './domains/search/factories/hybrid-search.factory.js';
+import { createSearchEmbeddingAndOptimizerServices } from './bootstrap/search-and-embedding.js';
 import { MemoryEmbeddingService } from './domains/memory/services/memory-embedding-service.js';
 import { ForgettingPolicyService } from './domains/forgetting/services/forgetting-policy-service.js';
 import { getPerformanceMonitor } from './domains/monitoring/services/performance-monitor.js';
@@ -25,7 +25,6 @@ import type { IBatchScheduler } from './shared/interfaces/batch-scheduler.interf
 import type { IConsolidationScoreService } from './shared/interfaces/consolidation-score.interface.js';
 import type { IDatabaseOptimizer } from './shared/interfaces/database-optimizer.interface.js';
 import type { IReflexionWorker } from './shared/interfaces/reflexion-worker.interface.js';
-import { DatabaseOptimizer } from './infrastructure/database/database-optimizer.js';
 import { ConsolidationScoreService } from './infrastructure/consolidation-score-service.js';
 import { ReflexionWorker } from './infrastructure/reflexion-worker.js';
 import { getVectorSearchEngine } from './domains/search/algorithms/vector-search-engine.js';
@@ -77,13 +76,13 @@ export interface ServerServices {
 
 export async function initializeServices(db: Database.Database): Promise<ServerServices> {
   try {
-    const searchEngine = new SearchEngine();
-    const embeddingService = new MemoryEmbeddingService();
-    // 검색 경로는 별도 인스턴스를 사용해 remember 경로와 provider 상태를 공유하지 않도록 분리한다.
-    const queryEmbeddingService = new MemoryEmbeddingService();
-    const hybridSearchEngine = HybridSearchFactory.createDefaultEngine(db, queryEmbeddingService);
-    const forgettingPolicyService = new ForgettingPolicyService();
-    const databaseOptimizer = new DatabaseOptimizer(db);
+    const {
+      searchEngine,
+      embeddingService,
+      hybridSearchEngine,
+      forgettingPolicyService,
+      databaseOptimizer,
+    } = createSearchEmbeddingAndOptimizerServices(db);
     const errorLoggingService = new ErrorLoggingService();
     const performanceAlertService = new PerformanceAlertService('./logs');
     const anchorCacheService = new AnchorCacheService(db, embeddingService);

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -19,6 +19,7 @@ import { createAnchorStack } from './bootstrap/anchor-stack.js';
 import { createWriteCoalescingMetaAndScore } from './bootstrap/write-and-meta.js';
 import { createMonitoringAndSchedulers } from './bootstrap/monitoring-schedulers.js';
 import { createBatchTelemetryRelationAndSleep } from './bootstrap/batch-telemetry-relation.js';
+import { createRuntimeDiagnosticsSampler } from './bootstrap/runtime-diagnostics-sampler.js';
 import { startFailureAndReflexion } from './bootstrap/failure-reflexion.js';
 import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
 import type { FailureDetector } from './domains/monitoring/services/failure-detector.js';
@@ -29,7 +30,6 @@ import type { IReflexionWorker } from './shared/interfaces/reflexion-worker.inte
 import { getVectorSearchEngine } from './domains/search/algorithms/vector-search-engine.js';
 import { SleepConsolidationService } from './domains/consolidation/services/sleep-consolidation-service.js';
 import type { RelationGraphPort } from './domains/relation/ports/relation-graph.port.js';
-import { logger } from './shared/utils/logger.js';
 import { WalCheckpointScheduler } from './infrastructure/database/wal-checkpoint-scheduler.js';
 import { DatabaseLockMonitor } from './infrastructure/database/database-lock-monitor.js';
 import type { MetaMemoryService } from './domains/memory/services/meta-memory-service.js';
@@ -107,96 +107,12 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       runtimeDiagnosticsLogger,
       reflexionWorker
     );
-    let runtimeDiagnosticsSamplerCleanup: (() => Promise<void>) | undefined;
-    if (mementoConfig.diagnosticsEnabled) {
-      let runtimeDiagnosticsSamplerStopped = false;
-      let runtimeDiagnosticsSamplerInFlight: Promise<void> | null = null;
-      let runtimeDiagnosticsSamplerTimer: ReturnType<typeof setTimeout> | null = null;
-      const scheduleRuntimeDiagnosticsSampler = (): void => {
-        if (runtimeDiagnosticsSamplerStopped) {
-          return;
-        }
+    const { runtimeDiagnosticsSamplerCleanup } = createRuntimeDiagnosticsSampler({
+      mementoConfig,
+      batchScheduler,
+      runtimeDiagnosticsLogger
+    });
 
-        runtimeDiagnosticsSamplerTimer = setTimeout(() => {
-          runtimeDiagnosticsSamplerTimer = null;
-          void runRuntimeDiagnosticsSampler();
-        }, mementoConfig.diagnosticsIntervalMs);
-        runtimeDiagnosticsSamplerTimer.unref?.();
-      };
-
-      const runRuntimeDiagnosticsSampler = async (): Promise<void> => {
-        if (runtimeDiagnosticsSamplerStopped) {
-          return;
-        }
-
-        const currentRun = (async () => {
-          if (runtimeDiagnosticsSamplerStopped) {
-            return;
-          }
-
-          try {
-            const batchSchedulerStatus = batchScheduler.getStatus();
-            await runtimeDiagnosticsLogger.writeSample({
-              type: 'runtime_sample',
-              timestamp: new Date().toISOString(),
-              memory: process.memoryUsage(),
-              uptime: process.uptime(),
-              batchScheduler: {
-                isRunning: batchSchedulerStatus.isRunning,
-                activeJobs: batchSchedulerStatus.activeJobs ?? [],
-                uptime: batchSchedulerStatus.uptime ?? 0,
-                lastExecution: batchSchedulerStatus.lastExecution
-                  ? Object.fromEntries(
-                      Array.from(batchSchedulerStatus.lastExecution.entries()).map(([jobName, executedAt]) => [
-                        jobName,
-                        executedAt.toISOString()
-                      ])
-                    )
-                  : undefined,
-                totalExecutions: batchSchedulerStatus.totalExecutions
-                  ? Object.fromEntries(batchSchedulerStatus.totalExecutions.entries())
-                  : undefined,
-                errorCount: batchSchedulerStatus.errorCount
-                  ? Object.fromEntries(batchSchedulerStatus.errorCount.entries())
-                  : undefined
-              },
-              walCheckpointEnabled: mementoConfig.walCheckpointEnabled,
-              dbLockMonitorEnabled: mementoConfig.dbLockMonitorEnabled
-            });
-          } catch (error) {
-            try {
-              logger.error('런타임 진단 샘플 기록 실패', {
-                error: error instanceof Error ? error.message : String(error)
-              });
-            } catch {
-              // diagnostics best-effort: sampler failure must not abort bootstrap
-            }
-          }
-        })();
-
-        runtimeDiagnosticsSamplerInFlight = currentRun;
-        try {
-          await currentRun;
-        } finally {
-          if (runtimeDiagnosticsSamplerInFlight === currentRun) {
-            runtimeDiagnosticsSamplerInFlight = null;
-          }
-        }
-        if (!runtimeDiagnosticsSamplerStopped) {
-          scheduleRuntimeDiagnosticsSampler();
-        }
-      };
-
-      scheduleRuntimeDiagnosticsSampler();
-      runtimeDiagnosticsSamplerCleanup = async () => {
-        runtimeDiagnosticsSamplerStopped = true;
-        if (runtimeDiagnosticsSamplerTimer) {
-          clearTimeout(runtimeDiagnosticsSamplerTimer);
-          runtimeDiagnosticsSamplerTimer = null;
-        }
-        await runtimeDiagnosticsSamplerInFlight;
-      };
-    }
     return {
       searchEngine,
       hybridSearchEngine,

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -17,15 +17,14 @@ import { PerformanceAlertService } from './domains/monitoring/services/performan
 import { WriteCoalescingManager, type CoalescedWrite } from './shared/utils/write-coalescing.js';
 import { DatabaseUtils } from './shared/utils/database.js';
 import { createAnchorStack } from './bootstrap/anchor-stack.js';
+import { startFailureAndReflexion } from './bootstrap/failure-reflexion.js';
 import type { AnchorManager } from './domains/anchor/services/anchor/anchor-manager.js';
-import { FailureDetector } from './domains/monitoring/services/failure-detector.js';
-import { AsyncTaskQueue } from './infrastructure/async-optimizer.js';
+import type { FailureDetector } from './domains/monitoring/services/failure-detector.js';
 import type { IBatchScheduler } from './shared/interfaces/batch-scheduler.interface.js';
 import type { IConsolidationScoreService } from './shared/interfaces/consolidation-score.interface.js';
 import type { IDatabaseOptimizer } from './shared/interfaces/database-optimizer.interface.js';
 import type { IReflexionWorker } from './shared/interfaces/reflexion-worker.interface.js';
 import { ConsolidationScoreService } from './infrastructure/consolidation-score-service.js';
-import { ReflexionWorker } from './infrastructure/reflexion-worker.js';
 import { getVectorSearchEngine } from './domains/search/algorithms/vector-search-engine.js';
 import { getBatchScheduler } from './infrastructure/scheduler/batch-scheduler.js';
 import { SleepConsolidationService } from './domains/consolidation/services/sleep-consolidation-service.js';
@@ -90,11 +89,7 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       hybridSearchEngine,
       errorLoggingService
     );
-    const failureEventQueue = new AsyncTaskQueue(5);
-    const failureDetector = new FailureDetector(failureEventQueue);
-    await failureDetector.startQueue();
-    const reflexionWorker = new ReflexionWorker(failureDetector, db);
-    await reflexionWorker.start();
+    const { failureDetector, reflexionWorker } = await startFailureAndReflexion(db);
     const performanceMonitor = getPerformanceMonitor();
     performanceMonitor.initialize(db);
     const runtimeDiagnosticsLogger = new RuntimeDiagnosticsLogger(

--- a/packages/memento-core/src/bootstrap/anchor-stack.ts
+++ b/packages/memento-core/src/bootstrap/anchor-stack.ts
@@ -1,0 +1,39 @@
+import Database from 'better-sqlite3';
+import type { HybridSearchEngine } from '../domains/search/algorithms/hybrid-search-engine.js';
+import { getVectorSearchEngine } from '../domains/search/algorithms/vector-search-engine.js';
+import { AnchorManager } from '../domains/anchor/services/anchor/anchor-manager.js';
+import { AnchorCacheService } from '../domains/anchor/services/anchor/anchor-cache-service.js';
+import { AnchorSearchService } from '../domains/anchor/services/anchor/anchor-search-service.js';
+import { MemoryEmbeddingService } from '../domains/memory/services/memory-embedding-service.js';
+import { ErrorLoggingService } from '../domains/monitoring/services/error-logging-service.js';
+
+export async function createAnchorStack(
+  db: Database.Database,
+  embeddingService: MemoryEmbeddingService,
+  hybridSearchEngine: HybridSearchEngine,
+  errorLoggingService: ErrorLoggingService
+): Promise<{
+  vectorSearchEngine: ReturnType<typeof getVectorSearchEngine>;
+  anchorCacheService: AnchorCacheService;
+  anchorSearchService: AnchorSearchService;
+  anchorManager: AnchorManager;
+}> {
+  const anchorCacheService = new AnchorCacheService(db, embeddingService);
+  const vectorSearchEngine = getVectorSearchEngine();
+  const anchorSearchService = new AnchorSearchService(anchorCacheService, {
+    db,
+    hybridSearchEngine,
+    vectorSearchEngine
+  });
+  const anchorManager = new AnchorManager(anchorCacheService, anchorSearchService, {
+    db,
+    errorLoggingService
+  });
+  await anchorCacheService.restoreCacheFromDB(db);
+  return {
+    vectorSearchEngine,
+    anchorCacheService,
+    anchorSearchService,
+    anchorManager
+  };
+}

--- a/packages/memento-core/src/bootstrap/batch-telemetry-relation.ts
+++ b/packages/memento-core/src/bootstrap/batch-telemetry-relation.ts
@@ -1,0 +1,52 @@
+import Database from 'better-sqlite3';
+import { mementoConfig } from '../shared/config/index.js';
+import { getBatchScheduler } from '../infrastructure/scheduler/batch-scheduler.js';
+import { SleepConsolidationService } from '../domains/consolidation/services/sleep-consolidation-service.js';
+import { createRelationGraph } from '../infrastructure/relation-graph-factory.js';
+import { IntrospectionScanCache } from '../domains/memory/services/introspection-scan-cache.js';
+import { TelemetryRepository } from '../domains/telemetry/repositories/telemetry-repository.js';
+import { TelemetryService } from '../domains/telemetry/services/telemetry-service.js';
+import type { MemoryEmbeddingService } from '../domains/memory/services/memory-embedding-service.js';
+import type { RuntimeDiagnosticsLogger } from '../domains/monitoring/services/runtime-diagnostics-logger.js';
+import type { IReflexionWorker } from '../shared/interfaces/reflexion-worker.interface.js';
+
+export async function createBatchTelemetryRelationAndSleep(
+  db: Database.Database,
+  embeddingService: MemoryEmbeddingService,
+  runtimeDiagnosticsLogger: RuntimeDiagnosticsLogger,
+  reflexionWorker: IReflexionWorker | undefined
+): Promise<{
+  introspectionScanCache: IntrospectionScanCache;
+  telemetryRepository: TelemetryRepository;
+  batchScheduler: ReturnType<typeof getBatchScheduler>;
+  telemetryService: TelemetryService;
+  relationGraph: ReturnType<typeof createRelationGraph>;
+  sleepConsolidationService: SleepConsolidationService;
+}> {
+  const introspectionScanCache = new IntrospectionScanCache();
+  const telemetryRepository = new TelemetryRepository(db);
+  const batchScheduler = getBatchScheduler();
+  batchScheduler.setDiagnosticsLogger(runtimeDiagnosticsLogger);
+  batchScheduler.setTelemetryCleanupRepository(telemetryRepository);
+  const telemetryService = new TelemetryService(telemetryRepository, () => getBatchScheduler());
+  batchScheduler.setIntrospectionScanCache(introspectionScanCache);
+  const relationGraph = createRelationGraph(db);
+  const sleepConsolidationService = new SleepConsolidationService(db, {
+    relationGraph: relationGraph,
+    memoryEmbeddingService: embeddingService,
+    telemetryService
+  });
+  batchScheduler.setSleepConsolidationService(sleepConsolidationService);
+  if (mementoConfig.batchSchedulerEnabled) {
+    await batchScheduler.start(db, reflexionWorker);
+  }
+
+  return {
+    introspectionScanCache,
+    telemetryRepository,
+    batchScheduler,
+    telemetryService,
+    relationGraph,
+    sleepConsolidationService
+  };
+}

--- a/packages/memento-core/src/bootstrap/failure-reflexion.ts
+++ b/packages/memento-core/src/bootstrap/failure-reflexion.ts
@@ -1,0 +1,15 @@
+import { FailureDetector } from '../domains/monitoring/services/failure-detector.js';
+import { AsyncTaskQueue } from '../infrastructure/async-optimizer.js';
+import { ReflexionWorker } from '../infrastructure/reflexion-worker.js';
+
+export async function startFailureAndReflexion(db: import('better-sqlite3').Database): Promise<{
+  failureDetector: FailureDetector;
+  reflexionWorker: ReflexionWorker;
+}> {
+  const failureEventQueue = new AsyncTaskQueue(5);
+  const failureDetector = new FailureDetector(failureEventQueue);
+  await failureDetector.startQueue();
+  const reflexionWorker = new ReflexionWorker(failureDetector, db);
+  await reflexionWorker.start();
+  return { failureDetector, reflexionWorker };
+}

--- a/packages/memento-core/src/bootstrap/monitoring-schedulers.ts
+++ b/packages/memento-core/src/bootstrap/monitoring-schedulers.ts
@@ -1,0 +1,67 @@
+import Database from 'better-sqlite3';
+import { mementoConfig } from '../shared/config/index.js';
+import { getPerformanceMonitor } from '../domains/monitoring/services/performance-monitor.js';
+import { logger } from '../shared/utils/logger.js';
+import { WalCheckpointScheduler } from '../infrastructure/database/wal-checkpoint-scheduler.js';
+import { DatabaseLockMonitor } from '../infrastructure/database/database-lock-monitor.js';
+import { RuntimeDiagnosticsLogger } from '../domains/monitoring/services/runtime-diagnostics-logger.js';
+
+export async function createMonitoringAndSchedulers(db: Database.Database): Promise<{
+  performanceMonitor: ReturnType<typeof getPerformanceMonitor>;
+  runtimeDiagnosticsLogger: RuntimeDiagnosticsLogger;
+  walCheckpointScheduler: WalCheckpointScheduler;
+  databaseLockMonitor: DatabaseLockMonitor;
+}> {
+  const performanceMonitor = getPerformanceMonitor();
+  performanceMonitor.initialize(db);
+  const runtimeDiagnosticsLogger = new RuntimeDiagnosticsLogger(
+    mementoConfig.diagnosticsEnabled,
+    mementoConfig.diagnosticsLogDir
+  );
+  await runtimeDiagnosticsLogger.writeEvent({
+    type: 'bootstrap_start',
+    timestamp: new Date().toISOString(),
+    diagnosticsEnabled: mementoConfig.diagnosticsEnabled
+  });
+  const walCheckpointScheduler = new WalCheckpointScheduler(
+    db,
+    {
+      intervalMs: mementoConfig.walCheckpointIntervalMs,
+      walSizeWarningThreshold: mementoConfig.walSizeWarningThreshold,
+      walSizeDangerThreshold: mementoConfig.walSizeDangerThreshold,
+      useDedicatedConnection: mementoConfig.walCheckpointUseDedicatedConnection,
+      maxRetries: mementoConfig.walCheckpointMaxRetries,
+      retryBackoffMs: mementoConfig.walCheckpointRetryBackoffMs
+    },
+    logger,
+    performanceMonitor,
+    runtimeDiagnosticsLogger
+  );
+  const databaseLockMonitor = new DatabaseLockMonitor(
+    db,
+    {
+      intervalMs: mementoConfig.lockMonitorIntervalMs,
+      warningThresholdMs: mementoConfig.lockMonitorWarningThresholdMs,
+      dangerThresholdMs: mementoConfig.lockMonitorDangerThresholdMs,
+      criticalThresholdMs: mementoConfig.lockMonitorCriticalThresholdMs
+    },
+    logger,
+    performanceMonitor,
+    walCheckpointScheduler,
+    runtimeDiagnosticsLogger
+  );
+  if (mementoConfig.walCheckpointEnabled) {
+    walCheckpointScheduler.start();
+    logger.info('WAL 체크포인트 스케줄러 시작됨');
+  }
+  if (mementoConfig.dbLockMonitorEnabled) {
+    databaseLockMonitor.start();
+    logger.info('데이터베이스 락 모니터 시작됨');
+  }
+  return {
+    performanceMonitor,
+    runtimeDiagnosticsLogger,
+    walCheckpointScheduler,
+    databaseLockMonitor
+  };
+}

--- a/packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts
+++ b/packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts
@@ -1,0 +1,109 @@
+import type { RuntimeDiagnosticsLogger } from '../domains/monitoring/services/runtime-diagnostics-logger.js';
+import type { IBatchScheduler } from '../shared/interfaces/batch-scheduler.interface.js';
+import type { MementoConfig } from '../shared/types/index.js';
+import { logger } from '../shared/utils/logger.js';
+
+export function createRuntimeDiagnosticsSampler({
+  mementoConfig,
+  batchScheduler,
+  runtimeDiagnosticsLogger,
+}: {
+  mementoConfig: Pick<
+    MementoConfig,
+    'diagnosticsEnabled' | 'diagnosticsIntervalMs' | 'walCheckpointEnabled' | 'dbLockMonitorEnabled'
+  >;
+  batchScheduler: IBatchScheduler;
+  runtimeDiagnosticsLogger: RuntimeDiagnosticsLogger;
+}): { runtimeDiagnosticsSamplerCleanup?: () => Promise<void> } {
+  let runtimeDiagnosticsSamplerCleanup: (() => Promise<void>) | undefined;
+  if (mementoConfig.diagnosticsEnabled) {
+    let runtimeDiagnosticsSamplerStopped = false;
+    let runtimeDiagnosticsSamplerInFlight: Promise<void> | null = null;
+    let runtimeDiagnosticsSamplerTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRuntimeDiagnosticsSampler = (): void => {
+      if (runtimeDiagnosticsSamplerStopped) {
+        return;
+      }
+
+      runtimeDiagnosticsSamplerTimer = setTimeout(() => {
+        runtimeDiagnosticsSamplerTimer = null;
+        void runRuntimeDiagnosticsSampler();
+      }, mementoConfig.diagnosticsIntervalMs);
+      runtimeDiagnosticsSamplerTimer.unref?.();
+    };
+
+    const runRuntimeDiagnosticsSampler = async (): Promise<void> => {
+      if (runtimeDiagnosticsSamplerStopped) {
+        return;
+      }
+
+      const currentRun = (async () => {
+        if (runtimeDiagnosticsSamplerStopped) {
+          return;
+        }
+
+        try {
+          const batchSchedulerStatus = batchScheduler.getStatus();
+          await runtimeDiagnosticsLogger.writeSample({
+            type: 'runtime_sample',
+            timestamp: new Date().toISOString(),
+            memory: process.memoryUsage(),
+            uptime: process.uptime(),
+            batchScheduler: {
+              isRunning: batchSchedulerStatus.isRunning,
+              activeJobs: batchSchedulerStatus.activeJobs ?? [],
+              uptime: batchSchedulerStatus.uptime ?? 0,
+              lastExecution: batchSchedulerStatus.lastExecution
+                ? Object.fromEntries(
+                    Array.from(batchSchedulerStatus.lastExecution.entries()).map(([jobName, executedAt]) => [
+                      jobName,
+                      executedAt.toISOString()
+                    ])
+                  )
+                : undefined,
+              totalExecutions: batchSchedulerStatus.totalExecutions
+                ? Object.fromEntries(batchSchedulerStatus.totalExecutions.entries())
+                : undefined,
+              errorCount: batchSchedulerStatus.errorCount
+                ? Object.fromEntries(batchSchedulerStatus.errorCount.entries())
+                : undefined
+            },
+            walCheckpointEnabled: mementoConfig.walCheckpointEnabled,
+            dbLockMonitorEnabled: mementoConfig.dbLockMonitorEnabled
+          });
+        } catch (error) {
+          try {
+            logger.error('런타임 진단 샘플 기록 실패', {
+              error: error instanceof Error ? error.message : String(error)
+            });
+          } catch {
+            // diagnostics best-effort: sampler failure must not abort bootstrap
+          }
+        }
+      })();
+
+      runtimeDiagnosticsSamplerInFlight = currentRun;
+      try {
+        await currentRun;
+      } finally {
+        if (runtimeDiagnosticsSamplerInFlight === currentRun) {
+          runtimeDiagnosticsSamplerInFlight = null;
+        }
+      }
+      if (!runtimeDiagnosticsSamplerStopped) {
+        scheduleRuntimeDiagnosticsSampler();
+      }
+    };
+
+    scheduleRuntimeDiagnosticsSampler();
+    runtimeDiagnosticsSamplerCleanup = async () => {
+      runtimeDiagnosticsSamplerStopped = true;
+      if (runtimeDiagnosticsSamplerTimer) {
+        clearTimeout(runtimeDiagnosticsSamplerTimer);
+        runtimeDiagnosticsSamplerTimer = null;
+      }
+      await runtimeDiagnosticsSamplerInFlight;
+    };
+  }
+  return { runtimeDiagnosticsSamplerCleanup };
+}

--- a/packages/memento-core/src/bootstrap/search-and-embedding.ts
+++ b/packages/memento-core/src/bootstrap/search-and-embedding.ts
@@ -1,0 +1,31 @@
+import { SearchEngine } from '../domains/search/algorithms/search-engine.js';
+import type { HybridSearchEngine } from '../domains/search/algorithms/hybrid-search-engine.js';
+import { HybridSearchFactory } from '../domains/search/factories/hybrid-search.factory.js';
+import { MemoryEmbeddingService } from '../domains/memory/services/memory-embedding-service.js';
+import { ForgettingPolicyService } from '../domains/forgetting/services/forgetting-policy-service.js';
+import { DatabaseOptimizer } from '../infrastructure/database/database-optimizer.js';
+
+export function createSearchEmbeddingAndOptimizerServices(db: import('better-sqlite3').Database): {
+  searchEngine: SearchEngine;
+  embeddingService: MemoryEmbeddingService;
+  queryEmbeddingService: MemoryEmbeddingService;
+  hybridSearchEngine: HybridSearchEngine;
+  forgettingPolicyService: ForgettingPolicyService;
+  databaseOptimizer: DatabaseOptimizer;
+} {
+  const searchEngine = new SearchEngine();
+  const embeddingService = new MemoryEmbeddingService();
+  // 검색 경로는 별도 인스턴스를 사용해 remember 경로와 provider 상태를 공유하지 않도록 분리한다.
+  const queryEmbeddingService = new MemoryEmbeddingService();
+  const hybridSearchEngine = HybridSearchFactory.createDefaultEngine(db, queryEmbeddingService);
+  const forgettingPolicyService = new ForgettingPolicyService();
+  const databaseOptimizer = new DatabaseOptimizer(db);
+  return {
+    searchEngine,
+    embeddingService,
+    queryEmbeddingService,
+    hybridSearchEngine,
+    forgettingPolicyService,
+    databaseOptimizer,
+  };
+}

--- a/packages/memento-core/src/bootstrap/write-and-meta.ts
+++ b/packages/memento-core/src/bootstrap/write-and-meta.ts
@@ -1,0 +1,65 @@
+import Database from 'better-sqlite3';
+import { mementoConfig } from '../shared/config/index.js';
+import { WriteCoalescingManager, type CoalescedWrite } from '../shared/utils/write-coalescing.js';
+import { DatabaseUtils } from '../shared/utils/database.js';
+import { logger } from '../shared/utils/logger.js';
+import type { SqlParam } from '../shared/types/index.js';
+import { ConsolidationScoreService } from '../infrastructure/consolidation-score-service.js';
+import { MetaMemoryService } from '../domains/memory/services/meta-memory-service.js';
+
+export function createWriteCoalescingMetaAndScore(db: Database.Database): {
+  writeCoalescingManager: WriteCoalescingManager;
+  consolidationScoreService: ConsolidationScoreService | undefined;
+  metaMemoryService: MetaMemoryService;
+} {
+  let consolidationScoreService: ConsolidationScoreService | undefined;
+  const writeCoalescingManager = new WriteCoalescingManager(
+    1000,
+    async (writes: CoalescedWrite[]) => {
+      if (!db || writes.length === 0) return;
+      const currentDb = db;
+      try {
+        await DatabaseUtils.runTransaction(currentDb, async () => {
+          for (const write of writes) {
+            const updates: string[] = [];
+            const params: SqlParam[] = [];
+            if (write.fields.recall_count !== undefined) {
+              updates.push('recall_count = ?');
+              params.push(write.fields.recall_count);
+            }
+            if (write.fields.last_accessed_at !== undefined) {
+              updates.push('last_accessed_at = ?');
+              params.push(write.fields.last_accessed_at);
+            }
+            if (mementoConfig.consolidationScoreEnabled) {
+              if (write.fields.g_value !== undefined) {
+                updates.push('g_value = ?');
+                params.push(write.fields.g_value);
+              }
+              if (write.fields.consolidation_score !== undefined) {
+                updates.push('consolidation_score = ?');
+                params.push(write.fields.consolidation_score);
+              }
+            }
+            if (updates.length > 0) {
+              params.push(write.memoryId);
+              DatabaseUtils.run(
+                currentDb,
+                `UPDATE memory_item SET ${updates.join(', ')} WHERE id = ?`,
+                params
+              );
+            }
+          }
+        });
+      } catch (error) {
+        logger.error(`⚠️ Write coalescing flush 실패: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  );
+  if (mementoConfig.consolidationScoreEnabled) {
+    consolidationScoreService = new ConsolidationScoreService();
+  }
+  const metaMemoryService = new MetaMemoryService(db, writeCoalescingManager);
+  logger.info('MetaMemoryService 초기화 완료');
+  return { writeCoalescingManager, consolidationScoreService, metaMemoryService };
+}

--- a/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
+++ b/packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts
@@ -88,10 +88,11 @@ describe('dependency boundaries', () => {
   });
 
   it('wires relationGraph through the domain port from bootstrap to tool context', async () => {
-    const [portSource, toolTypesSource, bootstrapSource, contextSource] = await Promise.all([
+    const [portSource, toolTypesSource, bootstrapSource, batchTelemetryRelationSource, contextSource] = await Promise.all([
       readSource('domains/relation/ports/relation-graph.port.ts'),
       readSource('tools/types.ts'),
       readSource('bootstrap.ts'),
+      readSource('bootstrap/batch-telemetry-relation.ts'),
       readSource('context.ts'),
     ]);
 
@@ -99,8 +100,8 @@ describe('dependency boundaries', () => {
     expect(toolTypesSource).toContain('relationGraph?: RelationGraphPort;');
     expect(toolTypesSource).not.toContain('services/relation-graph.js');
     expect(bootstrapSource).toContain('relationGraph: RelationGraphPort;');
-    expect(bootstrapSource).toContain('const relationGraph = createRelationGraph(db);');
-    expect(bootstrapSource).toContain('relationGraph: relationGraph,');
+    expect(batchTelemetryRelationSource).toContain('const relationGraph = createRelationGraph(db);');
+    expect(bootstrapSource).toContain('createBatchTelemetryRelationAndSleep');
     expect(contextSource).toContain('relationGraph: serverContext.services.relationGraph');
   });
 });


### PR DESCRIPTION
## 요약
이슈 #214 (부모 #180 Wave 1): `packages/memento-core/src/bootstrap.ts`의 `initializeServices`를 `src/bootstrap/*.ts` 모듈로 분리했습니다. **런타임 동작·`ServerServices` 계약은 동일**합니다.

## 변경 하이라이트
- 검색/임베딩, 앵커 스택, 실패·리플렉션, 모니터링·WAL·락, 쓰기 병합·메타, 배치·텔레메트리·관계·슬립, 런타임 진단 샘플러를 각각 전용 모듈로 추출
- `dependency-boundaries.spec.ts`: `createRelationGraph` 문자열 위치를 `batch-telemetry-relation.ts`로 조정
- 설계·구현 계획 문서: `docs/superpowers/specs/2026-05-01-issue-214-wave1-bootstrap-design.md`, `docs/superpowers/plans/2026-05-01-issue-214-wave1-bootstrap.md`

## 검증
- `npm run type-check`
- `npm test`
- `npm run lint` (에러 0)

Closes #214
Related #180

Made with [Cursor](https://cursor.com)