### PR TITLE
chore(core): vector-search-quality-metrics console → logger (#177)

### DIFF
--- a/docs/superpowers/specs/2026-05-01-issue-177-vector-search-quality-console-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-177-vector-search-quality-console-design.md
@@ -1,0 +1,29 @@
+# Issue #177: `vector-search-quality-metrics.ts` console 제거
+
+## 맥락
+
+- 대상: `packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts`
+- slop-detector가 **실행 코드**의 `console.error` / `console.warn` / `console.log`(`printQualityAlert` 내)를 Critical로 보고함.
+- 파일은 `src/test/helpers`이지만, 이슈 범위는 **콘솔 직접 호출 제거**이며 God 함수 분리는 별도 이슈로 미룸.
+
+## 설계 결정
+
+1. **`printQualityAlert`의 콘솔 출력**을 `@memento/core` 공용 `logger`(`shared/utils/logger.js`)로 교체한다.
+   - `critical` → `logger.error`
+   - `warning` → `logger.warn`
+   - 그 외(info) → `logger.info`
+2. **PII 마스킹·MCP 모드·CLI quiet**는 기존 `logger` 구현을 그대로 활용한다.
+3. **통합 테스트**에서 `console` 스파이를 `logger` 스파이로 바꾸고, 감지 시 `warn`/`error`/`info` 중 하나 이상 호출되면 통과하도록 완화한다(심각도에 따라 분기).
+
+## 대안 및 기각
+
+| 접근 | 장점 | 단점 | 결론 |
+|------|------|------|------|
+| A. `logger` 사용 | 프로젝트 관례, 마스킹 일관 | `logger`가 `mcpLogger`에 의존 | **채택** |
+| B. `process.stderr.write` 직접 | 의존 최소 | 관례 이탈, 마스킵 미적용 | 기각 |
+| C. 출력 콜백 주입 | 테스트 용이 | 공개 API 변경 범위 큼 | 이슈 범위 초과 |
+
+## 검증
+
+- `packages/memento-core`에서 `test-vector-search-quality-with-consolidation` 관련 Vitest 통과
+- `npm run lint` (해당 파일 포함)

--- a/packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts
+++ b/packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts
@@ -20,6 +20,7 @@ import {
   calculateRecallAtK,
   calculateNDCGAtK
 } from './search-quality-metrics.js';
+import { logger } from '../../shared/utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -2595,14 +2596,11 @@ export function printQualityAlert(
   // 콘솔 출력
   if (output === 'console' || output === 'both') {
     if (detection.severity === 'critical') {
-      // Critical은 stderr로 출력
-      console.error(alertText);
+      logger.error(alertText);
     } else if (detection.severity === 'warning') {
-      // Warning은 console.warn으로 출력
-      console.warn(alertText);
+      logger.warn(alertText);
     } else {
-      // Info는 console.log로 출력
-      console.log(alertText);
+      logger.info(alertText);
     }
   }
   

--- a/packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts
+++ b/packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts
@@ -49,6 +49,7 @@ import {
   seedTestDatabase,
   cleanupTestDatabase
 } from './helpers/consolidation-test-data.js';
+import { logger } from '../shared/utils/logger.js';
 
 describe('벡터 검색 품질 검증 통합 테스트', () => {
   let db: Database.Database;
@@ -1973,9 +1974,10 @@ describe('벡터 검색 품질 검증 통합 테스트', () => {
       );
       
       // When: 품질 저하 감지 및 경고 출력
-      const consoleSpy = {
-        warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
-        error: vi.spyOn(console, 'error').mockImplementation(() => {})
+      const loggerSpy = {
+        warn: vi.spyOn(logger, 'warn').mockImplementation(() => {}),
+        error: vi.spyOn(logger, 'error').mockImplementation(() => {}),
+        info: vi.spyOn(logger, 'info').mockImplementation(() => {}),
       };
       
       const detection = detectQualityDegradation(comparison);
@@ -1983,12 +1985,17 @@ describe('벡터 검색 품질 검증 통합 테스트', () => {
       
       // Then: 경고 메시지가 출력되어야 함 (감지된 경우에만)
       if (detection.detected) {
-        expect(consoleSpy.warn).toHaveBeenCalled();
+        const n =
+          loggerSpy.warn.mock.calls.length +
+          loggerSpy.error.mock.calls.length +
+          loggerSpy.info.mock.calls.length;
+        expect(n).toBeGreaterThan(0);
       }
       
       // 정리
-      consoleSpy.warn.mockRestore();
-      consoleSpy.error.mockRestore();
+      loggerSpy.warn.mockRestore();
+      loggerSpy.error.mockRestore();
+      loggerSpy.info.mockRestore();
     });
 
     it('품질 저하 경고 메시지를 파일로 저장할 수 있어야 함', async () => {
@@ -2225,9 +2232,10 @@ describe('벡터 검색 품질 검증 통합 테스트', () => {
       );
       
       // When: 통합 함수 사용
-      const consoleSpy = {
-        warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
-        error: vi.spyOn(console, 'error').mockImplementation(() => {})
+      const loggerSpy = {
+        warn: vi.spyOn(logger, 'warn').mockImplementation(() => {}),
+        error: vi.spyOn(logger, 'error').mockImplementation(() => {}),
+        info: vi.spyOn(logger, 'info').mockImplementation(() => {}),
       };
       
       const detection = detectAndAlertQualityDegradation(
@@ -2243,12 +2251,17 @@ describe('벡터 검색 품질 검증 통합 테스트', () => {
       
       // 감지된 경우 경고 메시지가 출력되어야 함
       if (detection.detected) {
-        expect(consoleSpy.warn).toHaveBeenCalled();
+        const n =
+          loggerSpy.warn.mock.calls.length +
+          loggerSpy.error.mock.calls.length +
+          loggerSpy.info.mock.calls.length;
+        expect(n).toBeGreaterThan(0);
       }
       
       // 정리
-      consoleSpy.warn.mockRestore();
-      consoleSpy.error.mockRestore();
+      loggerSpy.warn.mockRestore();
+      loggerSpy.error.mockRestore();
+      loggerSpy.info.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace `console.error` / `console.warn` / `console.log` in `printQualityAlert` with the shared `logger` (`packages/memento-core/src/shared/utils/logger.js`) so slop-detector no longer flags runtime console usage in `vector-search-quality-metrics.ts`.
- Update consolidation quality integration tests to spy on `logger` instead of `console`, asserting that at least one log path fires when degradation is detected.
- Add a short design note: `docs/superpowers/specs/2026-05-01-issue-177-vector-search-quality-console-design.md`.

Out of scope for this PR: God-function splits (`calculateKendallTau`, etc.) mentioned as optional follow-up in #177.

## Test plan

- [x] `npx vitest run packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts`

Closes #177

Made with [Cursor](https://cursor.com)