### PR TITLE
chore: .slopconfig.yaml 추가 (#162)

### DIFF
--- a/.slopconfig.yaml
+++ b/.slopconfig.yaml
@@ -1,0 +1,13 @@
+version: "2.0"
+ignore:
+  - "**/coverage/**"
+  - "graphify-out/**"
+  - "**/.next/**"
+  - "**/node_modules/**"
+  - "**/dist/**"
+  - "test-results/**"
+  - ".nyc_output/**"
+  - "**/.rpt2_cache/**"
+  - "**/.rts2_cache_cjs/**"
+  - "**/.rts2_cache_es/**"
+  - "**/.rts2_cache_umd/**"

--- a/docs/superpowers/plans/2026-05-01-issue-162-slopconfig.md
+++ b/docs/superpowers/plans/2026-05-01-issue-162-slopconfig.md
@@ -1,0 +1,121 @@
+# Issue #162 — `.slopconfig.yaml` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a root `.slopconfig.yaml` so `slop-detector --project . --js` skips dependency, build, coverage, and graphify artifacts per spec `docs/superpowers/specs/2026-05-01-issue-162-slopconfig-design.md`.
+
+**Architecture:** Single configuration file at repository root; no application code changes. Verification is manual CLI plus optional `npm test` to confirm the repo still passes.
+
+**Tech Stack:** `slop-detector` (ai-slop-detector) v4.x CLI, YAML config `version: "2.0"`.
+
+---
+
+## Files
+
+| File | Action |
+|------|--------|
+| `.slopconfig.yaml` (repo root) | **Create** — `version` + `ignore` list per spec §3.1 |
+
+No TypeScript, test, or CI file changes in scope.
+
+---
+
+### Task 1: Add `.slopconfig.yaml`
+
+**Files:**
+- Create: `.slopconfig.yaml`
+
+- [ ] **Step 1: Create the config file**
+
+Create `.slopconfig.yaml` at the repository root with exactly:
+
+```yaml
+version: "2.0"
+ignore:
+  - "**/coverage/**"
+  - "graphify-out/**"
+  - "**/.next/**"
+  - "**/node_modules/**"
+  - "**/dist/**"
+  - "test-results/**"
+  - ".nyc_output/**"
+  - "**/.rpt2_cache/**"
+  - "**/.rts2_cache_cjs/**"
+  - "**/.rts2_cache_es/**"
+  - "**/.rts2_cache_umd/**"
+```
+
+- [ ] **Step 2: Commit the config**
+
+```bash
+git add .slopconfig.yaml
+git commit -m "chore: add .slopconfig.yaml to exclude build artifacts from slop scan"
+```
+
+---
+
+### Task 2: Manual verification (slop-detector)
+
+**Files:** none
+
+- [ ] **Step 1: Run slop-detector from repo root**
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+slop-detector --project . --js --config .slopconfig.yaml 2>&1 | head -80
+```
+
+**Expected:** Command completes without requiring edits; output should not be dominated by paths under `node_modules/`, `coverage/`, `graphify-out/`, or `**/.next/**` (exact UI varies by CLI version).
+
+- [ ] **Step 2: (Optional) Compare without config**
+
+```bash
+slop-detector --project . --js --config /dev/null 2>&1 | head -20
+```
+
+Only if your CLI accepts a dummy config; if not, skip. Purpose: confirm config is being read when default discovery is ambiguous.
+
+---
+
+### Task 3: Regression — test suite
+
+**Files:** none
+
+- [ ] **Step 1: Run full tests**
+
+```bash
+npm test
+```
+
+**Expected:** All tests pass (same as baseline on `main`).
+
+- [ ] **Step 2: Final commit** (only if you changed anything after Task 1; otherwise skip)
+
+If no further changes, no commit.
+
+---
+
+### Task 4: Push / PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin chore/issue-162-slopconfig
+```
+
+Link PR to GitHub issue #162 in the description.
+
+**Expected:** Remote branch exists; PR references #162.
+
+---
+
+## Spec coverage (self-review)
+
+| Spec § | Task |
+|--------|------|
+| §2.1 root `.slopconfig.yaml` v2 | Task 1 |
+| §3.1 ignore list | Task 1 YAML |
+| §3.2 CLI verification | Task 2 |
+| §2.2 no CI / no automated slop test | No tasks (explicit non-goals) |
+
+No placeholders; paths match spec.

--- a/docs/superpowers/specs/2026-05-01-issue-162-slopconfig-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-162-slopconfig-design.md
@@ -1,0 +1,71 @@
+# 설계: 이슈 #162 — `.slopconfig.yaml`로 빌드·리포트 산출물 slop 분석 제외
+
+**상태**: 브레인스토밍 승인 완료  
+**날짜**: 2026-05-01  
+**이슈**: [GitHub #162](https://github.com/jee1/memento/issues/162)
+
+---
+
+## 1. 배경·문제
+
+`slop-detector --project . --js` 실행 시 **빌드·생성 아티팩트**가 분석 대상에 포함되어 결과가 오염된다. 대표적으로 `demo/.next/**`(Next.js), `coverage/**`(Istanbul 리포트) 등이 언급되었다. `graphify-out/**`는 코드 그래프 산출물로 소스가 아니다.
+
+---
+
+## 2. 목표·비목표
+
+### 2.1 목표
+
+- 저장소 **루트**에 `.slopconfig.yaml`(스키마 `version: "2.0"`)을 추가한다.
+- `ignore` 목록으로 의존성·빌드·테스트 리포트·graphify 산출물을 제외하여, 로컬 전체 프로젝트 스캔 시 **실제 소스**에 집중할 수 있게 한다.
+- `slop-detector` CLI의 `--config` 도움말이 가리키는 파일명(`.slopconfig.yaml`)과 일치시킨다.
+
+### 2.2 비목표
+
+- CI에 slop 하드 게이트 추가.
+- 패턴 ID 비활성화·점수 임계값 튜닝.
+- ignore 목록에 대한 자동화된 단위 테스트(검증은 **수동 CLI**).
+
+---
+
+## 3. 설계 방침 (승인된 B안)
+
+`.gitignore`에서 이미 “소스가 아님”으로 취급하는 유형과 맞춘다.
+
+### 3.1 `ignore` 패턴 (확정)
+
+| 패턴 | 이유 |
+|------|------|
+| `**/coverage/**` | 커버리지 HTML/JS 리포트 |
+| `graphify-out/**` | graphify 산출물 |
+| `**/.next/**` | Next.js 빌드(`demo/.next` 포함·이동 대비) |
+| `**/node_modules/**` | 의존성 |
+| `**/dist/**` | 패키지 컴파일 산출물 |
+| `test-results/**` | Playwright 등 테스트 산출물 |
+| `.nyc_output/**` | nyc 캐시 |
+| `**/.rpt2_cache/**` | 마이크로번들/rollup 캐시 |
+| `**/.rts2_cache_cjs/**` | 동일 계열 캐시 |
+| `**/.rts2_cache_es/**` | 동일 계열 캐시 |
+| `**/.rts2_cache_umd/**` | 동일 계열 캐시 |
+
+### 3.2 검증
+
+워크트리(또는 클론) 루트에서:
+
+```bash
+slop-detector --project . --js
+```
+
+필요 시 명시:
+
+```bash
+slop-detector --project . --js --config .slopconfig.yaml
+```
+
+기대: 위 경로들이 **개별 파일 이슈**로 과도하게 뜨지 않음(도구 출력 형식에 따름).
+
+---
+
+## 4. 출처
+
+- 브레인스토밍: 사용자 옵션 **2**(생성물·캐시 확장) + **B안**(.gitignore 정렬) 승인.


### PR DESCRIPTION
## 요약
이슈 #162: `slop-detector --project . --js` 시 빌드·커버리지·graphify 산출물 등이 스캔에 섞이지 않도록 루트 `.slopconfig.yaml`을 추가합니다.

## 변경 사항
- `.slopconfig.yaml` (`version: "2.0"`, `ignore` 목록 — 스펙 `docs/superpowers/specs/2026-05-01-issue-162-slopconfig-design.md` 준수)
- 브레인스토밍·플랜 문서 (`docs/superpowers/specs/`, `docs/superpowers/plans/`)

## 검증
- `slop-detector --project . --js --config .slopconfig.yaml` (무시 경로가 deficit 목록에 과도하게 노출되지 않음)
- `npm test` 통과

Fixes #162

Made with [Cursor](https://cursor.com)