### PR TITLE
docs: Draft PR 가이드 및 printQualityAlert 콘솔 사용 문서화 (#177)

### DIFF
--- a/DEVELOPMENT_RULES.md
+++ b/DEVELOPMENT_RULES.md
@@ -78,6 +78,7 @@ AI가 코드를 정확히 이해하고 검증할 수 있도록 비즈니스 로�
 *   **브랜치 명명:** `feature/*`, `fix/*`, `docs/*`, `chore/*` 형식을 따릅니다.
 *   **커밋 메시지:** Conventional Commits 준수. **한국어 설명 포함**을 강력히 권장합니다.
     *   예: `feat(search): 하이브리드 검색 엔진 추가`
+*   **Pull Request:** 원격에 처음 올리는 PR은 **Draft PR**로 등록합니다. CI 통과, 셀프 리뷰, 설명·체크리스트 정리가 끝난 뒤 Ready for review로 전환합니다. (예: GitHub CLI `gh pr create --draft`)
 
 ### 문서화 원칙
 *   **한국어 우선:** 모든 문서는 한국어를 기본으로 작성하며, 필요시 영어로 번역합니다.

--- a/packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts
+++ b/packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts
@@ -2592,7 +2592,10 @@ export function printQualityAlert(
   
   const alertText = lines.join('\n');
   
-  // 콘솔 출력
+  // `output: 'console'`: 터미널로 사람이 읽는 QA 알림만 보냄. 심각도에 따라 stderr/stdout을
+  // 나누기 위해 `console.*`를 쓴다(도입: #38, tasks-0009). 운영 로그(logger)와 역할이 다르므로
+  // 여기서는 logger로 바꾸지 않는다.
+  /* eslint-disable no-console -- matches QualityAlertOptions.output "console" contract */
   if (output === 'console' || output === 'both') {
     if (detection.severity === 'critical') {
       // Critical은 stderr로 출력
@@ -2605,6 +2608,7 @@ export function printQualityAlert(
       console.log(alertText);
     }
   }
+  /* eslint-enable no-console */
   
   // 파일 출력
   if ((output === 'file' || output === 'both') && filePath) {


### PR DESCRIPTION
## 변경 사항

- `DEVELOPMENT_RULES.md`: 원격에 처음 올리는 PR은 **Draft PR**로 등록하고, CI·셀프 리뷰 후 Ready for review로 전환하도록 명시했습니다.
- `packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts`: Issue #177 후속으로 `printQualityAlert`의 의도적 `console` 사용을 주석으로 문서화했습니다.

## 참고

- 로컬 설정(`.claude/settings.local.json`) 및 graphify 산출물 변경은 포함하지 않았습니다.

Made with [Cursor](https://cursor.com)