### PR TITLE
chore(slop): #221 worktrees ignore + DEVELOPMENT_RULES 안내

### DIFF
--- a/.slopconfig.yaml
+++ b/.slopconfig.yaml
@@ -4,6 +4,7 @@ ignore:
   - "graphify-out/**"
   - "**/.next/**"
   - "**/node_modules/**"
+  - "**/.worktrees/**"
   - "**/dist/**"
   - "test-results/**"
   - ".nyc_output/**"

--- a/DEVELOPMENT_RULES.md
+++ b/DEVELOPMENT_RULES.md
@@ -95,3 +95,14 @@ it('should behavior when condition', async () => {
 ### 품질 게이트
 *   **검증 필수:** 커밋 전 `lint`, `type-check`, `test` 통과가 필수입니다.
 *   **실패 우선 테스트:** 버그 수정 시, 버그 재현 테스트를 먼저 작성합니다.
+
+### 선택적 정적 스캔 (slop-detector)
+*   **도구:** PyPI 패키지 `ai-slop-detector`, CLI `slop-detector`.
+*   **설치:** `pip install ai-slop-detector`
+*   **권장 명령(저장소 루트):**
+    *   패키지 소스: `slop-detector --project packages --js --config .slopconfig.yaml`
+    *   대시보드 정적 스크립트: `slop-detector --project static/js --js --config .slopconfig.yaml`
+    *   루트 전체(설정 반영): `slop-detector --project . --js --config .slopconfig.yaml`
+*   **`--gate`:** 상단 요약에 Python/LDR가 0으로 보일 수 있다. **`--js` 사용 시 JS/TS Analysis 구간을 게이트 판단의 주된 근거로 본다.**
+*   **CI:** 본 저장소의 필수 CI 게이트에는 포함하지 않는다(후속 이슈에서 선택).
+*   **테스트 경로 무시:** 기본 `.slopconfig`에서는 `*.spec.ts` 등을 대량 제외하지 않는다. 팀 정책에 따라 로컬에서만 ignore를 추가할 수 있다.

--- a/docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md
+++ b/docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md
@@ -1,0 +1,119 @@
+# Issue #221 — slop-detector 범위·설정·문서 정리 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.slopconfig.yaml`에 git worktree 경로를 무시 목록에 추가하고, `DEVELOPMENT_RULES.md`에 권장 `slop-detector` 명령과 `--gate` 해석을 문서화하여 이슈 #221을 반영한다(CI 게이트 없음).
+
+**Architecture:** 루트 설정 파일 한 줄 추가 + 개발 규칙 문서에 선택적 도구 절 추가. 런타임 코드 변경 없음.
+
+**Tech Stack:** `ai-slop-detector`(PyPI), 기존 `.slopconfig.yaml` v2.0.
+
+---
+
+### Task 1: `.slopconfig.yaml`에 worktree 무시 추가
+
+**Files:**
+- Modify: `.slopconfig.yaml`
+
+- [ ] **Step 1: `ignore` 목록에 패턴 추가**
+
+`ignore:` 배열에 다음 항목을 **알파벳·논리적 순서에 맞게** 삽입한다(기존 항목과 중복 없음).
+
+```yaml
+  - "**/.worktrees/**"
+```
+
+권장 위치: `**/node_modules/**` 근처(둘 다 `**/` 로 시작하는 로컬·도구 산출 경로 그룹).
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add .slopconfig.yaml
+git commit -m "chore(slop): ignore git worktrees in .slopconfig (#221)"
+```
+
+---
+
+### Task 2: `DEVELOPMENT_RULES.md`에 slop-detector 안내 추가
+
+**Files:**
+- Modify: `DEVELOPMENT_RULES.md` — `### 품질 게이트`의 두 항목(검증 필수, 실패 우선 테스트) **뒤**에 새 소절 삽입
+
+- [ ] **Step 1: 「선택적 정적 스캔 (slop-detector)」 소절 추가**
+
+`*   **실패 우선 테스트:**` 줄 **다음**에 빈 줄 하나를 넣고, 아래 마크다운을 그대로 삽입한다.
+
+```markdown
+### 선택적 정적 스캔 (slop-detector)
+*   **도구:** PyPI 패키지 `ai-slop-detector`, CLI `slop-detector`.
+*   **설치:** `pip install ai-slop-detector`
+*   **권장 명령(저장소 루트):**
+    *   패키지 소스: `slop-detector --project packages --js --config .slopconfig.yaml`
+    *   대시보드 정적 스크립트: `slop-detector --project static/js --js --config .slopconfig.yaml`
+    *   루트 전체(설정 반영): `slop-detector --project . --js --config .slopconfig.yaml`
+*   **`--gate`:** 상단 요약에 Python/LDR가 0으로 보일 수 있다. **`--js` 사용 시 JS/TS Analysis 구간을 게이트 판단의 주된 근거로 본다.**
+*   **CI:** 본 저장소의 필수 CI 게이트에는 포함하지 않는다(후속 이슈에서 선택).
+*   **테스트 경로 무시:** 기본 `.slopconfig`에서는 `*.spec.ts` 등을 대량 제외하지 않는다. 팀 정책에 따라 로컬에서만 ignore를 추가할 수 있다.
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add DEVELOPMENT_RULES.md
+git commit -m "docs: slop-detector 권장 명령 및 게이트 해석 안내 (#221)"
+```
+
+---
+
+### Task 3: 설계·플랜 산출물 정리(이미 반영된 경우 스킵)
+
+**Files:**
+- `docs/superpowers/specs/2026-05-02-issue-221-slop-scope-design.md`
+- `docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md`
+
+- [ ] **Step 1:** 위 파일이 저장소에 포함되어 있으면 한 커밋으로 묶거나, Task 2와 함께 `docs:` 커밋으로 추가한다.
+
+```bash
+git add docs/superpowers/specs/2026-05-02-issue-221-slop-scope-design.md docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md
+git commit -m "docs: issue #221 slop scope spec and plan"
+```
+
+---
+
+### Task 4: 검증
+
+- [ ] **Step 1:** `npm test` 및 `npm run lint` (저장소 루트) — 문서·YAML만 변경 시 회귀 없어야 한다.
+
+```bash
+npm test && npm run lint
+```
+
+기대: 기존과 동일하게 통과.
+
+- [ ] **Step 2 (선택):** `slop-detector` 가 설치된 환경에서:
+
+```bash
+slop-detector --project packages --js --config .slopconfig.yaml 2>&1 | head -40
+```
+
+기대: 명령이 스캔을 시작하고 치명적 설정 오류가 없음.
+
+---
+
+## Self-review (플랜 작성자용)
+
+| 스펙 요구 | 태스크 |
+|-----------|--------|
+| `**/.worktrees/**` ignore | Task 1 |
+| 권장 명령·`--gate`·CI 비포함·테스트 무시 정책 문서화 | Task 2 |
+| 프로덕션 Critical 백로그 | 설계 문서 §3.3 (코드 변경 없음) |
+| CI 하드 게이트 없음 | 명시됨 |
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 태스크마다 새 서브에이전트, 태스크 사이 리뷰  
+**2. Inline Execution** — 이 세션에서 `executing-plans`로 순차 실행
+
+원하는 방식을 알려 주세요.

--- a/docs/superpowers/specs/2026-05-02-issue-221-slop-scope-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-221-slop-scope-design.md
@@ -1,0 +1,78 @@
+# 설계: 이슈 #221 — slop-detector 저장소 범위·설정 정리
+
+**상태**: 승인됨 (CI 하드 게이트 제외, 설정·문서 중심)  
+**날짜**: 2026-05-02  
+**이슈**: [GitHub #221](https://github.com/jee1/memento/issues/221)
+
+---
+
+## 1. 배경·문제
+
+[`ai-slop-detector`](https://pypi.org/project/ai-slop-detector/)로 JS/TS를 스캔할 때 **분석 루트(`--project`)에 따라 결과가 크게 달라진다**. 루트 전체(`.`)를 쓰면 `.worktrees/`, `demo/.next/` 등이 포함되어 파일 수가 불필요하게 늘고, 번들·워크트리 복제본이 Critical로 잡혀 **실제 코드베이스 신호 대비 노이즈**가 커진다.
+
+이슈 #162에서 `.slopconfig.yaml`로 빌드·캐시·`graphify-out` 등은 제외했으나, **git worktree 디렉터리(`**/.worktrees/**`)** 는 명시되지 않았다.
+
+`--gate` 사용 시 Python 파일이 없으면 상단 요약의 LDR/DDC가 0으로 나와 Gate 표시가 오해를 부를 수 있으므로, **`--js` 스캔 시에는 JS/TS Analysis 블록을 주된 해석 기준**으로 삼는다.
+
+---
+
+## 2. 목표·비목표
+
+### 2.1 목표
+
+- 루트 `.slopconfig.yaml`의 `ignore`에 **`**/.worktrees/**`** 를 추가하여, 로컬 워크트리 체크아웃이 루트 전체 스캔에 섞이지 않게 한다.
+- `DEVELOPMENT_RULES.md`에 **권장 `slop-detector` 명령**(패키지·`static/js`·루트)과 **`--gate` 해석 주의**, **`--config .slopconfig.yaml` 사용**을 문서화한다.
+- 프로덕션 코드 중 Critical 후보는 **별도 리팩터링 없이** 아래 표로 백로그를 고정한다(후속 이슈에서 처리).
+
+### 2.2 비목표
+
+- **GitHub Actions 등 CI에 slop 하드 게이트 추가** — 도구가 pip 기반이고 `--gate` 요약이 JS 전용 스캔에서 혼동될 수 있어, 본 이슈에서는 제외한다. 후속 이슈에서 워크플로·기준선을 논의한다.
+- 기본 `.slopconfig`에서 `*.spec.ts`·`src/test/**` 등을 **대량 무시하지 않는다** — Vitest 패턴 오탐과 품질 신호의 균형은 팀 정책에 맞춰 **선택적으로 로컬 전용 설정**으로 조정한다(본 저장소 기본값 변경 아님).
+
+---
+
+## 3. 설계
+
+### 3.1 `.slopconfig.yaml` 변경
+
+| 추가 패턴 | 이유 |
+|-----------|------|
+| `**/.worktrees/**` | git worktree로 추가 체크아웃된 트리는 소스 복제본이며 루트 `--project .` 시 노이즈·중복 분석 유발 |
+
+기존 #162 패턴(`**/node_modules/**`, `**/.next/**`, `graphify-out/**` 등)은 유지한다. `demo/.next`는 이미 `**/.next/**`로 포함된다.
+
+### 3.2 문서 (`DEVELOPMENT_RULES.md`)
+
+품질 게이트 소절의 필수 항목(검증 필수, 실패 우선 테스트) **다음**에 **「선택적 정적 스캔 (slop-detector)」** 소절을 추가한다.
+
+- 설치: `pip install ai-slop-detector`
+- 권장:
+  - `slop-detector --project packages --js --config .slopconfig.yaml`
+  - 필요 시: `slop-detector --project static/js --js --config .slopconfig.yaml`
+  - 루트: `slop-detector --project . --js --config .slopconfig.yaml`
+- `--gate`: 상단 비-Python 요약과 불일치 가능 → **JS/TS Analysis 구간을 우선 참고**
+- CI 필수 게이트 편입은 하지 않음(본 이슈).
+
+### 3.3 프로덕션 Critical 후보 백로그 (리팩터링 본 이슈 범위 아님)
+
+| 우선 검토 파일 |
+|----------------|
+| `packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts` |
+| `packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts` |
+| `packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts` |
+| `packages/memento-core/src/domains/memory/tools/recall-tool.ts` |
+| `packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts` |
+
+---
+
+## 4. 검증
+
+- `.slopconfig.yaml`에 `**/.worktrees/**` 가 포함되었는지 확인한다.
+- (도구가 설치된 환경에서) 위 문서의 명령이 오류 없이 실행되는지 선택적으로 확인한다.
+
+---
+
+## 5. 출처
+
+- 이슈 #221 본문, #162 설계(`docs/superpowers/specs/2026-05-01-issue-162-slopconfig-design.md`)
+- 브레인스토밍: CI 게이트 **미포함** 합의


### PR DESCRIPTION
## 요약
이슈 #221 대응: `slop-detector` 스캔 범위·문서 정리 (CI 하드 게이트 제외, 합의된 추천안).

## 변경
- `.slopconfig.yaml`: `**/.worktrees/**` 무시 추가 (git worktree 복제본이 루트 `--project .` 스캔에 섞이지 않도록)
- `DEVELOPMENT_RULES.md`: 권장 `slop-detector` 명령, `--gate` 해석(JS/TS Analysis), CI 비포함, 테스트 파일 대량 제외 정책
- `docs/superpowers/specs/2026-05-02-issue-221-slop-scope-design.md`, `docs/superpowers/plans/2026-05-02-issue-221-slop-scope.md` 추가

## 비목표 (본 PR)
- CI에 slop 게이트 추가
- Critical 후보 프로덕션 파일 리팩터링 (설계서 §3.3 백로그로만 기록)

Closes #221

Made with [Cursor](https://cursor.com)