### PR TITLE
feat(core): memory_review_candidate schema (issue #240)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-240-memory-review-candidate.md
+++ b/docs/superpowers/plans/2026-05-02-issue-240-memory-review-candidate.md
@@ -1,0 +1,56 @@
+# Issue #240 memory_review_candidate schema — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SQLite table `memory_review_candidate` with FK, partial unique index on `pending` per `memory_id`, queue index, migration `33.0`, idempotent `ensureMemoryReviewCandidateSchema`, tests, and `@memento/core` export.
+
+**Architecture:** Follow migrations `031`/`032` (TypeScript `Migration` class, idempotent `up`). Mirror DDL in `ensure-memory-review-candidate-schema.ts` like `ensure-meta-memory-stats-schema.ts`. Call ensure from `init.ts` after other ensures. Append same DDL to `schema.sql` for fresh installs.
+
+**Tech Stack:** TypeScript, better-sqlite3, Vitest, SQLite 3 partial indexes.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-240-memory-review-candidate-design.md` (on branch `issue/240-memory-review-candidate` in worktree).
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts` | Create |
+| `packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts` | Create |
+| `packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts` | Create |
+| `packages/memento-core/src/infrastructure/database/database/init.ts` | Modify |
+| `packages/memento-core/src/infrastructure/database/database/schema.sql` | Modify |
+| `packages/memento-core/src/index.ts` | Modify |
+
+---
+
+### Task 1: Migration 033
+
+**Files:** Create `033-memory-review-candidate-schema.ts` (class `MemoryReviewCandidateSchemaMigration`, `version = '33.0'`, `validateBefore` requires `memory_item`, `up` creates table + two indexes with existence checks, `validateAfter` verifies table and indexes, `down` drops indexes/table and version row).
+
+### Task 2: Spec tests
+
+**Files:** Create `033-memory-review-candidate-schema.spec.ts` — table creation, idempotent `up`, duplicate pending throws, reviewed+pending same `memory_id` allowed. Use `db.pragma('foreign_keys = ON')` in setup.
+
+### Task 3: Ensure helper
+
+**Files:** Create `ensure-memory-review-candidate-schema.ts` — early return if no `memory_item`; same DDL as migration with `IF NOT EXISTS`.
+
+### Task 4: init + schema.sql + index export
+
+**Files:** `init.ts` import and call `ensureMemoryReviewCandidateSchema`; `schema.sql` append table + indexes; `index.ts` export ensure.
+
+**Verify:** `npm run type-check` and `npx vitest run packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts`.
+
+---
+
+## Self-review
+
+Spec sections (table, FK, partial unique, queue index, migration, ensure, init, tests, export) are all mapped above.
+
+---
+
+## Execution
+
+Inline execution applied in agent session; primary git branch for PR: `issue/240-memory-review-candidate` (worktree).

--- a/docs/superpowers/specs/2026-05-02-issue-240-memory-review-candidate-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-240-memory-review-candidate-design.md
@@ -1,0 +1,98 @@
+# 설계: 이슈 #240 — 리뷰 후보 저장 모델·마이그레이션
+
+**상태**: 초안 (구현 전 검토)  
+**날짜**: 2026-05-02  
+**이슈**: [GitHub #240](https://github.com/jee1/memento/issues/240)  
+**상위 맥락**: [GitHub #18](https://github.com/jee1/memento/issues/18) (기억 재생·자동 리뷰 MVP). 전체 제품 설계는 부모 이슈 분해 문서가 `main`에 합류하면 그 경로를 정식 출처로 링크한다. 본 문서는 #240 구현 범위만 고정한다.
+
+---
+
+## 1. 배경·문제
+
+중요 기억 자동 리뷰 MVP의 첫 단계로, 리뷰 **후보**를 SQLite에 안정적으로 저장하고 `pending` 행이 `memory_id`당 하나만 되도록 보장할 필요가 있다. 이후 이슈에서 산출 로직·Admin API·배치 Job이 이 테이블을 사용한다.
+
+---
+
+## 2. 목표·비목표
+
+### 2.1 목표 (#240)
+
+- `memory_review_candidate` 테이블과 제약·인덱스를 **번호 마이그레이션**으로 추가한다 (다음 사용 가능 번호: `033-`, 기존 최대 `032-` 기준).
+- `pending` 상태에 대해 **동일 `memory_id` 중복 삽입 방지**를 DB 계층에서 보장한다 (partial unique index).
+- 기본 조회 패턴 `(status, priority 내림차순, due_at 오름차순)`에 맞는 **복합 인덱스**를 둔다.
+- 마이그레이션과 동일 DDL의 **`ensureMemoryReviewCandidateSchema`** 멱등 함수를 추가하고, `init` 등 기존 경로에서 다른 `ensure*`와 같이 호출 가능하게 한다.
+- **신규 DB**와 **기존 DB(마이그레이션 연쇄)** 모두에서 마이그레이션이 성공하는지 **스펙 테스트**로 검증한다.
+- `@memento/core` **package entry**에서 ensure 함수를 re-export한다 (다른 `ensureMetaMemoryStatsSchema` 등과 동일 패턴).
+
+### 2.2 비목표 (#240)
+
+- 후보 **산출** 비즈니스 로직, **HTTP Admin** 엔드포인트, **BatchScheduler** Job 등록.
+- MCP 도구 노출, 대시보드 UI.
+- `memory_item` 삭제·하이브리드 랭킹 변경.
+
+---
+
+## 3. 데이터 모델
+
+### 3.1 테이블 `memory_review_candidate`
+
+| 컬럼 | 타입 | 제약 |
+|------|------|------|
+| `id` | TEXT | PRIMARY KEY |
+| `memory_id` | TEXT | NOT NULL, FK → `memory_item(id)` **ON DELETE CASCADE** |
+| `status` | TEXT | NOT NULL, `CHECK (status IN ('pending','reviewed','dismissed','expired'))` |
+| `priority` | REAL | NOT NULL |
+| `reason` | TEXT | NOT NULL |
+| `due_at` | TEXT | NOT NULL (ISO-8601 문자열; 기존 마이그레이션의 타임스탬프 관례와 정합) |
+| `created_at` | TEXT | NOT NULL |
+| `updated_at` | TEXT | NOT NULL |
+| `reviewed_at` | TEXT | NULL |
+| `dismissed_at` | TEXT | NULL |
+| `metadata_json` | TEXT | NULL (산출 시점 스냅샷 JSON; 정규화된 진실 원천 아님) |
+
+### 3.2 인덱스
+
+1. **Partial unique (pending 중복 방지)**  
+   - 유니크 대상: `memory_id`  
+   - 조건: `WHERE status = 'pending'`  
+   - SQLite 예: `CREATE UNIQUE INDEX ... ON memory_review_candidate(memory_id) WHERE status = 'pending';`
+
+2. **조회 큐**  
+   - `(status, priority DESC, due_at ASC)`  
+   - 프로젝트 SQLite 버전 전제에서 `CREATE INDEX ... ON memory_review_candidate(status, priority DESC, due_at ASC);` 형태로 정의하고, 기존 마이그레이션 파일들과 동일한 표현 관례를 따른다.
+
+인덱스 이름은 구현 시 `idx_memory_review_candidate_*` 네이밍으로 통일한다.
+
+---
+
+## 4. 구현 요약
+
+| 영역 | 내용 |
+|------|------|
+| 마이그레이션 | `033-memory-review-candidate-schema.ts` (+ 프로젝트가 `.sql` 분리 파일을 쓰면 동일 번호), `SchemaVersionManager` 등록 패턴 준수. |
+| ensure | `packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts`: `memory_item` 존재 시에만 DDL 실행; `CREATE TABLE IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS` / 일반 인덱스 `IF NOT EXISTS` 등으로 **멱등**. 참고: `ensure-meta-memory-stats-schema.ts`. Partial unique는 SQLite에서 `IF NOT EXISTS`와 함께 생성 가능하므로 ensure 경로와 마이그레이션 DDL을 동일하게 유지한다. |
+| init | `packages/memento-core/src/infrastructure/database/database/init.ts`에서 다른 ensure와 함께 호출해 구 DB·baseline 불일치 시에도 스키마가 수렴하도록 한다. |
+| 테스트 | `033-memory-review-candidate-schema.spec.ts`: (1) 최소 베이스 스키마 DB에 마이그레이션 적용, (2) 연쇄·재실행 시 idempotency, (3) 동일 `memory_id`에 `pending` 두 행 삽입 시 **실패** 확인. |
+| export | `packages/memento-core/src/index.ts` shared re-export 블록에 `ensureMemoryReviewCandidateSchema` 추가. |
+
+---
+
+## 5. 오류·동시성
+
+- 애플리케이션이 중복 삽입을 시도하면 partial unique 위반으로 실패한다. 상위 서비스는 추후 이슈에서 catch 후 “이미 pending 존재”로 처리할 수 있다 (#240에서는 서비스 로직 필수 아님).
+- FK는 `memory_item` 삭제 시 후보 행이 연쇄 삭제된다.
+
+---
+
+## 6. 검증 (완료 조건)
+
+- `npm test` 관련 마이그레이션 스펙 통과.
+- `npm run type-check` 통과.
+- 이슈 #240 본문의 완료 조건: 신규·기존 DB 마이그레이션 성공, `pending` 중복 불가, 스키마 테스트 통과.
+
+---
+
+## 7. 출처
+
+- [GitHub #240](https://github.com/jee1/memento/issues/240)  
+- 부모 분해 설계(예: 워크트리 `issue-18-decomposition`의 memory review decomposition 문서): 데이터 모델·인덱스 정의와 정합.

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -50,6 +50,7 @@ export {
   MementoHttpSecurityStartupError
 } from './shared/http/http-bind-policy.js';
 export { DatabaseUtils } from './shared/utils/database.js';
+export { ensureMemoryReviewCandidateSchema } from './shared/utils/ensure-memory-review-candidate-schema.js';
 export { logger } from './shared/utils/logger.js';
 export { loggingRateLimiter } from './shared/utils/logging-rate-limiter.js';
 export { withErrorHandling } from './shared/utils/error-handling.js';

--- a/packages/memento-core/src/infrastructure/database/database/init.ts
+++ b/packages/memento-core/src/infrastructure/database/database/init.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import { CoreMemoryService } from '../../../domains/memory/services/core-memory-service.js';
 import { mementoConfig } from '../../../shared/config/index.js';
 import { ensureMetaMemoryStatsSchema } from '../../../shared/utils/ensure-meta-memory-stats-schema.js';
+import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
 import { ensureQualityAssuranceSchema } from '../../../shared/utils/ensure-quality-assurance-schema.js';
 import { initializeMigrationStatusTable,loadMigrationStatusToConfig } from '../../../shared/utils/fts5-migration-status.js';
 import { logger } from '../../../shared/utils/logger.js';
@@ -610,6 +611,7 @@ export async function initializeDatabase(overrideDbPath?: string): Promise<Datab
     ensureMemoryItemTripleExtractionColumns(db);
     ensureMetaMemoryStatsSchema(db);
     ensureQualityAssuranceSchema(db);
+    ensureMemoryReviewCandidateSchema(db);
 
     // Core Memory 자동 로드 (always_load=true인 항목만)
     try {

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Migration 033 테스트 — memory_review_candidate
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { MemoryReviewCandidateSchemaMigration } from './033-memory-review-candidate-schema.js';
+
+function createMemoryItemTable(db: Database.Database): void {
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+    .get(name);
+  return !!row;
+}
+
+describe('Migration 033 - memory_review_candidate', () => {
+  let db: Database.Database;
+  let migration: MemoryReviewCandidateSchemaMigration;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMemoryItemTable(db);
+    migration = new MemoryReviewCandidateSchemaMigration();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates memory_review_candidate and indexes', async () => {
+    await migration.up(db);
+    expect(tableExists(db, 'memory_review_candidate')).toBe(true);
+    await expect(migration.validateAfter(db)).resolves.not.toThrow();
+  });
+
+  it('is idempotent — up() twice does not throw', async () => {
+    await migration.up(db);
+    await expect(migration.up(db)).resolves.not.toThrow();
+    await expect(migration.validateAfter(db)).resolves.not.toThrow();
+  });
+
+  it('rejects two pending rows for the same memory_id', async () => {
+    await migration.up(db);
+    db.exec(`
+      INSERT INTO memory_item (id, type, content) VALUES ('m1', 'episodic', 'a');
+      INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at
+      ) VALUES (
+        'c1', 'm1', 'pending', 0.5, 'test', '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+      );
+    `);
+    expect(() =>
+      db.exec(`
+        INSERT INTO memory_review_candidate (
+          id, memory_id, status, priority, reason, due_at, created_at, updated_at
+        ) VALUES (
+          'c2', 'm1', 'pending', 0.6, 'test2', '2026-01-02T00:00:00.000Z',
+          '2026-01-02T00:00:00.000Z', '2026-01-02T00:00:00.000Z'
+        );
+      `)
+    ).toThrow();
+  });
+
+  it('allows two rows for same memory_id if only one is pending', async () => {
+    await migration.up(db);
+    db.exec(`
+      INSERT INTO memory_item (id, type, content) VALUES ('m1', 'episodic', 'a');
+      INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at
+      ) VALUES (
+        'c1', 'm1', 'reviewed', 0.5, 'r', '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+      );
+      INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at
+      ) VALUES (
+        'c2', 'm1', 'pending', 0.6, 'p', '2026-01-02T00:00:00.000Z',
+        '2026-01-02T00:00:00.000Z', '2026-01-02T00:00:00.000Z'
+      );
+    `);
+    const n = db
+      .prepare(`SELECT COUNT(*) as n FROM memory_review_candidate WHERE memory_id = 'm1'`)
+      .get() as { n: number };
+    expect(n.n).toBe(2);
+  });
+});

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts
@@ -1,0 +1,94 @@
+/**
+ * Migration: 033 — memory_review_candidate table (Issue #240)
+ * Version: 33.0
+ */
+import type Database from 'better-sqlite3';
+import type { Migration } from '../types.js';
+
+export class MemoryReviewCandidateSchemaMigration implements Migration {
+  version = '33.0';
+  name = 'memory-review-candidate-schema';
+  description =
+    'Create memory_review_candidate for automatic memory review MVP (Issue #240)';
+
+  private tableExists(db: Database.Database, tableName: string): boolean {
+    const result = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+      .get(tableName);
+    return !!result;
+  }
+
+  private indexExists(db: Database.Database, indexName: string): boolean {
+    const row = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+      .get(indexName) as { name: string } | undefined;
+    return !!row;
+  }
+
+  async validateBefore(db: Database.Database): Promise<void> {
+    if (!this.tableExists(db, 'memory_item')) {
+      throw new Error('memory_item table does not exist. Cannot apply migration 033.');
+    }
+  }
+
+  async up(db: Database.Database): Promise<void> {
+    if (!this.tableExists(db, 'memory_item')) {
+      return;
+    }
+    db.exec(`
+CREATE TABLE IF NOT EXISTS memory_review_candidate (
+  id TEXT PRIMARY KEY NOT NULL,
+  memory_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','reviewed','dismissed','expired')),
+  priority REAL NOT NULL,
+  reason TEXT NOT NULL,
+  due_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  reviewed_at TEXT,
+  dismissed_at TEXT,
+  metadata_json TEXT,
+  FOREIGN KEY (memory_id) REFERENCES memory_item(id) ON DELETE CASCADE
+);
+`);
+    if (!this.indexExists(db, 'idx_memory_review_candidate_pending_memory_id')) {
+      db.exec(`
+CREATE UNIQUE INDEX idx_memory_review_candidate_pending_memory_id
+  ON memory_review_candidate(memory_id)
+  WHERE status = 'pending';
+`);
+    }
+    if (!this.indexExists(db, 'idx_memory_review_candidate_queue')) {
+      db.exec(`
+CREATE INDEX idx_memory_review_candidate_queue
+  ON memory_review_candidate(status, priority DESC, due_at ASC);
+`);
+    }
+  }
+
+  async down(db: Database.Database): Promise<void> {
+    db.exec('DROP INDEX IF EXISTS idx_memory_review_candidate_queue');
+    db.exec('DROP INDEX IF EXISTS idx_memory_review_candidate_pending_memory_id');
+    db.exec('DROP TABLE IF EXISTS memory_review_candidate');
+    if (this.tableExists(db, 'memento_schema_version')) {
+      db.prepare('DELETE FROM memento_schema_version WHERE version = ?').run('33.0');
+    }
+  }
+
+  async validateAfter(db: Database.Database): Promise<void> {
+    if (!this.tableExists(db, 'memory_item')) {
+      return;
+    }
+    if (!this.tableExists(db, 'memory_review_candidate')) {
+      throw new Error('memory_review_candidate table was not created');
+    }
+    if (!this.indexExists(db, 'idx_memory_review_candidate_pending_memory_id')) {
+      throw new Error('idx_memory_review_candidate_pending_memory_id was not created');
+    }
+    if (!this.indexExists(db, 'idx_memory_review_candidate_queue')) {
+      throw new Error('idx_memory_review_candidate_queue was not created');
+    }
+  }
+}
+
+export default MemoryReviewCandidateSchemaMigration;

--- a/packages/memento-core/src/infrastructure/database/database/schema.sql
+++ b/packages/memento-core/src/infrastructure/database/database/schema.sql
@@ -579,6 +579,27 @@ BEGIN
   WHERE memory_id = NEW.memory_id;
 END;
 
+-- Memory review candidates (migration 033, Issue #240)
+CREATE TABLE IF NOT EXISTS memory_review_candidate (
+  id TEXT PRIMARY KEY NOT NULL,
+  memory_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','reviewed','dismissed','expired')),
+  priority REAL NOT NULL,
+  reason TEXT NOT NULL,
+  due_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  reviewed_at TEXT,
+  dismissed_at TEXT,
+  metadata_json TEXT,
+  FOREIGN KEY (memory_id) REFERENCES memory_item(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_review_candidate_pending_memory_id
+  ON memory_review_candidate(memory_id)
+  WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_memory_review_candidate_queue
+  ON memory_review_candidate(status, priority DESC, due_at ASC);
+
 -- 초기 데이터 삽입 (선택사항)
 -- INSERT OR IGNORE INTO memory_item (id, type, content, importance, privacy_scope, pinned)
 -- VALUES ('welcome', 'semantic', 'Memento MCP Server에 오신 것을 환영합니다!', 1.0, 'private', TRUE);

--- a/packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts
+++ b/packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts
@@ -1,0 +1,38 @@
+/**
+ * memory_review_candidate 테이블·인덱스 보정 (마이그레이션 033과 동일 DDL, idempotent).
+ */
+
+import Database from 'better-sqlite3';
+
+export function ensureMemoryReviewCandidateSchema(db: Database.Database): void {
+  const hasMemoryItem = db
+    .prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_item' LIMIT 1`)
+    .get();
+  if (!hasMemoryItem) {
+    return;
+  }
+
+  db.exec(`
+CREATE TABLE IF NOT EXISTS memory_review_candidate (
+  id TEXT PRIMARY KEY NOT NULL,
+  memory_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','reviewed','dismissed','expired')),
+  priority REAL NOT NULL,
+  reason TEXT NOT NULL,
+  due_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  reviewed_at TEXT,
+  dismissed_at TEXT,
+  metadata_json TEXT,
+  FOREIGN KEY (memory_id) REFERENCES memory_item(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_review_candidate_pending_memory_id
+  ON memory_review_candidate(memory_id)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_memory_review_candidate_queue
+  ON memory_review_candidate(status, priority DESC, due_at ASC);
+`);
+}


### PR DESCRIPTION
## Summary

- Add SQLite table `memory_review_candidate` with FK to `memory_item` (ON DELETE CASCADE).
- Partial unique index: at most one `pending` row per `memory_id`.
- Composite index `(status, priority DESC, due_at ASC)` for queue reads.
- Migration **33.0** (`033-memory-review-candidate-schema.ts`) + Vitest spec.
- Idempotent `ensureMemoryReviewCandidateSchema` wired in `init.ts`; same DDL in `schema.sql` for fresh installs.
- Re-export `ensureMemoryReviewCandidateSchema` from `@memento/core`.

## Docs

- Spec: `docs/superpowers/specs/2026-05-02-issue-240-memory-review-candidate-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-issue-240-memory-review-candidate.md`

## Out of scope (follow-ups)

- Review candidate scoring, Admin API, BatchScheduler job (parent #18).

Closes #240

Made with [Cursor](https://cursor.com)