### PR TITLE
feat(core): memory review candidate selection (draft, #241)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-241-memory-review-candidate-selection.md
+++ b/docs/superpowers/plans/2026-05-02-issue-241-memory-review-candidate-selection.md
@@ -1,0 +1,669 @@
+# Issue #241 memory review candidate selection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `selectMemoryReviewCandidates` in `@memento/core` that reads `memory_item` + `meta_memory_stats`, applies env-driven thresholds, excludes pinned / soft-deleted / pending rows, and returns each candidate with `priority`, `reason`, and `score_breakdown` (no DB writes).
+
+**Architecture:** Hybrid (spec §4-C): one SQL query JOINs `memory_item` LEFT JOIN `meta_memory_stats`, filters with `NOT EXISTS` for pending candidates, orders with a wide LIMIT `K`, then TypeScript recomputes `stale_days`, filters by stale threshold, assigns `priority`/`reason`/`score_breakdown`, sorts by `priority` DESC, slices to `maxCandidates`. Pure date/score helpers live in a separate module for fast Vitest coverage.
+
+**Tech Stack:** TypeScript (ESM), `better-sqlite3`, Vitest, existing migrations `011-meta-memory-stats-schema` and `033-memory-review-candidate-schema` for `:memory:` integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-241-memory-review-candidate-selection-design.md`
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts` | Create |
+| `packages/memento-core/src/index.ts` | Modify — re-export public API + types |
+
+---
+
+### Task 1: Types + scoring helpers + unit tests
+
+**Files:**
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts`
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts`
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts`
+
+- [ ] **Step 1: Write failing tests** in `memory-review-candidate-selection-scoring.spec.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  MS_PER_DAY,
+  parseSqliteInstant,
+  resolveStaleAnchor,
+  computeStaleDays,
+  computeStaleRatio,
+  computePriority,
+  buildScoreBreakdown,
+  buildReason,
+  isMemoryRowActive,
+  passesEligibility,
+} from './memory-review-candidate-selection-scoring.js';
+import type { MemoryReviewCandidateSourceRow } from './memory-review-candidate-selection.types.js';
+
+describe('memory-review-candidate-selection-scoring', () => {
+  it('computeStaleDays uses floor of UTC day difference', () => {
+    const anchor = new Date('2026-05-01T12:00:00.000Z');
+    const now = new Date('2026-05-15T11:59:59.999Z');
+    expect(computeStaleDays(now, anchor)).toBe(13);
+    const now2 = new Date('2026-05-15T12:00:00.000Z');
+    expect(computeStaleDays(now2, anchor)).toBe(14);
+  });
+
+  it('resolveStaleAnchor uses last_recalled_at when present', () => {
+    const row: MemoryReviewCandidateSourceRow = {
+      memory_id: 'm1',
+      importance: 0.8,
+      pinned: 0,
+      is_deleted: 0,
+      deleted_at: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      last_recalled_at: '2026-04-01T00:00:00.000Z',
+    };
+    const r = resolveStaleAnchor(row);
+    expect(r?.kind).toBe('last_recalled_at');
+    expect(r?.anchor.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+  });
+
+  it('resolveStaleAnchor falls back to created_at when last_recalled_at null', () => {
+    const row: MemoryReviewCandidateSourceRow = {
+      memory_id: 'm1',
+      importance: 0.8,
+      pinned: 0,
+      is_deleted: 0,
+      deleted_at: null,
+      created_at: '2026-01-10T00:00:00.000Z',
+      last_recalled_at: null,
+    };
+    const r = resolveStaleAnchor(row);
+    expect(r?.kind).toBe('created_at_fallback');
+    expect(r?.anchor.toISOString()).toBe('2026-01-10T00:00:00.000Z');
+  });
+
+  it('computePriority matches spec §6.1', () => {
+    const staleRatio = 2; // e.g. stale_days=28, threshold=14 → min(2,3)=2
+    expect(computePriority(0.7, staleRatio)).toBe(0.7 * 1000 + 2 * 100);
+  });
+
+  it('passesEligibility respects importance and stale_days thresholds', () => {
+    const now = new Date('2026-05-15T12:00:00.000Z');
+    const anchor13 = new Date('2026-05-02T12:00:00.000Z'); // 13d before now
+    const row: MemoryReviewCandidateSourceRow = {
+      memory_id: 'm1',
+      importance: 0.7,
+      pinned: 0,
+      is_deleted: 0,
+      deleted_at: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      last_recalled_at: anchor13.toISOString(),
+    };
+    expect(passesEligibility(row, now, { importanceThreshold: 0.7, staleDays: 14 })).toBe(false);
+    const anchor14 = new Date('2026-05-01T12:00:00.000Z');
+    const row2 = { ...row, last_recalled_at: anchor14.toISOString() };
+    expect(passesEligibility(row2, now, { importanceThreshold: 0.7, staleDays: 14 })).toBe(true);
+  });
+
+  it('isMemoryRowActive excludes pinned and soft-deleted', () => {
+    const base: MemoryReviewCandidateSourceRow = {
+      memory_id: 'm1',
+      importance: 0.8,
+      pinned: 0,
+      is_deleted: 0,
+      deleted_at: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      last_recalled_at: null,
+    };
+    expect(isMemoryRowActive(base)).toBe(true);
+    expect(isMemoryRowActive({ ...base, pinned: 1 })).toBe(false);
+    expect(isMemoryRowActive({ ...base, is_deleted: 1 })).toBe(false);
+    expect(isMemoryRowActive({ ...base, deleted_at: '2026-01-02' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts`
+
+Expected: FAIL (module not found / exports missing).
+
+- [ ] **Step 3: Add `memory-review-candidate-selection.types.ts`**
+
+```typescript
+/** Anchor kind for stale_days (spec §6.2) */
+export type MemoryReviewStaleAnchorKind = 'last_recalled_at' | 'created_at_fallback';
+
+/** One row from the SQL JOIN (spec §5.1) */
+export interface MemoryReviewCandidateSourceRow {
+  memory_id: string;
+  importance: number;
+  pinned: number | boolean;
+  is_deleted: number | boolean;
+  deleted_at: string | null;
+  created_at: string;
+  last_recalled_at: string | null;
+}
+
+export interface MemoryReviewCandidateScoreBreakdown {
+  importance: number;
+  stale_days: number;
+  anchor_kind: MemoryReviewStaleAnchorKind;
+  threshold_importance: number;
+  threshold_stale_days: number;
+}
+
+export interface MemoryReviewCandidateSelectionItem {
+  memory_id: string;
+  priority: number;
+  reason: string;
+  score_breakdown: MemoryReviewCandidateScoreBreakdown;
+}
+
+export interface MemoryReviewCandidateSelectionThresholds {
+  importanceThreshold: number;
+  staleDays: number;
+  maxCandidates: number;
+}
+
+/** Caller-supplied options (tests inject `now`) */
+export interface MemoryReviewCandidateSelectionOptions extends MemoryReviewCandidateSelectionThresholds {
+  now: Date;
+}
+```
+
+- [ ] **Step 4: Implement `memory-review-candidate-selection-scoring.ts`**
+
+```typescript
+import type {
+  MemoryReviewCandidateSourceRow,
+  MemoryReviewCandidateScoreBreakdown,
+  MemoryReviewStaleAnchorKind,
+} from './memory-review-candidate-selection.types.js';
+
+export const MS_PER_DAY = 86_400_000;
+
+export function parseSqliteInstant(value: string | null | undefined): Date | null {
+  if (value == null || value === '') return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function resolveStaleAnchor(
+  row: MemoryReviewCandidateSourceRow
+): { anchor: Date; kind: MemoryReviewStaleAnchorKind } | null {
+  const fromRecall = parseSqliteInstant(row.last_recalled_at);
+  if (fromRecall) return { anchor: fromRecall, kind: 'last_recalled_at' };
+  const created = parseSqliteInstant(row.created_at);
+  if (!created) return null;
+  return { anchor: created, kind: 'created_at_fallback' };
+}
+
+export function computeStaleDays(now: Date, anchor: Date): number {
+  return Math.floor((now.getTime() - anchor.getTime()) / MS_PER_DAY);
+}
+
+export function computeStaleRatio(staleDays: number, thresholdStaleDays: number): number {
+  const denom = Math.max(thresholdStaleDays, 1);
+  return Math.min(staleDays / denom, 3);
+}
+
+export function computePriority(importance: number, staleRatio: number): number {
+  return importance * 1000 + staleRatio * 100;
+}
+
+export function isMemoryRowActive(row: MemoryReviewCandidateSourceRow): boolean {
+  const pinned = row.pinned === true || row.pinned === 1;
+  const deleted = row.is_deleted === true || row.is_deleted === 1;
+  const soft = row.deleted_at != null && row.deleted_at !== '';
+  return !pinned && !deleted && !soft;
+}
+
+export function passesEligibility(
+  row: MemoryReviewCandidateSourceRow,
+  now: Date,
+  thresholds: { importanceThreshold: number; staleDays: number }
+): boolean {
+  if (!isMemoryRowActive(row)) return false;
+  if (row.importance < thresholds.importanceThreshold) return false;
+  const anchorInfo = resolveStaleAnchor(row);
+  if (!anchorInfo) return false;
+  const staleDays = computeStaleDays(now, anchorInfo.anchor);
+  return staleDays >= thresholds.staleDays;
+}
+
+export function buildScoreBreakdown(
+  row: MemoryReviewCandidateSourceRow,
+  staleDays: number,
+  anchorKind: MemoryReviewStaleAnchorKind,
+  thresholds: { importanceThreshold: number; staleDays: number }
+): MemoryReviewCandidateScoreBreakdown {
+  return {
+    importance: row.importance,
+    stale_days: staleDays,
+    anchor_kind: anchorKind,
+    threshold_importance: thresholds.importanceThreshold,
+    threshold_stale_days: thresholds.staleDays,
+  };
+}
+
+export function buildReason(
+  row: MemoryReviewCandidateSourceRow,
+  staleDays: number,
+  anchorKind: MemoryReviewStaleAnchorKind,
+  thresholds: { importanceThreshold: number; staleDays: number }
+): string {
+  return `eligible: importance=${row.importance.toFixed(3)}>=${thresholds.importanceThreshold}, stale=${staleDays}d>=${thresholds.staleDays}d, anchor=${anchorKind}`;
+}
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts \
+  packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts \
+  packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts
+git commit -m "feat(core): add memory review candidate selection scoring helpers (#241)"
+```
+
+---
+
+### Task 2: Env parsing + tests
+
+**Files:**
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts`
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts`
+
+- [ ] **Step 1: Write failing tests** in `memory-review-candidate-selection-env.spec.ts`
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseMemoryReviewSelectionEnv } from './memory-review-candidate-selection-env.js';
+
+describe('parseMemoryReviewSelectionEnv', () => {
+  const keys = [
+    'MEMORY_REVIEW_IMPORTANCE_THRESHOLD',
+    'MEMORY_REVIEW_STALE_DAYS',
+    'MEMORY_REVIEW_MAX_CANDIDATES',
+  ] as const;
+
+  beforeEach(() => {
+    for (const k of keys) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of keys) delete process.env[k];
+  });
+
+  it('returns defaults when env unset', () => {
+    const t = parseMemoryReviewSelectionEnv();
+    expect(t.importanceThreshold).toBe(0.7);
+    expect(t.staleDays).toBe(14);
+    expect(t.maxCandidates).toBe(50);
+  });
+
+  it('parses valid overrides', () => {
+    process.env.MEMORY_REVIEW_IMPORTANCE_THRESHOLD = '0.85';
+    process.env.MEMORY_REVIEW_STALE_DAYS = '30';
+    process.env.MEMORY_REVIEW_MAX_CANDIDATES = '12';
+    const t = parseMemoryReviewSelectionEnv();
+    expect(t.importanceThreshold).toBe(0.85);
+    expect(t.staleDays).toBe(30);
+    expect(t.maxCandidates).toBe(12);
+  });
+
+  it('clamps invalid importance to default', () => {
+    process.env.MEMORY_REVIEW_IMPORTANCE_THRESHOLD = '2';
+    const t = parseMemoryReviewSelectionEnv();
+    expect(t.importanceThreshold).toBe(0.7);
+  });
+
+  it('falls back stale days and max when non-positive', () => {
+    process.env.MEMORY_REVIEW_STALE_DAYS = '0';
+    process.env.MEMORY_REVIEW_MAX_CANDIDATES = '-3';
+    const t = parseMemoryReviewSelectionEnv();
+    expect(t.staleDays).toBe(14);
+    expect(t.maxCandidates).toBe(50);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `memory-review-candidate-selection-env.ts`**
+
+```typescript
+import type { MemoryReviewCandidateSelectionThresholds } from './memory-review-candidate-selection.types.js';
+
+const DEFAULT_IMPORTANCE = 0.7;
+const DEFAULT_STALE_DAYS = 14;
+const DEFAULT_MAX = 50;
+
+function clampImportance(n: number): number {
+  if (!Number.isFinite(n) || n < 0 || n > 1) return DEFAULT_IMPORTANCE;
+  return n;
+}
+
+function clampPositiveInt(n: number, fallback: number): number {
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) return fallback;
+  return n;
+}
+
+export function parseMemoryReviewSelectionEnv(): MemoryReviewCandidateSelectionThresholds {
+  const rawImp = process.env.MEMORY_REVIEW_IMPORTANCE_THRESHOLD;
+  const importanceThreshold =
+    rawImp === undefined || rawImp === '' ? DEFAULT_IMPORTANCE : clampImportance(parseFloat(rawImp));
+
+  const rawStale = process.env.MEMORY_REVIEW_STALE_DAYS;
+  const staleParsed = rawStale === undefined || rawStale === '' ? NaN : parseInt(rawStale, 10);
+  const staleDays = clampPositiveInt(staleParsed, DEFAULT_STALE_DAYS);
+
+  const rawMax = process.env.MEMORY_REVIEW_MAX_CANDIDATES;
+  const maxParsed = rawMax === undefined || rawMax === '' ? NaN : parseInt(rawMax, 10);
+  const maxCandidates = clampPositiveInt(maxParsed, DEFAULT_MAX);
+
+  return { importanceThreshold, staleDays, maxCandidates };
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts \
+  packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts
+git commit -m "feat(core): parse MEMORY_REVIEW_* env for candidate selection (#241)"
+```
+
+---
+
+### Task 3: Service + integration tests + exports
+
+**Files:**
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts`
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts`
+- Modify: `packages/memento-core/src/index.ts`
+
+- [ ] **Step 1: Write failing integration test** (pattern from `meta-memory-introspection-service.spec.ts`: `:memory:` DB, minimal `memory_item`, run migrations `011` and `033`).
+
+Create `memory-review-candidate-selection-service.spec.ts` with:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { MetaMemoryStatsSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+import { MemoryReviewCandidateSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+import { selectMemoryReviewCandidates } from './memory-review-candidate-selection-service.js';
+
+function createBaseMemoryItemTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      pinned INTEGER DEFAULT 0,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted INTEGER DEFAULT 0 NOT NULL,
+      deleted_at TEXT
+    );
+  `);
+}
+
+describe('selectMemoryReviewCandidates', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    createBaseMemoryItemTable(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns a stale high-importance memory with reason and score_breakdown', () => {
+    const now = new Date('2026-05-20T12:00:00.000Z');
+    const oldRecall = '2026-04-01T12:00:00.000Z'; // >14d before now
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES ('mem_a', 'semantic', 'x', 0.75, 'private', '2026-01-01T00:00:00.000Z', 0, 0, NULL);
+    `);
+    db.exec(`
+      INSERT INTO meta_memory_stats (memory_id, recall_count, success_count, failure_count, avg_confidence, last_recalled_at, created_at, updated_at)
+      VALUES ('mem_a', 1, 1, 0, 0.9, '${oldRecall}', datetime('now'), datetime('now'));
+    `);
+
+    const items = selectMemoryReviewCandidates(db, {
+      now,
+      importanceThreshold: 0.7,
+      staleDays: 14,
+      maxCandidates: 50,
+    });
+
+    expect(items.some((i) => i.memory_id === 'mem_a')).toBe(true);
+    const hit = items.find((i) => i.memory_id === 'mem_a')!;
+    expect(hit.priority).toBeGreaterThan(0);
+    expect(hit.reason).toContain('eligible:');
+    expect(hit.score_breakdown.anchor_kind).toBe('last_recalled_at');
+    expect(hit.score_breakdown.stale_days).toBeGreaterThanOrEqual(14);
+  });
+
+  it('excludes memory with pending review candidate', () => {
+    const now = new Date('2026-05-20T12:00:00.000Z');
+    const oldRecall = '2026-04-01T12:00:00.000Z';
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES ('mem_b', 'semantic', 'x', 0.75, 'private', '2026-01-01T00:00:00.000Z', 0, 0, NULL);
+    `);
+    db.exec(`
+      INSERT INTO meta_memory_stats (memory_id, recall_count, success_count, failure_count, avg_confidence, last_recalled_at, created_at, updated_at)
+      VALUES ('mem_b', 1, 1, 0, 0.9, '${oldRecall}', datetime('now'), datetime('now'));
+    `);
+    db.exec(`
+      INSERT INTO memory_review_candidate (id, memory_id, status, priority, reason, due_at, created_at, updated_at)
+      VALUES ('cand1', 'mem_b', 'pending', 1.0, 'test', datetime('now'), datetime('now'), datetime('now'));
+    `);
+
+    const items = selectMemoryReviewCandidates(db, {
+      now,
+      importanceThreshold: 0.7,
+      staleDays: 14,
+      maxCandidates: 50,
+    });
+    expect(items.some((i) => i.memory_id === 'mem_b')).toBe(false);
+  });
+});
+```
+
+Adjust `INSERT INTO meta_memory_stats` column list to match migration 011 exactly (copy from `meta-memory-introspection-service.spec.ts`).
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts`
+
+- [ ] **Step 3: Implement `memory-review-candidate-selection-service.ts`**
+
+```typescript
+import Database from 'better-sqlite3';
+import { ensureMetaMemoryStatsSchema } from '../../../shared/utils/ensure-meta-memory-stats-schema.js';
+import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
+import type {
+  MemoryReviewCandidateSelectionItem,
+  MemoryReviewCandidateSelectionOptions,
+  MemoryReviewCandidateSourceRow,
+} from './memory-review-candidate-selection.types.js';
+import {
+  resolveStaleAnchor,
+  computeStaleDays,
+  computeStaleRatio,
+  computePriority,
+  buildScoreBreakdown,
+  buildReason,
+  passesEligibility,
+} from './memory-review-candidate-selection-scoring.js';
+import { parseMemoryReviewSelectionEnv } from './memory-review-candidate-selection-env.js';
+
+function selectionWindowLimit(maxCandidates: number): number {
+  return Math.max(maxCandidates * 10, 200);
+}
+
+export function selectMemoryReviewCandidates(
+  db: Database.Database,
+  options?: Partial<MemoryReviewCandidateSelectionOptions>
+): MemoryReviewCandidateSelectionItem[] {
+  const env = parseMemoryReviewSelectionEnv();
+  const merged: MemoryReviewCandidateSelectionOptions = {
+    importanceThreshold: options?.importanceThreshold ?? env.importanceThreshold,
+    staleDays: options?.staleDays ?? env.staleDays,
+    maxCandidates: options?.maxCandidates ?? env.maxCandidates,
+    now: options?.now ?? new Date(),
+  };
+
+  ensureMetaMemoryStatsSchema(db);
+  ensureMemoryReviewCandidateSchema(db);
+
+  const limitK = selectionWindowLimit(merged.maxCandidates);
+  const stmt = db.prepare(`
+    SELECT
+      m.id AS memory_id,
+      m.importance AS importance,
+      m.pinned AS pinned,
+      m.is_deleted AS is_deleted,
+      m.deleted_at AS deleted_at,
+      m.created_at AS created_at,
+      s.last_recalled_at AS last_recalled_at
+    FROM memory_item m
+    LEFT JOIN meta_memory_stats s ON s.memory_id = m.id
+    WHERE (m.pinned = 0 OR m.pinned IS NULL)
+      AND m.is_deleted = 0
+      AND (m.deleted_at IS NULL OR m.deleted_at = '')
+      AND m.importance >= ?
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_review_candidate c
+        WHERE c.memory_id = m.id AND c.status = 'pending'
+      )
+    ORDER BY m.importance DESC, COALESCE(s.last_recalled_at, m.created_at) ASC
+    LIMIT ?
+  `);
+
+  const rows = stmt.all(merged.importanceThreshold, limitK) as MemoryReviewCandidateSourceRow[];
+
+  const items: MemoryReviewCandidateSelectionItem[] = [];
+  for (const row of rows) {
+    if (!passesEligibility(row, merged.now, merged)) continue;
+    const anchorInfo = resolveStaleAnchor(row);
+    if (!anchorInfo) continue;
+    const staleDays = computeStaleDays(merged.now, anchorInfo.anchor);
+    const staleRatio = computeStaleRatio(staleDays, merged.staleDays);
+    const priority = computePriority(row.importance, staleRatio);
+    const score_breakdown = buildScoreBreakdown(row, staleDays, anchorInfo.kind, merged);
+    const reason = buildReason(row, staleDays, anchorInfo.kind, merged);
+    items.push({ memory_id: row.memory_id, priority, reason, score_breakdown });
+  }
+
+  items.sort((a, b) => b.priority - a.priority);
+  return items.slice(0, merged.maxCandidates);
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts`
+
+- [ ] **Step 5: Export from `packages/memento-core/src/index.ts`**
+
+Add:
+
+```typescript
+export {
+  selectMemoryReviewCandidates,
+} from './domains/memory/services/memory-review-candidate-selection-service.js';
+export { parseMemoryReviewSelectionEnv } from './domains/memory/services/memory-review-candidate-selection-env.js';
+export type {
+  MemoryReviewCandidateSelectionItem,
+  MemoryReviewCandidateSelectionOptions,
+  MemoryReviewCandidateSelectionThresholds,
+  MemoryReviewCandidateSourceRow,
+  MemoryReviewCandidateScoreBreakdown,
+  MemoryReviewStaleAnchorKind,
+} from './domains/memory/services/memory-review-candidate-selection.types.js';
+```
+
+- [ ] **Step 6: Type-check + full core tests**
+
+Run: `npm run type-check`
+
+Run: `npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts \
+  packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts \
+  packages/memento-core/src/index.ts
+git commit -m "feat(core): select memory review candidates from DB (#241)"
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec section | Covered by |
+|--------------|------------|
+| §3 stale definition + NULL fallback | Task 1 `resolveStaleAnchor`, tests |
+| §5 types | Task 1 types file + Task 3 output shape |
+| §6 priority / reason / breakdown | Task 1 helpers + Task 3 assembly |
+| §7 SQL + window K | Task 3 `selectionWindowLimit` + SQL |
+| §8 env vars | Task 2 + merge in Task 3 |
+| §9 module location | File paths under `domains/memory/services/` |
+| §10 tests | Tasks 1–3 specs |
+| §2.2 non-goals (no INSERT) | Service only SELECTs |
+
+**Placeholder scan:** None intentional; integration test SQL must match real `meta_memory_stats` columns — verify against `011-meta-memory-stats-schema.ts` before committing.
+
+---
+
+## Execution
+
+Plan saved on branch `issue/241-review-candidates` under `docs/superpowers/plans/`.
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-02-issue-241-memory-review-candidate-selection.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-02-issue-241-memory-review-candidate-selection-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-241-memory-review-candidate-selection-design.md
@@ -1,0 +1,174 @@
+# 설계: 이슈 #241 — 중요 기억 리뷰 후보 산출 서비스
+
+**상태**: 초안 (구현 전 검토)  
+**날짜**: 2026-05-02  
+**이슈**: [GitHub #241](https://github.com/jee1/memento/issues/241)  
+**상위 맥락**: [GitHub #18](https://github.com/jee1/memento/issues/18) · 스키마·저장 모델은 [이슈 #240 설계](./2026-05-02-issue-240-memory-review-candidate-design.md)와 정합한다.
+
+---
+
+## 1. 배경·문제
+
+`memory_review_candidate` 테이블(#240)이 준비되었으므로, **어떤 기억을 후보로 올릴지**를 `memory_item`과 `meta_memory_stats`만으로 결정하는 순수 산출 로직이 필요하다. 본 이슈는 조회·점수화·설명 문자열까지를 `@memento/core`에 두고, HTTP·배치·INSERT는 범위 밖으로 둔다.
+
+---
+
+## 2. 목표·비목표
+
+### 2.1 목표 (#241)
+
+- 후보 산출에 사용하는 **입력 row 타입**(DB JOIN 결과에 대응)을 TypeScript로 정의한다.
+- 환경 변수 `MEMORY_REVIEW_IMPORTANCE_THRESHOLD`, `MEMORY_REVIEW_STALE_DAYS`, `MEMORY_REVIEW_MAX_CANDIDATES`를 읽어 **검증된 숫자 옵션**으로 주입 가능하게 한다(기본값·범위 검증 포함).
+- 각 후보마다 **`priority`(REAL)**, **`reason`(짧은 설명 문자열)**, **`score_breakdown`(구조체)** 를 계산해 반환한다.
+- **제외 규칙**: `pinned`, soft-deleted(`is_deleted`가 TRUE이거나 `deleted_at`이 NULL이 아님 — 구현 시 스키마에 맞게 하나의 일관 규칙으로 문서화), 이미 `memory_review_candidate`에 **`status = 'pending'`** 인 행이 있는 `memory_id`.
+- **단위 테스트**: stale 일수 경계, importance 임계 경계, `priority`·`reason`·`score_breakdown`의 결정적(deterministic) 동작.
+
+### 2.2 비목표 (#241)
+
+- `memory_review_candidate`에 대한 **INSERT/UPDATE**, Admin HTTP, `BatchScheduler` Job, MCP 도구.
+- 대시보드 UI, 하이브리드 검색·랭킹 공식 변경.
+- `last_accessed` / `last_accessed_at`를 stale 판단에 사용하는 방식(#241 범위 밖; 아래 §3에서 고정).
+
+---
+
+## 3. “오래됨(stale)” 정의 (승인된 추천안)
+
+- **회상 시각의 유일한 근원**: `meta_memory_stats.last_recalled_at` (ISO 문자열 또는 DB TIMESTAMP, 서비스에서는 UTC 기준으로 파싱).
+- **`last_recalled_at`이 NULL**인 경우(통계 행 없음·한 번도 회상 집계 없음): **stale 앵커 시각**을 `memory_item.created_at`으로 둔다.  
+  - 이유: NULL을 “무한히 오래됨”으로만 두면 **생성 직후 고중요 메모리**가 곧바로 후보에 들어가 MVP 노이즈가 커진다. “회상 이력이 없으면 생성 시점부터 경과 일수”로 stale를 잰다.
+- **stale 일수**: `stale_days = floor( (now_utc - anchor_utc) / 1일 )` (일 단위 정수; 테스트에서는 고정 `now` 주입).
+- **후보 조건**: `importance >= MEMORY_REVIEW_IMPORTANCE_THRESHOLD` **이고** `stale_days >= MEMORY_REVIEW_STALE_DAYS`.
+
+`memory_item.last_accessed` / `last_accessed_at`는 본 서비스에서 **읽지 않는다**.
+
+---
+
+## 4. 접근 방식 비교·권장
+
+| 접근 | 요약 | 장점 | 단점 |
+|------|------|------|------|
+| A. 단일 SQL | 필터·정렬·LIMIT까지 SQL | DB 부하 적음 | `reason`/`score_breakdown` 생성이 SQL에 비대해짐 |
+| B. 전량 TS | 행 전부 로드 후 필터·점수 | 테스트 단순 | 대용량에서 메모리·이동 비용 |
+| **C. 하이브리드 (권장)** | SQL로 JOIN·하드 필터·pending 제외까지, 상위 N 후보 윈도만 가져온 뒤 TS에서 `priority`/`reason`/`score_breakdown`·최종 정렬·`MAX` 적용 | 테스트·설명 필드에 유리, 쿼리는 단순 유지 | 윈도 크기를 합리적으로 잡아야 함(§7) |
+
+**권장: C.** `score_breakdown`과 사람이 읽을 `reason`은 TypeScript에서만 생성한다.
+
+---
+
+## 5. 데이터 모델·타입
+
+### 5.1 입력 row (`MemoryReviewCandidateSourceRow` 등 명명은 구현 시 일관되게)
+
+최소 필드(이름은 구현에서 확정):
+
+| 필드 | 출처 | 비고 |
+|------|------|------|
+| `memory_id` | `memory_item.id` | PK |
+| `importance` | `memory_item.importance` | 0~1 |
+| `pinned` | `memory_item.pinned` | TRUE면 제외 |
+| `is_deleted` | `memory_item.is_deleted` | TRUE면 제외 |
+| `deleted_at` | `memory_item.deleted_at` | NULL이 아니면 제외(soft delete) |
+| `created_at` | `memory_item.created_at` | NULL 앵커용 |
+| `last_recalled_at` | `meta_memory_stats.last_recalled_at` | LEFT JOIN; NULL 허용 |
+
+### 5.2 출력 (`MemoryReviewCandidateSelectionItem`)
+
+| 필드 | 타입 | 비고 |
+|------|------|------|
+| `memory_id` | string | |
+| `priority` | number | 내림차순 정렬용(§6) |
+| `reason` | string | 한 줄 요약(로캘은 구현에서 영문 고정 또는 프로젝트 관례 따름) |
+| `score_breakdown` | object | §6.2 스키마 고정 |
+
+서비스 반환 타입: `MemoryReviewCandidateSelectionItem[]` (길이 ≤ `MEMORY_REVIEW_MAX_CANDIDATES`).
+
+---
+
+## 6. 점수·우선순위·문구
+
+### 6.1 `priority` (결정적·단조)
+
+다음 **고정 공식**을 사용한다(구현·테스트가 동일해야 함):
+
+- `stale_ratio = min(stale_days / max(MEMORY_REVIEW_STALE_DAYS, 1), 3)` — 상한 3으로 포화.
+- `priority = importance * 1000 + stale_ratio * 100`
+
+즉 importance가 우선이고, 동일 importance에서는 더 오래된 것이 위로 온다.
+
+### 6.2 `score_breakdown` (JSON 직렬화 가능한 평면 객체)
+
+필수 키:
+
+- `importance` — 입력값
+- `stale_days` — 정수
+- `anchor_kind` — `'last_recalled_at' | 'created_at_fallback'`
+- `threshold_importance` — 사용된 임계값
+- `threshold_stale_days` — 사용된 일수 임계값
+
+### 6.3 `reason`
+
+기계 생성 한 줄. 예(영문 패턴 권장):  
+`eligible: importance=0.82>=0.7, stale=45d>=14d, anchor=last_recalled_at`
+
+---
+
+## 7. 쿼리·윈도·상한
+
+- **pending 제외**: `NOT EXISTS (SELECT 1 FROM memory_review_candidate c WHERE c.memory_id = memory_item.id AND c.status = 'pending')`.
+- **JOIN**: `memory_item` LEFT JOIN `meta_memory_stats` ON `memory_id`.
+- **하드 필터**: `NOT pinned`, soft-delete 제외 규칙은 §2.1과 동일, `importance >= threshold`.
+- **윈도**: SQL 단계에서 `ORDER BY importance DESC, COALESCE(last_recalled_at, created_at) ASC` 등으로 상위 `K`행만 가져온 뒤 TS에서 `stale_days` 재계산·컷·`priority`·최종 `MAX_CANDIDATES` 적용.  
+  - `K`는 `max(MEMORY_REVIEW_MAX_CANDIDATES * 10, 200)` 같은 상수로 두어 “stale 컷 후에도 MAX를 채울” 여유를 둔다(구현 주석으로 근거 명시).
+
+---
+
+## 8. 설정(환경 변수)
+
+| 변수 | 의미 | 기본값 제안 | 검증 |
+|------|------|-------------|------|
+| `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | 최소 importance | `0.7` | 0~1 |
+| `MEMORY_REVIEW_STALE_DAYS` | 최소 stale 일수 | `14` | 정수 ≥ 1 |
+| `MEMORY_REVIEW_MAX_CANDIDATES` | 반환 최대 개수 | `50` | 정수 ≥ 1 |
+
+파싱 실패 시: 서버 부트스트랩 정책에 맞게 **명시적 에러** 또는 **기본값 + 경고 로그** 중 하나를 택한다 — 구현 시 `MetaMemoryService` 등 기존 env 처리 패턴을 따른다.
+
+---
+
+## 9. 모듈 배치·의존성
+
+- 위치: `packages/memento-core/src/domains/memory/services/` (파일명 예: `memory-review-candidate-selection-service.ts`).
+- 의존: `better-sqlite3`의 `Database` 또는 기존 repository 추상화가 있으면 그에 맞춤. **도메인 순수 함수**(`computeStaleDays`, `computePriority`, `buildReason`)는 DB 없이 단위 테스트한다.
+- 공개 API: `selectMemoryReviewCandidates(db, options)` 형태; `options`에 `now: Date`, 임계값·max(또는 env에서 읽은 값)를 넣어 테스트가 `now`를 고정한다.
+
+---
+
+## 10. 테스트 계획 (Vitest)
+
+- `stale_days` 경계: `STALE_DAYS=14`, anchor가 정확히 13일 전 → 제외, 14일 전 → 포함.
+- `importance` 경계: 0.699 제외, 0.7 포함.
+- `pinned` / `is_deleted` / `deleted_at` / pending 행 각각 제외.
+- `last_recalled_at` NULL → `created_at` 앵커로 stale 계산.
+- `priority` 정렬: 동일 importance에서 stale 큰 것이 앞선다.
+- `score_breakdown.anchor_kind` 값 검증.
+
+---
+
+## 11. 완료 조건 (이슈 본문과 매핑)
+
+- `importance >= threshold` 이고 stale 일수 조건을 만족하는 메모리가 후보에 포함된다.
+- pinned·soft-deleted·pending 후보는 제외된다.
+- 각 항목에 `reason`과 `score_breakdown`이 채워진다.
+- `npm test`에서 본 서비스 관련 스펙이 통과한다.
+
+---
+
+## 12. 다음 이슈(참고)
+
+- 산출 결과를 `memory_review_candidate`에 **INSERT**(partial unique와 충돌 처리), Admin API, 스케줄러 Job 연동.
+
+---
+
+## 13. 출처
+
+- [GitHub #241](https://github.com/jee1/memento/issues/241)  
+- [GitHub #240](./2026-05-02-issue-240-memory-review-candidate-design.md)

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseMemoryReviewSelectionEnv } from './memory-review-candidate-selection-env.js';
+
+describe('parseMemoryReviewSelectionEnv', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses defaults when MEMORY_REVIEW_* vars are unset', () => {
+    expect(parseMemoryReviewSelectionEnv()).toEqual({
+      importanceThreshold: 0.7,
+      staleDays: 14,
+      maxCandidates: 50,
+    });
+  });
+
+  it('applies valid env overrides', () => {
+    vi.stubEnv('MEMORY_REVIEW_IMPORTANCE_THRESHOLD', '0.25');
+    vi.stubEnv('MEMORY_REVIEW_STALE_DAYS', '30');
+    vi.stubEnv('MEMORY_REVIEW_MAX_CANDIDATES', '100');
+    expect(parseMemoryReviewSelectionEnv()).toEqual({
+      importanceThreshold: 0.25,
+      staleDays: 30,
+      maxCandidates: 100,
+    });
+  });
+
+  it('falls back importance when value is outside [0, 1]', () => {
+    vi.stubEnv('MEMORY_REVIEW_IMPORTANCE_THRESHOLD', '2');
+    expect(parseMemoryReviewSelectionEnv().importanceThreshold).toBe(0.7);
+  });
+
+  it('falls back staleDays when value is below 1', () => {
+    vi.stubEnv('MEMORY_REVIEW_STALE_DAYS', '0');
+    expect(parseMemoryReviewSelectionEnv().staleDays).toBe(14);
+  });
+
+  it('falls back maxCandidates when value is negative', () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_CANDIDATES', '-3');
+    expect(parseMemoryReviewSelectionEnv().maxCandidates).toBe(50);
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts
@@ -1,0 +1,35 @@
+import type { MemoryReviewCandidateSelectionThresholds } from './memory-review-candidate-selection.types.js';
+
+const DEFAULT_IMPORTANCE_THRESHOLD = 0.7;
+const DEFAULT_STALE_DAYS = 14;
+const DEFAULT_MAX_CANDIDATES = 50;
+
+function parseImportanceThreshold(raw: string | undefined): number {
+  if (raw === undefined || raw === '') {
+    return DEFAULT_IMPORTANCE_THRESHOLD;
+  }
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    return DEFAULT_IMPORTANCE_THRESHOLD;
+  }
+  return n;
+}
+
+function parsePositiveInt(raw: string | undefined, defaultValue: number): number {
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    return defaultValue;
+  }
+  return n;
+}
+
+export function parseMemoryReviewSelectionEnv(): MemoryReviewCandidateSelectionThresholds {
+  return {
+    importanceThreshold: parseImportanceThreshold(process.env.MEMORY_REVIEW_IMPORTANCE_THRESHOLD),
+    staleDays: parsePositiveInt(process.env.MEMORY_REVIEW_STALE_DAYS, DEFAULT_STALE_DAYS),
+    maxCandidates: parsePositiveInt(process.env.MEMORY_REVIEW_MAX_CANDIDATES, DEFAULT_MAX_CANDIDATES),
+  };
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts
@@ -86,7 +86,7 @@ describe('memory-review-candidate-selection-scoring', () => {
   });
 
   describe('passesEligibility', () => {
-    const thresholds = { threshold_importance: 0.4, threshold_stale_days: 14 };
+    const thresholds = { importanceThreshold: 0.4, staleDays: 14, maxCandidates: 50 };
 
     it('is false at 13 stale days and true at 14 for threshold 14', () => {
       const now = new Date('2025-05-15T00:00:00.000Z');
@@ -125,14 +125,16 @@ describe('memory-review-candidate-selection-scoring', () => {
         importance: 0.55,
         last_recalled_at: new Date(now.getTime() - 20 * MS_PER_DAY).toISOString(),
       });
-      const options = { threshold_importance: 0.4, threshold_stale_days: 14, now };
+      const options = { importanceThreshold: 0.4, staleDays: 14, maxCandidates: 50, now };
       const b = buildScoreBreakdown(row, options);
       expect(b.importance).toBe(0.55);
       expect(b.stale_days).toBe(20);
       expect(b.anchor_kind).toBe('last_recalled_at');
       expect(b.threshold_importance).toBe(0.4);
       expect(b.threshold_stale_days).toBe(14);
-      expect(buildReason(b)).toContain('last recalled');
+      expect(buildReason(b)).toBe(
+        'eligible: importance=0.550>=0.4, stale=20d>=14d, anchor=last_recalled_at',
+      );
     });
   });
 

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MS_PER_DAY,
+  buildReason,
+  buildScoreBreakdown,
+  computePriority,
+  computeStaleDays,
+  computeStaleRatio,
+  isMemoryRowActive,
+  parseSqliteInstant,
+  passesEligibility,
+  resolveStaleAnchor,
+} from './memory-review-candidate-selection-scoring.js';
+import type { MemoryReviewCandidateSourceRow } from './memory-review-candidate-selection.types.js';
+
+function baseRow(overrides: Partial<MemoryReviewCandidateSourceRow> = {}): MemoryReviewCandidateSourceRow {
+  return {
+    memory_id: 'm1',
+    importance: 0.5,
+    pinned: false,
+    is_deleted: false,
+    deleted_at: null,
+    created_at: '2020-01-01T00:00:00.000Z',
+    last_recalled_at: null,
+    ...overrides,
+  };
+}
+
+describe('memory-review-candidate-selection-scoring', () => {
+  describe('computeStaleDays', () => {
+    it('floors whole days and distinguishes 13 vs 14 day boundary', () => {
+      const now = new Date('2025-05-15T12:00:00.000Z');
+      const anchor13 = new Date(now.getTime() - 13 * MS_PER_DAY);
+      const anchor14 = new Date(now.getTime() - 14 * MS_PER_DAY);
+      const anchorJustUnder14 = new Date(now.getTime() - (14 * MS_PER_DAY - 1));
+
+      expect(computeStaleDays(anchor13, now)).toBe(13);
+      expect(computeStaleDays(anchor14, now)).toBe(14);
+      expect(computeStaleDays(anchorJustUnder14, now)).toBe(13);
+    });
+  });
+
+  describe('resolveStaleAnchor', () => {
+    it('prefers last_recalled_at when parseable', () => {
+      const row = baseRow({
+        last_recalled_at: '2025-04-01T00:00:00.000Z',
+        created_at: '2020-01-01T00:00:00.000Z',
+      });
+      const r = resolveStaleAnchor(row);
+      expect(r?.kind).toBe('last_recalled_at');
+      expect(r?.instant.toISOString()).toBe('2025-04-01T00:00:00.000Z');
+    });
+
+    it('falls back to created_at when last recall missing or invalid', () => {
+      const row = baseRow({
+        last_recalled_at: null,
+        created_at: '2024-06-01 00:00:00',
+      });
+      const r = resolveStaleAnchor(row);
+      expect(r?.kind).toBe('created_at_fallback');
+      expect(r?.instant.toISOString()).toBe('2024-06-01T00:00:00.000Z');
+    });
+
+    it('returns null when created_at is invalid', () => {
+      const row = baseRow({
+        last_recalled_at: '',
+        created_at: 'not-a-date',
+      });
+      expect(resolveStaleAnchor(row)).toBeNull();
+    });
+  });
+
+  describe('computeStaleRatio', () => {
+    it('caps at 3 and uses max(threshold,1) as denominator', () => {
+      expect(computeStaleRatio(10, 5)).toBe(2);
+      expect(computeStaleRatio(30, 10)).toBe(3);
+      expect(computeStaleRatio(5, 0)).toBe(3);
+    });
+  });
+
+  describe('computePriority', () => {
+    it('combines importance and stale ratio per formula', () => {
+      expect(computePriority(0.5, 1)).toBeCloseTo(600, 10);
+      expect(computePriority(0.8, 2)).toBeCloseTo(1000, 10);
+    });
+  });
+
+  describe('passesEligibility', () => {
+    const thresholds = { threshold_importance: 0.4, threshold_stale_days: 14 };
+
+    it('is false at 13 stale days and true at 14 for threshold 14', () => {
+      const now = new Date('2025-05-15T00:00:00.000Z');
+      const recall13 = new Date(now.getTime() - 13 * MS_PER_DAY).toISOString();
+      const recall14 = new Date(now.getTime() - 14 * MS_PER_DAY).toISOString();
+
+      const row13 = baseRow({
+        importance: 0.5,
+        last_recalled_at: recall13,
+      });
+      const row14 = baseRow({
+        importance: 0.5,
+        last_recalled_at: recall14,
+      });
+
+      expect(passesEligibility(row13, { ...thresholds, now })).toBe(false);
+      expect(passesEligibility(row14, { ...thresholds, now })).toBe(true);
+    });
+  });
+
+  describe('isMemoryRowActive', () => {
+    it('excludes pinned, deleted flags, and non-empty deleted_at', () => {
+      expect(isMemoryRowActive(baseRow({ pinned: true }))).toBe(false);
+      expect(isMemoryRowActive(baseRow({ pinned: 1 }))).toBe(false);
+      expect(isMemoryRowActive(baseRow({ is_deleted: true }))).toBe(false);
+      expect(isMemoryRowActive(baseRow({ is_deleted: 1 }))).toBe(false);
+      expect(isMemoryRowActive(baseRow({ deleted_at: '2025-01-01' }))).toBe(false);
+      expect(isMemoryRowActive(baseRow())).toBe(true);
+    });
+  });
+
+  describe('buildScoreBreakdown and buildReason', () => {
+    it('includes thresholds and anchor kind in breakdown and reason', () => {
+      const now = new Date('2025-05-15T00:00:00.000Z');
+      const row = baseRow({
+        importance: 0.55,
+        last_recalled_at: new Date(now.getTime() - 20 * MS_PER_DAY).toISOString(),
+      });
+      const options = { threshold_importance: 0.4, threshold_stale_days: 14, now };
+      const b = buildScoreBreakdown(row, options);
+      expect(b.importance).toBe(0.55);
+      expect(b.stale_days).toBe(20);
+      expect(b.anchor_kind).toBe('last_recalled_at');
+      expect(b.threshold_importance).toBe(0.4);
+      expect(b.threshold_stale_days).toBe(14);
+      expect(buildReason(b)).toContain('last recalled');
+    });
+  });
+
+  describe('parseSqliteInstant', () => {
+    it('parses ISO and SQLite local datetime', () => {
+      expect(parseSqliteInstant('2024-01-02T03:04:05.000Z')?.toISOString()).toBe(
+        '2024-01-02T03:04:05.000Z',
+      );
+      expect(parseSqliteInstant('2024-01-02 03:04:05')?.toISOString()).toBe(
+        '2024-01-02T03:04:05.000Z',
+      );
+    });
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts
@@ -1,0 +1,113 @@
+import type {
+  MemoryReviewCandidateScoreBreakdown,
+  MemoryReviewCandidateSelectionOptions,
+  MemoryReviewCandidateSourceRow,
+  MemoryReviewStaleAnchorKind,
+} from './memory-review-candidate-selection.types.js';
+
+export const MS_PER_DAY = 86_400_000;
+
+const SQLITE_LOCAL_DATETIME = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/;
+
+export function parseSqliteInstant(value: string | null | undefined): Date | null {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (trimmed === '') return null;
+
+  const sqliteMatch = trimmed.match(SQLITE_LOCAL_DATETIME);
+  if (sqliteMatch) {
+    const isoUtc = `${sqliteMatch[1]}T${sqliteMatch[2]}Z`;
+    const parsedUtc = new Date(isoUtc);
+    if (!Number.isNaN(parsedUtc.getTime())) return parsedUtc;
+  }
+
+  const direct = new Date(trimmed);
+  if (!Number.isNaN(direct.getTime())) return direct;
+
+  return null;
+}
+
+export function resolveStaleAnchor(row: MemoryReviewCandidateSourceRow): {
+  instant: Date;
+  kind: MemoryReviewStaleAnchorKind;
+} | null {
+  const fromRecall = parseSqliteInstant(row.last_recalled_at);
+  if (fromRecall) {
+    return { instant: fromRecall, kind: 'last_recalled_at' };
+  }
+
+  const created = parseSqliteInstant(row.created_at);
+  if (!created) return null;
+
+  return { instant: created, kind: 'created_at_fallback' };
+}
+
+export function computeStaleDays(anchor: Date, now: Date): number {
+  const diffMs = now.getTime() - anchor.getTime();
+  return Math.floor(diffMs / MS_PER_DAY);
+}
+
+export function computeStaleRatio(staleDays: number, thresholdStaleDays: number): number {
+  const denom = Math.max(thresholdStaleDays, 1);
+  return Math.min(staleDays / denom, 3);
+}
+
+export function computePriority(importance: number, staleRatio: number): number {
+  return importance * 1000 + staleRatio * 100;
+}
+
+function isTruthyFlag(value: number | boolean | undefined): boolean {
+  return value === true || value === 1;
+}
+
+function isNonEmptyDeletedAt(value: string | null | undefined): boolean {
+  if (value == null) return false;
+  return String(value).trim() !== '';
+}
+
+export function isMemoryRowActive(row: MemoryReviewCandidateSourceRow): boolean {
+  if (isTruthyFlag(row.pinned)) return false;
+  if (isTruthyFlag(row.is_deleted)) return false;
+  if (isNonEmptyDeletedAt(row.deleted_at)) return false;
+  return true;
+}
+
+export function passesEligibility(
+  row: MemoryReviewCandidateSourceRow,
+  options: MemoryReviewCandidateSelectionOptions,
+): boolean {
+  if (!isMemoryRowActive(row)) return false;
+  if (row.importance < options.threshold_importance) return false;
+
+  const resolved = resolveStaleAnchor(row);
+  if (!resolved) return false;
+
+  const staleDays = computeStaleDays(resolved.instant, options.now);
+  return staleDays >= options.threshold_stale_days;
+}
+
+export function buildScoreBreakdown(
+  row: MemoryReviewCandidateSourceRow,
+  options: MemoryReviewCandidateSelectionOptions,
+): MemoryReviewCandidateScoreBreakdown {
+  const resolved = resolveStaleAnchor(row);
+  const stale_days = resolved ? computeStaleDays(resolved.instant, options.now) : 0;
+  const anchor_kind: MemoryReviewStaleAnchorKind = resolved?.kind ?? 'created_at_fallback';
+
+  return {
+    importance: row.importance,
+    stale_days,
+    anchor_kind,
+    threshold_importance: options.threshold_importance,
+    threshold_stale_days: options.threshold_stale_days,
+  };
+}
+
+export function buildReason(breakdown: MemoryReviewCandidateScoreBreakdown): string {
+  const anchor =
+    breakdown.anchor_kind === 'last_recalled_at' ? 'last recalled' : 'created (fallback anchor)';
+  return (
+    `importance ${breakdown.importance} vs threshold ${breakdown.threshold_importance}; ` +
+    `stale ${breakdown.stale_days}d vs ${breakdown.threshold_stale_days}d (${anchor})`
+  );
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts
@@ -77,13 +77,13 @@ export function passesEligibility(
   options: MemoryReviewCandidateSelectionOptions,
 ): boolean {
   if (!isMemoryRowActive(row)) return false;
-  if (row.importance < options.threshold_importance) return false;
+  if (row.importance < options.importanceThreshold) return false;
 
   const resolved = resolveStaleAnchor(row);
   if (!resolved) return false;
 
   const staleDays = computeStaleDays(resolved.instant, options.now);
-  return staleDays >= options.threshold_stale_days;
+  return staleDays >= options.staleDays;
 }
 
 export function buildScoreBreakdown(
@@ -98,16 +98,14 @@ export function buildScoreBreakdown(
     importance: row.importance,
     stale_days,
     anchor_kind,
-    threshold_importance: options.threshold_importance,
-    threshold_stale_days: options.threshold_stale_days,
+    threshold_importance: options.importanceThreshold,
+    threshold_stale_days: options.staleDays,
   };
 }
 
 export function buildReason(breakdown: MemoryReviewCandidateScoreBreakdown): string {
-  const anchor =
-    breakdown.anchor_kind === 'last_recalled_at' ? 'last recalled' : 'created (fallback anchor)';
   return (
-    `importance ${breakdown.importance} vs threshold ${breakdown.threshold_importance}; ` +
-    `stale ${breakdown.stale_days}d vs ${breakdown.threshold_stale_days}d (${anchor})`
+    `eligible: importance=${breakdown.importance.toFixed(3)}>=${breakdown.threshold_importance}, ` +
+    `stale=${breakdown.stale_days}d>=${breakdown.threshold_stale_days}d, anchor=${breakdown.anchor_kind}`
   );
 }

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Memory review candidate selection service — integration tests (Issue #241)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { selectMemoryReviewCandidates } from './memory-review-candidate-selection-service.js';
+import { MetaMemoryStatsSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+import { MemoryReviewCandidateSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+
+const FIXED_NOW = new Date('2026-06-01T12:00:00.000Z');
+
+function createBaseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+      deleted_at TEXT
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memento_schema_version (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      migration_name TEXT NOT NULL,
+      checksum TEXT,
+      applied_by TEXT DEFAULT 'system',
+      description TEXT
+    );
+  `);
+}
+
+describe('selectMemoryReviewCandidates', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES (
+        'mem_stale',
+        'semantic',
+        'Stale high-importance memory',
+        0.85,
+        'private',
+        '2020-01-15 00:00:00',
+        0,
+        0,
+        NULL
+      )
+    `);
+
+    db.exec(`
+      INSERT INTO meta_memory_stats (
+        memory_id, recall_count, success_count, failure_count,
+        avg_confidence, last_recalled_at, created_at, updated_at
+      ) VALUES (
+        'mem_stale',
+        10, 8, 2,
+        0.8,
+        '2020-06-01 00:00:00',
+        '2020-06-01 00:00:00',
+        '2020-06-01 00:00:00'
+      )
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('includes eligible stale high-importance memory with last_recalled anchor and eligible reason', () => {
+    const results = selectMemoryReviewCandidates(db, {
+      importanceThreshold: 0.7,
+      staleDays: 14,
+      maxCandidates: 50,
+      now: FIXED_NOW,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].memory_id).toBe('mem_stale');
+    expect(results[0].score_breakdown.anchor_kind).toBe('last_recalled_at');
+    expect(results[0].reason).toContain('eligible:');
+  });
+
+  it('excludes memory that already has a pending memory_review_candidate row', () => {
+    db.exec(`
+      INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at
+      ) VALUES (
+        'cand-1', 'mem_stale', 'pending', 0.5, 'queued',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z'
+      )
+    `);
+
+    const results = selectMemoryReviewCandidates(db, {
+      importanceThreshold: 0.7,
+      staleDays: 14,
+      maxCandidates: 50,
+      now: FIXED_NOW,
+    });
+
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts
@@ -1,0 +1,87 @@
+/**
+ * Memory review candidate selection — DB-backed scan + scoring (Issue #241).
+ */
+
+import Database from 'better-sqlite3';
+import { ensureMetaMemoryStatsSchema } from '../../../shared/utils/ensure-meta-memory-stats-schema.js';
+import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
+import { parseMemoryReviewSelectionEnv } from './memory-review-candidate-selection-env.js';
+import {
+  buildReason,
+  buildScoreBreakdown,
+  computePriority,
+  computeStaleDays,
+  computeStaleRatio,
+  passesEligibility,
+  resolveStaleAnchor,
+} from './memory-review-candidate-selection-scoring.js';
+import type {
+  MemoryReviewCandidateSelectionItem,
+  MemoryReviewCandidateSelectionOptions,
+  MemoryReviewCandidateSourceRow,
+} from './memory-review-candidate-selection.types.js';
+
+const SELECT_CANDIDATE_ROWS_SQL = `
+SELECT
+  m.id AS memory_id,
+  m.importance AS importance,
+  m.pinned AS pinned,
+  m.is_deleted AS is_deleted,
+  m.deleted_at AS deleted_at,
+  m.created_at AS created_at,
+  s.last_recalled_at AS last_recalled_at
+FROM memory_item m
+LEFT JOIN meta_memory_stats s ON s.memory_id = m.id
+WHERE (m.pinned = 0 OR m.pinned IS NULL)
+  AND m.is_deleted = 0
+  AND (m.deleted_at IS NULL OR m.deleted_at = '')
+  AND m.importance >= ?
+  AND NOT EXISTS (
+    SELECT 1 FROM memory_review_candidate c
+    WHERE c.memory_id = m.id AND c.status = 'pending'
+  )
+ORDER BY m.importance DESC, COALESCE(s.last_recalled_at, m.created_at) ASC
+LIMIT ?
+`;
+
+export function selectionWindowLimit(maxCandidates: number): number {
+  return Math.max(maxCandidates * 10, 200);
+}
+
+export function selectMemoryReviewCandidates(
+  db: Database.Database,
+  options?: Partial<MemoryReviewCandidateSelectionOptions>,
+): MemoryReviewCandidateSelectionItem[] {
+  ensureMetaMemoryStatsSchema(db);
+  ensureMemoryReviewCandidateSchema(db);
+
+  const env = parseMemoryReviewSelectionEnv();
+  const merged: MemoryReviewCandidateSelectionOptions = {
+    importanceThreshold: options?.importanceThreshold ?? env.importanceThreshold,
+    staleDays: options?.staleDays ?? env.staleDays,
+    maxCandidates: options?.maxCandidates ?? env.maxCandidates,
+    now: options?.now ?? new Date(),
+  };
+
+  const stmt = db.prepare(SELECT_CANDIDATE_ROWS_SQL);
+  const rows = stmt.all(
+    merged.importanceThreshold,
+    selectionWindowLimit(merged.maxCandidates),
+  ) as MemoryReviewCandidateSourceRow[];
+
+  const items: MemoryReviewCandidateSelectionItem[] = [];
+  for (const row of rows) {
+    if (!passesEligibility(row, merged)) continue;
+    const resolved = resolveStaleAnchor(row);
+    if (!resolved) continue;
+    const staleDays = computeStaleDays(resolved.instant, merged.now);
+    const staleRatio = computeStaleRatio(staleDays, merged.staleDays);
+    const priority = computePriority(row.importance, staleRatio);
+    const score_breakdown = buildScoreBreakdown(row, merged);
+    const reason = buildReason(score_breakdown);
+    items.push({ memory_id: row.memory_id, priority, reason, score_breakdown });
+  }
+
+  items.sort((a, b) => b.priority - a.priority);
+  return items.slice(0, merged.maxCandidates);
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
@@ -1,0 +1,35 @@
+export type MemoryReviewStaleAnchorKind = 'last_recalled_at' | 'created_at_fallback';
+
+export interface MemoryReviewCandidateSourceRow {
+  memory_id: string;
+  importance: number;
+  pinned: number | boolean;
+  is_deleted: number | boolean;
+  deleted_at: string | null;
+  created_at: string;
+  last_recalled_at: string | null;
+}
+
+export interface MemoryReviewCandidateScoreBreakdown {
+  importance: number;
+  stale_days: number;
+  anchor_kind: MemoryReviewStaleAnchorKind;
+  threshold_importance: number;
+  threshold_stale_days: number;
+}
+
+export interface MemoryReviewCandidateSelectionThresholds {
+  threshold_importance: number;
+  threshold_stale_days: number;
+}
+
+export interface MemoryReviewCandidateSelectionOptions extends MemoryReviewCandidateSelectionThresholds {
+  now: Date;
+}
+
+export interface MemoryReviewCandidateSelectionItem {
+  memory_id: string;
+  priority: number;
+  breakdown: MemoryReviewCandidateScoreBreakdown;
+  reason: string;
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
@@ -19,8 +19,9 @@ export interface MemoryReviewCandidateScoreBreakdown {
 }
 
 export interface MemoryReviewCandidateSelectionThresholds {
-  threshold_importance: number;
-  threshold_stale_days: number;
+  importanceThreshold: number;
+  staleDays: number;
+  maxCandidates: number;
 }
 
 export interface MemoryReviewCandidateSelectionOptions extends MemoryReviewCandidateSelectionThresholds {
@@ -30,6 +31,6 @@ export interface MemoryReviewCandidateSelectionOptions extends MemoryReviewCandi
 export interface MemoryReviewCandidateSelectionItem {
   memory_id: string;
   priority: number;
-  breakdown: MemoryReviewCandidateScoreBreakdown;
+  score_breakdown: MemoryReviewCandidateScoreBreakdown;
   reason: string;
 }

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -51,6 +51,19 @@ export {
 } from './shared/http/http-bind-policy.js';
 export { DatabaseUtils } from './shared/utils/database.js';
 export { ensureMemoryReviewCandidateSchema } from './shared/utils/ensure-memory-review-candidate-schema.js';
+export {
+  selectMemoryReviewCandidates,
+  selectionWindowLimit
+} from './domains/memory/services/memory-review-candidate-selection-service.js';
+export { parseMemoryReviewSelectionEnv } from './domains/memory/services/memory-review-candidate-selection-env.js';
+export type {
+  MemoryReviewStaleAnchorKind as StaleAnchorKind,
+  MemoryReviewCandidateSourceRow as SourceRow,
+  MemoryReviewCandidateScoreBreakdown as ScoreBreakdown,
+  MemoryReviewCandidateSelectionItem as SelectionItem,
+  MemoryReviewCandidateSelectionThresholds as Thresholds,
+  MemoryReviewCandidateSelectionOptions as Options
+} from './domains/memory/services/memory-review-candidate-selection.types.js';
 export { logger } from './shared/utils/logger.js';
 export { loggingRateLimiter } from './shared/utils/logging-rate-limiter.js';
 export { withErrorHandling } from './shared/utils/error-handling.js';


### PR DESCRIPTION
## 개요

이슈 [#241](https://github.com/jee1/memento/issues/241)에 따라 `memory_item`과 `meta_memory_stats`를 조인해 **리뷰 후보**를 산출하는 서비스를 `@memento/core`에 추가합니다. `memory_review_candidate`에 대한 INSERT·HTTP·배치는 범위 밖입니다 (이슈 본문·설계와 동일).

## 포함 사항

- **스코어링·타입**: stale 일수(`last_recalled_at` 우선, 없으면 `created_at` 앵커), `priority` 공식, `score_breakdown` / `reason`, pinned·soft-delete·importance 필터.
- **환경 변수**: `MEMORY_REVIEW_IMPORTANCE_THRESHOLD`, `MEMORY_REVIEW_STALE_DAYS`, `MEMORY_REVIEW_MAX_CANDIDATES` 파싱(`parseMemoryReviewSelectionEnv`).
- **조회 API**: `selectMemoryReviewCandidates(db, options?)` — pending 후보 제외 SQL, 윈도 `max(maxCandidates*10, 200)`, 정렬 후 상한 적용.
- **문서**: `docs/superpowers/specs/2026-05-02-issue-241-memory-review-candidate-selection-design.md`, `docs/superpowers/plans/2026-05-02-issue-241-memory-review-candidate-selection.md`
- **export**: `packages/memento-core/src/index.ts`에서 공개 API·타입 re-export.

## 설계·의존

- 부모 맥락: [#18](https://github.com/jee1/memento/issues/18), 스키마 선행: [#240](https://github.com/jee1/memento/issues/240).

## 검증

- `npm test` (로컬 워크트리 기준 전체 통과).

## 메모

- Draft로 올려 두었습니다. 머지 전에 리뷰·문구·export 이름 등 조정 가능합니다.

Made with [Cursor](https://cursor.com)