### PR TITLE
feat(core): memory review candidate persistence (#242)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-242-memory-review-candidate-persistence.md
+++ b/docs/superpowers/plans/2026-05-02-issue-242-memory-review-candidate-persistence.md
@@ -1,0 +1,775 @@
+# Issue #242 memory review candidate persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `@memento/core` persistence for `memory_review_candidate`: idempotent pending upsert, list/get, safe `pending → reviewed|dismissed|expired` transitions, `AppErrorContract`-compatible errors (404/409), review updates `memory_item.last_accessed` + `last_accessed_at`, Vitest coverage. No `memento-server` HTTP in this issue.
+
+**Architecture:** Single domain service module (`memory-review-candidate-persistence-service.ts`) next to #241 selection service; shared types + small error class file; all entry points call `ensureMemoryReviewCandidateSchema`. SQLite transactions for `markReviewed` (candidate + memory touch). Upsert uses `SELECT pending id by memory_id` then `UPDATE` or `INSERT` (never second `pending` row).
+
+**Tech Stack:** TypeScript (ESM), `better-sqlite3`, Vitest, `node:crypto` `randomUUID`, migrations `033-memory-review-candidate-schema`, `011-meta-memory-stats-schema` (reuse #241 test fixture pattern).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-242-memory-review-candidate-persistence-design.md`
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts` | Create |
+| `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts` | Create |
+| `packages/memento-core/src/index.ts` | Modify — export new public API + types + error |
+
+---
+
+## Shared test fixture (copy into spec `beforeEach`)
+
+Use the same pattern as `memory-review-candidate-selection-service.spec.ts`: `Database(':memory:')`, `createBaseSchema` **extended** with `last_accessed_at TEXT` (and keep `last_accessed TIMESTAMP`), then `MetaMemoryStatsSchemaMigration().up`, `MemoryReviewCandidateSchemaMigration().up`, insert at least one `memory_item` row with fixed `content` + `importance` for invariant assertions.
+
+Fixed clock string for `now` parameter: `'2026-06-01T12:00:00.000Z'`.
+
+---
+
+### Task 1: Types module
+
+**Files:**
+
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts`
+
+- [ ] **Step 1: Add types file**
+
+```typescript
+export type MemoryReviewCandidateStatus = 'pending' | 'reviewed' | 'dismissed' | 'expired';
+
+/** DB row shape for `memory_review_candidate` */
+export interface MemoryReviewCandidateRow {
+  id: string;
+  memory_id: string;
+  status: MemoryReviewCandidateStatus;
+  priority: number;
+  reason: string;
+  due_at: string;
+  created_at: string;
+  updated_at: string;
+  reviewed_at: string | null;
+  dismissed_at: string | null;
+  metadata_json: string | null;
+}
+
+/** One pending upsert row (aligned with #241 selection output fields used by batch) */
+export interface UpsertPendingMemoryReviewCandidateInput {
+  memory_id: string;
+  priority: number;
+  reason: string;
+  due_at: string;
+  metadata_json?: string | null;
+}
+
+export interface UpsertPendingMemoryReviewCandidatesResult {
+  inserted: number;
+  updated: number;
+}
+
+export interface ListMemoryReviewCandidatesQuery {
+  status?: MemoryReviewCandidateStatus;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts
+git commit -m "feat(core): add memory review candidate persistence types (#242)"
+```
+
+---
+
+### Task 2: Domain error class
+
+**Files:**
+
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts`
+
+- [ ] **Step 1: Add error module**
+
+```typescript
+import { ErrorCategory, type AppErrorContract } from '../../../shared/types/error-types.js';
+
+export const MEMORY_REVIEW_CANDIDATE_NOT_FOUND = 'memory_review_candidate_not_found';
+export const MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE = 'memory_review_candidate_not_actionable';
+
+export class MemoryReviewCandidateError extends Error implements AppErrorContract {
+  readonly code: string;
+  readonly category = ErrorCategory.MEMORY;
+  readonly statusCode: number;
+
+  constructor(message: string, code: string, statusCode: number) {
+    super(message);
+    this.name = 'MemoryReviewCandidateError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+
+  static notFound(id: string): MemoryReviewCandidateError {
+    return new MemoryReviewCandidateError(
+      `Memory review candidate not found: ${id}`,
+      MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
+      404,
+    );
+  }
+
+  static notActionable(id: string, status: string): MemoryReviewCandidateError {
+    return new MemoryReviewCandidateError(
+      `Memory review candidate is not actionable (id=${id}, status=${status})`,
+      MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+      409,
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts
+git commit -m "feat(core): add memory review candidate domain errors (#242)"
+```
+
+---
+
+### Task 3: Upsert + result counts (TDD)
+
+**Files:**
+
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts` (start with only upsert + imports)
+- Create: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts`
+
+- [ ] **Step 1: Write failing tests** — upsert insert then upsert update same `memory_id`, assert `pending` row count stays 1 and `priority` changes
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { MetaMemoryStatsSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+import { MemoryReviewCandidateSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+import { upsertPendingMemoryReviewCandidates } from './memory-review-candidate-persistence-service.js';
+
+const NOW = '2026-06-01T12:00:00.000Z';
+
+function createBaseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      last_accessed_at TEXT,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+      deleted_at TEXT
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memento_schema_version (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      migration_name TEXT NOT NULL,
+      checksum TEXT,
+      applied_by TEXT DEFAULT 'system',
+      description TEXT
+    );
+  `);
+}
+
+describe('memory-review-candidate-persistence upsert', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES ('mem_a', 'semantic', 'hello', 0.9, 'private', '2020-01-01 00:00:00', 0, 0, NULL)
+    `);
+    db.exec(`
+      INSERT INTO meta_memory_stats (
+        memory_id, recall_count, success_count, failure_count,
+        avg_confidence, last_recalled_at, created_at, updated_at
+      ) VALUES (
+        'mem_a', 1, 1, 0, 0.9, '2020-02-01 00:00:00', '2020-02-01 00:00:00', '2020-02-01 00:00:00'
+      )
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('inserts pending on first upsert and updates same memory_id on second (idempotent)', () => {
+    const first = upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 100, reason: 'r1', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    expect(first.inserted).toBe(1);
+    expect(first.updated).toBe(0);
+
+    const rows1 = db
+      .prepare(`SELECT priority, reason FROM memory_review_candidate WHERE memory_id = 'mem_a'`)
+      .all() as { priority: number; reason: string }[];
+    expect(rows1).toHaveLength(1);
+    expect(rows1[0].priority).toBe(100);
+
+    const second = upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 200, reason: 'r2', due_at: '2026-08-01T00:00:00.000Z' }],
+      NOW,
+    );
+    expect(second.inserted).toBe(0);
+    expect(second.updated).toBe(1);
+
+    const rows2 = db
+      .prepare(`SELECT COUNT(*) as c FROM memory_review_candidate WHERE memory_id = 'mem_a' AND status = 'pending'`)
+      .get() as { c: number };
+    expect(rows2.c).toBe(1);
+    const pr = db
+      .prepare(`SELECT priority, reason FROM memory_review_candidate WHERE memory_id = 'mem_a'`)
+      .get() as { priority: number; reason: string };
+    expect(pr.priority).toBe(200);
+    expect(pr.reason).toBe('r2');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (function missing)
+
+```bash
+cd /home/jee1lee/git/memento/.worktrees/issue-242-memory-review-persistence
+npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+```
+
+Expected: FAIL (export not found or TS compile error).
+
+- [ ] **Step 3: Implement `upsertPendingMemoryReviewCandidates`**
+
+Create `memory-review-candidate-persistence-service.ts`:
+
+```typescript
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
+import type {
+  UpsertPendingMemoryReviewCandidateInput,
+  UpsertPendingMemoryReviewCandidatesResult,
+} from './memory-review-candidate-persistence.types.js';
+
+export function upsertPendingMemoryReviewCandidates(
+  db: Database.Database,
+  items: UpsertPendingMemoryReviewCandidateInput[],
+  now: string,
+): UpsertPendingMemoryReviewCandidatesResult {
+  ensureMemoryReviewCandidateSchema(db);
+  let inserted = 0;
+  let updated = 0;
+
+  const run = db.transaction(() => {
+    const selectPending = db.prepare<{ id: string }, [string]>(
+      `SELECT id FROM memory_review_candidate WHERE memory_id = ? AND status = 'pending'`,
+    );
+    const updatePending = db.prepare(
+      `UPDATE memory_review_candidate SET
+        priority = @priority,
+        reason = @reason,
+        due_at = @due_at,
+        metadata_json = @metadata_json,
+        updated_at = @updated_at
+      WHERE id = @id`,
+    );
+    const insert = db.prepare(
+      `INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at, metadata_json
+      ) VALUES (
+        @id, @memory_id, 'pending', @priority, @reason, @due_at, @created_at, @updated_at, @metadata_json
+      )`,
+    );
+
+    for (const item of items) {
+      const existing = selectPending.get(item.memory_id);
+      if (existing) {
+        updatePending.run({
+          id: existing.id,
+          priority: item.priority,
+          reason: item.reason,
+          due_at: item.due_at,
+          metadata_json: item.metadata_json ?? null,
+          updated_at: now,
+        });
+        updated += 1;
+      } else {
+        insert.run({
+          id: randomUUID(),
+          memory_id: item.memory_id,
+          priority: item.priority,
+          reason: item.reason,
+          due_at: item.due_at,
+          created_at: now,
+          updated_at: now,
+          metadata_json: item.metadata_json ?? null,
+        });
+        inserted += 1;
+      }
+    }
+  });
+
+  run();
+  return { inserted, updated };
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+npx vitest run packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+git commit -m "feat(core): idempotent pending upsert for memory review candidates (#242)"
+```
+
+---
+
+### Task 4: `getMemoryReviewCandidateById` + `listMemoryReviewCandidates`
+
+**Files:**
+
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts`
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts`
+
+- [ ] **Step 1: Add failing tests** — after upsert one row, `getMemoryReviewCandidateById` returns row; `listMemoryReviewCandidates` with `{ status: 'pending' }` returns length 1
+
+```typescript
+import {
+  upsertPendingMemoryReviewCandidates,
+  getMemoryReviewCandidateById,
+  listMemoryReviewCandidates,
+} from './memory-review-candidate-persistence-service.js';
+
+it('get and list return pending candidate', () => {
+  upsertPendingMemoryReviewCandidates(
+    db,
+    [{ memory_id: 'mem_a', priority: 42, reason: 'x', due_at: '2026-07-01T00:00:00.000Z' }],
+    NOW,
+  );
+  const rows = listMemoryReviewCandidates(db, { status: 'pending' });
+  expect(rows).toHaveLength(1);
+  const one = getMemoryReviewCandidateById(db, rows[0].id);
+  expect(one?.memory_id).toBe('mem_a');
+  expect(one?.status).toBe('pending');
+});
+```
+
+- [ ] **Step 2: Run vitest — expect FAIL**
+
+- [ ] **Step 3: Append to service file** — add `mapRow`, `getMemoryReviewCandidateById`, `listMemoryReviewCandidates` (import `MemoryReviewCandidateRow`, `ListMemoryReviewCandidatesQuery` from types)
+
+```typescript
+import type {
+  MemoryReviewCandidateRow,
+  ListMemoryReviewCandidatesQuery,
+  UpsertPendingMemoryReviewCandidateInput,
+  UpsertPendingMemoryReviewCandidatesResult,
+} from './memory-review-candidate-persistence.types.js';
+
+function mapRow(r: Record<string, unknown>): MemoryReviewCandidateRow {
+  return {
+    id: String(r.id),
+    memory_id: String(r.memory_id),
+    status: r.status as MemoryReviewCandidateRow['status'],
+    priority: Number(r.priority),
+    reason: String(r.reason),
+    due_at: String(r.due_at),
+    created_at: String(r.created_at),
+    updated_at: String(r.updated_at),
+    reviewed_at: r.reviewed_at == null ? null : String(r.reviewed_at),
+    dismissed_at: r.dismissed_at == null ? null : String(r.dismissed_at),
+    metadata_json: r.metadata_json == null ? null : String(r.metadata_json),
+  };
+}
+
+export function getMemoryReviewCandidateById(
+  db: Database.Database,
+  id: string,
+): MemoryReviewCandidateRow | null {
+  ensureMemoryReviewCandidateSchema(db);
+  const r = db.prepare(`SELECT * FROM memory_review_candidate WHERE id = ?`).get(id) as
+    | Record<string, unknown>
+    | undefined;
+  return r ? mapRow(r) : null;
+}
+
+export function listMemoryReviewCandidates(
+  db: Database.Database,
+  query: ListMemoryReviewCandidatesQuery = {},
+): MemoryReviewCandidateRow[] {
+  ensureMemoryReviewCandidateSchema(db);
+  if (query.status) {
+    return db
+      .prepare(
+        `SELECT * FROM memory_review_candidate WHERE status = ? ORDER BY priority DESC, due_at ASC`,
+      )
+      .all(query.status)
+      .map((row) => mapRow(row as Record<string, unknown>));
+  }
+  return db
+    .prepare(`SELECT * FROM memory_review_candidate ORDER BY priority DESC, due_at ASC`)
+    .all()
+    .map((row) => mapRow(row as Record<string, unknown>));
+}
+```
+
+- [ ] **Step 4: Run vitest — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(core): list/get memory review candidates (#242)"
+```
+
+---
+
+### Task 5: `markMemoryReviewCandidateReviewed` (transaction + memory touch)
+
+**Files:**
+
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts`
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+```typescript
+import { markMemoryReviewCandidateReviewed } from './memory-review-candidate-persistence-service.js';
+import {
+  MemoryReviewCandidateError,
+  MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+} from './memory-review-candidate-persistence-error.js';
+
+it('markReviewed updates candidate and memory_item access timestamps', () => {
+  upsertPendingMemoryReviewCandidates(
+    db,
+    [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+    NOW,
+  );
+  const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+  markMemoryReviewCandidateReviewed(db, row.id, NOW);
+
+  const cand = getMemoryReviewCandidateById(db, row.id);
+  expect(cand?.status).toBe('reviewed');
+  expect(cand?.reviewed_at).toBe(NOW);
+
+  const mem = db.prepare(`SELECT last_accessed_at FROM memory_item WHERE id = 'mem_a'`).get() as {
+    last_accessed_at: string | null;
+  };
+  expect(mem.last_accessed_at).toBe(NOW);
+});
+
+it('second markReviewed throws not actionable', () => {
+  upsertPendingMemoryReviewCandidates(
+    db,
+    [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+    NOW,
+  );
+  const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+  markMemoryReviewCandidateReviewed(db, row.id, NOW);
+  expect(() => markMemoryReviewCandidateReviewed(db, row.id, NOW)).toThrow(MemoryReviewCandidateError);
+  try {
+    markMemoryReviewCandidateReviewed(db, row.id, NOW);
+  } catch (e) {
+    expect(e).toBeInstanceOf(MemoryReviewCandidateError);
+    expect((e as MemoryReviewCandidateError).code).toBe(MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE);
+    expect((e as MemoryReviewCandidateError).statusCode).toBe(409);
+  }
+});
+```
+
+- [ ] **Step 2: Run vitest — FAIL**
+
+- [ ] **Step 3: Implement** (import `MemoryReviewCandidateError`)
+
+```typescript
+import { MemoryReviewCandidateError } from './memory-review-candidate-persistence-error.js';
+
+export function markMemoryReviewCandidateReviewed(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<{ status: string }, [string]>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) {
+      throw MemoryReviewCandidateError.notFound(candidateId);
+    }
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare(
+        `UPDATE memory_review_candidate SET status = 'reviewed', reviewed_at = ?, updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const mem = db
+      .prepare<{ memory_id: string }, [string]>(`SELECT memory_id FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!mem) throw MemoryReviewCandidateError.notFound(candidateId);
+    db.prepare(
+      `UPDATE memory_item SET last_accessed = CURRENT_TIMESTAMP, last_accessed_at = ? WHERE id = ?`,
+    ).run(now, mem.memory_id);
+  });
+  run();
+}
+```
+
+- [ ] **Step 4: Run vitest — PASS**
+
+- [ ] **Step 5: Commit** `feat(core): mark memory review candidate reviewed (#242)`
+
+---
+
+### Task 6: `markMemoryReviewCandidateDismissed` + invariants
+
+**Files:**
+
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts`
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```typescript
+import { markMemoryReviewCandidateDismissed } from './memory-review-candidate-persistence-service.js';
+
+it('dismiss updates only candidate row', () => {
+  upsertPendingMemoryReviewCandidates(
+    db,
+    [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+    NOW,
+  );
+  const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+  const before = db.prepare(`SELECT content, importance FROM memory_item WHERE id = 'mem_a'`).get() as {
+    content: string;
+    importance: number;
+  };
+  markMemoryReviewCandidateDismissed(db, row.id, NOW);
+  const after = db.prepare(`SELECT content, importance FROM memory_item WHERE id = 'mem_a'`).get() as {
+    content: string;
+    importance: number;
+  };
+  expect(after).toEqual(before);
+  expect(getMemoryReviewCandidateById(db, row.id)?.status).toBe('dismissed');
+});
+```
+
+- [ ] **Step 2: FAIL → Step 3: Implement** (mirror `markReviewed` but no `memory_item` update)
+
+```typescript
+export function markMemoryReviewCandidateDismissed(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<{ status: string }, [string]>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) throw MemoryReviewCandidateError.notFound(candidateId);
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare(
+        `UPDATE memory_review_candidate SET status = 'dismissed', dismissed_at = ?, updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+  });
+  run();
+}
+```
+
+- [ ] **Step 4: PASS → Step 5: Commit** `feat(core): dismiss memory review candidate (#242)`
+
+---
+
+### Task 7: `markMemoryReviewCandidateExpired` + not-found 404
+
+**Files:**
+
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts`
+- Modify: `packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts`
+
+- [ ] **Step 1: Add tests**
+
+```typescript
+import { markMemoryReviewCandidateExpired } from './memory-review-candidate-persistence-service.js';
+import { MEMORY_REVIEW_CANDIDATE_NOT_FOUND } from './memory-review-candidate-persistence-error.js';
+
+it('expire moves pending to expired without touching memory_item importance', () => {
+  upsertPendingMemoryReviewCandidates(
+    db,
+    [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+    NOW,
+  );
+  const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+  const beforeImp = (
+    db.prepare(`SELECT importance FROM memory_item WHERE id = 'mem_a'`).get() as { importance: number }
+  ).importance;
+  markMemoryReviewCandidateExpired(db, row.id, NOW);
+  expect(getMemoryReviewCandidateById(db, row.id)?.status).toBe('expired');
+  const afterImp = (
+    db.prepare(`SELECT importance FROM memory_item WHERE id = 'mem_a'`).get() as { importance: number }
+  ).importance;
+  expect(afterImp).toBe(beforeImp);
+});
+
+it('unknown id on expire throws not found', () => {
+  expect(() =>
+    markMemoryReviewCandidateExpired(db, '00000000-0000-0000-0000-000000000000', NOW),
+  ).toThrow(MemoryReviewCandidateError);
+  try {
+    markMemoryReviewCandidateExpired(db, '00000000-0000-0000-0000-000000000000', NOW);
+  } catch (e) {
+    expect((e as MemoryReviewCandidateError).code).toBe(MEMORY_REVIEW_CANDIDATE_NOT_FOUND);
+    expect((e as MemoryReviewCandidateError).statusCode).toBe(404);
+  }
+});
+```
+
+- [ ] **Step 2: Implement `markMemoryReviewCandidateExpired`**
+
+```typescript
+export function markMemoryReviewCandidateExpired(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<{ status: string }, [string]>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) throw MemoryReviewCandidateError.notFound(candidateId);
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare(
+        `UPDATE memory_review_candidate SET status = 'expired', updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+  });
+  run();
+}
+```
+
+- [ ] **Step 3: Run vitest PASS → Step 4: Commit** `feat(core): expire memory review candidate (#242)`
+
+---
+
+### Task 8: Package exports + verification
+
+**Files:**
+
+- Modify: `packages/memento-core/src/index.ts`
+
+- [ ] **Step 1: Re-export** (mirror #241 block style)
+
+```typescript
+export {
+  upsertPendingMemoryReviewCandidates,
+  getMemoryReviewCandidateById,
+  listMemoryReviewCandidates,
+  markMemoryReviewCandidateReviewed,
+  markMemoryReviewCandidateDismissed,
+  markMemoryReviewCandidateExpired,
+} from './domains/memory/services/memory-review-candidate-persistence-service.js';
+export type {
+  MemoryReviewCandidateStatus,
+  MemoryReviewCandidateRow,
+  UpsertPendingMemoryReviewCandidateInput,
+  UpsertPendingMemoryReviewCandidatesResult,
+  ListMemoryReviewCandidatesQuery,
+} from './domains/memory/services/memory-review-candidate-persistence.types.js';
+export {
+  MemoryReviewCandidateError,
+  MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
+  MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+} from './domains/memory/services/memory-review-candidate-persistence-error.js';
+```
+
+- [ ] **Step 2: Run full checks**
+
+```bash
+cd /home/jee1lee/git/memento/.worktrees/issue-242-memory-review-persistence
+npm run type-check
+npm test
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit** `feat(core): export memory review candidate persistence API (#242)`
+
+---
+
+## Plan self-review (spec coverage)
+
+| Spec section | Tasks |
+|--------------|-------|
+| Upsert 멱등 | Task 3 |
+| list/get | Task 4 |
+| pending→reviewed/dismissed/expired | Tasks 5–7 |
+| 404 not found / 409 not actionable | Tasks 5–7 tests + error class |
+| review updates `last_accessed`/`last_accessed_at` | Task 5 SQL |
+| dismiss does not change memory body/importance | Task 6 |
+| Core-only (no server) | No server files in map |
+| `index.ts` export | Task 8 |
+
+**Placeholder scan:** none intentional.
+
+**Type consistency:** `MemoryReviewCandidateRow`, `now: string` ISO used consistently; `mapRow` coerces DB types.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to** `docs/superpowers/plans/2026-05-02-issue-242-memory-review-candidate-persistence.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline Execution** — execute tasks in this session using executing-plans checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-02-issue-242-memory-review-candidate-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-242-memory-review-candidate-persistence-design.md
@@ -1,0 +1,121 @@
+# 설계: 이슈 #242 — 리뷰 후보 저장소와 review/dismiss 상태 전이 (`@memento/core`)
+
+**상태**: 초안 (구현 전 검토)  
+**날짜**: 2026-05-02  
+**이슈**: [GitHub #242](https://github.com/jee1/memento/issues/242)  
+**범위 결정**: **Core만** — `packages/memento-server` Admin HTTP·409 응답 매핑은 별도 이슈. 본 문서는 persistence·도메인 오류 계약·Vitest까지 고정한다.
+
+**선행 정합**
+
+- 스키마·인덱스: [이슈 #240 설계](./2026-05-02-issue-240-memory-review-candidate-design.md), 마이그레이션 `033-memory-review-candidate-schema`.
+- 후보 산출(읽기 전용): [이슈 #241 설계](./2026-05-02-issue-241-memory-review-candidate-selection-design.md), `selectMemoryReviewCandidates`.
+
+---
+
+## 1. 배경·문제
+
+#241까지는 후보를 **고르기만** 하고 DB에 쓰지 않는다. 자동 리뷰 MVP를 진행하려면 선정된 후보를 **안전하게 저장**하고, 사용자(또는 이후 배치)의 **review / dismiss / expire** 액션을 **명시적 상태 전이**로 반영해야 한다. 동일 배치·동일 `memory_id`에 대한 **중복 실행은 멱등**해야 하며, 이미 종료된 후보에 대한 잘못된 액션은 **HTTP 409에 매핑할 수 있는 도메인 계약**으로 표현한다.
+
+---
+
+## 2. 구현 접근 비교 (2~3안)
+
+| 접근 | 요약 | 장점 | 단점 |
+|------|------|------|------|
+| **A. 도메인 서비스 + 얇은 SQLite 헬퍼** | `memory-review-candidate-persistence-service.ts`가 전이 규칙·타임스탬프·`memory_item` 갱신을 소유하고, SQL은 같은 모듈 또는 `*-sqlite.helpers.ts`에 둔다. | #241 `selectMemoryReviewCandidates`와 동일 계층(`domains/memory/services/`)이라 탐색·테스트 일관성이 좋다. | 파일이 커지면 후속 분리 필요. |
+| **B. 인터페이스 repository + `infrastructure` 구현** | `IMemoryReviewCandidateRepository` + `*-sqlite.impl.ts` 패턴. | 경계가 명확해 교체 테스트에 유리하다. | 보일러플레이트 증가, 현재 후보 기능 규모 대비 과할 수 있다. |
+| **C. SQL 전부 meta-memory-service류에 통합** | 기존 대형 서비스에 메서드 추가. | 파일 수 최소. | 책임 혼잡, diff 리뷰·충돌 비용 큼. |
+
+**선택: A (추천)** — 이슈가 요구하는 단위가 "repository **또는** service persistence"이고, #241과 나란히 두는 것이 PR 단위·인지 부하에 유리하다. 이후 HTTP·배치가 붙으면 필요 시 B로 추출한다.
+
+---
+
+## 3. 목표·비목표
+
+### 3.1 목표 (#242)
+
+- **Upsert(멱등)**: 동일 `memory_id`에 대해 `pending` 후보를 다시 넣는 연산을 **중복 행 없이** 수렴시킨다 (DB partial unique와 애플리케이션 로직 정합).
+- **조회**: 후보 단건 `get`·목록 `list` (필터: `status`, 정렬은 #240 큐 인덱스 `(status, priority DESC, due_at ASC)`와 맞춘다).
+- **전이**: `pending → reviewed`, `pending → dismissed`, `pending → expired`만 허용. `updated_at`은 전이 시 갱신. `reviewed_at` / `dismissed_at`은 각각 해당 전이에서 설정.
+- **도메인 오류**: 이미 `pending`이 아닌 후보에 review/dismiss 시, 호출자가 HTTP 409로 매핑할 수 있는 **안정적인 `code` + `AppErrorContract`**(또는 동등 필드를 가진 에러 클래스)를 던진다.
+- **review 시 `memory_item`**: `last_accessed`, `last_accessed_at` 갱신(기존 `pin-tool` 등과 동일한 SQL 관례).
+- **테스트**: (1) 동일 배치 입력 두 번 — `pending` 행 수 불변(또는 동일 `memory_id`당 1행 유지), (2) review/dismiss 후 재액션 시 도메인 오류, (3) dismiss가 `memory_item` 본문·중요도 필드를 변경하지 않음을 assert.
+
+### 3.2 비목표 (#242)
+
+- `packages/memento-server` 라우트, 실제 HTTP 409 응답, MCP 도구, `BatchScheduler` Job 등록.
+- 후보 **산출 알고리즘** 변경(#241 범위).
+- 스키마·마이그레이션 번호 변경.
+
+---
+
+## 4. 아키텍처·공개 API
+
+- **위치**: `packages/memento-core/src/domains/memory/services/`
+  - 예: `memory-review-candidate-persistence.types.ts` (행 DTO, 입력 타입, 상태 리터럴 타입)
+  - 예: `memory-review-candidate-persistence-service.ts` (공개 함수들)
+  - 예: `memory-review-candidate-persistence-service.spec.ts`
+- **`Database` 타입**: 기존과 같이 `better-sqlite3` 동기 API. 서비스 함수는 `(db: Database, …) => …` 형태를 #241과 맞춘다.
+- **스키마 보장**: 공개 진입점에서 `ensureMemoryReviewCandidateSchema(db)` 호출.
+
+**제안 공개 함수 (이름은 구현 시 일관되게 조정 가능)**
+
+- `upsertPendingMemoryReviewCandidates(db, items: UpsertPendingInput[], now: IsoString): UpsertPendingResult`  
+  - **멱등**: 동일 `memory_id`로 이미 `pending`이 있으면 **새 행을 만들지 않고** `priority`, `reason`, `due_at`, `metadata_json`, `updated_at`만 갱신한다(배치 재실행 시 스냅샷 최신화 + 완료 조건 "중복 pending 없음" 동시 만족).
+- `listMemoryReviewCandidates(db, query: ListQuery): Row[]`
+- `getMemoryReviewCandidateById(db, id: string): Row | null`
+- `markMemoryReviewCandidateReviewed(db, candidateId: string, now: IsoString): void`
+- `markMemoryReviewCandidateDismissed(db, candidateId: string, now: IsoString): void`
+- `markMemoryReviewCandidateExpired(db, candidateId: string, now: IsoString): void`
+
+`markMemoryReviewCandidateReviewed`는 `UPDATE memory_review_candidate … WHERE id = ? AND status = 'pending'` 후 `changes` 검사 → 성공 시 동일 트랜잭션에서 `memory_item`의 `last_accessed`, `last_accessed_at` 갱신.
+
+---
+
+## 5. 오류 모델 (409 매핑용)
+
+- **도메인 전용 에러** 추가: 예 `MemoryReviewCandidateStateError` — `AppErrorContract`와 호환되는 필드(`code`, `category`, `message`, `statusCode`)를 갖는다.
+
+| 상황 | `code` (예시) | 제안 `statusCode` |
+|------|----------------|-------------------|
+| id 없음 | `memory_review_candidate_not_found` | 404 |
+| `status !== 'pending'` 에 review/dismiss | `memory_review_candidate_not_actionable` | 409 |
+| 잘못된 전이 | `memory_review_candidate_not_actionable` 또는 `invalid_transition` | 409 |
+
+후속 HTTP 이슈에서는 `statusCode`를 그대로 응답에 사용하면 된다.
+
+---
+
+## 6. 데이터·동시성
+
+- **트랜잭션**: review는 후보 행 + `memory_item` 접근 시각을 한 트랜잭션에서 처리.
+- **Dismiss**: `memory_review_candidate`만 갱신. **`memory_item`의 본문·중요도 관련 컬럼은 UPDATE하지 않는다.**
+- **Expire**: `memory_item` 비터치.
+
+타임스탬프 문자열·`CURRENT_TIMESTAMP` 혼용은 `pin-tool`·`write-and-meta` 관례에 맞춘다.
+
+---
+
+## 7. 테스트 계획 (Vitest)
+
+- **파일**: `memory-review-candidate-persistence-service.spec.ts`
+- **픽스처**: 033 마이그레이션/ensure + 최소 `memory_item` 행 — #241 스펙과 동일 패턴 재사용.
+- **케이스**: upsert 멱등, review 후 `last_accessed`/`last_accessed_at`, dismiss 후 memory 본문·중요도 불변, 이중 review/dismiss 시 409, expire.
+
+---
+
+## 8. 완료 조건 (이슈 본문과 정합)
+
+- 중복 batch 실행이 `pending` 후보를 중복 생성하지 않는다.
+- review 액션은 후보 상태와 memory 접근 시각만 갱신한다.
+- dismiss 액션은 memory 본문과 중요도를 변경하지 않는다.
+- `npm test` / `npm run type-check` 통과.
+- **export**: 후속 서버 이슈를 위해 `packages/memento-core/src/index.ts`에서 공개 API export를 권장한다.
+
+---
+
+## 9. 출처
+
+- [GitHub #242](https://github.com/jee1/memento/issues/242)
+- [#240 설계](./2026-05-02-issue-240-memory-review-candidate-design.md)
+- [#241 설계](./2026-05-02-issue-241-memory-review-candidate-selection-design.md)

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts
@@ -1,0 +1,33 @@
+import { ErrorCategory, type AppErrorContract } from '../../../shared/types/error-types.js';
+
+export const MEMORY_REVIEW_CANDIDATE_NOT_FOUND = 'memory_review_candidate_not_found';
+export const MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE = 'memory_review_candidate_not_actionable';
+
+export class MemoryReviewCandidateError extends Error implements AppErrorContract {
+  readonly code: string;
+  readonly category = ErrorCategory.MEMORY;
+  readonly statusCode: number;
+
+  constructor(message: string, code: string, statusCode: number) {
+    super(message);
+    this.name = 'MemoryReviewCandidateError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+
+  static notFound(id: string): MemoryReviewCandidateError {
+    return new MemoryReviewCandidateError(
+      `Memory review candidate not found: ${id}`,
+      MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
+      404,
+    );
+  }
+
+  static notActionable(id: string, status: string): MemoryReviewCandidateError {
+    return new MemoryReviewCandidateError(
+      `Memory review candidate is not actionable (id=${id}, status=${status})`,
+      MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+      409,
+    );
+  }
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { MetaMemoryStatsSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+import { MemoryReviewCandidateSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+import { upsertPendingMemoryReviewCandidates } from './memory-review-candidate-persistence-service.js';
+
+const NOW = '2026-06-01T12:00:00.000Z';
+
+function createBaseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      last_accessed_at TEXT,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+      deleted_at TEXT
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memento_schema_version (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      migration_name TEXT NOT NULL,
+      checksum TEXT,
+      applied_by TEXT DEFAULT 'system',
+      description TEXT
+    );
+  `);
+}
+
+describe('memory-review-candidate-persistence upsert', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES ('mem_a', 'semantic', 'hello', 0.9, 'private', '2020-01-01 00:00:00', 0, 0, NULL)
+    `);
+    db.exec(`
+      INSERT INTO meta_memory_stats (
+        memory_id, recall_count, success_count, failure_count,
+        avg_confidence, last_recalled_at, created_at, updated_at
+      ) VALUES (
+        'mem_a', 1, 1, 0, 0.9, '2020-02-01 00:00:00', '2020-02-01 00:00:00', '2020-02-01 00:00:00'
+      )
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('inserts pending on first upsert and updates same memory_id on second (idempotent)', () => {
+    const first = upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 100, reason: 'r1', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    expect(first.inserted).toBe(1);
+    expect(first.updated).toBe(0);
+
+    const rows1 = db
+      .prepare(`SELECT priority, reason FROM memory_review_candidate WHERE memory_id = 'mem_a'`)
+      .all() as { priority: number; reason: string }[];
+    expect(rows1).toHaveLength(1);
+    expect(rows1[0].priority).toBe(100);
+
+    const second = upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 200, reason: 'r2', due_at: '2026-08-01T00:00:00.000Z' }],
+      NOW,
+    );
+    expect(second.inserted).toBe(0);
+    expect(second.updated).toBe(1);
+
+    const rows2 = db
+      .prepare(`SELECT COUNT(*) as c FROM memory_review_candidate WHERE memory_id = 'mem_a' AND status = 'pending'`)
+      .get() as { c: number };
+    expect(rows2.c).toBe(1);
+    const pr = db
+      .prepare(`SELECT priority, reason FROM memory_review_candidate WHERE memory_id = 'mem_a'`)
+      .get() as { priority: number; reason: string };
+    expect(pr.priority).toBe(200);
+    expect(pr.reason).toBe('r2');
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { MetaMemoryStatsSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
 import { MemoryReviewCandidateSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
-import { upsertPendingMemoryReviewCandidates } from './memory-review-candidate-persistence-service.js';
+import {
+  upsertPendingMemoryReviewCandidates,
+  getMemoryReviewCandidateById,
+  listMemoryReviewCandidates,
+} from './memory-review-candidate-persistence-service.js';
 
 const NOW = '2026-06-01T12:00:00.000Z';
 
@@ -95,5 +99,18 @@ describe('memory-review-candidate-persistence upsert', () => {
       .get() as { priority: number; reason: string };
     expect(pr.priority).toBe(200);
     expect(pr.reason).toBe('r2');
+  });
+
+  it('get and list return pending candidate', () => {
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 42, reason: 'x', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    const rows = listMemoryReviewCandidates(db, { status: 'pending' });
+    expect(rows).toHaveLength(1);
+    const one = getMemoryReviewCandidateById(db, rows[0].id);
+    expect(one?.memory_id).toBe('mem_a');
+    expect(one?.status).toBe('pending');
   });
 });

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -8,10 +8,12 @@ import {
   listMemoryReviewCandidates,
   markMemoryReviewCandidateReviewed,
   markMemoryReviewCandidateDismissed,
+  markMemoryReviewCandidateExpired,
 } from './memory-review-candidate-persistence-service.js';
 import {
   MemoryReviewCandidateError,
   MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+  MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
 } from './memory-review-candidate-persistence-error.js';
 
 const NOW = '2026-06-01T12:00:00.000Z';
@@ -179,6 +181,39 @@ describe('memory-review-candidate-persistence upsert', () => {
     };
     expect(after).toEqual(before);
     expect(getMemoryReviewCandidateById(db, row.id)?.status).toBe('dismissed');
+  });
+  it('expire moves pending to expired without touching memory_item importance', () => {
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+    const beforeImp = (
+      db.prepare(`SELECT importance FROM memory_item WHERE id = 'mem_a'`).get() as { importance: number }
+    ).importance;
+    markMemoryReviewCandidateExpired(db, row.id, NOW);
+    expect(getMemoryReviewCandidateById(db, row.id)?.status).toBe('expired');
+    const afterImp = (
+      db.prepare(`SELECT importance FROM memory_item WHERE id = 'mem_a'`).get() as { importance: number }
+    ).importance;
+    expect(afterImp).toBe(beforeImp);
+  });
+
+  it('unknown id on expire throws not found', () => {
+    let caught: unknown;
+    expect(() => {
+      try {
+        markMemoryReviewCandidateExpired(db, '00000000-0000-0000-0000-000000000000', NOW);
+      } catch (e) {
+        caught = e;
+        throw e;
+      }
+    }).toThrow(MemoryReviewCandidateError);
+    expect(caught).toMatchObject({
+      code: MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
+      statusCode: 404,
+    });
   });
 
 });

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -6,7 +6,12 @@ import {
   upsertPendingMemoryReviewCandidates,
   getMemoryReviewCandidateById,
   listMemoryReviewCandidates,
+  markMemoryReviewCandidateReviewed,
 } from './memory-review-candidate-persistence-service.js';
+import {
+  MemoryReviewCandidateError,
+  MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+} from './memory-review-candidate-persistence-error.js';
 
 const NOW = '2026-06-01T12:00:00.000Z';
 
@@ -112,5 +117,47 @@ describe('memory-review-candidate-persistence upsert', () => {
     const one = getMemoryReviewCandidateById(db, rows[0].id);
     expect(one?.memory_id).toBe('mem_a');
     expect(one?.status).toBe('pending');
+  });
+
+  it('markReviewed updates candidate and memory_item access timestamps', () => {
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+    markMemoryReviewCandidateReviewed(db, row.id, NOW);
+
+    const cand = getMemoryReviewCandidateById(db, row.id);
+    expect(cand?.status).toBe('reviewed');
+    expect(cand?.reviewed_at).toBe(NOW);
+
+    const mem = db.prepare(`SELECT last_accessed_at FROM memory_item WHERE id = 'mem_a'`).get() as {
+      last_accessed_at: string | null;
+    };
+    expect(mem.last_accessed_at).toBe(NOW);
+  });
+
+  it('second markReviewed throws not actionable', () => {
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+    markMemoryReviewCandidateReviewed(db, row.id, NOW);
+    let caught: unknown;
+    expect(() => {
+      try {
+        markMemoryReviewCandidateReviewed(db, row.id, NOW);
+      } catch (e) {
+        caught = e;
+        throw e;
+      }
+    }).toThrow(MemoryReviewCandidateError);
+    expect(caught).toMatchObject({
+      code: MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+      statusCode: 409,
+    });
   });
 });

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -7,6 +7,7 @@ import {
   getMemoryReviewCandidateById,
   listMemoryReviewCandidates,
   markMemoryReviewCandidateReviewed,
+  markMemoryReviewCandidateDismissed,
 } from './memory-review-candidate-persistence-service.js';
 import {
   MemoryReviewCandidateError,
@@ -160,4 +161,25 @@ describe('memory-review-candidate-persistence upsert', () => {
       statusCode: 409,
     });
   });
+  it('dismiss updates only candidate row', () => {
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_a', priority: 1, reason: 'q', due_at: '2026-07-01T00:00:00.000Z' }],
+      NOW,
+    );
+    const row = listMemoryReviewCandidates(db, { status: 'pending' })[0];
+    const before = db.prepare(`SELECT content, importance FROM memory_item WHERE id = 'mem_a'`).get() as {
+      content: string;
+      importance: number;
+    };
+    markMemoryReviewCandidateDismissed(db, row.id, NOW);
+    const after = db.prepare(`SELECT content, importance FROM memory_item WHERE id = 'mem_a'`).get() as {
+      content: string;
+      importance: number;
+    };
+    expect(after).toEqual(before);
+    expect(getMemoryReviewCandidateById(db, row.id)?.status).toBe('dismissed');
+  });
+
 });
+

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -181,3 +181,32 @@ export function markMemoryReviewCandidateDismissed(
   });
   run();
 }
+
+export function markMemoryReviewCandidateExpired(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<[string], { status: string }>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) {
+      throw MemoryReviewCandidateError.notFound(candidateId);
+    }
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare<[string, string]>(
+        `UPDATE memory_review_candidate SET status = 'expired', updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+  });
+  run();
+}
+

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -7,6 +7,7 @@ import type {
   UpsertPendingMemoryReviewCandidateInput,
   UpsertPendingMemoryReviewCandidatesResult,
 } from './memory-review-candidate-persistence.types.js';
+import { MemoryReviewCandidateError } from './memory-review-candidate-persistence-error.js';
 
 export function upsertPendingMemoryReviewCandidates(
   db: Database.Database,
@@ -117,3 +118,39 @@ export function listMemoryReviewCandidates(
     .all()
     .map((row) => mapRow(row));
 }
+
+export function markMemoryReviewCandidateReviewed(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<[string], { status: string }>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) {
+      throw MemoryReviewCandidateError.notFound(candidateId);
+    }
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare<[string, string, string]>(
+        `UPDATE memory_review_candidate SET status = 'reviewed', reviewed_at = ?, updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const mem = db
+      .prepare<[string], { memory_id: string }>(`SELECT memory_id FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!mem) throw MemoryReviewCandidateError.notFound(candidateId);
+    db.prepare<[string, string]>(
+      `UPDATE memory_item SET last_accessed = CURRENT_TIMESTAMP, last_accessed_at = ? WHERE id = ?`,
+    ).run(now, mem.memory_id);
+  });
+  run();
+}
+

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -2,6 +2,8 @@ import type Database from 'better-sqlite3';
 import { randomUUID } from 'node:crypto';
 import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
 import type {
+  ListMemoryReviewCandidatesQuery,
+  MemoryReviewCandidateRow,
   UpsertPendingMemoryReviewCandidateInput,
   UpsertPendingMemoryReviewCandidatesResult,
 } from './memory-review-candidate-persistence.types.js';
@@ -66,4 +68,52 @@ export function upsertPendingMemoryReviewCandidates(
 
   run();
   return { inserted, updated };
+}
+
+function mapRow(r: Record<string, unknown>): MemoryReviewCandidateRow {
+  return {
+    id: String(r.id),
+    memory_id: String(r.memory_id),
+    status: r.status as MemoryReviewCandidateRow['status'],
+    priority: Number(r.priority),
+    reason: String(r.reason),
+    due_at: String(r.due_at),
+    created_at: String(r.created_at),
+    updated_at: String(r.updated_at),
+    reviewed_at: r.reviewed_at == null ? null : String(r.reviewed_at),
+    dismissed_at: r.dismissed_at == null ? null : String(r.dismissed_at),
+    metadata_json: r.metadata_json == null ? null : String(r.metadata_json),
+  };
+}
+
+export function getMemoryReviewCandidateById(
+  db: Database.Database,
+  id: string,
+): MemoryReviewCandidateRow | null {
+  ensureMemoryReviewCandidateSchema(db);
+  const r = db
+    .prepare<[string], Record<string, unknown>>(`SELECT * FROM memory_review_candidate WHERE id = ?`)
+    .get(id);
+  return r ? mapRow(r) : null;
+}
+
+export function listMemoryReviewCandidates(
+  db: Database.Database,
+  query: ListMemoryReviewCandidatesQuery = {},
+): MemoryReviewCandidateRow[] {
+  ensureMemoryReviewCandidateSchema(db);
+  if (query.status) {
+    return db
+      .prepare<[string], Record<string, unknown>>(
+        `SELECT * FROM memory_review_candidate WHERE status = ? ORDER BY priority DESC, due_at ASC`,
+      )
+      .all(query.status)
+      .map((row) => mapRow(row));
+  }
+  return db
+    .prepare<[], Record<string, unknown>>(
+      `SELECT * FROM memory_review_candidate ORDER BY priority DESC, due_at ASC`,
+    )
+    .all()
+    .map((row) => mapRow(row));
 }

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -1,0 +1,69 @@
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { ensureMemoryReviewCandidateSchema } from '../../../shared/utils/ensure-memory-review-candidate-schema.js';
+import type {
+  UpsertPendingMemoryReviewCandidateInput,
+  UpsertPendingMemoryReviewCandidatesResult,
+} from './memory-review-candidate-persistence.types.js';
+
+export function upsertPendingMemoryReviewCandidates(
+  db: Database.Database,
+  items: UpsertPendingMemoryReviewCandidateInput[],
+  now: string,
+): UpsertPendingMemoryReviewCandidatesResult {
+  ensureMemoryReviewCandidateSchema(db);
+  let inserted = 0;
+  let updated = 0;
+
+  const run = db.transaction(() => {
+    const selectPending = db.prepare<[string], { id: string }>(
+      `SELECT id FROM memory_review_candidate WHERE memory_id = ? AND status = 'pending'`,
+    );
+    const updatePending = db.prepare(
+      `UPDATE memory_review_candidate SET
+        priority = @priority,
+        reason = @reason,
+        due_at = @due_at,
+        metadata_json = @metadata_json,
+        updated_at = @updated_at
+      WHERE id = @id`,
+    );
+    const insert = db.prepare(
+      `INSERT INTO memory_review_candidate (
+        id, memory_id, status, priority, reason, due_at, created_at, updated_at, metadata_json
+      ) VALUES (
+        @id, @memory_id, 'pending', @priority, @reason, @due_at, @created_at, @updated_at, @metadata_json
+      )`,
+    );
+
+    for (const item of items) {
+      const existing = selectPending.get(item.memory_id);
+      if (existing) {
+        updatePending.run({
+          id: existing.id,
+          priority: item.priority,
+          reason: item.reason,
+          due_at: item.due_at,
+          metadata_json: item.metadata_json ?? null,
+          updated_at: now,
+        });
+        updated += 1;
+      } else {
+        insert.run({
+          id: randomUUID(),
+          memory_id: item.memory_id,
+          priority: item.priority,
+          reason: item.reason,
+          due_at: item.due_at,
+          created_at: now,
+          updated_at: now,
+          metadata_json: item.metadata_json ?? null,
+        });
+        inserted += 1;
+      }
+    }
+  });
+
+  run();
+  return { inserted, updated };
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -154,3 +154,30 @@ export function markMemoryReviewCandidateReviewed(
   run();
 }
 
+export function markMemoryReviewCandidateDismissed(
+  db: Database.Database,
+  candidateId: string,
+  now: string,
+): void {
+  ensureMemoryReviewCandidateSchema(db);
+  const run = db.transaction(() => {
+    const cur = db
+      .prepare<[string], { status: string }>(`SELECT status FROM memory_review_candidate WHERE id = ?`)
+      .get(candidateId);
+    if (!cur) {
+      throw MemoryReviewCandidateError.notFound(candidateId);
+    }
+    if (cur.status !== 'pending') {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+    const info = db
+      .prepare<[string, string, string]>(
+        `UPDATE memory_review_candidate SET status = 'dismissed', dismissed_at = ?, updated_at = ? WHERE id = ? AND status = 'pending'`,
+      )
+      .run(now, now, candidateId);
+    if (info.changes === 0) {
+      throw MemoryReviewCandidateError.notActionable(candidateId, cur.status);
+    }
+  });
+  run();
+}

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts
@@ -1,0 +1,34 @@
+export type MemoryReviewCandidateStatus = 'pending' | 'reviewed' | 'dismissed' | 'expired';
+
+/** DB row shape for `memory_review_candidate` */
+export interface MemoryReviewCandidateRow {
+  id: string;
+  memory_id: string;
+  status: MemoryReviewCandidateStatus;
+  priority: number;
+  reason: string;
+  due_at: string;
+  created_at: string;
+  updated_at: string;
+  reviewed_at: string | null;
+  dismissed_at: string | null;
+  metadata_json: string | null;
+}
+
+/** One pending upsert row (aligned with #241 selection output fields used by batch) */
+export interface UpsertPendingMemoryReviewCandidateInput {
+  memory_id: string;
+  priority: number;
+  reason: string;
+  due_at: string;
+  metadata_json?: string | null;
+}
+
+export interface UpsertPendingMemoryReviewCandidatesResult {
+  inserted: number;
+  updated: number;
+}
+
+export interface ListMemoryReviewCandidatesQuery {
+  status?: MemoryReviewCandidateStatus;
+}

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -64,6 +64,26 @@ export type {
   MemoryReviewCandidateSelectionThresholds as Thresholds,
   MemoryReviewCandidateSelectionOptions as Options
 } from './domains/memory/services/memory-review-candidate-selection.types.js';
+export {
+  upsertPendingMemoryReviewCandidates,
+  getMemoryReviewCandidateById,
+  listMemoryReviewCandidates,
+  markMemoryReviewCandidateReviewed,
+  markMemoryReviewCandidateDismissed,
+  markMemoryReviewCandidateExpired,
+} from './domains/memory/services/memory-review-candidate-persistence-service.js';
+export type {
+  MemoryReviewCandidateStatus,
+  MemoryReviewCandidateRow,
+  UpsertPendingMemoryReviewCandidateInput,
+  UpsertPendingMemoryReviewCandidatesResult,
+  ListMemoryReviewCandidatesQuery,
+} from './domains/memory/services/memory-review-candidate-persistence.types.js';
+export {
+  MemoryReviewCandidateError,
+  MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
+  MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
+} from './domains/memory/services/memory-review-candidate-persistence-error.js';
 export { logger } from './shared/utils/logger.js';
 export { loggingRateLimiter } from './shared/utils/logging-rate-limiter.js';
 export { withErrorHandling } from './shared/utils/error-handling.js';


### PR DESCRIPTION
## Summary
Implements GitHub **#242** (core only): idempotent pending upsert, list/get, `pending → reviewed|dismissed|expired` transitions, `MemoryReviewCandidateError` with 404/409 mapping for future HTTP, review updates `memory_item.last_accessed` / `last_accessed_at`, Vitest coverage. Exports from `@memento/core`.

## Design / plan
- Spec: `docs/superpowers/specs/2026-05-02-issue-242-memory-review-candidate-persistence-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-issue-242-memory-review-candidate-persistence.md`

## Notes
- Builds on #240 (schema) and #241 (selection).
- Server Admin HTTP / 409 responses are **out of scope** (follow-up).

Closes #242

Made with [Cursor](https://cursor.com)