### PR TITLE
feat: memory review candidates admin API and batch job (#243)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-issue-243-memory-review-admin-api.md
+++ b/docs/superpowers/plans/2026-05-02-issue-243-memory-review-admin-api.md
@@ -1,0 +1,638 @@
+# Issue #243 memory review admin API + batch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `GET /admin/memory/review-candidates` (metadata-only rows), `POST .../:id/review`, `POST .../:id/dismiss` with 200/400/404/409 mapping to `MemoryReviewCandidateError`; add `BatchScheduler` job `memory_review_candidates` (select → upsert) on a configurable interval; extend `POST /admin/batch/run` to accept `memory_review_candidates`; add Vitest coverage in `memento-server` and `memento-core`. No dashboard UI.
+
+**Architecture:** Thin Express handlers in `admin.routes.ts` call `@memento/core` persistence/selection functions already exported from `index.ts`. `BatchScheduler` gains a private `runMemoryReviewCandidatesJob()` mirroring `runMemoryCleanup` (DB open check → `selectMemoryReviewCandidates` → map to upsert inputs with env-driven `due_at` → `upsertPendingMemoryReviewCandidates`). `runJob` union extended; schedule via `scheduleJob('memory_review_candidates', …, priority 8)`.
+
+**Tech Stack:** TypeScript ESM, Express 5, `better-sqlite3`, Vitest, `uuid` (`validate`) in memento-server, `@memento/core` public APIs: `selectMemoryReviewCandidates`, `upsertPendingMemoryReviewCandidates`, `listMemoryReviewCandidates`, `markMemoryReviewCandidateReviewed`, `markMemoryReviewCandidateDismissed`, `MemoryReviewCandidateError`.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-243-memory-review-admin-api-design.md`
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `packages/memento-core/src/index.ts` | Modify — export `MetaMemoryStatsSchemaMigration` + `MemoryReviewCandidateSchemaMigration` for server Vitest fixtures |
+| `packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts` | Modify — add `memoryReviewCandidatesInterval: number` |
+| `packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts` | Modify — validate interval ≥ 60000 |
+| `packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts` | Modify — defaults, `start()`, `runJob`, new private job method |
+| `packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts` | Modify — pass new config in `beforeEach`; add `runJob('memory_review_candidates')` + `activeJobs` tests |
+| `packages/memento-server/src/server/routes/admin.routes.ts` | Modify — routes + imports |
+| `packages/memento-server/src/server/routes/admin.routes.spec.ts` | Modify — new `describe` for review-candidates API |
+
+---
+
+## Constants (copy into implementation)
+
+- Env `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS`: default `86_400_000` (24h), min `60_000`.
+- Env `MEMORY_REVIEW_CANDIDATE_DUE_DAYS`: default `14`, min `1`, max `366` (read inside batch job mapping via `resolveValidatedNumber` from `@memento/core` shared `environment` — same as other batch env reads in `batch-scheduler.ts`).
+
+---
+
+### Task 0: Export migrations for server tests
+
+**Files:**
+
+- Modify: `packages/memento-core/src/index.ts`
+
+- [ ] **Step 1: Re-export migration classes** (paths match dist layout after `tsc`)
+
+```typescript
+export { MetaMemoryStatsSchemaMigration } from './infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+export { MemoryReviewCandidateSchemaMigration } from './infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+```
+
+- [ ] **Step 2: Build core + commit**
+
+```bash
+npm run build -w @memento/core
+git add packages/memento-core/src/index.ts
+git commit -m "feat(core): export migrations for admin review-candidate tests (#243)"
+```
+
+---
+
+### Task 1: Extend `BatchJobConfig` + validation
+
+**Files:**
+
+- Modify: `packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts`
+- Modify: `packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts`
+
+- [ ] **Step 1: Add field to interface**
+
+In `BatchJobConfig`, after `telemetryCleanupInterval` (or nearby batch intervals), add:
+
+```typescript
+  /** Issue #243: refresh memory_review_candidate pending rows from selection */
+  memoryReviewCandidatesInterval: number;
+```
+
+- [ ] **Step 2: Validate in `validateBatchJobConfig`**
+
+Append before the closing `}`:
+
+```typescript
+  if (config.memoryReviewCandidatesInterval < 60000) {
+    throw new Error('memoryReviewCandidatesInterval must be at least 1 minute');
+  }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts \
+  packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts
+git commit -m "feat(core): add memoryReviewCandidatesInterval to batch config (#243)"
+```
+
+---
+
+### Task 2: `BatchScheduler` — defaults, schedule, `runJob`, job body
+
+**Files:**
+
+- Modify: `packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts`
+
+- [ ] **Step 1: Constructor default + env**
+
+Inside the `this.config = { ... }` object in the constructor (near other `resolveValidatedNumber` calls), add:
+
+```typescript
+      memoryReviewCandidatesInterval: resolveValidatedNumber(
+        'MEMORY_REVIEW_CANDIDATES_INTERVAL_MS',
+        24 * 60 * 60 * 1000,
+        n => n >= 60_000,
+        '최솟값 60000'
+      ),
+```
+
+- [ ] **Step 2: Import domain functions at top of file**
+
+Add to existing imports (same style as other scheduler imports):
+
+```typescript
+import { selectMemoryReviewCandidates } from '../../domains/memory/services/memory-review-candidate-selection-service.js';
+import { upsertPendingMemoryReviewCandidates } from '../../domains/memory/services/memory-review-candidate-persistence-service.js';
+```
+
+(`resolveValidatedNumber` is already imported in this file.)
+
+- [ ] **Step 3: Schedule in `start()` after `meta_memory_introspection` block**
+
+After the `scheduleJob('meta_memory_introspection', …)` block and **before** `this.startJobProcessor()`, add:
+
+```typescript
+    this.scheduleJob(
+      'memory_review_candidates',
+      this.config.memoryReviewCandidatesInterval,
+      async () => {
+        await this.runMemoryReviewCandidatesJob();
+      },
+      8
+    );
+```
+
+Use priority **8** so it stays below priority-7 quality batch jobs.
+
+- [ ] **Step 4: Implement `private async runMemoryReviewCandidatesJob(): Promise<BatchJobResult>`**
+
+Place near other `run*` private methods:
+
+```typescript
+  private async runMemoryReviewCandidatesJob(): Promise<BatchJobResult> {
+    const startTime = new Date();
+    const result: BatchJobResult = {
+      jobType: 'memory_review_candidates',
+      startTime,
+      endTime: new Date(),
+      duration: 0,
+      success: false,
+      processed: 0,
+      errors: [],
+      warnings: []
+    };
+
+    try {
+      if (!this.db) {
+        throw new Error('Database not initialized');
+      }
+      if (!DatabaseUtils.isOpen(this.db)) {
+        throw new Error('Database connection is not open. The database may have been closed.');
+      }
+
+      const items = selectMemoryReviewCandidates(this.db);
+      const dueDays = resolveValidatedNumber(
+        'MEMORY_REVIEW_CANDIDATE_DUE_DAYS',
+        14,
+        n => n >= 1 && n <= 366,
+        '1-366'
+      );
+      const nowIso = new Date().toISOString();
+      const dueAt = new Date(Date.now() + dueDays * 86_400_000).toISOString();
+
+      const inputs = items.map(i => ({
+        memory_id: i.memory_id,
+        priority: i.priority,
+        reason: i.reason,
+        due_at: dueAt,
+        metadata_json: JSON.stringify({ score_breakdown: i.score_breakdown })
+      }));
+
+      const upsert = upsertPendingMemoryReviewCandidates(this.db, inputs, nowIso);
+      result.success = true;
+      result.processed = inputs.length;
+      result.details = { inserted: upsert.inserted, updated: upsert.updated };
+
+      this.log('Memory review candidates batch completed', {
+        selected: items.length,
+        inserted: upsert.inserted,
+        updated: upsert.updated
+      });
+    } catch (error) {
+      result.errors.push(error instanceof Error ? error.message : String(error));
+      this.log('Memory review candidates batch failed', {
+        error: error instanceof Error ? error.message : String(error)
+      }, 'error');
+    } finally {
+      result.endTime = new Date();
+      result.duration = result.endTime.getTime() - result.startTime.getTime();
+    }
+
+    return result;
+  }
+```
+
+Do **not** log `memory_item.content`; the above logs counts only.
+
+- [ ] **Step 5: Extend `runJob` union + switch**
+
+Change signature to include `'memory_review_candidates'` in the union type, add:
+
+```typescript
+      case 'memory_review_candidates':
+        result = await this.runMemoryReviewCandidatesJob();
+        break;
+```
+
+- [ ] **Step 6: Duplicate `start()` path if file has restart helper**
+
+If `batch-scheduler.ts` contains a second `start`/`reschedule` block (search for duplicate `scheduleJob('cleanup'`) around line 1030), add the same `memory_review_candidates` `scheduleJob` there too so restarts behave identically.
+
+- [ ] **Step 7: Run core tests**
+
+```bash
+npm run test:prepare && npx vitest --run packages/memento-core/src/infrastructure/scheduler/batch-scheduler.spec.ts
+```
+
+Expected: PASS (fix any missing config in test constructor).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
+git commit -m "feat(core): add memory_review_candidates batch job (#243)"
+```
+
+---
+
+### Task 3: `batch-scheduler.spec.ts` — config + smoke tests
+
+**Files:**
+
+- Modify: `packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts`
+
+- [ ] **Step 1: Extend `beforeEach` scheduler config**
+
+In `new BatchScheduler({ ... })` (first `beforeEach` around line 27), add:
+
+```typescript
+      memoryReviewCandidatesInterval: 60000,
+```
+
+- [ ] **Step 2: Add tests under `describe('runJob - 수동 작업 실행', …)`**
+
+```typescript
+    it('memory_review_candidates 작업을 수동으로 실행해야 함', async () => {
+      await scheduler.start(db);
+
+      const result = await scheduler.runJob('memory_review_candidates');
+
+      expect(result).toBeDefined();
+      expect(result.jobType).toBe('memory_review_candidates');
+      expect(result).toHaveProperty('success');
+    });
+```
+
+```typescript
+    it('시작 후 activeJobs에 memory_review_candidates가 포함되어야 함', async () => {
+      await scheduler.start(db);
+      const status = scheduler.getStatus();
+      expect(status.activeJobs).toContain('memory_review_candidates');
+    });
+```
+
+- [ ] **Step 3: Run file + commit**
+
+```bash
+npx vitest --run packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
+git add packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
+git commit -m "test(core): cover memory_review_candidates batch (#243)"
+```
+
+---
+
+### Task 4: Admin HTTP routes
+
+**Files:**
+
+- Modify: `packages/memento-server/src/server/routes/admin.routes.ts`
+
+- [ ] **Step 1: Imports**
+
+Add to `@memento/core` import list (same block as `getBatchScheduler`):
+
+```typescript
+  listMemoryReviewCandidates,
+  markMemoryReviewCandidateReviewed,
+  markMemoryReviewCandidateDismissed,
+  MemoryReviewCandidateError,
+  type MemoryReviewCandidateStatus
+} from '@memento/core';
+```
+
+Add at file top (after express imports):
+
+```typescript
+import { validate as uuidValidate } from 'uuid';
+```
+
+- [ ] **Step 2: Helper `parseReviewCandidateStatusQuery`**
+
+Near `parseCleanupParams`, add:
+
+```typescript
+const MEMORY_REVIEW_STATUSES: MemoryReviewCandidateStatus[] = [
+  'pending',
+  'reviewed',
+  'dismissed',
+  'expired'
+];
+
+function parseReviewCandidateStatusQuery(
+  raw: unknown
+): { status?: MemoryReviewCandidateStatus } | { error: string; status: number } {
+  if (raw === undefined || raw === '') {
+    return {};
+  }
+  if (typeof raw !== 'string' || !MEMORY_REVIEW_STATUSES.includes(raw as MemoryReviewCandidateStatus)) {
+    return { error: 'Invalid status query', status: 400 };
+  }
+  return { status: raw as MemoryReviewCandidateStatus };
+}
+```
+
+- [ ] **Step 3: `GET /admin/memory/review-candidates`**
+
+Inside `createAdminRouter`:
+
+```typescript
+  router.get('/memory/review-candidates', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const parsed = parseReviewCandidateStatusQuery(req.query['status']);
+      if ('error' in parsed) {
+        return res.status(parsed.status).json({ error: parsed.error });
+      }
+      const rows = listMemoryReviewCandidates(db, parsed.status ? { status: parsed.status } : {});
+      return res.json({
+        message: 'Memory review candidates',
+        candidates: rows,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      logger.error('List review candidates failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to list review candidates',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+```
+
+- [ ] **Step 4: `POST .../review` and `POST .../dismiss`**
+
+```typescript
+  router.post('/memory/review-candidates/:id/review', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { id } = req.params;
+      if (!uuidValidate(id)) {
+        return res.status(400).json({ error: 'Invalid candidate id' });
+      }
+      const nowIso = new Date().toISOString();
+      markMemoryReviewCandidateReviewed(db, id, nowIso);
+      const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
+    } catch (error) {
+      if (error instanceof MemoryReviewCandidateError) {
+        return res.status(error.statusCode).json({ error: error.message, code: error.code });
+      }
+      logger.error('Review candidate review failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to mark reviewed',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+  router.post('/memory/review-candidates/:id/dismiss', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { id } = req.params;
+      if (!uuidValidate(id)) {
+        return res.status(400).json({ error: 'Invalid candidate id' });
+      }
+      const nowIso = new Date().toISOString();
+      markMemoryReviewCandidateDismissed(db, id, nowIso);
+      const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
+    } catch (error) {
+      if (error instanceof MemoryReviewCandidateError) {
+        return res.status(error.statusCode).json({ error: error.message, code: error.code });
+      }
+      logger.error('Review candidate dismiss failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to dismiss candidate',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+```
+
+**Note:** For large DBs, replace post-mutation `listMemoryReviewCandidates(db, {}).find` with `getMemoryReviewCandidateById` (exported from `@memento/core`) in a follow-up.
+
+- [ ] **Step 5: Extend `POST /admin/batch/run` allowlist**
+
+Replace the `includes` array:
+
+```typescript
+      if (!jobType || !['cleanup', 'monitoring', 'memory_review_candidates'].includes(jobType)) {
+        return res.status(400).json({
+          error: 'Invalid job type. Must be "cleanup", "monitoring", or "memory_review_candidates"'
+        });
+      }
+```
+
+- [ ] **Step 6: Build + server tests subset**
+
+```bash
+npm run build -w @memento/core && npm run build -w memento-server
+npx vitest --run packages/memento-server/src/server/routes/admin.routes.spec.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/memento-server/src/server/routes/admin.routes.ts
+git commit -m "feat(server): admin review-candidates API and batch/run (#243)"
+```
+
+---
+
+### Task 5: `admin.routes.spec.ts` — integration tests
+
+**Files:**
+
+- Modify: `packages/memento-server/src/server/routes/admin.routes.spec.ts`
+
+- [ ] **Step 1: Imports for migrations + core**
+
+```typescript
+import { randomUUID } from 'node:crypto';
+import {
+  MemoryReviewCandidateSchemaMigration,
+  MetaMemoryStatsSchemaMigration,
+  upsertPendingMemoryReviewCandidates
+} from '@memento/core';
+```
+
+(Task 0 must be done first.)
+
+- [ ] **Step 2: New `describe('Admin memory review candidates', …)`**
+
+Pattern: mirror `Project memory admin routes` — `Database(':memory:')`, `app.use('/admin', createAdminRouter(database, null));`, `listen`.
+
+**Setup helper** (inline in spec file, copied from `memory-review-candidate-selection-service.spec.ts`):
+
+```typescript
+function createBaseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+      deleted_at TEXT
+    );
+  `);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS memento_schema_version (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      migration_name TEXT NOT NULL,
+      checksum TEXT,
+      applied_by TEXT DEFAULT 'system',
+      description TEXT
+    );
+  `);
+}
+```
+
+`beforeEach`: `createBaseSchema(db)` → `await new MetaMemoryStatsSchemaMigration().up(db)` → `await new MemoryReviewCandidateSchemaMigration().up(db)` → insert one `memory_item` + one `meta_memory_stats` row (copy the two `INSERT` blocks from `packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts` lines 52–79, using `mem_stale`).
+
+Seed pending candidate and capture id:
+
+```typescript
+const NOW = '2026-06-01T12:00:00.000Z';
+upsertPendingMemoryReviewCandidates(
+  db,
+  [
+    {
+      memory_id: 'mem_stale',
+      priority: 10,
+      reason: 'test seed',
+      due_at: '2026-07-01T00:00:00.000Z',
+      metadata_json: null
+    }
+  ],
+  NOW
+);
+const row = db.prepare(`SELECT id FROM memory_review_candidate WHERE memory_id = ? AND status = 'pending'`).get('mem_stale') as { id: string };
+const pendingId = row.id;
+```
+
+Tests:
+
+```typescript
+  it('GET /admin/memory/review-candidates returns 200 and no memory_item.content field', async () => {
+    const res = await getAdmin(port, '/admin/memory/review-candidates');
+    expect(res.statusCode).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(Array.isArray(json.candidates)).toBe(true);
+    const first = json.candidates[0];
+    if (first) {
+      expect(first).not.toHaveProperty('content');
+      expect(first).toHaveProperty('memory_id');
+    }
+  });
+
+  it('GET /admin/memory/review-candidates?status=bad returns 400', async () => {
+    const res = await getAdmin(port, '/admin/memory/review-candidates?status=bad');
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('POST review twice returns 409 on second call', async () => {
+    const res1 = await postAdminJson(port, `/admin/memory/review-candidates/${pendingId}/review`, {});
+    expect(res1.statusCode).toBe(200);
+    const res2 = await postAdminJson(port, `/admin/memory/review-candidates/${pendingId}/review`, {});
+    expect(res2.statusCode).toBe(409);
+    const j2 = JSON.parse(res2.body);
+    expect(j2.code).toBe('memory_review_candidate_not_actionable');
+  });
+
+  it('POST dismiss for unknown UUID returns 404', async () => {
+    const id = randomUUID();
+    const res = await postAdminJson(port, `/admin/memory/review-candidates/${id}/dismiss`, {});
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('POST review with invalid id returns 400', async () => {
+    const res = await postAdminJson(port, '/admin/memory/review-candidates/not-a-uuid/review', {});
+    expect(res.statusCode).toBe(400);
+  });
+```
+
+- [ ] **Step 3: Run vitest + commit**
+
+```bash
+npx vitest --run packages/memento-server/src/server/routes/admin.routes.spec.ts
+git add packages/memento-server/src/server/routes/admin.routes.spec.ts
+git commit -m "test(server): admin memory review candidates routes (#243)"
+```
+
+---
+
+### Task 6: Full gate
+
+- [ ] **Step 1: Root test + lint**
+
+```bash
+npm test
+npm run lint
+```
+
+Expected: all PASS, lint clean.
+
+- [ ] **Step 2: Final commit** (only if fixes needed)
+
+```bash
+git add -A
+git commit -m "chore: fix lint for #243"
+```
+
+---
+
+## Plan self-review
+
+| Spec section | Task coverage |
+|--------------|---------------|
+| GET list metadata-only | Task 4 route + Task 5 assert no `content` |
+| status query 400 | Task 4 parser + Task 5 |
+| POST review/dismiss + 404/409 | Task 4 + Task 5 |
+| Batch schedule + `getStatus` | Task 2–3 |
+| `runJob` + `/admin/batch/run` | Task 2 + Task 4 step 5 |
+| Logging without memory content | Task 2 log lines (counts only); routes use generic errors |
+| `due_at` / `metadata_json` | Task 2 mapping |
+| Server test DB setup | Task 0 exports + Task 5 |
+
+**Placeholder scan:** none.
+
+**Type consistency:** `runJob('memory_review_candidates')` matches extended union; admin `jobType` string matches.
+
+---
+
+## Execution handoff
+
+**Plan complete.** 저장 위치: `docs/superpowers/plans/2026-05-02-issue-243-memory-review-admin-api.md` (워크트리 `feature/issue-243-review-candidates-api`에 커밋할 것).
+
+**실행 방식 선택:**
+
+1. **Subagent-Driven (권장)** — 태스크마다 새 서브에이전트, 태스크 사이 리뷰.  
+2. **Inline Execution** — 같은 세션에서 `executing-plans` 체크포인트로 순차 실행.
+
+구현을 시작할 때 어떤 방식으로 할지 알려 주세요.

--- a/docs/superpowers/specs/2026-05-02-issue-243-memory-review-admin-api-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-243-memory-review-admin-api-design.md
@@ -1,0 +1,179 @@
+# 설계: 이슈 #243 — 리뷰 후보 Admin HTTP API 및 배치 연동 (`memento-server` + `BatchScheduler`)
+
+**상태**: 초안 (구현 전 검토)  
+**날짜**: 2026-05-02  
+**이슈**: [GitHub #243](https://github.com/jee1/memento/issues/243)  
+**상위**: [#18](https://github.com/jee1/memento/issues/18)  
+**선행**: [#240](https://github.com/jee1/memento/issues/240), [#241](https://github.com/jee1/memento/issues/241), [#242](https://github.com/jee1/memento/issues/242) — 코어 스키마·선정·persist API는 `main` 기준으로 반영됨을 가정한다.
+
+---
+
+## 1. 배경·목표
+
+에이전트/운영자가 **리뷰 큐**를 HTTP admin으로 조회하고 `review` / `dismiss`를 처리할 수 있게 한다. 후보 행은 배치가 주기적으로 `#241 select` + `#242 upsert`로 갱신한다.
+
+**비목표**
+
+- 대시보드 정적 UI(별도 이슈).
+- MCP 도구 노출.
+- `memory_item` 본문을 **목록** 응답에 포함하지 않는다(아래 §3 확정).
+
+---
+
+## 2. 구현 접근 비교 (2~3안)
+
+| 접근 | 요약 | 장점 | 단점 |
+|------|------|------|------|
+| **A. `admin.routes.ts`에 라우트 직접 추가** | `GET/POST`를 기존 파일에 이어 붙인다. | 패턴 일치(consolidation, batch 등), diff 한 파일에 모여 리뷰 용이. | 파일이 비대해질 수 있음(후속 분리 가능). |
+| **B. `admin/admin-memory-review.routes.ts` 분리** | `createAdminRouter`에서 `router.use`로 등록. | 관심사 분리, 테스트 파일도 분리하기 쉬움. | 신규 파일·와이어링 증가. |
+| **C. 배치 로직을 별도 Job 클래스로 추출** | `MemoryReviewCandidatesBatchJob` 등. | 단위 테스트·의존성 주입에 유리. | #243 규모 대비 보일러플레이트. |
+
+**선택**
+
+- **라우팅: A** — 이슈 범위·기존 `admin.routes` 패턴에 맞춘다. 파일이 700줄을 넘기면 후속 리팩터로 B를 검토한다.
+- **배치: `BatchScheduler` private 메서드 + `scheduleJob`** — 기존 `runMemoryCleanup` 등과 동일한 `BatchJobResult` 계약을 따른다(C안은 보류).
+
+---
+
+## 3. HTTP API 계약
+
+모든 경로는 기존과 같이 **`/admin` 마운트 + 브라우저 세션**(`http-server.ts`의 `browserSessionAuth`) 하에서만 동작한다. 별도 API 키 미들웨어를 두지 않는다.
+
+### 3.1 `GET /admin/memory/review-candidates`
+
+**쿼리**
+
+- `status` (선택): `pending` \| `reviewed` \| `dismissed` \| `expired`. 생략 시 **전체** 상태(코어 `listMemoryReviewCandidates` 기본 동작과 정합).
+
+**응답 200**
+
+- 본문: `{ "candidates": CandidateDto[], "timestamp": string }` 형태(필드명은 구현 시 기존 admin JSON 관례에 맞춤).
+- **`CandidateDto`**: `MemoryReviewCandidateRow`를 JSON으로 직렬화한 것과 동등 **단, `memory_item.content` 등 본문 필드는 포함하지 않는다.**  
+  즉 큐 테이블 컬럼(`id`, `memory_id`, `status`, `priority`, `reason`, `due_at`, 타임스탬프들, `metadata_json`)만 노출한다.  
+  메모리 본문이 필요하면 기존 admin의 메모리/그래프 등 **별도 엔드포인트**로 `memory_id`를 넘겨 조회한다.
+
+**에러**
+
+- DB 미연결 등 서버 오류: **500** (기존 admin 라우트와 동일).
+- 잘못된 `status` 값: **400** + `{ "error": "..." }`.
+
+**로깅**
+
+- 성공/실패 로그에 **memory 본문(`memory_item.content`)을 남기지 않는다** (이슈 완료 조건).  
+  권장: `candidate_id`·`memory_id`·건수·HTTP 상태 중심. `reason` 문자열은 본문이 아니나 길이가 길 수 있으므로 로그에는 **길이 상한이 있는 요약**만 남기거나 생략한다.
+
+### 3.2 `POST /admin/memory/review-candidates/:id/review`
+
+- **본문**: `{}` 허용(추가 필드 없음).
+- **동작**: `markMemoryReviewCandidateReviewed(db, id, nowIso)` 호출. `nowIso`는 `new Date().toISOString()` (서버 UTC).
+- **응답**: 200 + 갱신된 후보 DTO 또는 `{ "ok": true, ... }` — 구현 시 기존 admin 성공 응답 스타일에 맞춰 한 가지로 통일.
+
+### 3.3 `POST /admin/memory/review-candidates/:id/dismiss`
+
+- **본문**: `{}` 허용.
+- **동작**: `markMemoryReviewCandidateDismissed(db, id, nowIso)`.
+
+### 3.4 도메인 오류 → HTTP (`MemoryReviewCandidateError`)
+
+| 조건 | HTTP | 응답 바디 |
+|------|------|-----------|
+| 존재하지 않는 `:id` | **404** | `{ "error", "code": "memory_review_candidate_not_found" }` |
+| `pending`이 아님(review/dismiss) | **409** | `{ "error", "code": "memory_review_candidate_not_actionable" }` |
+| `:id`가 UUID 형식이 아님 등 **명백한 클라이언트 오류** | **400** | 검증 메시지 |
+
+구현은 `instanceof MemoryReviewCandidateError`이면 `err.statusCode`를 그대로 사용한다(#242 설계와 정합).
+
+---
+
+## 4. 배치 스케줄러
+
+### 4.1 작업 이름·주기
+
+- **스케줄 키(인터벌 맵 / `getStatus().activeJobs`에 나타나는 이름)**: `memory_review_candidates` (이슈 본문과 동일 문자열).
+- **주기**: 신규 `BatchJobConfig` 필드 + 환경변수로 설정 가능하게 한다.  
+  예: `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS`, 기본값 **24h** (`86_400_000`). 최솟값은 `resolveValidatedNumber` 관례에 맞춰 **≥ 60_000** 으로 검증한다.
+
+### 4.2 실행 본문 (`runMemoryReviewCandidates` 등)
+
+1. `this.db` 열림 여부 확인(`runMemoryCleanup`과 동일 패턴).
+2. `selectMemoryReviewCandidates(this.db)` 호출(옵션은 env `#241`과 동일 파서 재사용).
+3. 각 `MemoryReviewCandidateSelectionItem`을 `UpsertPendingMemoryReviewCandidateInput`으로 매핑:
+   - `memory_id`, `priority`, `reason` — 그대로.
+   - **`due_at`**: 선정 결과에 필드가 없으므로 배치 시각 기준으로 계산한다.  
+     **확정 규칙**: 환경변수 `MEMORY_REVIEW_CANDIDATE_DUE_DAYS`(정수, 기본 **14**)만큼 `Date.now()`에 일 단위 오프셋을 더한 시각을 ISO 문자열로 저장한다.
+   - **`metadata_json`**: `JSON.stringify({ score_breakdown })` (본문 없음 — 큐 메타만).
+4. `upsertPendingMemoryReviewCandidates(db, inputs, nowIso)` 호출.
+5. `BatchJobResult`: `jobType: 'memory_review_candidates'`, `processed` = upsert 입력 길이, `details` = `{ inserted, updated }` (#242 반환 타입).
+
+### 4.3 `BatchScheduler.start`
+
+- `this.scheduleJob('memory_review_candidates', interval, () => { … }, priority)` 로 등록.  
+  **priority**는 기존 `scheduleJob` 호출에서 사용 중인 숫자와 겹치지 않게 배정한다.
+
+### 4.4 `runJob` (수동 실행)
+
+- `runJob`의 `jobType` 유니온에 **`memory_review_candidates`** 를 추가하고, `switch`에서 배치 본문을 호출한다.
+- `lastExecution` / `totalExecutions` 맵 키는 스케줄 이름과 동일하게 `memory_review_candidates`를 사용한다.
+
+---
+
+## 5. `POST /admin/batch/run` 허용 목록
+
+현재 라우터는 `cleanup` \| `monitoring` 만 허용하나, `runJob`은 `healthcheck` \| `meta_memory_introspection` 도 지원한다.
+
+**#243 범위(필수)**
+
+- 허용 배열에 **`memory_review_candidates`** 를 추가한다.
+
+**비목표(명시적)**
+
+- 동일 PR에서 `healthcheck`·`meta_memory_introspection` 을 `/admin/batch/run`에 노출할지는 제품 정책에 따른 별 결정으로 둔다.
+
+**요청 바디**
+
+- `{ "jobType": "memory_review_candidates" }` → `runJob` 위임 → 200 + `result`.
+
+---
+
+## 6. 테스트 계획
+
+### 6.1 `packages/memento-server`
+
+- **`admin.routes.spec.ts` 확장**(또는 동일 패턴 신규 파일): 기존 헬퍼로
+  - `GET .../review-candidates` 200, 응답에 `memory_item` 본문 필드가 **없음**을 assert.
+  - 잘못된 `status` → 400.
+  - `POST .../review` / `dismiss` — 픽스처 후보 `pending`에서 200, 재호출 시 **409**.
+  - 존재하지 않는 UUID → 404.
+
+### 6.2 `packages/memento-core`
+
+- **`batch-scheduler.spec.ts`** (또는 소형 통합 spec): `runJob('memory_review_candidates')` 또는 스케줄 등록 후 `getStatus().activeJobs`에 키가 포함되는지 검증. 테스트 DB에는 최소 `memory_item` + 033 스키마가 있어야 `select`가 의미 있게 동작한다.
+
+---
+
+## 7. 완료 조건 (이슈 본문과 매핑)
+
+| 이슈 조건 | 설계 대응 |
+|-----------|-----------|
+| 기존 admin 인증 유지 | §3 세션 미변경 |
+| 200/400/404/409 일관 | §3.4 표 + 잘못된 쿼리 400 |
+| 배치가 후보 생성·스케줄러 상태 노출 | §4 |
+| 로그에 memory content 미기록 | §3.1 로깅 + 응답에 본문 미포함 |
+
+---
+
+## 8. 출처
+
+- [GitHub #243](https://github.com/jee1/memento/issues/243)
+- [#242 설계](./2026-05-02-issue-242-memory-review-candidate-persistence-design.md)
+- [#241 설계](./2026-05-02-issue-241-memory-review-candidate-selection-design.md)
+- [#240 설계](./2026-05-02-issue-240-memory-review-candidate-design.md)
+
+---
+
+## 9. Spec self-review (체크리스트)
+
+- **Placeholder**: 없음.
+- **내부 정합**: `due_at`은 §4.2 단일 규칙으로 고정.
+- **범위**: 서버 라우트 + 스케줄러 + 테스트만; UI·MCP 제외.
+- **모호성 해소**: 목록 응답은 **큐 테이블 메타만**; 본문은 다른 admin API.

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -132,4 +132,7 @@ export { TelemetryService } from './domains/telemetry/services/telemetry-service
 export { TelemetryRepository } from './domains/telemetry/repositories/telemetry-repository.js';
 export { TelemetryEventsMigration } from './infrastructure/database/database/migration/migrations/027-telemetry-events.js';
 export { TelemetryDailyMetricsMigration } from './infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.js';
+export { MetaMemoryStatsSchemaMigration } from './infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.js';
+export { MemoryReviewCandidateSchemaMigration } from './infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.js';
+
 export type { RecallResultItem } from './domains/memory/tools/recall-tool.js';

--- a/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
@@ -28,6 +28,7 @@ describe('BatchScheduler', () => {
       cleanupInterval: 60000, // 최소 1분
       monitoringInterval: 10000, // 최소 10초
       healthCheckInterval: 10000,
+      memoryReviewCandidatesInterval: 60000,
       maxBatchSize: 100,
       enableLogging: false, // 테스트 중 로그 최소화
       enableNotifications: false,
@@ -309,6 +310,22 @@ describe('BatchScheduler', () => {
       expect(result).toBeDefined();
       expect(result.jobType).toBe('healthcheck');
       expect(result).toHaveProperty('success');
+    });
+
+    it('memory_review_candidates 작업을 수동으로 실행해야 함', async () => {
+      await scheduler.start(db);
+
+      const result = await scheduler.runJob('memory_review_candidates');
+
+      expect(result).toBeDefined();
+      expect(result.jobType).toBe('memory_review_candidates');
+      expect(result).toHaveProperty('success');
+    });
+
+    it('시작 후 activeJobs에 memory_review_candidates가 포함되어야 함', async () => {
+      await scheduler.start(db);
+      const status = scheduler.getStatus();
+      expect(status.activeJobs).toContain('memory_review_candidates');
     });
   });
 

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
@@ -22,6 +22,8 @@ export interface BatchJobConfig {
   metaMemoryIntrospectionInterval: number;
   sleepConsolidationInterval: number;
   telemetryCleanupInterval: number;
+  /** Issue #243: refresh memory_review_candidate pending rows from selection */
+  memoryReviewCandidatesInterval: number;
 
   maxBatchSize: number;
   enableLogging: boolean;

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts
@@ -46,6 +46,9 @@ export function validateBatchJobConfig(config: BatchJobConfig): void {
   if (config.telemetryCleanupInterval < 60000) {
     throw new Error('telemetryCleanupInterval must be at least 1 minute');
   }
+  if (config.memoryReviewCandidatesInterval < 60000) {
+    throw new Error('memoryReviewCandidatesInterval must be at least 1 minute');
+  }
   if (config.weeklyRelationValidationTimeout !== undefined) {
     if (
       typeof config.weeklyRelationValidationTimeout !== 'number' ||

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
@@ -46,6 +46,9 @@ import { resolveValidatedNumber } from '../../shared/config/environment.js';
 import type { BatchJobConfig, BatchJobResult, SchedulerStatus } from './batch-scheduler-types.js';
 export type { BatchJobConfig, BatchJobResult, SchedulerStatus } from './batch-scheduler-types.js';
 import { validateBatchJobConfig } from './batch-scheduler-validate-config.js';
+import { selectMemoryReviewCandidates } from '../../domains/memory/services/memory-review-candidate-selection-service.js';
+import { upsertPendingMemoryReviewCandidates } from '../../domains/memory/services/memory-review-candidate-persistence-service.js';
+
 import { collectBatchSchedulerDatabaseStats } from './batch-scheduler-database-stats.js';
 import { BatchJobExecutionCoordinator } from './batch-job-execution-coordinator.js';
 
@@ -131,6 +134,12 @@ export class BatchScheduler implements IBatchScheduler {
       ),
       telemetryCleanupInterval: resolveValidatedNumber(
         'TELEMETRY_CLEANUP_INTERVAL_MS',
+        24 * 60 * 60 * 1000,
+        n => n >= 60_000,
+        '최솟값 60000'
+      ),
+      memoryReviewCandidatesInterval: resolveValidatedNumber(
+        'MEMORY_REVIEW_CANDIDATES_INTERVAL_MS',
         24 * 60 * 60 * 1000,
         n => n >= 60_000,
         '최솟값 60000'
@@ -281,6 +290,15 @@ export class BatchScheduler implements IBatchScheduler {
       this.config.metaMemoryIntrospectionInterval,
       async () => { await this.runMetaMemoryIntrospection(); },
       6
+    );
+
+    this.scheduleJob(
+      'memory_review_candidates',
+      this.config.memoryReviewCandidatesInterval,
+      async () => {
+        await this.runMemoryReviewCandidatesJob();
+      },
+      8
     );
 
     // 작업 큐 처리 시작
@@ -479,6 +497,71 @@ export class BatchScheduler implements IBatchScheduler {
     } catch (error) {
       result.errors.push(error instanceof Error ? error.message : String(error));
       this.log('Memory cleanup failed:', error, 'error');
+    } finally {
+      result.endTime = new Date();
+      result.duration = result.endTime.getTime() - result.startTime.getTime();
+    }
+
+    return result;
+  }
+
+  /**
+   * Issue #243: memory_review_candidate 큐를 선정 결과로 갱신
+   */
+  private async runMemoryReviewCandidatesJob(): Promise<BatchJobResult> {
+    const startTime = new Date();
+    const result: BatchJobResult = {
+      jobType: 'memory_review_candidates',
+      startTime,
+      endTime: new Date(),
+      duration: 0,
+      success: false,
+      processed: 0,
+      errors: [],
+      warnings: []
+    };
+
+    try {
+      if (!this.db) {
+        throw new Error('Database not initialized');
+      }
+      if (!DatabaseUtils.isOpen(this.db)) {
+        throw new Error('Database connection is not open. The database may have been closed.');
+      }
+
+      const items = selectMemoryReviewCandidates(this.db);
+      const dueDays = resolveValidatedNumber(
+        'MEMORY_REVIEW_CANDIDATE_DUE_DAYS',
+        14,
+        n => n >= 1 && n <= 366,
+        '1-366'
+      );
+      const nowIso = new Date().toISOString();
+      const dueAt = new Date(Date.now() + dueDays * 86_400_000).toISOString();
+
+      const inputs = items.map(i => ({
+        memory_id: i.memory_id,
+        priority: i.priority,
+        reason: i.reason,
+        due_at: dueAt,
+        metadata_json: JSON.stringify({ score_breakdown: i.score_breakdown })
+      }));
+
+      const upsert = upsertPendingMemoryReviewCandidates(this.db, inputs, nowIso);
+      result.success = true;
+      result.processed = inputs.length;
+      result.details = { inserted: upsert.inserted, updated: upsert.updated };
+
+      this.log('Memory review candidates batch completed', {
+        selected: items.length,
+        inserted: upsert.inserted,
+        updated: upsert.updated
+      });
+    } catch (error) {
+      result.errors.push(error instanceof Error ? error.message : String(error));
+      this.log('Memory review candidates batch failed', {
+        error: error instanceof Error ? error.message : String(error)
+      }, 'error');
     } finally {
       result.endTime = new Date();
       result.duration = result.endTime.getTime() - result.startTime.getTime();
@@ -945,7 +1028,7 @@ export class BatchScheduler implements IBatchScheduler {
    * 직접 실행하되 lastExecution과 totalExecutions을 기록함
    */
   async runJob(
-    jobType: 'cleanup' | 'monitoring' | 'healthcheck' | 'meta_memory_introspection'
+    jobType: 'cleanup' | 'monitoring' | 'healthcheck' | 'meta_memory_introspection' | 'memory_review_candidates'
   ): Promise<BatchJobResult> {
     let result: BatchJobResult;
 
@@ -961,6 +1044,9 @@ export class BatchScheduler implements IBatchScheduler {
         break;
       case 'meta_memory_introspection':
         result = await this.runMetaMemoryIntrospection();
+        break;
+      case 'memory_review_candidates':
+        result = await this.runMemoryReviewCandidatesJob();
         break;
       default:
         throw new Error(`Unknown job type: ${jobType}`);
@@ -1032,6 +1118,15 @@ export class BatchScheduler implements IBatchScheduler {
       this.scheduleJob('monitoring', this.config.monitoringInterval, async () => { await this.runMonitoring(); }, 2);
     } else if (jobName === 'healthcheck') {
       this.scheduleJob('healthcheck', this.config.healthCheckInterval, async () => { await this.runHealthCheck(); }, 3);
+    } else if (jobName === 'memory_review_candidates') {
+      this.scheduleJob(
+        'memory_review_candidates',
+        this.config.memoryReviewCandidatesInterval,
+        async () => {
+          await this.runMemoryReviewCandidatesJob();
+        },
+        8
+      );
     } else {
       this.log(`Unknown job type for restart: ${jobName}`);
       return false;

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'crypto';
 import express from 'express';
 import http from 'http';
 import Database from 'better-sqlite3';
@@ -13,7 +14,10 @@ import {
   TelemetryService,
   TelemetryRepository,
   TelemetryEventsMigration,
-  TelemetryDailyMetricsMigration
+  TelemetryDailyMetricsMigration,
+  MetaMemoryStatsSchemaMigration,
+  MemoryReviewCandidateSchemaMigration,
+  upsertPendingMemoryReviewCandidates
 } from '@memento/core';
 
 async function listen(app: express.Express): Promise<{ server: http.Server; port: number }> {
@@ -931,3 +935,168 @@ describe('Project memory admin routes', () => {
     }
   });
 });
+
+describe('admin.routes memory review candidates', () => {
+  let db: Database.Database;
+  let pendingId: string;
+  const NOW = '2026-06-01T12:00:00.000Z';
+
+  function createBaseSchema(database: Database.Database): void {
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS memory_item (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        content TEXT NOT NULL,
+        importance REAL DEFAULT 0.5,
+        privacy_scope TEXT DEFAULT 'private',
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        last_accessed TIMESTAMP,
+        last_accessed_at TEXT,
+        pinned BOOLEAN DEFAULT FALSE,
+        tags TEXT,
+        source TEXT,
+        project_id TEXT,
+        is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+        deleted_at TEXT
+      );
+    `);
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS memento_schema_version (
+        version TEXT PRIMARY KEY,
+        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        migration_name TEXT NOT NULL,
+        checksum TEXT,
+        applied_by TEXT DEFAULT 'system',
+        description TEXT
+      );
+    `);
+  }
+
+  function makeApp(database: Database.Database) {
+    const app = express();
+    app.use('/admin', createAdminRouter(database, null));
+    return app;
+  }
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at)
+      VALUES (
+        'mem_stale',
+        'semantic',
+        'Stale high-importance memory',
+        0.85,
+        'private',
+        '2020-01-15 00:00:00',
+        0,
+        0,
+        NULL
+      )
+    `);
+    db.exec(`
+      INSERT INTO meta_memory_stats (
+        memory_id, recall_count, success_count, failure_count,
+        avg_confidence, last_recalled_at, created_at, updated_at
+      ) VALUES (
+        'mem_stale',
+        10, 8, 2,
+        0.8,
+        '2020-06-01 00:00:00',
+        '2020-06-01 00:00:00',
+        '2020-06-01 00:00:00'
+      )
+    `);
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [
+        {
+          memory_id: 'mem_stale',
+          priority: 0.7,
+          reason: 'test seed',
+          due_at: '2026-07-01T00:00:00.000Z',
+          metadata_json: null
+        }
+      ],
+      NOW
+    );
+    const row = db
+      .prepare(`SELECT id FROM memory_review_candidate WHERE memory_id = ? AND status = 'pending'`)
+      .get('mem_stale') as { id: string };
+    pendingId = row.id;
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('GET /admin/memory/review-candidates returns 200 and no memory_item.content field', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/review-candidates');
+      expect(res.statusCode).toBe(200);
+      const json = JSON.parse(res.body) as { candidates: unknown[] };
+      expect(Array.isArray(json.candidates)).toBe(true);
+      const first = json.candidates[0] as Record<string, unknown> | undefined;
+      if (first) {
+        expect(first).not.toHaveProperty('content');
+        expect(first).toHaveProperty('memory_id');
+      }
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/review-candidates?status=bad returns 400', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/review-candidates?status=bad');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('POST review twice returns 409 on second call', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res1 = await postAdminJson(port, `/admin/memory/review-candidates/${pendingId}/review`, {});
+      expect(res1.statusCode).toBe(200);
+      const res2 = await postAdminJson(port, `/admin/memory/review-candidates/${pendingId}/review`, {});
+      expect(res2.statusCode).toBe(409);
+      const j2 = JSON.parse(res2.body) as { code: string };
+      expect(j2.code).toBe('memory_review_candidate_not_actionable');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('POST dismiss for unknown UUID returns 404', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const id = randomUUID();
+      const res = await postAdminJson(port, `/admin/memory/review-candidates/${id}/dismiss`, {});
+      expect(res.statusCode).toBe(404);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('POST review with invalid id returns 400', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await postAdminJson(port, '/admin/memory/review-candidates/not-a-uuid/review', {});
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});
+

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -17,7 +17,9 @@ import {
   TelemetryDailyMetricsMigration,
   MetaMemoryStatsSchemaMigration,
   MemoryReviewCandidateSchemaMigration,
-  upsertPendingMemoryReviewCandidates
+  upsertPendingMemoryReviewCandidates,
+  getBatchScheduler,
+  resetBatchScheduler
 } from '@memento/core';
 
 async function listen(app: express.Express): Promise<{ server: http.Server; port: number }> {
@@ -974,6 +976,7 @@ describe('admin.routes memory review candidates', () => {
 
   function makeApp(database: Database.Database) {
     const app = express();
+    app.use(express.json());
     app.use('/admin', createAdminRouter(database, null));
     return app;
   }
@@ -1096,6 +1099,26 @@ describe('admin.routes memory review candidates', () => {
       expect(res.statusCode).toBe(400);
     } finally {
       await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('POST /admin/batch/run accepts memory_review_candidates (200 with started scheduler)', async () => {
+    resetBatchScheduler();
+    const scheduler = getBatchScheduler();
+    await scheduler.start(db);
+    try {
+      const { server, port } = await listen(makeApp(db));
+      try {
+        const res = await postAdminJson(port, '/admin/batch/run', { jobType: 'memory_review_candidates' });
+        expect(res.statusCode).toBe(200);
+        const body = JSON.parse(res.body) as { result?: { jobType?: string } };
+        expect(body.result?.jobType).toBe('memory_review_candidates');
+      } finally {
+        await new Promise<void>(r => server.close(() => r()));
+      }
+    } finally {
+      await scheduler.stop();
+      resetBatchScheduler();
     }
   });
 });

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -5,6 +5,7 @@
  */
 
 import { Router } from 'express';
+import { validate as uuidValidate } from 'uuid';
 import type Database from 'better-sqlite3';
 import type { ServerServices } from '../bootstrap.js';
 import {
@@ -14,6 +15,11 @@ import {
   MigrateEmbeddingsTool,
   ConvertEpisodicToSemanticTool,
   GetMetaMemoryStatsTool,
+  listMemoryReviewCandidates,
+  markMemoryReviewCandidateReviewed,
+  markMemoryReviewCandidateDismissed,
+  MemoryReviewCandidateError,
+  type MemoryReviewCandidateStatus,
   logger,
   createToolContext
 } from '@memento/core';
@@ -48,6 +54,26 @@ function parseCleanupParams(query: Record<string, unknown>): { olderThanDays: nu
   }
   return { olderThanDays, types };
 }
+
+const MEMORY_REVIEW_STATUSES: MemoryReviewCandidateStatus[] = [
+  'pending',
+  'reviewed',
+  'dismissed',
+  'expired'
+];
+
+function parseReviewCandidateStatusQuery(
+  raw: unknown
+): { status?: MemoryReviewCandidateStatus } | { error: string; status: number } {
+  if (raw === undefined || raw === '') {
+    return {};
+  }
+  if (typeof raw !== 'string' || !MEMORY_REVIEW_STATUSES.includes(raw as MemoryReviewCandidateStatus)) {
+    return { error: 'Invalid status query', status: 400 };
+  }
+  return { status: raw as MemoryReviewCandidateStatus };
+}
+
 
 /**
  * Admin 라우터 생성
@@ -275,6 +301,87 @@ export function createAdminRouter(
     }
   });
 
+
+  router.get('/memory/review-candidates', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const parsed = parseReviewCandidateStatusQuery(req.query['status']);
+      if ('error' in parsed) {
+        return res.status(parsed.status).json({ error: parsed.error });
+      }
+      const rows = listMemoryReviewCandidates(db, parsed.status ? { status: parsed.status } : {});
+      return res.json({
+        message: 'Memory review candidates',
+        candidates: rows,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      logger.error('List review candidates failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to list review candidates',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+  router.post('/memory/review-candidates/:id/review', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { id } = req.params;
+      if (!uuidValidate(id)) {
+        return res.status(400).json({ error: 'Invalid candidate id' });
+      }
+      const nowIso = new Date().toISOString();
+      markMemoryReviewCandidateReviewed(db, id, nowIso);
+      const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
+    } catch (error) {
+      if (error instanceof MemoryReviewCandidateError) {
+        return res.status(error.statusCode).json({ error: error.message, code: error.code });
+      }
+      logger.error('Review candidate review failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to mark reviewed',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+  router.post('/memory/review-candidates/:id/dismiss', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const { id } = req.params;
+      if (!uuidValidate(id)) {
+        return res.status(400).json({ error: 'Invalid candidate id' });
+      }
+      const nowIso = new Date().toISOString();
+      markMemoryReviewCandidateDismissed(db, id, nowIso);
+      const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
+    } catch (error) {
+      if (error instanceof MemoryReviewCandidateError) {
+        return res.status(error.statusCode).json({ error: error.message, code: error.code });
+      }
+      logger.error('Review candidate dismiss failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return res.status(500).json({
+        error: 'Failed to mark dismissed',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
   // 배치 스케줄러 상태
   router.get('/batch/status', async (req, res) => {
     try {
@@ -302,9 +409,9 @@ export function createAdminRouter(
     try {
       const { jobType } = req.body;
 
-      if (!jobType || !['cleanup', 'monitoring'].includes(jobType)) {
+      if (!jobType || !['cleanup', 'monitoring', 'memory_review_candidates'].includes(jobType)) {
         return res.status(400).json({
-          error: 'Invalid job type. Must be "cleanup" or "monitoring"'
+          error: 'Invalid job type. Must be "cleanup", "monitoring", or "memory_review_candidates"'
         });
       }
 


### PR DESCRIPTION
## 요약
GitHub #243 — 리뷰 후보를 HTTP admin으로 조회·review/dismiss하고, `BatchScheduler`가 `memory_review_candidates` 잡으로 선정 결과를 주기적으로 upsert합니다.

## 변경 사항
- **Core**: `memoryReviewCandidatesInterval` 설정, `runMemoryReviewCandidatesJob`, `runJob` / `start` / `restartJob`에 스케줄 등록, 마이그레이션 클래스 re-export(서버 테스트 픽스처)
- **Server**: `GET /admin/memory/review-candidates`, `POST .../:id/review`, `POST .../:id/dismiss`, `POST /admin/batch/run`에 `memory_review_candidates` 허용
- **Tests**: admin 라우트·배치 스케줄러·`/admin/batch/run` 통합
- **Docs**: 설계·구현 계획 (`docs/superpowers/specs/`, `docs/superpowers/plans/`)

## 설계·이슈
- Closes #243 (또는 Fixes — 저장소 컨벤션에 맞게 조정)
- Spec: `docs/superpowers/specs/2026-05-02-issue-243-memory-review-admin-api-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-issue-243-memory-review-admin-api.md`

## 검증
- `npm test`, `npm run lint` 통과

## 참고
- 목록 응답은 큐 메타데이터만 (memory 본문 미포함).
- 후속: `getMemoryReviewCandidateById`로 POST 응답 조회 최적화 가능.

Made with [Cursor](https://cursor.com)