### PR TITLE
docs: 기억 리뷰 MVP API·운영 가이드 (#244)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -205,6 +205,9 @@ const results = await client.callTool({
 | Endpoint | Description | Method |
 |----------|-------------|--------|
 | `/admin/memory/cleanup` | Memory cleanup | POST |
+| `/admin/memory/review-candidates` | Memory review candidate queue | GET |
+| `/admin/memory/review-candidates/:id/review` | Mark review candidate as reviewed | POST |
+| `/admin/memory/review-candidates/:id/dismiss` | Dismiss review candidate | POST |
 | `/admin/stats/forgetting` | Forgetting statistics | GET |
 | `/admin/stats/performance` | Performance statistics | GET |
 | `/admin/stats/errors` | Error statistics | GET |
@@ -212,7 +215,7 @@ const results = await client.callTool({
 | `/admin/alerts/performance` | Performance alerts | GET |
 | `/admin/database/optimize` | Database optimization | POST |
 
-**Other HTTP admin**: Batch status/run (`/admin/batch/*`), performance metrics/alerts (`/admin/performance/*`), relation extract/get/visualize (`/admin/relations/*`). See [docs/api/ko/api-reference.md](docs/api/ko/api-reference.md) (or [docs/api/en/api-reference.md](docs/api/en/api-reference.md) if available).
+**Other HTTP admin**: Batch status/run (`/admin/batch/*`, including `jobType` `memory_review_candidates`), performance metrics/alerts (`/admin/performance/*`), relation extract/get/visualize (`/admin/relations/*`). See [docs/api/en/api-reference.md](docs/api/en/api-reference.md). For the memory review MVP (endpoints, env, batch), use the **"Memory review candidates (MVP)"** section there.
 
 ### Resources
 
@@ -236,6 +239,11 @@ const results = await client.callTool({
 | `EMBEDDING_PROVIDER` | minilm | Embedding provider (tfidf, lightweight, minilm, openai, gemini) |
 | `CORS_ALLOWED_ORIGINS` | (empty) | CORS allowed origins (comma-separated; empty = no cross-origin) |
 | `ENABLE_PII_MASKING` | true | PII masking (security; see [docs/reference/en/security.md](docs/reference/en/security.md)) |
+| `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | Memory review: minimum importance (0-1). Details in [docs/api/en/api-reference.md](docs/api/en/api-reference.md) ("Memory review candidates (MVP)") |
+| `MEMORY_REVIEW_STALE_DAYS` | `14` | Memory review: minimum stale age in days (integer ≥ 1) |
+| `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | Memory review: max candidates from selection (integer ≥ 1) |
+| `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` | `memory_review_candidates` batch interval in ms (minimum `60000`) |
+| `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | Days added when the batch computes `due_at` (1–366) |
 
 > **Note**: For TTL, LLM/Ollama, search limits, and more, see `env.example`.
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,9 @@ const results = await client.callTool({
 | `/admin/memory/cleanup` | 메모리 정리 | POST |
 | `/admin/memory/convert-episodic-to-semantic` | Episodic → Semantic 변환 | POST |
 | `/admin/memory/meta-stats` | 메타 메모리 통계 조회 | GET |
+| `/admin/memory/review-candidates` | 기억 리뷰 후보 목록 | GET |
+| `/admin/memory/review-candidates/:id/review` | 기억 리뷰 후보 처리(리뷰 완료) | POST |
+| `/admin/memory/review-candidates/:id/dismiss` | 기억 리뷰 후보 기각 | POST |
 | `/admin/stats/forgetting` | 망각 통계 조회 | GET |
 
 #### 앵커 관리
@@ -401,7 +404,7 @@ const results = await client.callTool({
 |-----------|------|--------|
 | `/admin/database/optimize` | 데이터베이스 최적화 | POST |
 
-**기타 HTTP admin**: 배치 상태/실행(`/admin/batch/*`), 성능 메트릭·알림(`/admin/performance/*`), 관계 추출·조회·시각화(`/admin/relations/*`) 등은 [docs/api/ko/api-reference.md](docs/api/ko/api-reference.md)를 참고하세요.
+**기타 HTTP admin**: 배치 상태/실행(`/admin/batch/*`, `jobType`에 `memory_review_candidates` 포함), 성능 메트릭·알림(`/admin/performance/*`), 관계 추출·조회·시각화(`/admin/relations/*`) 등은 [docs/api/ko/api-reference.md](docs/api/ko/api-reference.md)를 참고하세요. 기억 리뷰 후보 API·환경 변수·배치 연동은 같은 문서의 **「기억 리뷰 후보 (MVP)」** 절을 참고하세요.
 
 ### Resources
 
@@ -429,6 +432,11 @@ const results = await client.callTool({
 | `CONSOLIDATION_TEST_ITEM_COUNT` | 100 | 벤치마크 테스트 데이터 크기 |
 | `CORS_ALLOWED_ORIGINS` | (비어 있음) | CORS 허용 오리진 (쉼표 구분, 비어 있으면 크로스 오리진 미허용) |
 | `ENABLE_PII_MASKING` | true | PII 마스킹 활성화 (보안, [docs/reference/ko/security.md](docs/reference/ko/security.md) 참고) |
+| `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | 기억 리뷰 후보: 최소 importance (0~1). 상세·예시는 [docs/api/ko/api-reference.md](docs/api/ko/api-reference.md) 「기억 리뷰 후보 (MVP)」 |
+| `MEMORY_REVIEW_STALE_DAYS` | `14` | 기억 리뷰 후보: 최소 stale 일수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | 기억 리뷰 후보: 선정 시 최대 개수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` | 배치 `memory_review_candidates` 스케줄 간격(ms), 최소 `60000` |
+| `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | 배치가 `due_at`에 더하는 일 수 (1~366) |
 
 > **참고**: 망각 TTL, LLM/Ollama, 검색 한도 등 추가 변수는 `env.example`을 참고하세요.
 

--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -693,6 +693,127 @@ Retrieves forgetting statistics.
 }
 ```
 
+#### Memory review candidates (MVP)
+
+Operators and agents can inspect the **review queue** (`memory_review_candidate`) over the HTTP Admin API and call `review` or `dismiss` on a candidate. Rows are refreshed periodically by the `memory_review_candidates` batch job. All routes are mounted under **`/admin`** and require the same **browser session** authentication as other admin endpoints.
+
+> **GitHub #244 note**: Names such as `MEMORY_REVIEW_INTERVAL_MS` or `MEMORY_REVIEW_CANDIDATE_TTL_DAYS` from the issue draft do not match or are not defined in current `main`. The paths and variables below reflect the **runtime**.
+
+##### List candidates
+
+```http
+GET /admin/memory/review-candidates
+GET /admin/memory/review-candidates?status=pending
+```
+
+**Query parameters**
+
+- `status` (optional): `pending` \| `reviewed` \| `dismissed` \| `expired`. Omit to return all statuses.
+
+**Response (200)**
+
+Each element of `candidates` contains only queue metadata (`id`, `memory_id`, `status`, `priority`, `reason`, `due_at`, timestamps, `metadata_json`). **`memory_item.content` and other memory body fields are not included.** Fetch the memory body via another endpoint using `memory_id`.
+
+```json
+{
+  "message": "Memory review candidates",
+  "candidates": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "memory_id": "mem_abc123",
+      "status": "pending",
+      "priority": 0.82,
+      "reason": "stale_high_importance",
+      "due_at": "2026-05-16T12:00:00.000Z",
+      "created_at": "2026-05-02T10:00:00.000Z",
+      "updated_at": "2026-05-02T10:00:00.000Z",
+      "reviewed_at": null,
+      "dismissed_at": null,
+      "metadata_json": "{\"score_breakdown\":{}}"
+    }
+  ],
+  "timestamp": "2026-05-02T12:00:00.000Z"
+}
+```
+
+**Errors**
+
+- `400`: invalid `status` value
+- `500`: database not connected or other server error
+
+##### Mark reviewed
+
+```http
+POST /admin/memory/review-candidates/:id/review
+Content-Type: application/json
+
+{}
+```
+
+**Response (200)**
+
+```json
+{
+  "ok": true,
+  "candidate": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "memory_id": "mem_abc123",
+    "status": "reviewed",
+    "priority": 0.82,
+    "reason": "stale_high_importance",
+    "due_at": "2026-05-16T12:00:00.000Z",
+    "created_at": "2026-05-02T10:00:00.000Z",
+    "updated_at": "2026-05-02T12:00:00.000Z",
+    "reviewed_at": "2026-05-02T12:00:00.000Z",
+    "dismissed_at": null,
+    "metadata_json": null
+  },
+  "timestamp": "2026-05-02T12:00:00.000Z"
+}
+```
+
+**Errors**
+
+- `400`: `:id` is not a UUID
+- `404`: candidate missing — body includes `code`: `memory_review_candidate_not_found`
+- `409`: not `pending` (e.g. double submit) — `code`: `memory_review_candidate_not_actionable`
+- `500`: other server error
+
+##### Dismiss candidate
+
+```http
+POST /admin/memory/review-candidates/:id/dismiss
+Content-Type: application/json
+
+{}
+```
+
+Responses and error mapping match **Mark reviewed**; on success `status` becomes `dismissed`.
+
+##### Batch: select and upsert queue
+
+```http
+POST /admin/batch/run
+Content-Type: application/json
+
+{ "jobType": "memory_review_candidates" }
+```
+
+- The `BatchScheduler` job registered as `memory_review_candidates` runs the same logic on `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS`.
+- `jobType` must be one of the allowed values (e.g. `cleanup`, `monitoring`, `memory_review_candidates`); invalid values return **400**.
+
+##### Environment variables (memory review MVP)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | Minimum importance for candidacy (0–1; invalid values fall back to default) |
+| `MEMORY_REVIEW_STALE_DAYS` | `14` | Minimum stale age in days (integer ≥ 1) |
+| `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | Max candidates from selection / upsert path (integer ≥ 1) |
+| `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` (24h) | Scheduler interval for `memory_review_candidates` in ms (minimum `60000`) |
+| `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | Days added to “now” when the batch computes each row’s `due_at` (1–366) |
+
+Tune **selection sensitivity** with the first three variables; tune **schedule cadence and due dates** with the last two.
+
 ### Performance Monitoring API
 
 #### Performance Statistics

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -813,6 +813,127 @@ GET /admin/stats/forgetting
 }
 ```
 
+#### 기억 리뷰 후보 (MVP)
+
+에이전트/운영자가 **리뷰 큐**(`memory_review_candidate`)를 HTTP Admin으로 조회하고, `review` 또는 `dismiss`로 처리합니다. 후보 행은 배치 작업 `memory_review_candidates`가 주기적으로 선정·갱신합니다. 모든 경로는 **`/admin` 마운트**와 기존과 동일한 **브라우저 세션** 인증 하에서만 동작합니다.
+
+> **GitHub #244 참고**: 이슈 초안에 등장한 `MEMORY_REVIEW_INTERVAL_MS`, `MEMORY_REVIEW_CANDIDATE_TTL_DAYS` 등은 현재 `main` 코드와 이름이 다르거나 정의되어 있지 않습니다. 아래 환경 변수와 경로는 **런타임 기준**입니다.
+
+##### 후보 목록
+
+```http
+GET /admin/memory/review-candidates
+GET /admin/memory/review-candidates?status=pending
+```
+
+**쿼리 파라미터**
+
+- `status` (선택): `pending` \| `reviewed` \| `dismissed` \| `expired`. 생략 시 전체 상태.
+
+**응답 (200)**
+
+`candidates` 배열 원소는 큐 테이블 메타(`id`, `memory_id`, `status`, `priority`, `reason`, `due_at`, 타임스탬프, `metadata_json`)만 포함합니다. **`memory_item.content` 등 기억 본문은 포함하지 않습니다.** 본문이 필요하면 `memory_id`로 다른 메모리 조회 API를 사용합니다.
+
+```json
+{
+  "message": "Memory review candidates",
+  "candidates": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "memory_id": "mem_abc123",
+      "status": "pending",
+      "priority": 0.82,
+      "reason": "stale_high_importance",
+      "due_at": "2026-05-16T12:00:00.000Z",
+      "created_at": "2026-05-02T10:00:00.000Z",
+      "updated_at": "2026-05-02T10:00:00.000Z",
+      "reviewed_at": null,
+      "dismissed_at": null,
+      "metadata_json": "{\"score_breakdown\":{}}"
+    }
+  ],
+  "timestamp": "2026-05-02T12:00:00.000Z"
+}
+```
+
+**에러**
+
+- `400`: 잘못된 `status` 값
+- `500`: DB 미연결 등 서버 오류
+
+##### 후보 리뷰 완료
+
+```http
+POST /admin/memory/review-candidates/:id/review
+Content-Type: application/json
+
+{}
+```
+
+**응답 (200)**
+
+```json
+{
+  "ok": true,
+  "candidate": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "memory_id": "mem_abc123",
+    "status": "reviewed",
+    "priority": 0.82,
+    "reason": "stale_high_importance",
+    "due_at": "2026-05-16T12:00:00.000Z",
+    "created_at": "2026-05-02T10:00:00.000Z",
+    "updated_at": "2026-05-02T12:00:00.000Z",
+    "reviewed_at": "2026-05-02T12:00:00.000Z",
+    "dismissed_at": null,
+    "metadata_json": null
+  },
+  "timestamp": "2026-05-02T12:00:00.000Z"
+}
+```
+
+**에러**
+
+- `400`: `:id`가 UUID 형식이 아님
+- `404`: 후보 없음 — 본문에 `code`: `memory_review_candidate_not_found` 포함
+- `409`: `pending`이 아님(재호출 등) — `code`: `memory_review_candidate_not_actionable`
+- `500`: 그 외 서버 오류
+
+##### 후보 기각
+
+```http
+POST /admin/memory/review-candidates/:id/dismiss
+Content-Type: application/json
+
+{}
+```
+
+응답·에러 매핑은 **리뷰 완료**와 동일하며, 성공 시 `status`가 `dismissed`로 갱신됩니다.
+
+##### 배치: 후보 선정·큐 갱신
+
+```http
+POST /admin/batch/run
+Content-Type: application/json
+
+{ "jobType": "memory_review_candidates" }
+```
+
+- 스케줄러에 등록된 주기(`BatchScheduler`의 `memory_review_candidates` 작업)로도 동일 로직이 실행됩니다.
+- `jobType`으로 `cleanup`, `monitoring`, `memory_review_candidates` 등 허용된 값만 전달할 수 있습니다(잘못된 값은 400).
+
+##### 환경 변수 (기억 리뷰 MVP)
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | 후보로 고려할 최소 importance (0~1; 잘못된 값은 기본값으로 대체) |
+| `MEMORY_REVIEW_STALE_DAYS` | `14` | 최소 stale 일수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | 선정 단계에서 반환·큐에 반영할 최대 후보 수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` (24h) | 배치 `memory_review_candidates` 스케줄 간격(ms). 최소 `60000` |
+| `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | 배치가 `due_at`을 계산할 때 기준 시각에 더하는 일 수 (1~366) |
+
+운영 시 **후보 선정 민감도**는 위 표의 앞 세 변수로, **스케줄 간격·마감 시각**은 마지막 두 변수로 조정합니다.
+
 ### 성능 모니터링 API
 
 #### 성능 통계


### PR DESCRIPTION
Closes #244

## 요약
- `docs/api/ko/api-reference.md`, `docs/api/en/api-reference.md`에 기억 리뷰 후보(MVP) HTTP 계약, 예시 응답, 배치 `memory_review_candidates`, 환경 변수 표를 추가했습니다. 변수 이름은 런타임(`main`) 기준이며, 이슈 #244 초안과 다른 점은 문서에 짧게 명시했습니다.
- `README.md`, `README.en.md`의 HTTP admin 표와 환경 변수 표를 확장하고 API 참조로 연결했습니다.

## 참고
- `npm run docs:audit-links`는 저장소 내 기존 깨진 링크 때문에 전체가 실패할 수 있습니다. 본 PR에서 수정한 경로에서 새로 추가된 깨진 링크는 없습니다.

## 작업 위치
- 브랜치: `docs/issue-244-memory-review-docs` (워크트리에서 푸시)

Made with [Cursor](https://cursor.com)