### PR TITLE
docs(integrations): L1 guide upgrade — @memento/assistant SDK sections

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -61,6 +61,8 @@ http://localhost:9001/graph
 
 Personal AI assistants like OpenClaw, NanoClaw, and ZeroClaw can use Memento as a shared long-term memory backend. Guide: [docs/integrations/](./docs/integrations/README.md)
 
+Use the `@memento/assistant` SDK for deterministic auto recall/remember with just two hooks — [SDK quickstart](./docs/integrations/_shared/sdk-quickstart.md)
+
 ## 🚀 Quick Start
 
 ### 🥇 **One-click Installation (Recommended)**

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ http://localhost:9001/graph
 
 OpenClaw / NanoClaw / ZeroClaw 같은 개인 AI 비서가 Memento를 공유 장기 기억 백엔드로 사용할 수 있습니다. 가이드: [docs/integrations/](./docs/integrations/README.md)
 
+`@memento/assistant` SDK를 사용하면 자동 recall/remember를 코드 두 줄로 붙일 수 있습니다 — [SDK quickstart](./docs/integrations/_shared/sdk-quickstart.md)
+
 ## 🚀 빠른 시작
 
 ### 🥇 **원클릭 설치 (권장)**

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -22,4 +22,8 @@
 
 ## 더 깊은 통합 (옵션)
 
-베어 MCP만으로 부족하면 `@memento/assistant` SDK를 사용해 *결정론적 자동 회상/저장*을 얻을 수 있습니다. v0.2에서 별도 가이드 추가 예정.
+베어 MCP만으로 부족하면 `@memento/assistant` SDK를 사용해 *결정론적 자동 회상/저장*을 얻을 수 있습니다.
+
+- **빠른 시작**: [`_shared/sdk-quickstart.md`](./_shared/sdk-quickstart.md)
+- Node.js / TypeScript 비서에서 두 개의 훅(`beforeUserTurn` / `afterAssistantTurn`)만 붙이면 됩니다.
+- ZeroClaw(Rust)는 Node.js SDK를 직접 사용할 수 없으며, 베어 MCP + 시스템 프롬프트 패턴을 권장합니다.

--- a/docs/integrations/_shared/sdk-quickstart.md
+++ b/docs/integrations/_shared/sdk-quickstart.md
@@ -1,0 +1,179 @@
+# `@memento/assistant` SDK Quickstart
+
+이 문서는 `@memento/assistant` SDK를 사용해 외부 비서에 Memento 장기기억을 붙이는 방법을 다룹니다. 베어 MCP 방식과의 차이, stdio/HTTP 빠른 시작, 라이프사이클 훅 통합 위치, 환경변수 레퍼런스, 그리고 Memento가 다운돼도 비서가 멈추지 않는 degraded 모드까지 순서대로 안내합니다.
+
+---
+
+## 1. 왜 SDK인가 — 베어 MCP와의 차이
+
+베어 MCP 방식은 비서의 LLM이 `recall`·`remember` 도구를 **자기 의지로** 호출하는 구조입니다. 즉 LLM이 깜빡이면 기억을 불러오거나 저장하지 않습니다. SDK는 이 호출을 비서 루프에서 **결정론적으로 자동화**합니다.
+
+| 특성 | 베어 MCP | @memento/assistant SDK |
+|------|---------|------------------------|
+| 회상 트리거 | LLM 자기 의지 | 매 턴 자동 |
+| 저장 트리거 | LLM 자기 의지 | 매 턴 자동 |
+| 실패 처리 | LLM이 에러 처리 필요 | 내장 서킷브레이커 + 리트라이 |
+| 비서 언어 | 어떤 언어든 (TOML/JSON config만) | Node.js / TypeScript 필수 |
+| Rust(ZeroClaw) | ✅ | ❌ (v0.2+ 예정) |
+
+> ZeroClaw 등 Node.js 이외의 비서는 베어 MCP 방식만 사용할 수 있습니다. [`../zeroclaw.md`](../zeroclaw.md) 참고.
+
+---
+
+## 2. 5분: stdio quickstart
+
+설치:
+
+```bash
+npm install @memento/assistant
+```
+
+환경변수를 별도로 설정하지 않으면 SDK는 `npx -y memento-mcp-server@latest`를 자식 프로세스로 자동 기동합니다. 로컬에서 빠르게 시작하는 가장 간단한 경로입니다.
+
+```ts
+import { MementoAssistant } from '@memento/assistant';
+
+const memory = MementoAssistant.fromEnv(
+  { ownerId: 'user-123', channel: 'telegram' },
+  process.env,
+);
+
+const ctx = await memory.beforeUserTurn({
+  userMessage: '내 생일이 언제야?',
+  conversationId: 'conv-abc',
+});
+
+const systemPrompt = ctx.systemContext
+  ? `${baseSystemPrompt}\n\n${ctx.systemContext}`
+  : baseSystemPrompt;
+
+await memory.afterAssistantTurn({
+  userMessage: '내 생일이 언제야?',
+  assistantReply: '5월 10일이에요.',
+  conversationId: 'conv-abc',
+});
+```
+
+`ctx.systemContext`가 비어 있지 않을 때의 실제 포맷은 다음과 같습니다:
+
+```
+<memento>
+- 기억 내용 1
+- 기억 내용 2
+</memento>
+```
+
+이 블록을 base 시스템 프롬프트 뒤에 이어붙이면 LLM이 이전 기억을 바탕으로 응답합니다.
+
+---
+
+## 3. 30분: HTTP quickstart
+
+Memento 서버가 이미 떠 있는 환경(홈서버, NanoClaw 컨테이너 등)이라면 HTTP 트랜스포트를 권장합니다.
+
+```bash
+export MEMENTO_TRANSPORT=http
+export MEMENTO_URL=http://localhost:9001
+export MEMENTO_TOKEN=<admin-api-key>
+```
+
+NanoClaw 컨테이너 안에서 호스트의 Memento 서버에 연결할 때는 다음을 사용하세요:
+
+```bash
+export MEMENTO_URL=http://host.docker.internal:9001
+```
+
+나머지 코드는 stdio 예제와 완전히 동일합니다. `MementoAssistant.fromEnv`가 환경변수를 읽어 트랜스포트를 자동으로 선택합니다.
+
+```ts
+import { MementoAssistant } from '@memento/assistant';
+
+const memory = MementoAssistant.fromEnv(
+  { ownerId: 'user-123', channel: 'telegram' },
+  process.env,
+);
+
+// 이후 코드는 stdio quickstart와 동일
+```
+
+---
+
+## 4. 라이프사이클 훅 통합 위치
+
+SDK 훅을 비서 루프의 **정확한 위치**에 삽입하는 것이 핵심입니다.
+
+```ts
+// 비서 루프 의사코드
+while (true) {
+  const userMessage = await receiveMessage();
+
+  // ① beforeUserTurn — LLM 호출 직전
+  const ctx = await memory.beforeUserTurn({ userMessage, conversationId });
+  const systemPrompt = ctx.systemContext
+    ? `${basePrompt}\n\n${ctx.systemContext}`
+    : basePrompt;
+
+  const reply = await llm.chat({ systemPrompt, userMessage });
+  await sendReply(reply);
+
+  // ② afterAssistantTurn — 응답 전송 직후
+  await memory.afterAssistantTurn({ userMessage, assistantReply: reply, conversationId });
+}
+```
+
+**중요**: `beforeUserTurn`이 반환한 `ctx`는 **해당 턴의 LLM 호출에만** 사용하세요. 다음 턴에 재사용하면 기억이 오래된 상태로 고정됩니다.
+
+---
+
+## 5. 환경변수 표
+
+| 환경변수 | 설명 |
+|----------|------|
+| `MEMENTO_TRANSPORT` | `stdio`(기본) 또는 `http` |
+| `MEMENTO_URL` | HTTP 서버 URL |
+| `MEMENTO_TOKEN` | HTTP 인증 토큰 |
+| `MEMENTO_STDIO_COMMAND` | stdio 커스텀 명령 (기본: `npx -y memento-mcp-server@latest`) |
+| `MEMENTO_OWNER_ID` | `ownerId` 기본값 |
+| `MEMENTO_CHANNEL` | `channel` 기본값 |
+| `MEMENTO_ASSISTANT_LOG` | `off`(기본) / `warn` / `info` / `debug` |
+
+`fromEnv` 옵션(`ownerId`, `channel` 등)이 환경변수보다 우선합니다. 운영 환경에서는 환경변수로 관리하고, 개발·테스트에서는 옵션 객체로 직접 전달하는 방식이 일반적입니다.
+
+`Policy` 기본값:
+
+| 필드 | 기본값 | 선택 가능 값 |
+|------|--------|-------------|
+| `autoRecall` | `'always'` | `'always'` \| `'heuristic'` \| `'off'` |
+| `autoRemember` | `'turn'` | `'turn'` \| `'decision'` \| `'off'` |
+| `crossChannelRecall` | `'on'` | `'on'` \| `'off'` |
+| `recallLimit` | `8` | — |
+| `recallTimeoutMs` | `1500` | — |
+| `degradeOnError` | `true` | — |
+| `tokenBudget` | `1200` | — |
+
+---
+
+## 6. Degraded 모드 — 비서가 죽지 않는다
+
+SDK는 **절대 throw하지 않습니다**. Memento 서버가 다운되거나 타임아웃이 발생해도 비서 루프는 계속 동작합니다.
+
+```ts
+const ctx = await memory.beforeUserTurn({ userMessage, conversationId });
+if (ctx.degraded) {
+  // 기억 없이 계속 진행 — 비서가 멈추지 않음
+}
+```
+
+`afterAssistantTurn`도 마찬가지입니다. 저장에 실패하면 RetryQueue에서 최대 3회 재시도하고, 모두 실패할 경우 조용히 drop합니다.
+
+**서킷브레이커**: 연속 5회 실패 시 서킷이 open 상태로 전환되어 30초 동안 Memento 호출을 건너뜁니다. 30초 후 half-open 상태로 전환되어 다음 요청으로 복구를 시도합니다. 이 동작은 `degradeOnError: true`(기본값)일 때 활성화됩니다.
+
+---
+
+## 7. 다음 단계
+
+- [OpenClaw 가이드](../openclaw.md)
+- [NanoClaw 가이드](../nanoclaw.md)
+- [ZeroClaw 가이드](../zeroclaw.md) (SDK 미지원 — 베어 MCP 사용)
+- [시스템 프롬프트 패턴](./system-prompt.md)
+- [통합 가이드 허브](../README.md)

--- a/docs/integrations/_shared/system-prompt.md
+++ b/docs/integrations/_shared/system-prompt.md
@@ -163,3 +163,19 @@ Memento는 **augmentation**이지 **dependency**가 아닙니다. 서버가 죽�
 - [NanoClaw 가이드](../nanoclaw.md) — 컨테이너 멀티채널 비서 통합
 - [ZeroClaw 가이드](../zeroclaw.md) — 24/7 무인 봇 통합
 - [통합 가이드 허브](../README.md) — 처음으로 돌아가기
+
+---
+
+## 한 단계 더: `@memento/assistant` 사용 시
+
+SDK가 매 턴 `<memento>...</memento>` 펜스 블록을 자동으로 만들어 시스템 프롬프트에 합성합니다.
+이 경우 위의 권장 프롬프트는 *짧아져도* 됩니다 — recall 호출 의지를 LLM에 부탁할 필요가 없으니까요.
+
+권장 SDK용 시스템 프롬프트:
+```
+당신은 사용자의 개인 비서입니다. 시스템 프롬프트에 포함된 <memento>...</memento> 블록은
+이 사용자에 관해 이전에 알게 된 사실/선호/사건의 회상입니다. 답변에 적극 활용하세요.
+없으면 그냥 답변하세요.
+```
+
+자동 저장 정책 옵션은 [`./sdk-quickstart.md`](./sdk-quickstart.md) 참조.

--- a/docs/integrations/nanoclaw.md
+++ b/docs/integrations/nanoclaw.md
@@ -178,6 +178,64 @@ NanoClaw 자체 로그 위치(agent group 컨테이너의 stdout, journald, 또�
 
 ---
 
+## 한 단계 더: `@memento/assistant`로 자동 회상/저장
+
+베어 MCP로 기본 통합이 완료됐다면 `@memento/assistant` SDK를 추가해 **매 턴 결정론적 자동 recall/remember**를 얻을 수 있습니다.
+
+### NanoClaw 컨테이너에서 사용 시 주의
+
+NanoClaw는 컨테이너 기반이므로 SDK는 **컨테이너 내부에서 import**합니다. stdio child spawn은 컨테이너 격리와 충돌하므로 반드시 **HTTP transport를 사용**하세요.
+
+```bash
+# NanoClaw 컨테이너의 .env.local 또는 환경변수
+MEMENTO_TRANSPORT=http
+MEMENTO_URL=http://host.docker.internal:9001
+MEMENTO_TOKEN=<admin-api-key>
+```
+
+```ts
+import { MementoAssistant } from '@memento/assistant';
+
+const memory = MementoAssistant.fromEnv(
+  {
+    ownerId: agentGroup.name,  // NanoClaw agent group 이름 → ownerId
+    channel: moduleId,         // 채널 모듈 이름 → channel
+  },
+  process.env,
+);
+
+// agent 메시지 핸들러
+async function handleMessage(msg) {
+  const ctx = await memory.beforeUserTurn({
+    userMessage: msg.content,
+    conversationId: msg.sessionId,
+  });
+
+  const systemPrompt = ctx.systemContext
+    ? `${basePrompt}\n\n${ctx.systemContext}`
+    : basePrompt;
+
+  const reply = await agent.chat({ systemPrompt, userMessage: msg.content });
+
+  await memory.afterAssistantTurn({
+    userMessage: msg.content,
+    assistantReply: reply,
+    conversationId: msg.sessionId,
+  });
+}
+```
+
+### 식별자 매핑
+
+| Memento 파라미터 | NanoClaw 소스 | 예시 |
+|----------------|--------------|------|
+| `ownerId` | agent group 이름 | `'personal-assistant'` |
+| `channel` | 채널 모듈 이름 | `'telegram-bot'`, `'slack-app'` |
+
+환경변수 및 Policy 옵션은 [`_shared/sdk-quickstart.md`](./_shared/sdk-quickstart.md) 참조.
+
+---
+
 ## 다음 단계
 
 - [`./_shared/transports.md`](./_shared/transports.md) — stdio·HTTP 트랙 결정과 마이그레이션

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -147,6 +147,64 @@ OpenClaw 고유의 함정 두 가지를 짚어 둡니다.
 
 ---
 
+## 한 단계 더: `@memento/assistant`로 자동 회상/저장
+
+베어 MCP로 기본 통합이 완료됐다면 `@memento/assistant` SDK를 추가해 **매 턴 결정론적 자동 recall/remember**를 얻을 수 있습니다.
+
+### 게이트웨이 레벨 통합 (권장)
+
+skill 레벨에 개별 통합하면 매 skill마다 중복 코드가 생깁니다. **게이트웨이 메시지 파이프라인에 한 번** 붙이는 편이 효율적입니다.
+
+```ts
+import { MementoAssistant } from '@memento/assistant';
+
+const memory = MementoAssistant.fromEnv(
+  {
+    ownerId: gatewayUser.id,   // OpenClaw gateway user ID → ownerId
+    channel: adapterName,      // 어댑터 이름 (예: 'telegram', 'slack', 'discord')
+  },
+  process.env,
+);
+
+// 게이트웨이 메시지 핸들러
+async function handleMessage(msg) {
+  const conversationId = msg.conversationId ?? msg.channelId;
+
+  // ① 메시지 수신 후, LLM 호출 직전
+  const ctx = await memory.beforeUserTurn({
+    userMessage: msg.content,
+    conversationId,
+  });
+
+  const systemPrompt = ctx.systemContext
+    ? `${gatewayBasePrompt}\n\n${ctx.systemContext}`
+    : gatewayBasePrompt;
+
+  const reply = await gateway.llm.chat({ systemPrompt, userMessage: msg.content });
+  await gateway.send(reply);
+
+  // ② 응답 전송 직후
+  await memory.afterAssistantTurn({
+    userMessage: msg.content,
+    assistantReply: reply,
+    conversationId,
+  });
+}
+```
+
+### 식별자 매핑
+
+| Memento 파라미터 | OpenClaw 소스 | 예시 |
+|----------------|--------------|------|
+| `ownerId` | 게이트웨이 통합 user 객체의 안정적 ID | `'user_42'` |
+| `channel` | 어댑터 이름 또는 채널 종류 | `'telegram'`, `'slack'` |
+
+`ownerId`에는 raw 플랫폼 ID(텔레그램 `123456789` 등) 대신 **게이트웨이가 통합 관리하는 user ID**를 쓰세요. 같은 사람이 telegram·slack 두 채널에서 쓴 기억이 모두 같은 `ownerId` 아래에 모입니다.
+
+환경변수 및 Policy 옵션은 [`_shared/sdk-quickstart.md`](./_shared/sdk-quickstart.md) 참조.
+
+---
+
 ## 다음 단계
 
 - [`./_shared/transports.md`](./_shared/transports.md) — stdio·HTTP 트랙 결정과 마이그레이션

--- a/docs/integrations/zeroclaw.md
+++ b/docs/integrations/zeroclaw.md
@@ -123,6 +123,15 @@ curl -i -H "Authorization: Bearer $MEMENTO_TOKEN" \
 
 ---
 
+## SDK 사용에 관해
+
+ZeroClaw는 Rust 바이너리이므로 Node.js 기반 `@memento/assistant`를 직접 import 할 수 없습니다.
+v0.1에서는 베어 MCP 등록(stdio 또는 HTTP) + 권장 시스템 프롬프트 패턴으로 자동 회상/저장의 약 80%를 얻을 수 있습니다 ([`./_shared/system-prompt.md`](./_shared/system-prompt.md)).
+
+Rust 측 포팅(예: `memento-assistant-rs`)은 v0.2+ 로드맵 항목입니다. 트래킹 이슈가 열리면 여기에 링크합니다.
+
+---
+
 ## 다음 단계
 
 - [`./_shared/transports.md`](./_shared/transports.md) — stdio·HTTP 트랙 결정과 마이그레이션


### PR DESCRIPTION
## Summary

- `docs/integrations/_shared/sdk-quickstart.md` 신설 (L3 SDK 5분/30분 quickstart)
- `_shared/system-prompt.md` — SDK 사용 시 권장 프롬프트 섹션 추가
- `openclaw.md` — 게이트웨이 레벨 SDK 통합 섹션 추가
- `nanoclaw.md` — 컨테이너 환경 HTTP-only SDK 통합 섹션 추가
- `zeroclaw.md` — SDK 미적용 사유(Rust 바이너리) + v0.2+ Rust 포트 예고
- `docs/integrations/README.md` — "더 깊은 통합" 섹션을 실제 링크로 교체
- root `README.md` / `README.en.md` — SDK quickstart 링크 추가

Spec: `docs/superpowers/specs/2026-04-27-external-assistant-integration-design.md`
Plan: `docs/superpowers/plans/2026-04-27-external-assistant-l3-sdk.md` (Phase 3, Tasks 22-29)

## Test plan
- [x] `npm test` 전체 통과 (317 파일, 4158 tests, 1 skipped)
- [x] `npm run lint` 통과 (warnings only, 0 errors)
- [x] `npm run type-check` 통과
- [ ] OpenClaw / NanoClaw 가이드의 SDK 스니펫을 실제 비서에서 시도 (수동 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)