### PR TITLE
feat(admin): 리뷰 후보 행 메모리 프리뷰 (#253)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -208,6 +208,7 @@ const results = await client.callTool({
 |----------|-------------|--------|
 | `/admin/memory/cleanup` | Memory cleanup | POST |
 | `/admin/memory/review-candidates` | Memory review candidate queue | GET |
+| `/admin/memory/items/:memory_id` | Single memory JSON preview (dashboard, etc.) | GET |
 | `/admin/memory/review-candidates/:id/review` | Mark review candidate as reviewed | POST |
 | `/admin/memory/review-candidates/:id/dismiss` | Dismiss review candidate | POST |
 | `/admin/stats/forgetting` | Forgetting statistics | GET |

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ const results = await client.callTool({
 | `/admin/memory/convert-episodic-to-semantic` | Episodic → Semantic 변환 | POST |
 | `/admin/memory/meta-stats` | 메타 메모리 통계 조회 | GET |
 | `/admin/memory/review-candidates` | 기억 리뷰 후보 목록 | GET |
+| `/admin/memory/items/:memory_id` | 단일 기억 프리뷰(JSON, 대시보드 등) | GET |
 | `/admin/memory/review-candidates/:id/review` | 기억 리뷰 후보 처리(리뷰 완료) | POST |
 | `/admin/memory/review-candidates/:id/dismiss` | 기억 리뷰 후보 기각 | POST |
 | `/admin/stats/forgetting` | 망각 통계 조회 | GET |

--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -741,6 +741,47 @@ Each element of `candidates` contains only queue metadata (`id`, `memory_id`, `s
 - `400`: invalid `status` value
 - `500`: database not connected or other server error
 
+##### Single memory preview (Admin)
+
+When the review queue list omits body text, fetch one `memory_item` row by `memory_id` (e.g. for the dashboard preview pane).
+
+```http
+GET /admin/memory/items/:memory_id
+```
+
+- `:memory_id` must be URL-encoded and match **`mem_` + letters, digits, or `_`**. Anything else returns **400**.
+- Soft-deleted memories (`is_deleted = 1`) return **404**.
+
+**Response (200)**
+
+```json
+{
+  "message": "Memory item",
+  "memory": {
+    "id": "mem_abc123",
+    "type": "semantic",
+    "content": "…",
+    "importance": 0.82,
+    "privacy_scope": "private",
+    "pinned": false,
+    "created_at": "2026-05-02T10:00:00.000Z",
+    "last_accessed": null,
+    "last_accessed_at": null,
+    "tags": null,
+    "source": null,
+    "project_id": null,
+    "owner_id": null
+  },
+  "timestamp": "2026-05-03T12:00:00.000Z"
+}
+```
+
+**Errors**
+
+- `400`: invalid `memory_id` format
+- `404`: not found or deleted
+- `500`: database not connected or other server error
+
 ##### Mark reviewed
 
 ```http

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -861,6 +861,47 @@ GET /admin/memory/review-candidates?status=pending
 - `400`: 잘못된 `status` 값
 - `500`: DB 미연결 등 서버 오류
 
+##### 단일 기억 프리뷰 (Admin)
+
+리뷰 후보 목록에 본문이 없을 때, 대시보드 등에서 `memory_id`로 **`memory_item` 한 행**을 조회합니다.
+
+```http
+GET /admin/memory/items/:memory_id
+```
+
+- `:memory_id`는 URL 인코딩된 문자열이며, **`mem_` + 영문·숫자·밑줄(`_`)** 패턴만 허용합니다. 그 외 형식은 `400`입니다.
+- 소프트 삭제(`is_deleted = 1`)된 기억은 `404`입니다.
+
+**응답 (200)**
+
+```json
+{
+  "message": "Memory item",
+  "memory": {
+    "id": "mem_abc123",
+    "type": "semantic",
+    "content": "…",
+    "importance": 0.82,
+    "privacy_scope": "private",
+    "pinned": false,
+    "created_at": "2026-05-02T10:00:00.000Z",
+    "last_accessed": null,
+    "last_accessed_at": null,
+    "tags": null,
+    "source": null,
+    "project_id": null,
+    "owner_id": null
+  },
+  "timestamp": "2026-05-03T12:00:00.000Z"
+}
+```
+
+**에러**
+
+- `400`: 잘못된 `memory_id` 형식
+- `404`: 해당 ID 없음 또는 삭제됨
+- `500`: DB 미연결 등 서버 오류
+
 ##### 후보 리뷰 완료
 
 ```http

--- a/docs/superpowers/plans/2026-05-03-issue-253-memory-review-preview.md
+++ b/docs/superpowers/plans/2026-05-03-issue-253-memory-review-preview.md
@@ -1,0 +1,66 @@
+# Issue #253 — Memory review row preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add admin `GET /admin/memory/items/:memory_id` and dashboard Review Queue row selection with a responsive preview panel showing full reason/due and memory `content`.
+
+**Architecture:** Core holds SQL + id validation; Express admin router exposes JSON; static `review-candidates-panel.js` fetches preview on row activate; CSS grid stacks on narrow viewports.
+
+**Tech Stack:** TypeScript, better-sqlite3, Express, Vitest, vanilla JS, design tokens.
+
+---
+
+### Task 1: Core preview service
+
+**Files:**
+
+- Create: `packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts`
+- Create: `packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts`
+- Modify: `packages/memento-core/src/index.ts` (re-export)
+
+- [x] Implement `parseAdminMemoryItemIdParam` and `getAdminMemoryItemPreviewById`.
+- [x] Vitest: valid id, invalid id, found row, deleted row → null.
+
+### Task 2: Admin HTTP route
+
+**Files:**
+
+- Modify: `packages/memento-server/src/server/routes/admin.routes.ts`
+- Modify: `packages/memento-server/src/server/routes/admin.routes.spec.ts` (extend in-memory `memory_item` with `owner_id` if needed)
+
+- [x] `GET /admin/memory/items/:memory_id` → 200 JSON, 400, 404, 500 paths.
+- [x] Log without body content.
+
+### Task 3: Dashboard markup & styles
+
+**Files:**
+
+- Modify: `static/dashboard.html`
+- Modify: `static/css/dashboard.css`
+
+- [x] Two-column body + preview aside + placeholder/detail regions.
+- [x] Responsive single column ≤56rem.
+
+### Task 4: Panel JavaScript
+
+**Files:**
+
+- Modify: `static/js/review-candidates-panel.js`
+
+- [x] Render clickable rows with `data-*` for meta; fetch preview URL; loading/error in preview strip.
+- [x] Refresh clears selection.
+
+### Task 5: Wire tests & docs
+
+**Files:**
+
+- Modify: `packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts`
+- Modify: `docs/api/ko/api-reference.md`, `docs/api/en/api-reference.md`, `README.md`, `README.en.md`
+
+- [x] Static asset string expectations.
+- [x] API reference + README table row.
+
+### Task 6: Verification
+
+- [x] `npx vitest run` on touched specs.
+- [x] `npm run build` (workspace) before merge.

--- a/docs/superpowers/specs/2026-05-03-issue-253-memory-review-preview-design.md
+++ b/docs/superpowers/specs/2026-05-03-issue-253-memory-review-preview-design.md
@@ -1,0 +1,57 @@
+# 설계: 이슈 #253 — 후보 행 상세·메모리 프리뷰
+
+**날짜**: 2026-05-03  
+**이슈**: [GitHub #253](https://github.com/jee1/memento/issues/253)  
+**상위**: [#245](https://github.com/jee1/memento/issues/245)  
+**선행**: [#252](https://github.com/jee1/memento/issues/252)
+
+---
+
+## 1. 목표·비목표
+
+**목표**
+
+- 리뷰 후보 **행 선택** 시 우측(넓은 화면) 또는 **표 아래(좁은 화면)** 고정 **프리뷰 패널**에 다음을 표시한다.
+  - 큐 메타: `priority`, 전체 `reason`, `due_at`(로컬 가독 형식), `memory_id`
+  - 기억 본문: `GET /admin/memory/items/:memory_id` 응답의 `memory.content` 및 동봉 메타 필드
+- 목록 테이블의 `reason`은 **줄임(문자 상한 + CSS line-clamp)** 으로 겹침을 줄이고, 전문은 패널에서만 본다.
+- 스타일은 `static/css/tokens.css`·기존 `dashboard.css` 패턴을 따른다.
+
+**비목표 (#253 밖)**
+
+- `review` / `dismiss` POST UI → [#254](https://github.com/jee1/memento/issues/254)
+- 실시간 알림 → [#255](https://github.com/jee1/memento/issues/255)
+
+---
+
+## 2. Admin API: 단일 기억 프리뷰
+
+- **경로**: `GET /admin/memory/items/:memory_id`
+- **검증**: `:memory_id`는 `mem_[A-Za-z0-9_]{1,220}` (URL 디코드 후 검사). 불일치 시 `400`.
+- **조회**: `memory_item`에서 본문·메타 일부를 SELECT. `is_deleted = 1` 또는 없으면 `404`.
+- **로그**: `memory_id`만 기록, `content` 전문 미기록 (#243 정합).
+- **구현 위치**: `@memento/core`의 `admin-memory-item-preview-service.ts` + `memento-server` `admin.routes.ts`.
+
+---
+
+## 3. 대시보드 UI
+
+- **레이아웃**: `.review-candidates-body` 그리드 — `1fr | minmax(12rem, 28rem)`; `max-width: 56rem` 이하에서 **1열**(표 아래 패널).
+- **상호작용**: `tbody` 위임으로 `tr` 클릭 또는 Enter/Space(포커스 가능 행). 선택 행 `rc-row--selected` + `aria-selected`.
+- **클라이언트**: `mementoAdminFetch`로 목록·프리뷰 모두 호출. 프리뷰 URL은 `encodeURIComponent(memory_id)` 사용.
+- **새로고침**: 목록 재로드 시 선택·프리뷰 초기화.
+
+---
+
+## 4. 완료 조건 (#253 정합)
+
+- 행 선택 시 메모리 프리뷰(본문)가 표시된다.
+- 모바일·데스크톱에서 텍스트 겹침 없이 표시된다(#245 AC) — `pre-wrap`, `word-break`, 패널 `max-height`+스크롤.
+
+---
+
+## 5. 테스트
+
+- **core**: `parseAdminMemoryItemIdParam`, `getAdminMemoryItemPreviewById` 단위 테스트.
+- **server**: `GET /admin/memory/items/…` 200/400/404.
+- **dashboard**: HTML에 프리뷰 영역, JS에 `/admin/memory/items/` 포함 검증.

--- a/packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts
@@ -1,0 +1,76 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getAdminMemoryItemPreviewById,
+  parseAdminMemoryItemIdParam,
+} from './admin-memory-item-preview-service.js';
+
+function openDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TEXT,
+      last_accessed TEXT,
+      last_accessed_at TEXT,
+      pinned INTEGER DEFAULT 0,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      owner_id TEXT,
+      is_deleted INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return db;
+}
+
+describe('admin-memory-item-preview-service', () => {
+  afterEach(() => {
+    /* db closed per test */
+  });
+
+  it('parseAdminMemoryItemIdParam accepts mem_ ids', () => {
+    const ok = parseAdminMemoryItemIdParam('mem_abc_01');
+    expect(ok).toEqual({ memoryId: 'mem_abc_01' });
+  });
+
+  it('parseAdminMemoryItemIdParam rejects invalid ids', () => {
+    const bad = parseAdminMemoryItemIdParam('../etc');
+    expect(bad).toMatchObject({ error: 'Invalid memory id', status: 400 });
+  });
+
+  it('getAdminMemoryItemPreviewById returns preview', () => {
+    const db = openDb();
+    try {
+      db.prepare(
+        `INSERT INTO memory_item (
+          id, type, content, importance, privacy_scope, created_at, pinned, is_deleted
+        ) VALUES ('mem_x', 'semantic', 'hello body', 0.5, 'private', '2020-01-01', 0, 0)`,
+      ).run();
+      const row = getAdminMemoryItemPreviewById(db, 'mem_x');
+      expect(row).not.toBeNull();
+      expect(row!.content).toBe('hello body');
+      expect(row!.type).toBe('semantic');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('getAdminMemoryItemPreviewById returns null when deleted', () => {
+    const db = openDb();
+    try {
+      db.prepare(
+        `INSERT INTO memory_item (
+          id, type, content, importance, privacy_scope, created_at, pinned, is_deleted
+        ) VALUES ('mem_del', 'semantic', 'gone', 0.5, 'private', '2020-01-01', 0, 1)`,
+      ).run();
+      expect(getAdminMemoryItemPreviewById(db, 'mem_del')).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts
+++ b/packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts
@@ -1,0 +1,66 @@
+import type Database from 'better-sqlite3';
+
+/** Admin 단건 조회용 `memory_id` 경로 파라미터 (SQL 인젝션·경로 조작 방지). */
+const MEMORY_ID_PARAM_RE = /^mem_[A-Za-z0-9_]{1,220}$/;
+
+export type AdminMemoryItemPreview = {
+  id: string;
+  type: string;
+  content: string;
+  importance: number;
+  privacy_scope: string;
+  pinned: boolean;
+  created_at: string | null;
+  last_accessed: string | null;
+  last_accessed_at: string | null;
+  tags: string | null;
+  source: string | null;
+  project_id: string | null;
+  owner_id: string | null;
+};
+
+export function parseAdminMemoryItemIdParam(raw: string): { memoryId: string } | { error: string; status: number } {
+  const id = decodeURIComponent(raw);
+  if (!MEMORY_ID_PARAM_RE.test(id)) {
+    return { error: 'Invalid memory id', status: 400 };
+  }
+  return { memoryId: id };
+}
+
+/**
+ * `memory_item` 단건을 Admin JSON(프리뷰)용으로 조회한다. 삭제(soft)된 행은 null.
+ */
+export function getAdminMemoryItemPreviewById(db: Database.Database, memoryId: string): AdminMemoryItemPreview | null {
+  const row = db
+    .prepare(
+      `SELECT id, type, content, importance, privacy_scope, pinned,
+              created_at, last_accessed, last_accessed_at,
+              tags, source, project_id, owner_id, is_deleted
+         FROM memory_item WHERE id = ?`,
+    )
+    .get(memoryId) as Record<string, unknown> | undefined;
+
+  if (!row) {
+    return null;
+  }
+  const deleted = row.is_deleted === 1 || row.is_deleted === true;
+  if (deleted) {
+    return null;
+  }
+
+  return {
+    id: String(row.id),
+    type: String(row.type),
+    content: String(row.content),
+    importance: Number(row.importance),
+    privacy_scope: String(row.privacy_scope ?? 'private'),
+    pinned: Boolean(row.pinned),
+    created_at: row.created_at == null ? null : String(row.created_at),
+    last_accessed: row.last_accessed == null ? null : String(row.last_accessed),
+    last_accessed_at: row.last_accessed_at == null ? null : String(row.last_accessed_at),
+    tags: row.tags == null ? null : String(row.tags),
+    source: row.source == null ? null : String(row.source),
+    project_id: row.project_id == null ? null : String(row.project_id),
+    owner_id: row.owner_id == null ? null : String(row.owner_id),
+  };
+}

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -84,6 +84,11 @@ export {
   MEMORY_REVIEW_CANDIDATE_NOT_FOUND,
   MEMORY_REVIEW_CANDIDATE_NOT_ACTIONABLE,
 } from './domains/memory/services/memory-review-candidate-persistence-error.js';
+export {
+  parseAdminMemoryItemIdParam,
+  getAdminMemoryItemPreviewById,
+} from './domains/memory/services/admin-memory-item-preview-service.js';
+export type { AdminMemoryItemPreview } from './domains/memory/services/admin-memory-item-preview-service.js';
 export { logger } from './shared/utils/logger.js';
 export { loggingRateLimiter } from './shared/utils/logging-rate-limiter.js';
 export { withErrorHandling } from './shared/utils/error-handling.js';

--- a/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
+++ b/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
@@ -8,13 +8,15 @@ const dashboardHtml = readFileSync(resolve(root, 'static/dashboard.html'), 'utf8
 const tabsJs = readFileSync(resolve(root, 'static/js/dashboard-tabs.js'), 'utf8');
 const panelJs = readFileSync(resolve(root, 'static/js/review-candidates-panel.js'), 'utf8');
 
-describe('dashboard review candidates panel (#252)', () => {
+describe('dashboard review candidates panel (#252, #253)', () => {
   it('dashboard.html includes review tab, panel, and script', () => {
     expect(dashboardHtml).toContain('id="dashboard-tab-review"');
     expect(dashboardHtml).toContain('data-tab="review"');
     expect(dashboardHtml).toContain('id="tab-review-candidates"');
     expect(dashboardHtml).toContain('/static/js/review-candidates-panel.js');
     expect(dashboardHtml).toContain('id="rc-refresh-btn"');
+    expect(dashboardHtml).toContain('id="rc-preview-aside"');
+    expect(dashboardHtml).toContain('review-candidates-body');
   });
 
   it('dashboard-tabs.js uses m-tab selectors and review branch', () => {
@@ -25,8 +27,9 @@ describe('dashboard review candidates panel (#252)', () => {
     expect(tabsJs).toContain('initReviewCandidatesPanel');
   });
 
-  it('review-candidates-panel.js targets pending list endpoint', () => {
+  it('review-candidates-panel.js targets pending list and admin memory preview', () => {
     expect(panelJs).toContain('/admin/memory/review-candidates?status=pending');
+    expect(panelJs).toContain('/admin/memory/items/');
     expect(panelJs).toContain('initReviewCandidatesPanel');
   });
 });

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -958,6 +958,7 @@ describe('admin.routes memory review candidates', () => {
         tags TEXT,
         source TEXT,
         project_id TEXT,
+        owner_id TEXT,
         is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
         deleted_at TEXT
       );
@@ -1037,6 +1038,39 @@ describe('admin.routes memory review candidates', () => {
       db.close();
     } catch {
       /* ignore */
+    }
+  });
+
+  it('GET /admin/memory/items/mem_stale returns 200 with memory.content', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/items/mem_stale');
+      expect(res.statusCode).toBe(200);
+      const json = JSON.parse(res.body) as { memory?: { content?: string; id?: string } };
+      expect(json.memory?.id).toBe('mem_stale');
+      expect(json.memory?.content).toBe('Stale high-importance memory');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/items/bad..id returns 400', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/items/not%20valid');
+      expect(res.statusCode).toBe(400);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/memory/items/mem_missing returns 404', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/memory/items/mem_does_not_exist');
+      expect(res.statusCode).toBe(404);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
     }
   });
 

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -18,6 +18,8 @@ import {
   listMemoryReviewCandidates,
   markMemoryReviewCandidateReviewed,
   markMemoryReviewCandidateDismissed,
+  parseAdminMemoryItemIdParam,
+  getAdminMemoryItemPreviewById,
   MemoryReviewCandidateError,
   type MemoryReviewCandidateStatus,
   logger,
@@ -301,6 +303,36 @@ export function createAdminRouter(
     }
   });
 
+
+  router.get('/memory/items/:memory_id', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({ error: '데이터베이스가 연결되지 않았습니다' });
+      }
+      const parsedId = parseAdminMemoryItemIdParam(req.params.memory_id ?? '');
+      if ('error' in parsedId) {
+        return res.status(parsedId.status).json({ error: parsedId.error });
+      }
+      const item = getAdminMemoryItemPreviewById(db, parsedId.memoryId);
+      if (!item) {
+        return res.status(404).json({ error: 'Memory not found' });
+      }
+      logger.info('Admin memory item preview served', { memory_id: item.id });
+      return res.json({
+        message: 'Memory item',
+        memory: item,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('Admin memory item preview failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({
+        error: 'Failed to load memory item',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
 
   router.get('/memory/review-candidates', (req, res) => {
     try {

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -725,4 +725,110 @@ body {
   white-space: pre-wrap;
   word-break: break-word;
   max-width: 36rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.review-candidates-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 28rem);
+  gap: var(--spacing-md);
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.rc-main-col {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+@media (max-width: 56rem) {
+  .review-candidates-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rc-preview-aside {
+  min-height: 0;
+  border: 1px solid var(--color-tab-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-card);
+  padding: var(--spacing-md);
+  overflow: auto;
+}
+
+.rc-preview-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-base);
+  color: var(--color-text-main);
+}
+
+.rc-preview-placeholder {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.rc-preview-dl {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
+}
+
+.rc-preview-dl > div {
+  margin-bottom: var(--spacing-xs);
+}
+
+.rc-preview-dl dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.rc-preview-dl dd {
+  margin: 0.125rem 0 0;
+  color: var(--color-text-main);
+}
+
+.rc-preview-reason-full {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rc-preview-memory-status {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.rc-preview-content {
+  margin: 0;
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-main);
+  border: 1px solid var(--color-tab-border);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: var(--font-size-xs);
+  max-height: min(50vh, 28rem);
+  overflow: auto;
+}
+
+.review-candidates-table tbody tr.rc-row--selected {
+  box-shadow: inset 3px 0 0 0 var(--color-brand-primary);
+  background: var(--color-bg-card);
+}
+
+.review-candidates-table tbody tr.rc-row--clickable {
+  cursor: pointer;
+}
+
+.review-candidates-table tbody tr.rc-row--clickable:focus {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
 }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -168,20 +168,40 @@
         <div id="rc-loading" class="rc-banner hidden">Loading…</div>
         <div id="rc-error" class="rc-banner rc-banner--error hidden" role="alert"></div>
         <div id="rc-empty" class="rc-banner hidden">No pending review candidates.</div>
-        <div id="rc-table-wrap" class="review-candidates-table-wrap hidden">
-          <table id="rc-table" class="review-candidates-table">
-            <thead>
-              <tr>
-                <th scope="col">Priority</th>
-                <th scope="col">Memory ID</th>
-                <th scope="col">Status</th>
-                <th scope="col">Reason</th>
-                <th scope="col">Due</th>
-                <th scope="col">Candidate ID</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+        <div class="review-candidates-body">
+          <div class="rc-main-col">
+            <div id="rc-table-wrap" class="review-candidates-table-wrap hidden">
+              <table id="rc-table" class="review-candidates-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Priority</th>
+                    <th scope="col">Memory ID</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Reason</th>
+                    <th scope="col">Due</th>
+                    <th scope="col">Candidate ID</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <aside id="rc-preview-aside" class="rc-preview-aside" aria-label="Candidate and memory preview">
+            <div class="rc-preview-panel">
+              <h3 class="rc-preview-title">Preview</h3>
+              <p id="rc-preview-placeholder" class="rc-preview-placeholder">Select a row to load candidate details and memory content.</p>
+              <div id="rc-preview-detail" class="rc-preview-detail hidden">
+                <dl class="rc-preview-dl">
+                  <div><dt>Priority</dt><dd id="rc-preview-priority"></dd></div>
+                  <div><dt>Reason</dt><dd id="rc-preview-reason" class="rc-preview-reason-full"></dd></div>
+                  <div><dt>Due</dt><dd id="rc-preview-due" class="rc-cell-mono"></dd></div>
+                  <div><dt>Memory ID</dt><dd id="rc-preview-mid" class="rc-cell-mono"></dd></div>
+                </dl>
+                <p id="rc-preview-memory-status" class="rc-preview-memory-status" aria-live="polite"></p>
+                <pre id="rc-preview-content" class="rc-preview-content"></pre>
+              </div>
+            </div>
+          </aside>
         </div>
       </div>
     </div>

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -1,14 +1,15 @@
 /**
- * Review candidates panel (#252) — pending list via mementoAdminFetch
+ * Review candidates panel (#252 list, #253 row preview + memory body)
  */
 (function (global) {
   'use strict';
 
   const LIST_URL = '/admin/memory/review-candidates?status=pending';
-  const REASON_MAX = 120;
+  const REASON_TABLE_MAX = 120;
 
   let wired = false;
   let loadedOnce = false;
+  let selectedRow = null;
 
   function $(id) {
     return document.getElementById(id);
@@ -32,10 +33,167 @@
     if (!text) {
       return '';
     }
-    if (text.length <= REASON_MAX) {
+    if (text.length <= REASON_TABLE_MAX) {
       return text;
     }
-    return text.slice(0, REASON_MAX) + '…';
+    return text.slice(0, REASON_TABLE_MAX) + '…';
+  }
+
+  function formatDue(iso) {
+    if (!iso) {
+      return '';
+    }
+    const d = new Date(String(iso));
+    if (Number.isNaN(d.getTime())) {
+      return String(iso);
+    }
+    return d.toLocaleString();
+  }
+
+  function escapeHtml(s) {
+    return s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function escapeAttr(s) {
+    return escapeHtml(s).replace(/'/g, '&#39;');
+  }
+
+  function previewUrl(memoryId) {
+    return '/admin/memory/items/' + encodeURIComponent(memoryId);
+  }
+
+  function clearRowSelection() {
+    if (selectedRow) {
+      selectedRow.classList.remove('rc-row--selected');
+      selectedRow.setAttribute('aria-selected', 'false');
+      selectedRow = null;
+    }
+  }
+
+  function resetPreviewPanel() {
+    const ph = $('rc-preview-placeholder');
+    const det = $('rc-preview-detail');
+    const status = $('rc-preview-memory-status');
+    const content = $('rc-preview-content');
+    if (ph) {
+      setHidden(ph, false);
+    }
+    if (det) {
+      setHidden(det, true);
+    }
+    if (status) {
+      status.textContent = '';
+    }
+    if (content) {
+      content.textContent = '';
+    }
+  }
+
+  function setPreviewCandidateFields(priority, reason, due, memoryId) {
+    const p = $('rc-preview-priority');
+    const r = $('rc-preview-reason');
+    const d = $('rc-preview-due');
+    const m = $('rc-preview-mid');
+    if (p) {
+      p.textContent = String(priority ?? '');
+    }
+    if (r) {
+      r.textContent = String(reason ?? '');
+    }
+    if (d) {
+      d.textContent = formatDue(due);
+    }
+    if (m) {
+      m.textContent = String(memoryId ?? '');
+    }
+  }
+
+  async function loadMemoryPreview(memoryId) {
+    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+    const status = $('rc-preview-memory-status');
+    const content = $('rc-preview-content');
+    if (status) {
+      status.textContent = 'Loading memory…';
+    }
+    if (content) {
+      content.textContent = '';
+    }
+    try {
+      const res = await fetchFn(previewUrl(memoryId), { headers: { Accept: 'application/json' } });
+      const body = await res.json().catch(function () {
+        return {};
+      });
+      if (!res.ok) {
+        const msg = (body && (body.error || body.message)) || 'HTTP ' + res.status;
+        if (status) {
+          status.textContent = String(msg);
+        }
+        return;
+      }
+      const mem = body && body.memory;
+      const text = mem && mem.content != null ? String(mem.content) : '';
+      if (status) {
+        status.textContent = '';
+      }
+      if (content) {
+        content.textContent = text;
+      }
+    } catch (e) {
+      if (status) {
+        status.textContent = e instanceof Error ? e.message : 'Network error';
+      }
+    }
+  }
+
+  function onRowActivate(tr) {
+    if (!tr || !tr.dataset.memoryId) {
+      return;
+    }
+    clearRowSelection();
+    selectedRow = tr;
+    tr.classList.add('rc-row--selected');
+    tr.setAttribute('aria-selected', 'true');
+
+    const ph = $('rc-preview-placeholder');
+    const det = $('rc-preview-detail');
+    if (ph) {
+      setHidden(ph, true);
+    }
+    if (det) {
+      setHidden(det, false);
+    }
+    setPreviewCandidateFields(tr.dataset.priority, tr.dataset.reason, tr.dataset.due, tr.dataset.memoryId);
+    loadMemoryPreview(tr.dataset.memoryId);
+  }
+
+  function wireTableBody() {
+    const tbody = $('rc-table') && $('rc-table').querySelector('tbody');
+    if (!tbody || tbody.dataset.rcWired === '1') {
+      return;
+    }
+    tbody.dataset.rcWired = '1';
+    tbody.addEventListener('click', function (ev) {
+      const tr = ev.target && ev.target.closest && ev.target.closest('tr[data-memory-id]');
+      if (!tr) {
+        return;
+      }
+      onRowActivate(tr);
+    });
+    tbody.addEventListener('keydown', function (ev) {
+      if (ev.key !== 'Enter' && ev.key !== ' ') {
+        return;
+      }
+      const tr = ev.target && ev.target.closest && ev.target.closest('tr[data-memory-id]');
+      if (!tr) {
+        return;
+      }
+      ev.preventDefault();
+      onRowActivate(tr);
+    });
   }
 
   function renderTable(candidates) {
@@ -45,35 +203,43 @@
     if (!wrap || !tbody) {
       return;
     }
+    clearRowSelection();
+    resetPreviewPanel();
     tbody.textContent = '';
     for (let i = 0; i < candidates.length; i += 1) {
       const c = candidates[i];
       const tr = document.createElement('tr');
+      const memoryId = String(c.memory_id ?? '');
+      const reasonFull = String(c.reason ?? '');
+      const dueRaw = String(c.due_at ?? '');
+      tr.className = 'rc-row--clickable';
+      tr.setAttribute('role', 'button');
+      tr.setAttribute('tabindex', '0');
+      tr.setAttribute('aria-selected', 'false');
+      tr.dataset.memoryId = memoryId;
+      tr.dataset.priority = String(c.priority ?? '');
+      tr.dataset.reason = reasonFull;
+      tr.dataset.due = dueRaw;
       tr.innerHTML =
         '<td>' +
         escapeHtml(String(c.priority ?? '')) +
         '</td><td class="rc-cell-mono">' +
-        escapeHtml(String(c.memory_id ?? '')) +
+        escapeHtml(memoryId) +
         '</td><td>' +
         escapeHtml(String(c.status ?? '')) +
-        '</td><td class="rc-cell-reason">' +
-        escapeHtml(truncateReason(String(c.reason ?? ''))) +
+        '</td><td class="rc-cell-reason" title="' +
+        escapeAttr(reasonFull) +
+        '">' +
+        escapeHtml(truncateReason(reasonFull)) +
         '</td><td class="rc-cell-mono">' +
-        escapeHtml(String(c.due_at ?? '')) +
+        escapeHtml(formatDue(dueRaw)) +
         '</td><td class="rc-cell-mono">' +
         escapeHtml(String(c.id ?? '')) +
         '</td>';
       tbody.appendChild(tr);
     }
+    wireTableBody();
     setHidden(wrap, false);
-  }
-
-  function escapeHtml(s) {
-    return s
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
   }
 
   function showLoading(on) {
@@ -103,6 +269,8 @@
     hideTable();
     showEmpty(false);
     clearStatus();
+    clearRowSelection();
+    resetPreviewPanel();
 
     try {
       const res = await fetchFn(LIST_URL, { headers: { Accept: 'application/json' } });


### PR DESCRIPTION
## 변경 사항
GitHub #253 — 후보 행에서 priority / 전체 reason / due 및 `memory_item` 본문을 프리뷰 패널에 표시합니다.

## 변경 유형
- [x] ✨ 새로운 기능
- [x] ✅ 테스트 추가/수정
- [x] 📚 문서 업데이트

## 관련 이슈
- Closes https://github.com/jee1/memento/issues/253

## 상세
- **Admin API**: `GET /admin/memory/items/:memory_id` — `mem_*` 형식 검증, 소프트 삭제 시 404, 로그에 본문 미포함
- **Core**: `admin-memory-item-preview-service` + Vitest
- **대시보드**: 표 + 우측 프리뷰(좁은 화면에서는 아래 스택), 행 클릭·Enter/Space로 선택, `mementoAdminFetch`로 프리뷰 로드
- **문서**: ko/en API 레퍼런스, README, superpowers 설계·구현 플랜

## 테스트
- `npx vitest run` (해당 스펙) 및 `npm run build` 통과
- 수동: HTTP 대시보드 Review Queue 탭에서 행 선택 후 본문 로드 확인 권장

## 문서
- [x] README.md / README.en.md
- [x] API 문서 (ko/en)

## 지식 복리
해당 없음(기능 추가 위주).

Made with [Cursor](https://cursor.com)