### PR TITLE
fix(core): 명시 LLM provider일 때 미사용 클라우드 키 부재 WARN 생략 (#260)

### DIFF
--- a/packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts
+++ b/packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts
@@ -76,6 +76,42 @@ describe('LLM Provider 통합 테스트', () => {
     });
 
     /**
+     * Given: LLM_PROVIDER='ollama'이고 클라우드 API 키는 없고 Ollama만 정상 응답함
+     * When: LLMClientInitializer.initialize()를 호출함
+     * Then: OpenAI/Gemini 키 부재로 인한 경고(warnings)가 없어야 함 (이슈 #260)
+     */
+    it('should not warn about missing OpenAI/Gemini keys when LLM_PROVIDER is "ollama" and Ollama succeeds', async () => {
+      process.env.LLM_PROVIDER = 'ollama';
+      mockMementoConfig.openaiApiKey = undefined;
+      mockMementoConfig.geminiApiKey = undefined;
+      mockMementoConfig.ollamaBaseUrl = 'http://localhost:11434';
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ models: [] })
+      });
+      global.fetch = mockFetch as typeof global.fetch;
+
+      const mockAbortSignal = new EventTarget() as AbortSignal;
+      const mockTimeout = vi.fn((ms: number) => mockAbortSignal);
+      global.AbortSignal = {
+        ...originalAbortSignal,
+        timeout: mockTimeout
+      } as typeof AbortSignal;
+
+      const initializer = new LLMClientInitializer();
+      const result = await initializer.initialize();
+
+      expect(result.preferredProvider).toBe('ollama');
+      expect(
+        result.warnings.some(
+          (w) => w.includes('OPENAI_API_KEY') || w.includes('GEMINI_API_KEY')
+        )
+      ).toBe(false);
+    });
+
+    /**
      * Given: LLM_PROVIDER='ollama'이고 Ollama 연결 실패하지만 OpenAI API 키가 있음
      * When: LLMClientInitializer.initialize()를 호출함
      * Then: preferredProvider가 'openai'로 설정되고 fallback이 발생해야 함

--- a/packages/memento-core/src/shared/services/llm-client-initializer.ts
+++ b/packages/memento-core/src/shared/services/llm-client-initializer.ts
@@ -118,6 +118,18 @@ export class LLMClientInitializer {
     };
   }
 
+  /**
+   * 명시 LLM_PROVIDER일 때만 해당 클라우드 키 부재를 경고한다.
+   * ollama 전용 등으로 다른 provider를 쓰지 않는 경우 불필요한 WARN 로그를 막는다. auto는 탐색 목적상 기존과 같이 경고.
+   */
+  private shouldWarnMissingOpenaiKey(selectedProvider: LLMProvider): boolean {
+    return selectedProvider === 'openai' || selectedProvider === 'auto';
+  }
+
+  private shouldWarnMissingGeminiKey(selectedProvider: LLMProvider): boolean {
+    return selectedProvider === 'gemini' || selectedProvider === 'auto';
+  }
+
   private resolveLlmModelLabel(provider: LLMClientInitializationResult['preferredProvider']): string {
     if (provider === 'openai') return mementoConfig.openaiLlmModel ?? 'gpt-4o-mini';
     if (provider === 'ollama') return mementoConfig.ollamaModel;
@@ -175,16 +187,18 @@ export class LLMClientInitializer {
     selectedProvider: LLMProvider
   ): OpenAI | null {
     if (!mementoConfig.openaiApiKey) {
-      const warningMessage = 'OPENAI_API_KEY가 없습니다.';
-      this.addWarning(
-        result,
-        warningMessage,
-        'OpenAI API 키가 없어 초기화를 건너뜁니다.',
-        {
-          requestedProvider: selectedProvider,
-          reason: warningMessage
-        }
-      );
+      if (this.shouldWarnMissingOpenaiKey(selectedProvider)) {
+        const warningMessage = 'OPENAI_API_KEY가 없습니다.';
+        this.addWarning(
+          result,
+          warningMessage,
+          'OpenAI API 키가 없어 초기화를 건너뜁니다.',
+          {
+            requestedProvider: selectedProvider,
+            reason: warningMessage
+          }
+        );
+      }
       return null;
     }
 
@@ -226,16 +240,18 @@ export class LLMClientInitializer {
     selectedProvider: LLMProvider
   ): GoogleGenerativeAI | null {
     if (!mementoConfig.geminiApiKey) {
-      const warningMessage = 'GEMINI_API_KEY가 없습니다.';
-      this.addWarning(
-        result,
-        warningMessage,
-        'Gemini API 키가 없어 초기화를 건너뜁니다.',
-        {
-          requestedProvider: selectedProvider,
-          reason: warningMessage
-        }
-      );
+      if (this.shouldWarnMissingGeminiKey(selectedProvider)) {
+        const warningMessage = 'GEMINI_API_KEY가 없습니다.';
+        this.addWarning(
+          result,
+          warningMessage,
+          'Gemini API 키가 없어 초기화를 건너뜁니다.',
+          {
+            requestedProvider: selectedProvider,
+            reason: warningMessage
+          }
+        );
+      }
       return null;
     }
 


### PR DESCRIPTION
## 요약
- `LLM_PROVIDER`가 `openai` / `gemini` / `ollama`일 때, 선택되지 않은 클라우드의 API 키 부재는 `logger.warn` 및 `result.warnings`에 넣지 않습니다.
- `auto`는 기존처럼 탐색을 위해 양쪽 키 부재 경고를 유지합니다.
- 이슈 #260: Ollama 전용 환경에서 Gemini 키 없음 WARN 반복 제거.

## 테스트
- `npx vitest run packages/memento-core/src/shared/services/__tests__/llm-client-initializer packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration`

Closes #260

Made with [Cursor](https://cursor.com)