### PR TITLE
feat(dashboard): review/dismiss actions for memory review queue (#254)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-issue-254-review-dismiss-ui.md
+++ b/docs/superpowers/plans/2026-05-04-issue-254-review-dismiss-ui.md
@@ -1,0 +1,342 @@
+# Issue #254 — Review / Dismiss dashboard actions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `POST /admin/memory/review-candidates/:id/review` and `POST .../dismiss` from the dashboard preview panel, refresh the pending list via full refetch after success, surface 404/409/400/500 errors on `#rc-error`, and prevent double-submit with disabled buttons and `aria-busy`.
+
+**Architecture:** Extend `#rc-preview-detail` in `static/dashboard.html` with a two-button action row. `static/js/review-candidates-panel.js` adds `data-candidate-id` on each table row, enables actions only when a row is selected and preview is visible, uses `mementoAdminFetch` with JSON POST bodies, then calls existing `loadList()` on success (same path as initial load and poll). No server or core changes.
+
+**Tech Stack:** Static HTML/CSS/JS, `mementoAdminFetch`, Vitest string regression in `packages/memento-server`.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-issue-254-review-dismiss-ui-design.md`
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `static/dashboard.html` | Modify — inside `#rc-preview-detail`, add `#rc-preview-actions` with `#rc-btn-review` and `#rc-btn-dismiss` before closing `rc-preview-detail` |
+| `static/css/dashboard.css` | Modify — after `.rc-preview-content` block (~line 848), add `.rc-preview-actions` flex layout using spacing tokens |
+| `static/js/review-candidates-panel.js` | Modify — `data-candidate-id`, POST helpers, button wiring, `loadList` after success |
+| `packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts` | Modify — assert HTML button ids + JS POST path fragments |
+
+---
+
+## Constants (must match implementation)
+
+- List URL (unchanged): `/admin/memory/review-candidates?status=pending`
+- POST path template: `/admin/memory/review-candidates/<uuid>/review` and `.../dismiss` (use `encodeURIComponent` on `id` in JS)
+- Element IDs: `rc-preview-actions`, `rc-btn-review`, `rc-btn-dismiss` (plus existing `rc-error`, `rc-toast`)
+
+---
+
+### Task 1: Failing Vitest — require #254 strings
+
+**Files:**
+
+- Modify: `packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts`
+
+- [ ] **Step 1: Add a new `it` inside the first `describe` block** (after the existing `review-candidates-panel.js targets pending list...` test)
+
+Append this entire test:
+
+```typescript
+  it('review-candidates-panel.js POST review/dismiss paths and dashboard preview actions (#254)', () => {
+    expect(panelJs).toContain('/admin/memory/review-candidates/');
+    expect(panelJs).toContain('encodeURIComponent');
+    expect(panelJs).toContain("postCandidateAction('review')");
+    expect(panelJs).toContain("postCandidateAction('dismiss')");
+    expect(dashboardHtml).toContain('id="rc-preview-actions"');
+    expect(dashboardHtml).toContain('id="rc-btn-review"');
+    expect(dashboardHtml).toContain('id="rc-btn-dismiss"');
+  });
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+npx vitest run packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts -t "#254"
+```
+
+(저장소 루트에서 실행. `process.cwd()`가 `static/`을 올바르게 찾도록 유지.)
+
+Expected: **FAIL** (assertions not found in HTML/JS).
+
+- [ ] **Step 3: Commit test only (optional checkpoint)**
+
+```bash
+git add packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
+git commit -m "test(dashboard): add #254 regression expectations for review/dismiss UI"
+```
+
+---
+
+### Task 2: `dashboard.html` — preview action buttons
+
+**Files:**
+
+- Modify: `static/dashboard.html`
+
+- [ ] **Step 1: Insert markup** inside `<div id="rc-preview-detail" ...>`, **after** the `<pre id="rc-preview-content" ...></pre>` line and **before** the closing `</div>` of `rc-preview-detail`:
+
+```html
+                <div id="rc-preview-actions" class="rc-preview-actions" aria-busy="false">
+                  <button type="button" id="rc-btn-review" class="m-button m-button--secondary" disabled>Review</button>
+                  <button type="button" id="rc-btn-dismiss" class="m-button m-button--secondary" disabled>Dismiss</button>
+                </div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add static/dashboard.html
+git commit -m "feat(dashboard): add review/dismiss buttons to review preview (#254)"
+```
+
+---
+
+### Task 3: `dashboard.css` — action row layout
+
+**Files:**
+
+- Modify: `static/css/dashboard.css`
+
+- [ ] **Step 1: Append after `.rc-preview-content { ... }` block** (after its closing `}` and before `.review-candidates-table tbody tr.rc-row--selected`):
+
+```css
+.rc-preview-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.rc-preview-actions[aria-busy='true'] {
+  opacity: 0.65;
+  pointer-events: none;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add static/css/dashboard.css
+git commit -m "style(dashboard): layout for review preview actions (#254)"
+```
+
+---
+
+### Task 4: `review-candidates-panel.js` — POST + refetch + guards
+
+**Files:**
+
+- Modify: `static/js/review-candidates-panel.js`
+
+- [ ] **Step 1: Add module-level state** after existing `let toastHideTimer = null;`:
+
+```javascript
+  let actionInFlight = false;
+```
+
+- [ ] **Step 2: In `renderTable`**, after `const dueRaw = String(c.due_at ?? '');`, add:
+
+```javascript
+      const candidateId = String(c.id ?? '');
+```
+
+Change `tr.dataset` assignments to include:
+
+```javascript
+      tr.dataset.candidateId = candidateId;
+```
+
+(Keep existing `memoryId`, `reason`, `due`, etc.)
+
+- [ ] **Step 3: Add helpers** (after `previewUrl` function is a good place):
+
+```javascript
+  function reviewCandidatePostUrl(id, action) {
+    return '/admin/memory/review-candidates/' + encodeURIComponent(id) + '/' + action;
+  }
+
+  function getPreviewActionsEl() {
+    return $('rc-preview-actions');
+  }
+
+  function setPreviewActionsBusy(busy) {
+    const wrap = getPreviewActionsEl();
+    if (wrap) {
+      wrap.setAttribute('aria-busy', busy ? 'true' : 'false');
+    }
+  }
+
+  function syncReviewDismissButtons() {
+    const reviewBtn = $('rc-btn-review');
+    const dismissBtn = $('rc-btn-dismiss');
+    const id = selectedRow && selectedRow.dataset.candidateId ? String(selectedRow.dataset.candidateId) : '';
+    const detail = $('rc-preview-detail');
+    const visible = detail && !detail.classList.contains('hidden');
+    const enable = !!(id && visible && !actionInFlight);
+    if (reviewBtn) {
+      reviewBtn.disabled = !enable;
+    }
+    if (dismissBtn) {
+      dismissBtn.disabled = !enable;
+    }
+  }
+
+  function showActionToast(message) {
+    const t = $('rc-toast');
+    if (!t) {
+      return;
+    }
+    t.textContent = message;
+    t.classList.remove('hidden');
+    if (toastHideTimer) {
+      clearTimeout(toastHideTimer);
+    }
+    toastHideTimer = setTimeout(function () {
+      t.classList.add('hidden');
+      t.textContent = '';
+      toastHideTimer = null;
+    }, 4000);
+  }
+
+  async function postCandidateAction(action) {
+    const id = selectedRow && selectedRow.dataset.candidateId ? String(selectedRow.dataset.candidateId) : '';
+    if (!id || actionInFlight) {
+      return;
+    }
+    actionInFlight = true;
+    setPreviewActionsBusy(true);
+    syncReviewDismissButtons();
+    showError('');
+    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+    const url = reviewCandidatePostUrl(id, action);
+    try {
+      const res = await fetchFn(url, {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const body = await res.json().catch(function () {
+        return {};
+      });
+      if (!res.ok) {
+        const msg =
+          (body && (body.error || body.message)) ||
+          (res.status === 409
+            ? 'This candidate can no longer be updated (conflict).'
+            : res.status === 404
+              ? 'Review candidate not found.'
+              : 'HTTP ' + res.status);
+        showError(String(msg));
+        return;
+      }
+      showActionToast(action === 'review' ? 'Marked as reviewed.' : 'Dismissed.');
+      await loadList();
+    } catch (e) {
+      showError(e instanceof Error ? e.message : 'Network error');
+    } finally {
+      actionInFlight = false;
+      setPreviewActionsBusy(false);
+      syncReviewDismissButtons();
+    }
+  }
+```
+
+- [ ] **Step 4: Call `syncReviewDismissButtons()`** at end of `onRowActivate` (after `loadMemoryPreview(...)`).
+
+- [ ] **Step 5: Extend `resetPreviewPanel`** — after existing clears, call `syncReviewDismissButtons()` (buttons stay disabled when preview hidden).
+
+- [ ] **Step 6: Wire buttons once** inside `initReviewCandidatesPanel` after refresh button wiring (`if (!wired)` block):
+
+```javascript
+      const reviewBtn = $('rc-btn-review');
+      const dismissBtn = $('rc-btn-dismiss');
+      if (reviewBtn) {
+        reviewBtn.addEventListener('click', function () {
+          void postCandidateAction('review');
+        });
+      }
+      if (dismissBtn) {
+        dismissBtn.addEventListener('click', function () {
+          void postCandidateAction('dismiss');
+        });
+      }
+```
+
+- [ ] **Step 7: Ensure Task 1 test strings match** — if you used template literals for URLs, update `dashboard-review-candidates-panel.spec.ts` substring expectations accordingly (must stay in sync).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add static/js/review-candidates-panel.js
+git commit -m "feat(dashboard): POST review/dismiss with refetch and guards (#254)"
+```
+
+---
+
+### Task 5: Verify full spec file + graphify (code touch)
+
+**Files:** (none new)
+
+- [ ] **Step 1: Run Vitest for the dashboard static suite**
+
+```bash
+npm test --workspace packages/memento-server -- src/server/dashboard-review-candidates-panel.spec.ts
+```
+
+Expected: **all tests PASS**.
+
+- [ ] **Step 2: Lint (repo root)**
+
+```bash
+npm run lint
+```
+
+Expected: **PASS** (no new violations).
+
+- [ ] **Step 3: Graphify rebuild (repo rule)**
+
+```bash
+python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+```
+
+- [ ] **Step 4: Final commit** if graphify or lint produced changes:
+
+```bash
+git status
+git add -A
+git commit -m "chore: graphify refresh after #254 dashboard changes"   # only if files changed
+```
+
+---
+
+## Plan self-review (spec coverage)
+
+| Spec section | Tasks covering it |
+|--------------|-------------------|
+| POST review/dismiss from UI | Task 4 `postCandidateAction` |
+| Full refetch after success | Task 4 `await loadList()` in success branch |
+| 400/404/409/500 messaging | Task 4 `showError` + status fallbacks |
+| Disabled / in-flight / aria-busy | Task 2 markup, Task 3 CSS, Task 4 `actionInFlight` + `syncReviewDismissButtons` |
+| `data-candidate-id` | Task 4 `renderTable` |
+| Preview-only actions (option A) | Task 2 buttons inside `#rc-preview-detail` |
+| Tests | Task 1 + Task 5 |
+| graphify after code | Task 5 |
+
+**Placeholder scan:** None intentional.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-04-issue-254-review-dismiss-ui.md`.
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — run steps in this session with executing-plans checkpoints.
+
+Which approach do you want for implementation?

--- a/docs/superpowers/specs/2026-05-04-issue-254-review-dismiss-ui-design.md
+++ b/docs/superpowers/specs/2026-05-04-issue-254-review-dismiss-ui-design.md
@@ -1,0 +1,94 @@
+# 설계: 이슈 #254 — Review / Dismiss 버튼 및 목록 갱신 UX
+
+**날짜**: 2026-05-04  
+**이슈**: [GitHub #254](https://github.com/jee1/memento/issues/254)  
+**상위**: [#245](https://github.com/jee1/memento/issues/245)  
+**선행(권장)**: [#252](https://github.com/jee1/memento/issues/252), [#253](https://github.com/jee1/memento/issues/253)
+
+---
+
+## 1. 목표·비목표
+
+**목표**
+
+- `POST /admin/memory/review-candidates/:id/review`, `POST .../dismiss`를 대시보드에서 호출할 수 있다.
+- 성공 시 **항상** `GET /admin/memory/review-candidates?status=pending`로 목록을 다시 불러와 표를 갱신한다(폴링·초기 로드와 동일 경로, 단일 정책).
+- `400` / `404` / `409` / `500` 응답을 사용자에게 알린다(메시지는 서버 `error`·`code`를 우선).
+- 동일 후보에 대한 **중복 제출 방지**: 요청 진행 중 버튼 비활성·`aria-busy` 등 접근 가능한 잠금.
+- 스타일은 `static/css/tokens.css`·기존 `dashboard.css` 패턴을 따른다.
+
+**비목표 (#254 밖)**
+
+- 배치·선정 로직 변경, SSE/WebSocket.
+- 관리자 API에 별도 CSRF 토큰 필드 신설(현재 대시보드는 동일 출처 세션 쿠키 + `mementoAdminFetch`의 `credentials: 'same-origin'`).
+
+---
+
+## 2. 배치된 접근 방식 비교·선택
+
+| 옵션 | 설명 | 장단 |
+|------|------|------|
+| A | **프리뷰 패널에만** Review / Dismiss | 맥락(본문 확인 후 조치)에 맞음. 잘못된 행 조작 위험 낮음. 행 선택 필수. |
+| B | **테이블 행마다** 액션 컬럼 | 클릭 수 적음. 프리뷰 없이 조치 가능해 오조작·실수 가능성↑. |
+| C | A+B 동시 | 중복 UI, 유지보수 비용↑(YAGNI). |
+
+**채택: A** — 후보 행 선택 후 프리뷰 영역 하단(또는 메타 블록 아래)에 두 버튼을 둔다. `tr`에 `data-candidate-id`(UUID)를 심어 선택 시 프리뷰 로직이 동일 ID로 POST를 구성한다.
+
+---
+
+## 3. Admin API(기존 계약, UI가 맞출 것)
+
+- **Review**: `POST /admin/memory/review-candidates/:id/review`, 본문 `{}` 또는 생략(JSON).
+- **Dismiss**: `POST /admin/memory/review-candidates/:id/dismiss`.
+- **성공 `200`**: `{ ok: true, candidate, timestamp }` (`candidate`는 전체 목록 스캔 결과일 수 있음 — UI는 **목록 재조회 결과**만 신뢰).
+- **오류**: `MemoryReviewCandidateError` — `404` + `code: memory_review_candidate_not_found`, `409` + `code: memory_review_candidate_not_actionable`; `400` 잘못된 UUID; `500` 일반 실패.
+
+클라이언트는 `mementoAdminFetch` + `method: 'POST'`, `headers: { Accept: 'application/json', 'Content-Type': 'application/json' }`, `body: '{}'`.
+
+---
+
+## 4. 클라이언트 동작(상세)
+
+1. **행 렌더링**: 각 `tr`에 `data-candidate-id`(서버 `c.id`)를 설정한다. 기존 `data-memory-id` 등은 유지.
+2. **버튼 가시성**: 행이 선택되어 프리뷰 디테일이 열린 경우에만 Review/Dismiss를 **활성**으로 둔다(선택 없음·placeholder 상태에서는 `disabled`).
+3. **클릭 핸들러**:
+   - 진행 중 플래그가 켜져 있으면 무시.
+   - 플래그 ON → 두 버튼 `disabled` + `aria-busy="true"`(컨테이너에 위임 가능).
+   - 해당 후보 ID로 위 POST URL 호출.
+4. **성공**: 짧은 성공 피드백(기존 `#rc-toast` 재사용 가능, 3~5초 자동 숨김 정도) 후 **`loadList()`** 호출. `loadList`는 이미 `clearRowSelection`·`resetPreviewPanel`을 포함하므로 목록이 서버 상태와 일치한다.
+5. **실패**:
+   - `rc-error`에 사람이 읽을 메시지 표시(`body.error` 또는 상태코드 기본 문구). `409`/`404`는 “이미 처리됨·없음” 뉘앙스를 반영한 문구로 매핑 가능(서버 메시지 우선).
+   - 토스트만으로 치명적 오류를 빠뜨리지 않도록, **최소한 `rc-error` 또는 프리뷰 인라인 한 곳은 항상 채운다**(이슈의 “토스트 또는 인라인” 중 **인라인 우선**: `rc-error`를 기본, 성공만 토스트).
+6. **폴링과의 관계**: 재조회 후 `applyListSuccess`가 `lastPendingCount`를 갱신하므로 폴링 토스트 로직과 충돌하지 않는다.
+
+---
+
+## 5. HTML·CSS
+
+- `static/dashboard.html`: 프리뷰 패널(`#rc-preview-detail` 내부)에 버튼 그룹 컨테이너 추가, 예: `div.rc-preview-actions` 안에 `button#rc-btn-review`, `button#rc-btn-dismiss`. `type="button"`.
+- `static/css/dashboard.css`(또는 기존 review 후보 블록): 토큰 기반 간격·보조 버튼 스타일(`m-button--secondary` 등 기존 클래스 재사용).
+
+---
+
+## 6. 테스트
+
+- **서버**: 기존 `admin.routes.spec.ts`의 POST 시나리오 유지.
+- **대시보드 정적 검증**: `dashboard-review-candidates-panel.spec.ts`(또는 동일 패턴)에 다음을 문자열·구조로 검증:
+  - `review-candidates-panel.js`에 `POST` 대상 경로 `/admin/memory/review-candidates/` 및 `review`·`dismiss` 세그먼트 포함.
+  - `dashboard.html`에 액션 버튼 id 또는 `rc-preview-actions` 존재.
+
+(브라우저 E2E는 비범위 unless CI에 도입됨.)
+
+---
+
+## 7. 완료 조건 (#254 정합)
+
+- 대시보드에서 pending 후보를 선택한 뒤 Review 또는 Dismiss를 실행할 수 있다.
+- 성공 후 **재조회된** pending 목록이 표시된다.
+- `404`/`409` 등이 사용자에게 전달되고, 진행 중 중복 클릭이 막힌다.
+
+---
+
+## 8. 구현 후 graphify
+
+코드 변경이 끝나면 저장소 규칙에 따라 `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` 실행.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-05-03)
+# Graph Report - .  (2026-05-04)
 
 ## Corpus Check
-- 910 files · ~1,335,752 words
+- 912 files · ~1,342,013 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4603 nodes · 5620 edges · 907 communities detected
+- 4633 nodes · 5701 edges · 909 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -917,6 +917,8 @@
 - [[_COMMUNITY_Community 904|Community 904]]
 - [[_COMMUNITY_Community 905|Community 905]]
 - [[_COMMUNITY_Community 906|Community 906]]
+- [[_COMMUNITY_Community 907|Community 907]]
+- [[_COMMUNITY_Community 908|Community 908]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -960,336 +962,336 @@ Cohesion: 0.08
 Nodes (22): calculateKendallTau(), calculateQualityDegradation(), calculateRanks(), calculateSpearmanRho(), calculateTopKRetention(), compareQualityWithGroundTruth(), detectAndAlertQualityDegradation(), detectQualityDegradation() (+14 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.17
+Nodes (35): $(), applyListSuccess(), clearReviewTabBadge(), clearRowSelection(), clearStatus(), escapeAttr(), escapeHtml(), fetchReviewCandidateListJson() (+27 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.11
 Nodes (1): SearchRanking
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.12
 Nodes (1): ReflexionWorker
 
-### Community 8 - "Community 8"
+### Community 9 - "Community 9"
 Cohesion: 0.14
 Nodes (1): MemoryManager
 
-### Community 9 - "Community 9"
+### Community 10 - "Community 10"
 Cohesion: 0.15
 Nodes (2): LLMBasedRelationExtractor, TokenBucketRateLimiter
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.16
 Nodes (1): MementoClient
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.14
 Nodes (1): RelationGraph
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.16
 Nodes (20): clearSearch(), debugAnchorMap(), displayMemoryDetails(), drag(), escapeHtml(), getAnchorMapPalette(), highlightSearchResults(), layoutNodesByHop() (+12 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.13
 Nodes (3): generateVaultId(), ImmutableDataError, KnowledgeVaultService
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.13
 Nodes (1): CoreMemoryCacheService
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.16
 Nodes (2): generateId(), SemanticMemoryUpdateService
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
+Cohesion: 0.19
+Nodes (1): LLMClientInitializer
+
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (2): PerformanceOptimizer, Semaphore
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.16
 Nodes (4): AIAgent, aiAgentIntegrationExample(), LearningManager, ProjectManager
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.11
 Nodes (4): isValidImportance(), isValidMemoryType(), isValidPrivacyScope(), validateCreateMemoryParams()
 
-### Community 19 - "Community 19"
+### Community 21 - "Community 21"
 Cohesion: 0.13
 Nodes (2): SpacedRepetitionFactory, SpacedRepetitionServiceImpl
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.19
 Nodes (1): VectorCompatibilityService
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.15
 Nodes (1): PerformanceAlertService
 
-### Community 22 - "Community 22"
-Cohesion: 0.21
-Nodes (1): LLMClientInitializer
-
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.12
 Nodes (4): AdaptivePriorityCalculator, DefaultPriorityCalculator, TimeBasedPriorityCalculator, WeightedPriorityCalculator
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.16
 Nodes (4): AdaptivePerformanceAnalyzer, DefaultPerformanceAnalyzer, DetailedPerformanceAnalyzer, PredictivePerformanceAnalyzer
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.14
 Nodes (4): AdaptiveOptimalIntervalRecommender, DefaultOptimalIntervalRecommender, EnsembleOptimalIntervalRecommender, MLBasedOptimalIntervalRecommender
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.19
 Nodes (1): EmbeddingMigrationService
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.2
 Nodes (1): ContextInjector
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.16
 Nodes (1): DatabaseOptimizer
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.28
 Nodes (5): DatabaseUtils, getErrorMessage(), getErrorName(), getSqliteErrorCode(), log()
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.19
 Nodes (6): getSpacedRepetitionService(), initializeSpacedRepetition(), initializeSpacedRepetitionWithDefaults(), isSpacedRepetitionInitialized(), resetSpacedRepetition(), SpacedRepetitionContainer
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.18
 Nodes (4): percentile95Sorted(), periodCutoffIso(), rolling24hCutoffIso(), TelemetryRepository
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.2
 Nodes (2): CoreMemoryService, generateCoreId()
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.13
 Nodes (2): MockDatabase, MockPreparedStatement
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.14
 Nodes (1): KnowledgeVaultRepositorySqlite
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.18
 Nodes (1): SearchEngine
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.2
 Nodes (1): EmbeddingProviderFactory
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.24
 Nodes (7): getCurrentLogLevel(), getTimestamp(), MCPLogger, MCPLoggerStub, safeStderrWrite(), shouldLog(), shouldSendMCPProtocolLog()
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.19
 Nodes (1): AnchorSearchService
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.15
 Nodes (3): AdaptiveReviewScheduler, DefaultReviewScheduler, PriorityBasedReviewScheduler
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.2
 Nodes (2): normalizeProviderFilter(), RecallTool
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.19
 Nodes (1): ForgetTool
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.2
 Nodes (1): TripleExtractor
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.18
 Nodes (1): MiniLMEmbeddingService
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.2
 Nodes (1): LightweightEmbeddingService
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (1): OpenAIEmbeddingService
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.21
 Nodes (1): FailureDetector
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.2
 Nodes (1): ToolRegistry
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.13
 Nodes (3): createDashboardHarness(), FakeDocument, FakeElement
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.12
 Nodes (1): ServerState
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.21
 Nodes (1): MigrationLogger
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.17
 Nodes (2): convertAlwaysLoad(), CoreMemoryRepositorySqliteImpl
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.17
 Nodes (1): VectorSearchEngine
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.23
 Nodes (1): ForgettingPolicyService
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.19
 Nodes (1): TripleExtractionService
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.2
 Nodes (1): EmbeddingService
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.23
 Nodes (1): UnifiedEmbeddingService
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.24
 Nodes (15): countConsoleLogs(), findConsoleLogs(), findFiles(), isCliScript(), isCoreModule(), isTestFile(), main(), matchesPattern() (+7 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.29
 Nodes (15): beginAuthRequest(), bindDom(), checkSession(), createSessionGate(), ensureSessionGate(), getElementByIdFallback(), handleSignIn(), handleSignOut() (+7 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.22
 Nodes (13): clearStatus(), escHtml(), getGraphPalette(), getNodeFillColor(), getNodeStrokeColor(), getTypeBadgeClass(), loadGraph(), readGraphToken() (+5 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.28
 Nodes (15): appendLabeledLine(), closeSidePanel(), clusterColor(), ensureTooltip(), hideTooltip(), initEmbeddingMap(), loadEmbeddingMap(), openSidePanel() (+7 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.3
 Nodes (2): IntegrationTester, runIntegrationTests()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.17
 Nodes (3): LegacyClient, migrationExample(), ModernClient
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.23
 Nodes (1): MetaMemoryStatsSchemaMigration
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.25
 Nodes (1): FTS5ReflectionNotesMigration
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.13
 Nodes (7): AnchorError, AnchorNotFoundError, DatabaseValidationError, EmbeddingNotFoundError, MemoryNotFoundError, ServiceNotInitializedError, VectorDimensionMismatchError
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.16
 Nodes (1): VectorSearchFacade
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.13
 Nodes (1): SpacedRepetitionAlgorithmRefactored
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.15
 Nodes (1): TelemetryService
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.22
 Nodes (1): MetaMemoryService
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.23
 Nodes (1): MemoryEmbeddingService
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.19
 Nodes (1): ErrorLoggingService
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.14
 Nodes (2): handleFailure(), logError()
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.2
 Nodes (7): generateSampleEmbeddings(), generateSampleMemoryItems(), generateScenarioBasedTestData(), generateSeededEmbeddings(), initializeTestDatabase(), SeededRandom, seedTestDatabase()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.48
 Nodes (14): checkDependencies(), checkNodeVersion(), createDataDirectory(), createEnvFile(), createStartScripts(), initializeDatabase(), log(), logError() (+6 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.23
 Nodes (1): ConsolidationScoreFieldsMigration
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.15
 Nodes (1): JobQueue
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.23
 Nodes (2): isSqliteBusy(), UnpinTool
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.2
 Nodes (1): MockCoreMemoryRepository
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.27
 Nodes (1): RelationQualityValidator
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.23
 Nodes (1): GeminiEmbeddingService
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.16
 Nodes (1): QualityAssuranceService
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.33
 Nodes (1): PerformanceBenchmark
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.23
 Nodes (1): EmbeddingMigration
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.27
 Nodes (11): buildExactMatchQuery(), calculateSimilarity(), determineMergeStrategy(), extractProceduralMemory(), extractSkillName(), extractSteps(), extractWorkflowName(), generateTriggerConditions() (+3 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.19
 Nodes (1): AnchorManager
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.28
 Nodes (1): ForgettingAlgorithm
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.18
 Nodes (3): AdaptiveIntervalStrategy, ConservativeIntervalStrategy, DefaultIntervalStrategy
-
-### Community 88 - "Community 88"
-Cohesion: 0.44
-Nodes (12): $(), clearStatus(), escapeHtml(), hideTable(), initReviewCandidatesPanel(), loadList(), renderTable(), setHidden() (+4 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.36
@@ -2644,28 +2646,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 427 - "Community 427"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 428 - "Community 428"
 Cohesion: 1.0
 Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): createMetrics(), toBytes()
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Nodes (2): createMetrics(), toBytes()
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
@@ -2676,32 +2678,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 435 - "Community 435"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 436 - "Community 436"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 437 - "Community 437"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 438 - "Community 438"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 439 - "Community 439"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 440 - "Community 440"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 441 - "Community 441"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 442 - "Community 442"
 Cohesion: 1.0
@@ -4563,940 +4565,950 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 907 - "Community 907"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 908 - "Community 908"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 441`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 442`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 443`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 444`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 445`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 446`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 447`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 448`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 449`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 450`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 451`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 452`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 453`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 454`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 455`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 456`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 457`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 458`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 459`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 460`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 461`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 462`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 463`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 464`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 465`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 466`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 467`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 468`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 469`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 470`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 471`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 472`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 473`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 474`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 475`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 476`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 477`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 478`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 479`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 480`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 481`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 482`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 483`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 484`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 485`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 486`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 487`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 488`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 489`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 490`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 491`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 492`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 493`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 494`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 495`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 496`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 497`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 498`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 499`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `migrateDatabase()`, `migrate.ts`
+- **Thin community `Community 500`** (2 nodes): `migrateDatabase()`, `migrate.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 501`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 502`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 503`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 504`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 505`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 506`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 507`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 508`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 509`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 510`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 511`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 512`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 513`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 514`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 515`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 516`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 517`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 518`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 519`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 520`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 521`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 522`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 523`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 524`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 525`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `isMemoryItemType()`, `index.ts`
+- **Thin community `Community 526`** (2 nodes): `isMemoryItemType()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 527`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 528`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 529`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 530`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 531`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 532`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 533`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 534`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 535`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 536`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 537`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 538`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 539`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 542`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 543`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 544`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 548`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 552`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 553`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 556`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 557`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 558`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 559`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 560`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 561`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 562`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 563`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 564`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 565`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 566`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 567`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 568`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 569`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 570`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 571`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 572`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 573`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 574`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 575`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 576`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 577`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 578`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 579`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 580`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 581`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 582`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 583`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 584`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 585`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 586`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 587`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 589`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 591`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 592`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 593`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 594`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 595`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 596`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 597`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 598`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 599`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 600`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 601`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 602`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 603`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 604`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 605`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 607`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 608`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 609`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 610`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 612`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 613`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 614`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 615`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 616`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 617`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 618`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 619`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 620`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `types.ts`
+- **Thin community `Community 621`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 622`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `index.ts`
+- **Thin community `Community 623`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 624`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 625`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 626`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 627`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 628`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 629`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `transport.ts`
+- **Thin community `Community 630`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `index.ts`
+- **Thin community `Community 631`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 632`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 633`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 634`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 635`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 636`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 637`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 638`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 639`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 640`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 641`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 642`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 643`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 644`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 645`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 646`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 647`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 648`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 649`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 650`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 651`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 652`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 653`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 654`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 655`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 656`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 657`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `context.ts`
+- **Thin community `Community 658`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 659`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 660`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 661`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 662`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `index.ts`
+- **Thin community `Community 663`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 664`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 665`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `types.ts`
+- **Thin community `Community 666`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 667`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 668`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 669`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 670`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 671`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 672`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 673`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 674`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 675`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 676`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 677`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `index.ts`
+- **Thin community `Community 678`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `types.ts`
+- **Thin community `Community 688`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 695`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 705`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 722`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 723`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 724`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 725`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 726`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 727`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 728`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 729`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 730`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 731`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 732`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `error-types.ts`
+- **Thin community `Community 733`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 734`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 735`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `search.types.ts`
+- **Thin community `Community 736`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 738`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `constants.ts`
+- **Thin community `Community 739`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 740`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 747`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 748`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 750`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 751`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 752`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 753`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 754`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 755`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 756`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 757`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 758`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 759`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 775`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 776`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `index.ts`
+- **Thin community `Community 778`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `database-types.ts`
+- **Thin community `Community 780`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 784`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 785`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 786`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 787`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 790`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 792`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 797`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `index.ts`
+- **Thin community `Community 800`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 801`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 803`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 804`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 805`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 806`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 807`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 808`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 811`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 813`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 814`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 816`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 822`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 823`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `index.ts`
+- **Thin community `Community 832`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 834`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 844`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `types.ts`
+- **Thin community `Community 868`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 870`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 872`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 873`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 874`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 881`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 882`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 884`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 885`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 894`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `types.ts`
+- **Thin community `Community 895`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 908`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 617
+      "community": 619
     },
     {
       "label": "vitest.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 618
+      "community": 620
     },
     {
       "label": "assistant.spec.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 619
+      "community": 621
     },
     {
       "label": "types.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 620
+      "community": 622
     },
     {
       "label": "types.spec.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 621
+      "community": 623
     },
     {
       "label": "assistant.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 622
+      "community": 624
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 623
+      "community": 625
     },
     {
       "label": "after-assistant-turn.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "afterAssistantTurn()",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 441
+      "community": 442
     },
     {
       "label": "before-user-turn.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "shouldAutoRecall()",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 442
+      "community": 443
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 624
+      "community": 626
     },
     {
       "label": "auto-remember-policy.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "rememberDispatch()",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 625
+      "community": 627
     },
     {
       "label": "channel-scope.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 626
+      "community": 628
     },
     {
       "label": "http-transport.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 627
+      "community": 629
     },
     {
       "label": "mock-transport.spec.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 628
+      "community": 630
     },
     {
       "label": "transport.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 629
+      "community": 631
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 630
+      "community": 632
     },
     {
       "label": "http-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 631
+      "community": 633
     },
     {
       "label": "factory.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "createTransportFromEnv()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 444
+      "community": 445
     },
     {
       "label": "stdio-transport.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 632
+      "community": 634
     },
     {
       "label": "mock-transport.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 633
+      "community": 635
     },
     {
       "label": "retry-queue.spec.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 634
+      "community": 636
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 635
+      "community": 637
     },
     {
       "label": "retry-queue.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 636
+      "community": 638
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 637
+      "community": 639
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 638
+      "community": 640
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 639
+      "community": 641
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 640
+      "community": 642
     },
     {
       "label": "http.integration.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 641
+      "community": 643
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 642
+      "community": 644
     },
     {
       "label": "start-http-server.ts",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 643
+      "community": 645
     },
     {
       "label": "test-integration.js",
@@ -785,7 +785,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_integration_js",
-      "community": 61
+      "community": 62
     },
     {
       "label": "IntegrationTester",
@@ -793,7 +793,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L12",
       "id": "test_integration_integrationtester",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".constructor()",
@@ -801,7 +801,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L13",
       "id": "test_integration_integrationtester_constructor",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".runAllTests()",
@@ -809,7 +809,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L26",
       "id": "test_integration_integrationtester_runalltests",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testServerConnection()",
@@ -817,7 +817,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L66",
       "id": "test_integration_integrationtester_testserverconnection",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testBasicCRUD()",
@@ -825,7 +825,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L83",
       "id": "test_integration_integrationtester_testbasiccrud",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testSearchFeatures()",
@@ -833,7 +833,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L122",
       "id": "test_integration_integrationtester_testsearchfeatures",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testContextInjection()",
@@ -841,7 +841,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L158",
       "id": "test_integration_integrationtester_testcontextinjection",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testAdvancedFeatures()",
@@ -849,7 +849,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L192",
       "id": "test_integration_integrationtester_testadvancedfeatures",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testErrorHandling()",
@@ -857,7 +857,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L225",
       "id": "test_integration_integrationtester_testerrorhandling",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".testPerformance()",
@@ -865,7 +865,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L252",
       "id": "test_integration_integrationtester_testperformance",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".cleanup()",
@@ -873,7 +873,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L295",
       "id": "test_integration_integrationtester_cleanup",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".recordTest()",
@@ -881,7 +881,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L319",
       "id": "test_integration_integrationtester_recordtest",
-      "community": 61
+      "community": 62
     },
     {
       "label": ".printTestSummary()",
@@ -889,7 +889,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L325",
       "id": "test_integration_integrationtester_printtestsummary",
-      "community": 61
+      "community": 62
     },
     {
       "label": "runIntegrationTests()",
@@ -897,7 +897,7 @@
       "source_file": "packages/mcp-client/test-integration.js",
       "source_location": "L356",
       "id": "test_integration_runintegrationtests",
-      "community": 61
+      "community": 62
     },
     {
       "label": "test-basic.js",
@@ -905,7 +905,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 445
+      "community": 446
     },
     {
       "label": "testBasicFunctionality()",
@@ -913,7 +913,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 445
+      "community": 446
     },
     {
       "label": "performance-optimizer.js",
@@ -921,7 +921,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L1",
       "id": "packages_mcp_client_performance_optimizer_js",
-      "community": 16
+      "community": 18
     },
     {
       "label": "PerformanceOptimizer",
@@ -929,7 +929,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L9",
       "id": "performance_optimizer_performanceoptimizer",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".constructor()",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L10",
       "id": "performance_optimizer_performanceoptimizer_constructor",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".createMemoriesBatch()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L32",
       "id": "performance_optimizer_performanceoptimizer_creatememoriesbatch",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".parallelSearch()",
@@ -953,7 +953,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L87",
       "id": "performance_optimizer_performanceoptimizer_parallelsearch",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".cachedSearch()",
@@ -961,7 +961,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L143",
       "id": "performance_optimizer_performanceoptimizer_cachedsearch",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".streamSearch()",
@@ -969,7 +969,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L178",
       "id": "performance_optimizer_performanceoptimizer_streamsearch",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".compressedSearch()",
@@ -977,7 +977,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L226",
       "id": "performance_optimizer_performanceoptimizer_compressedsearch",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".runBenchmark()",
@@ -985,7 +985,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L260",
       "id": "performance_optimizer_performanceoptimizer_runbenchmark",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".recordMetric()",
@@ -993,7 +993,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L313",
       "id": "performance_optimizer_performanceoptimizer_recordmetric",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".getPerformanceStats()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L321",
       "id": "performance_optimizer_performanceoptimizer_getperformancestats",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".clearCache()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L342",
       "id": "performance_optimizer_performanceoptimizer_clearcache",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".generateCacheKey()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L348",
       "id": "performance_optimizer_performanceoptimizer_generatecachekey",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".delay()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L352",
       "id": "performance_optimizer_performanceoptimizer_delay",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".timeoutPromise()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L356",
       "id": "performance_optimizer_performanceoptimizer_timeoutpromise",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".analyzeBenchmarkResults()",
@@ -1041,7 +1041,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L362",
       "id": "performance_optimizer_performanceoptimizer_analyzebenchmarkresults",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".printBenchmarkResults()",
@@ -1049,7 +1049,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L380",
       "id": "performance_optimizer_performanceoptimizer_printbenchmarkresults",
-      "community": 16
+      "community": 18
     },
     {
       "label": "Semaphore",
@@ -1057,7 +1057,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L400",
       "id": "performance_optimizer_semaphore",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".constructor()",
@@ -1065,7 +1065,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L401",
       "id": "performance_optimizer_semaphore_constructor",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".acquire()",
@@ -1073,7 +1073,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L407",
       "id": "performance_optimizer_semaphore_acquire",
-      "community": 16
+      "community": 18
     },
     {
       "label": ".release()",
@@ -1081,7 +1081,7 @@
       "source_file": "packages/mcp-client/performance-optimizer.js",
       "source_location": "L418",
       "id": "performance_optimizer_semaphore_release",
-      "community": 16
+      "community": 18
     },
     {
       "label": "basic-usage.ts",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "basicUsageExample()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 446
+      "community": 447
     },
     {
       "label": "performance-examples.ts",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "advancedUsageExample()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 447
+      "community": 448
     },
     {
       "label": "migration-guide.ts",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_migration_guide_ts",
-      "community": 62
+      "community": 63
     },
     {
       "label": "LegacyClient",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L12",
       "id": "migration_guide_legacyclient",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".connect()",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L14",
       "id": "migration_guide_legacyclient_connect",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".callTool()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L18",
       "id": "migration_guide_legacyclient_calltool",
-      "community": 62
+      "community": 63
     },
     {
       "label": "ModernClient",
@@ -1241,7 +1241,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L26",
       "id": "migration_guide_modernclient",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".constructor()",
@@ -1249,7 +1249,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L31",
       "id": "migration_guide_modernclient_constructor",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".connect()",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L42",
       "id": "migration_guide_modernclient_connect",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".remember()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L47",
       "id": "migration_guide_modernclient_remember",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".recall()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L62",
       "id": "migration_guide_modernclient_recall",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".pin()",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L74",
       "id": "migration_guide_modernclient_pin",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".unpin()",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L81",
       "id": "migration_guide_modernclient_unpin",
-      "community": 62
+      "community": 63
     },
     {
       "label": ".forget()",
@@ -1297,7 +1297,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L88",
       "id": "migration_guide_modernclient_forget",
-      "community": 62
+      "community": 63
     },
     {
       "label": "migrationExample()",
@@ -1305,7 +1305,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L99",
       "id": "migration_guide_migrationexample",
-      "community": 62
+      "community": 63
     },
     {
       "label": "migrationSteps()",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L207",
       "id": "migration_guide_migrationsteps",
-      "community": 62
+      "community": 63
     },
     {
       "label": "compatibilityGuide()",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/mcp-client/examples/migration-guide.ts",
       "source_location": "L244",
       "id": "migration_guide_compatibilityguide",
-      "community": 62
+      "community": 63
     },
     {
       "label": "ai-agent-integration.ts",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_ai_agent_integration_ts",
-      "community": 17
+      "community": 19
     },
     {
       "label": "AIAgent",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L12",
       "id": "ai_agent_integration_aiagent",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".constructor()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L18",
       "id": "ai_agent_integration_aiagent_constructor",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".initialize()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L30",
       "id": "ai_agent_integration_aiagent_initialize",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".processMessage()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L35",
       "id": "ai_agent_integration_aiagent_processmessage",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".generateResponse()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L69",
       "id": "ai_agent_integration_aiagent_generateresponse",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".getMemoryStats()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L105",
       "id": "ai_agent_integration_aiagent_getmemorystats",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".searchMemories()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L116",
       "id": "ai_agent_integration_aiagent_searchmemories",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".cleanup()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L125",
       "id": "ai_agent_integration_aiagent_cleanup",
-      "community": 17
+      "community": 19
     },
     {
       "label": "ProjectManager",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L134",
       "id": "ai_agent_integration_projectmanager",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".constructor()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L138",
       "id": "ai_agent_integration_projectmanager_constructor",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".createProject()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L143",
       "id": "ai_agent_integration_projectmanager_createproject",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".addTask()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L154",
       "id": "ai_agent_integration_projectmanager_addtask",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".completeTask()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L167",
       "id": "ai_agent_integration_projectmanager_completetask",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".getProjectHistory()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L178",
       "id": "ai_agent_integration_projectmanager_getprojecthistory",
-      "community": 17
+      "community": 19
     },
     {
       "label": "LearningManager",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L191",
       "id": "ai_agent_integration_learningmanager",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".constructor()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L195",
       "id": "ai_agent_integration_learningmanager_constructor",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".studyTopic()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L200",
       "id": "ai_agent_integration_learningmanager_studytopic",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".reviewTopic()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L212",
       "id": "ai_agent_integration_learningmanager_reviewtopic",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".getLearningProgress()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L218",
       "id": "ai_agent_integration_learningmanager_getlearningprogress",
-      "community": 17
+      "community": 19
     },
     {
       "label": "aiAgentIntegrationExample()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/mcp-client/examples/ai-agent-integration.ts",
       "source_location": "L239",
       "id": "ai_agent_integration_aiagentintegrationexample",
-      "community": 17
+      "community": 19
     },
     {
       "label": "telemetry-cli.spec.ts",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "makeNullRunner()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 448
+      "community": 449
     },
     {
       "label": "telemetry-cli.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 644
+      "community": 646
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_auth_assets_spec_ts",
-      "community": 48
+      "community": 49
     },
     {
       "label": "FakeElement",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L18",
       "id": "dashboard_auth_assets_spec_fakeelement",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".addEventListener()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L27",
       "id": "dashboard_auth_assets_spec_fakeelement_addeventlistener",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".dispatch()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L33",
       "id": "dashboard_auth_assets_spec_fakeelement_dispatch",
-      "community": 48
+      "community": 49
     },
     {
       "label": "FakeDocument",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L40",
       "id": "dashboard_auth_assets_spec_fakedocument",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".constructor()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L45",
       "id": "dashboard_auth_assets_spec_fakedocument_constructor",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".addEventListener()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L50",
       "id": "dashboard_auth_assets_spec_fakedocument_addeventlistener",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".dispatchDOMContentLoaded()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L56",
       "id": "dashboard_auth_assets_spec_fakedocument_dispatchdomcontentloaded",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".querySelector()",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L62",
       "id": "dashboard_auth_assets_spec_fakedocument_queryselector",
-      "community": 48
+      "community": 49
     },
     {
       "label": ".getElementById()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L69",
       "id": "dashboard_auth_assets_spec_fakedocument_getelementbyid",
-      "community": 48
+      "community": 49
     },
     {
       "label": "createDeferred()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L74",
       "id": "dashboard_auth_assets_spec_createdeferred",
-      "community": 48
+      "community": 49
     },
     {
       "label": "createJsonResponse()",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L84",
       "id": "dashboard_auth_assets_spec_createjsonresponse",
-      "community": 48
+      "community": 49
     },
     {
       "label": "createNoContentResponse()",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L92",
       "id": "dashboard_auth_assets_spec_createnocontentresponse",
-      "community": 48
+      "community": 49
     },
     {
       "label": "flushPromises()",
@@ -1865,7 +1865,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L100",
       "id": "dashboard_auth_assets_spec_flushpromises",
-      "community": 48
+      "community": 49
     },
     {
       "label": "createDashboardHarness()",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L106",
       "id": "dashboard_auth_assets_spec_createdashboardharness",
-      "community": 48
+      "community": 49
     },
     {
       "label": "preventDefault()",
@@ -1881,7 +1881,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-auth-assets.spec.ts",
       "source_location": "L228",
       "id": "dashboard_auth_assets_spec_preventdefault",
-      "community": 48
+      "community": 49
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 645
+      "community": 647
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 646
+      "community": 648
     },
     {
       "label": "index-factory.spec.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 647
+      "community": 649
     },
     {
       "label": "context.spec.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 648
+      "community": 650
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 649
+      "community": 651
     },
     {
       "label": "server-factory.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "createServerFactory()",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 449
+      "community": 450
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 650
+      "community": 652
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 651
+      "community": 653
     },
     {
       "label": "stdio-server-impl.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "startStdioServer()",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 450
+      "community": 451
     },
     {
       "label": "server-factory.spec.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 652
+      "community": 654
     },
     {
       "label": "server-state.spec.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 653
+      "community": 655
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 654
+      "community": 656
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 451
+      "community": 452
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_ts",
-      "community": 49
+      "community": 50
     },
     {
       "label": "ServerState",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L19",
       "id": "server_state_serverstate",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".getInstance()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L33",
       "id": "server_state_serverstate_getinstance",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".constructor()",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L43",
       "id": "server_state_serverstate_constructor",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".isMcpServerInitialized()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L52",
       "id": "server_state_serverstate_ismcpserverinitialized",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".setMcpServerInitialized()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L61",
       "id": "server_state_serverstate_setmcpserverinitialized",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".isConsoleErrorOverridden()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L70",
       "id": "server_state_serverstate_isconsoleerroroverridden",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".setConsoleErrorOverridden()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L79",
       "id": "server_state_serverstate_setconsoleerroroverridden",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".isConsoleOverridden()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L88",
       "id": "server_state_serverstate_isconsoleoverridden",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".setConsoleOverridden()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L97",
       "id": "server_state_serverstate_setconsoleoverridden",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".isMcpTransportConnected()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L106",
       "id": "server_state_serverstate_ismcptransportconnected",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".setMcpTransportConnected()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L115",
       "id": "server_state_serverstate_setmcptransportconnected",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".reset()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L125",
       "id": "server_state_serverstate_reset",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".resetInstance()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L140",
       "id": "server_state_serverstate_resetinstance",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".getSnapshot()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L151",
       "id": "server_state_serverstate_getsnapshot",
-      "community": 49
+      "community": 50
     },
     {
       "label": ".restoreSnapshot()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/memento-server/src/server/server-state.ts",
       "source_location": "L167",
       "id": "server_state_serverstate_restoresnapshot",
-      "community": 49
+      "community": 50
     },
     {
       "label": "bootstrap.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 655
+      "community": 657
     },
     {
       "label": "index.spec.ts",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 656
+      "community": 658
     },
     {
       "label": "sse-server-impl.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 657
+      "community": 659
     },
     {
       "label": "mcp-logger.ts",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_ts",
-      "community": 37
+      "community": 38
     },
     {
       "label": "getCurrentLogLevel()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L15",
       "id": "mcp_logger_getcurrentloglevel",
-      "community": 37
+      "community": 38
     },
     {
       "label": "shouldLog()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L21",
       "id": "mcp_logger_shouldlog",
-      "community": 37
+      "community": 38
     },
     {
       "label": "shouldSendMCPProtocolLog()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L59",
       "id": "mcp_logger_shouldsendmcpprotocollog",
-      "community": 37
+      "community": 38
     },
     {
       "label": "getTimestamp()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L26",
       "id": "mcp_logger_gettimestamp",
-      "community": 37
+      "community": 38
     },
     {
       "label": "MCPLogger",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L82",
       "id": "mcp_logger_mcplogger",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".setServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L88",
       "id": "mcp_logger_mcplogger_setserver",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logMCPProtocol()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L100",
       "id": "mcp_logger_mcplogger_logmcpprotocol",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logServer()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L151",
       "id": "mcp_logger_mcplogger_logserver",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logBatch()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.ts",
       "source_location": "L175",
       "id": "mcp_logger_mcplogger_logbatch",
-      "community": 37
+      "community": 38
     },
     {
       "label": "instance-lock.ts",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "anchor-map.handler.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 659
+      "community": 661
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 660
+      "community": 662
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "makeMocks()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 452
+      "community": 453
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 453
+      "community": 454
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "createMockResponse()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 454
+      "community": 455
     },
     {
       "label": "index.ts",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 662
+      "community": 664
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "createServiceInjector()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 455
+      "community": 456
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 456
+      "community": 457
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "createMockResponse()",
@@ -3105,7 +3105,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 457
+      "community": 458
     },
     {
       "label": "session-store.spec.ts",
@@ -3113,7 +3113,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "session-store.ts",
@@ -3121,7 +3121,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createSessionStore()",
@@ -3129,7 +3129,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 458
+      "community": 459
     },
     {
       "label": "stdio-server.ts",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "admin.routes.ts",
@@ -3255,7 +3255,7 @@
       "label": "parseCleanupParams()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L37",
+      "source_location": "L39",
       "id": "admin_routes_parsecleanupparams",
       "community": 318
     },
@@ -3263,7 +3263,7 @@
       "label": "parseReviewCandidateStatusQuery()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L65",
+      "source_location": "L67",
       "id": "admin_routes_parsereviewcandidatestatusquery",
       "community": 318
     },
@@ -3271,7 +3271,7 @@
       "label": "createAdminRouter()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L81",
+      "source_location": "L83",
       "id": "admin_routes_createadminrouter",
       "community": 318
     },
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createToolsRouter()",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 459
+      "community": 460
     },
     {
       "label": "api.routes.ts",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createApiRouter()",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 460
+      "community": 461
     },
     {
       "label": "quality.routes.ts",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createQualityRouter()",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 461
+      "community": 462
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "buildGraphResponse()",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 462
+      "community": 463
     },
     {
       "label": "admin-graph.routes.ts",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 463
+      "community": 464
     },
     {
       "label": "admin-relations.routes.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 464
+      "community": 465
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 465
+      "community": 466
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -3617,7 +3617,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 466
+      "community": 467
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "runCli()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 467
+      "community": 468
     },
     {
       "label": "option-map.ts",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "testSimpleAlerts()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "testBasicFunctionality()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 469
+      "community": 470
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 470
+      "community": 471
     },
     {
       "label": "test-server-synchronization.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "testErrorLogging()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 471
+      "community": 472
     },
     {
       "label": "debug-http-v2.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "testFetch()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 472
+      "community": 473
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "initializeTestDatabase()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 473
+      "community": 474
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "testReflexionE2E()",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 474
+      "community": 475
     },
     {
       "label": "test-alerts-direct.ts",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "testAlertsDirect()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 475
+      "community": 476
     },
     {
       "label": "test-client.ts",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 477
+      "community": 478
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 478
+      "community": 479
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "brave-search-provider.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "createSearchProvider()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 479
+      "community": 480
     },
     {
       "label": "search-provider.ts",
@@ -4289,7 +4289,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "llm-provider.ts",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "claude-provider.spec.ts",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "types.ts",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "loadAgentConfig()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 480
+      "community": 481
     },
     {
       "label": "system-prompt.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "vitest.config.ts",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "utils.spec.ts",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "buildMemory()",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 481
+      "community": 482
     },
     {
       "label": "context-injector.ts",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_context_injector_ts",
-      "community": 27
+      "community": 28
     },
     {
       "label": "ContextInjector",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L46",
       "id": "context_injector_contextinjector",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".constructor()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L47",
       "id": "context_injector_contextinjector_constructor",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".inject()",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L52",
       "id": "context_injector_contextinjector_inject",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".searchRelevantMemories()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L106",
       "id": "context_injector_contextinjector_searchrelevantmemories",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".compressMemories()",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L158",
       "id": "context_injector_contextinjector_compressmemories",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".summarizeMemory()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L204",
       "id": "context_injector_contextinjector_summarizememory",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".generateContext()",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L230",
       "id": "context_injector_contextinjector_generatecontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".getContextHeader()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L249",
       "id": "context_injector_contextinjector_getcontextheader",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".formatMemories()",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L262",
       "id": "context_injector_contextinjector_formatmemories",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".getTypeEmoji()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L279",
       "id": "context_injector_contextinjector_gettypeemoji",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".getImportanceBar()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L292",
       "id": "context_injector_contextinjector_getimportancebar",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".getContextFooter()",
@@ -4457,7 +4457,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L301",
       "id": "context_injector_contextinjector_getcontextfooter",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".generateEmptyContext()",
@@ -4465,7 +4465,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L308",
       "id": "context_injector_contextinjector_generateemptycontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".estimateTokenCount()",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L321",
       "id": "context_injector_contextinjector_estimatetokencount",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".injectConversationContext()",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L337",
       "id": "context_injector_contextinjector_injectconversationcontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".injectTaskContext()",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L353",
       "id": "context_injector_contextinjector_injecttaskcontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".injectLearningContext()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L375",
       "id": "context_injector_contextinjector_injectlearningcontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".injectProjectContext()",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/memento-client/src/context-injector.ts",
       "source_location": "L391",
       "id": "context_injector_contextinjector_injectprojectcontext",
-      "community": 27
+      "community": 28
     },
     {
       "label": "types.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_memory_manager_ts",
-      "community": 8
+      "community": 9
     },
     {
       "label": "MemoryManager",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L35",
       "id": "memory_manager_memorymanager",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".constructor()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L36",
       "id": "memory_manager_memorymanager_constructor",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".create()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L45",
       "id": "memory_manager_memorymanager_create",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".get()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L55",
       "id": "memory_manager_memorymanager_get",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".update()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L70",
       "id": "memory_manager_memorymanager_update",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".delete()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L77",
       "id": "memory_manager_memorymanager_delete",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".search()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L89",
       "id": "memory_manager_memorymanager_search",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".searchByTags()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L123",
       "id": "memory_manager_memorymanager_searchbytags",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".searchByType()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L133",
       "id": "memory_manager_memorymanager_searchbytype",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".searchByProject()",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L143",
       "id": "memory_manager_memorymanager_searchbyproject",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".searchRecent()",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L153",
       "id": "memory_manager_memorymanager_searchrecent",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".searchPinned()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L168",
       "id": "memory_manager_memorymanager_searchpinned",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".findSimilar()",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L182",
       "id": "memory_manager_memorymanager_findsimilar",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".findRelated()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L203",
       "id": "memory_manager_memorymanager_findrelated",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".pin()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L222",
       "id": "memory_manager_memorymanager_pin",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".unpin()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L230",
       "id": "memory_manager_memorymanager_unpin",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".setImportance()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L238",
       "id": "memory_manager_memorymanager_setimportance",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".addTags()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L249",
       "id": "memory_manager_memorymanager_addtags",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".removeTags()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L264",
       "id": "memory_manager_memorymanager_removetags",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".setTags()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L279",
       "id": "memory_manager_memorymanager_settags",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".setPrivacyScope()",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L286",
       "id": "memory_manager_memorymanager_setprivacyscope",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".createBatch()",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L300",
       "id": "memory_manager_memorymanager_createbatch",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".deleteBatch()",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L319",
       "id": "memory_manager_memorymanager_deletebatch",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".pinBatch()",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L337",
       "id": "memory_manager_memorymanager_pinbatch",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".getStats()",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L359",
       "id": "memory_manager_memorymanager_getstats",
-      "community": 8
+      "community": 9
     },
     {
       "label": ".getPopularTags()",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/memento-client/src/memory-manager.ts",
       "source_location": "L399",
       "id": "memory_manager_memorymanager_getpopulartags",
-      "community": 8
+      "community": 9
     },
     {
       "label": "memento-client.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_memento_client_ts",
-      "community": 10
+      "community": 11
     },
     {
       "label": "MementoClient",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L57",
       "id": "memento_client_mementoclient",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".constructor()",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L62",
       "id": "memento_client_mementoclient_constructor",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".createHttpClient()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L80",
       "id": "memento_client_mementoclient_createhttpclient",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".handleHttpError()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L137",
       "id": "memento_client_mementoclient_handlehttperror",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".connect()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L169",
       "id": "memento_client_mementoclient_connect",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".disconnect()",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L191",
       "id": "memento_client_mementoclient_disconnect",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".connected()",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L203",
       "id": "memento_client_mementoclient_connected",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".healthCheck()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L210",
       "id": "memento_client_mementoclient_healthcheck",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".remember()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L222",
       "id": "memento_client_mementoclient_remember",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".recall()",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L238",
       "id": "memento_client_mementoclient_recall",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".hybridSearch()",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L273",
       "id": "memento_client_mementoclient_hybridsearch",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".getMemory()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L306",
       "id": "memento_client_mementoclient_getmemory",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".updateMemory()",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L339",
       "id": "memento_client_mementoclient_updatememory",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".forget()",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L422",
       "id": "memento_client_mementoclient_forget",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".pin()",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L438",
       "id": "memento_client_mementoclient_pin",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".unpin()",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L453",
       "id": "memento_client_mementoclient_unpin",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".link()",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L472",
       "id": "memento_client_mementoclient_link",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".export()",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L491",
       "id": "memento_client_mementoclient_export",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".feedback()",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L510",
       "id": "memento_client_mementoclient_feedback",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".injectContext()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L537",
       "id": "memento_client_mementoclient_injectcontext",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".ensureConnected()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L551",
       "id": "memento_client_mementoclient_ensureconnected",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".updateOptions()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L562",
       "id": "memento_client_mementoclient_updateoptions",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".getOptions()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/memento-client/src/memento-client.ts",
       "source_location": "L570",
       "id": "memento_client_mementoclient_getoptions",
-      "community": 10
+      "community": 11
     },
     {
       "label": "utils.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_ts",
-      "community": 18
+      "community": 20
     },
     {
       "label": "isValidMemoryType()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L18",
       "id": "utils_isvalidmemorytype",
-      "community": 18
+      "community": 20
     },
     {
       "label": "isValidPrivacyScope()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L25",
       "id": "utils_isvalidprivacyscope",
-      "community": 18
+      "community": 20
     },
     {
       "label": "isValidImportance()",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L32",
       "id": "utils_isvalidimportance",
-      "community": 18
+      "community": 20
     },
     {
       "label": "extractTagsFromContent()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L43",
       "id": "utils_extracttagsfromcontent",
-      "community": 18
+      "community": 20
     },
     {
       "label": "summarizeContent()",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L63",
       "id": "utils_summarizecontent",
-      "community": 18
+      "community": 20
     },
     {
       "label": "calculateImportance()",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L86",
       "id": "utils_calculateimportance",
-      "community": 18
+      "community": 20
     },
     {
       "label": "getDefaultSettingsForType()",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L125",
       "id": "utils_getdefaultsettingsfortype",
-      "community": 18
+      "community": 20
     },
     {
       "label": "normalizeQuery()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L182",
       "id": "utils_normalizequery",
-      "community": 18
+      "community": 20
     },
     {
       "label": "normalizeScore()",
@@ -5081,7 +5081,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L193",
       "id": "utils_normalizescore",
-      "community": 18
+      "community": 20
     },
     {
       "label": "groupSearchResults()",
@@ -5089,7 +5089,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L201",
       "id": "utils_groupsearchresults",
-      "community": 18
+      "community": 20
     },
     {
       "label": "getRelativeTime()",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L240",
       "id": "utils_getrelativetime",
-      "community": 18
+      "community": 20
     },
     {
       "label": "createDateRangeFilter()",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L262",
       "id": "utils_createdaterangefilter",
-      "community": 18
+      "community": 20
     },
     {
       "label": "serializeMemory()",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L282",
       "id": "utils_serializememory",
-      "community": 18
+      "community": 20
     },
     {
       "label": "deserializeMemory()",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L289",
       "id": "utils_deserializememory",
-      "community": 18
+      "community": 20
     },
     {
       "label": "toSafeCSVCell()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L296",
       "id": "utils_tosafecsvcell",
-      "community": 18
+      "community": 20
     },
     {
       "label": "memoriesToCSV()",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L307",
       "id": "utils_memoriestocsv",
-      "community": 18
+      "community": 20
     },
     {
       "label": "memoriesToMarkdown()",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L342",
       "id": "utils_memoriestomarkdown",
-      "community": 18
+      "community": 20
     },
     {
       "label": "validateCreateMemoryParams()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L393",
       "id": "utils_validatecreatememoryparams",
-      "community": 18
+      "community": 20
     },
     {
       "label": "validateSearchParams()",
@@ -5161,7 +5161,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L457",
       "id": "utils_validatesearchparams",
-      "community": 18
+      "community": 20
     },
     {
       "label": "createMementoClient()",
@@ -5169,7 +5169,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L498",
       "id": "utils_createmementoclient",
-      "community": 18
+      "community": 20
     },
     {
       "label": "index.ts",
@@ -5177,7 +5177,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "logger.ts",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "initializeServices()",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 482
+      "community": 483
     },
     {
       "label": "context.ts",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 483
+      "community": 484
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -5337,7 +5337,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 484
+      "community": 485
     },
     {
       "label": "anchor-stack.ts",
@@ -5345,7 +5345,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "createAnchorStack()",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 485
+      "community": 486
     },
     {
       "label": "failure-reflexion.ts",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "startFailureAndReflexion()",
@@ -5369,7 +5369,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 486
+      "community": 487
     },
     {
       "label": "search-and-embedding.ts",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 487
+      "community": 488
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 488
+      "community": 489
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 489
+      "community": 490
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_server_mcp_logger_ts",
-      "community": 37
+      "community": 38
     },
     {
       "label": "safeStderrWrite()",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L31",
       "id": "mcp_logger_safestderrwrite",
-      "community": 37
+      "community": 38
     },
     {
       "label": "MCPLoggerStub",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L36",
       "id": "mcp_logger_mcploggerstub",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".setServer()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L39",
       "id": "mcp_logger_mcploggerstub_setserver",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logServer()",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L43",
       "id": "mcp_logger_mcploggerstub_logserver",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logBatch()",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L50",
       "id": "mcp_logger_mcploggerstub_logbatch",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".logMCPProtocol()",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/memento-core/src/server/mcp-logger.ts",
       "source_location": "L57",
       "id": "mcp_logger_mcploggerstub_logmcpprotocol",
-      "community": 37
+      "community": 38
     },
     {
       "label": "reflexion-worker.ts",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_ts",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ReflexionWorker",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L33",
       "id": "reflexion_worker_reflexionworker",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".constructor()",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L57",
       "id": "reflexion_worker_reflexionworker_constructor",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".start()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L76",
       "id": "reflexion_worker_reflexionworker_start",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".stop()",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L110",
       "id": "reflexion_worker_reflexionworker_stop",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".startHealthCheck()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L144",
       "id": "reflexion_worker_reflexionworker_starthealthcheck",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".performHealthCheck()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L154",
       "id": "reflexion_worker_reflexionworker_performhealthcheck",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".attemptRestart()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L183",
       "id": "reflexion_worker_reflexionworker_attemptrestart",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".autoReflect()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L226",
       "id": "reflexion_worker_reflexionworker_autoreflect",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".isDuplicate()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L376",
       "id": "reflexion_worker_reflexionworker_isduplicate",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".generateEventKey()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L398",
       "id": "reflexion_worker_reflexionworker_generateeventkey",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".cleanupDuplicateWindow()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L406",
       "id": "reflexion_worker_reflexionworker_cleanupduplicatewindow",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".generateReflectionNote()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L418",
       "id": "reflexion_worker_reflexionworker_generatereflectionnote",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".generateLessonsLearned()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L433",
       "id": "reflexion_worker_reflexionworker_generatelessonslearned",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".generateSuggestedImprovements()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L446",
       "id": "reflexion_worker_reflexionworker_generatesuggestedimprovements",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".analyzeFailurePattern()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L478",
       "id": "reflexion_worker_reflexionworker_analyzefailurepattern",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".extractTaskGoal()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L533",
       "id": "reflexion_worker_reflexionworker_extracttaskgoal",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".convertToProceduralMemory()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L560",
       "id": "reflexion_worker_reflexionworker_converttoproceduralmemory",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".updateProceduralMemory()",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L616",
       "id": "reflexion_worker_reflexionworker_updateproceduralmemory",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".createProceduralMemory()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L767",
       "id": "reflexion_worker_reflexionworker_createproceduralmemory",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".parseReflectionNotes()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L837",
       "id": "reflexion_worker_reflexionworker_parsereflectionnotes",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".registerHandler()",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L867",
       "id": "reflexion_worker_reflexionworker_registerhandler",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".queueFailureEvent()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L880",
       "id": "reflexion_worker_reflexionworker_queuefailureevent",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".removeOldestQueuedEvent()",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L929",
       "id": "reflexion_worker_reflexionworker_removeoldestqueuedevent",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".processFailureEvent()",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L938",
       "id": "reflexion_worker_reflexionworker_processfailureevent",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".getStatus()",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L973",
       "id": "reflexion_worker_reflexionworker_getstatus",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".checkQueueBacklog()",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L985",
       "id": "reflexion_worker_reflexionworker_checkqueuebacklog",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".getReflexionMetrics()",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L998",
       "id": "reflexion_worker_reflexionworker_getreflexionmetrics",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".getIntegratedMetrics()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.ts",
       "source_location": "L1026",
       "id": "reflexion_worker_reflexionworker_getintegratedmetrics",
-      "community": 7
+      "community": 8
     },
     {
       "label": "async-optimizer.ts",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "createInput()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 490
+      "community": 491
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createRelationGraph()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 491
+      "community": 492
     },
     {
       "label": "consolidation-score-service.ts",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimizer_ts",
-      "community": 28
+      "community": 29
     },
     {
       "label": "DatabaseOptimizer",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L48",
       "id": "database_optimizer_databaseoptimizer",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".constructor()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L52",
       "id": "database_optimizer_databaseoptimizer_constructor",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzePerformance()",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L59",
       "id": "database_optimizer_databaseoptimizer_analyzeperformance",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzeTables()",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L74",
       "id": "database_optimizer_databaseoptimizer_analyzetables",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzeIndexes()",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L122",
       "id": "database_optimizer_databaseoptimizer_analyzeindexes",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzeQueries()",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L157",
       "id": "database_optimizer_databaseoptimizer_analyzequeries",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".generateIndexRecommendations()",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L186",
       "id": "database_optimizer_databaseoptimizer_generateindexrecommendations",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzeQueryPatterns()",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L234",
       "id": "database_optimizer_databaseoptimizer_analyzequerypatterns",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".generateQueryRecommendations()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L273",
       "id": "database_optimizer_databaseoptimizer_generatequeryrecommendations",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".assessQueryComplexity()",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L302",
       "id": "database_optimizer_databaseoptimizer_assessquerycomplexity",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".recordQuery()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L320",
       "id": "database_optimizer_databaseoptimizer_recordquery",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".createIndex()",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L338",
       "id": "database_optimizer_databaseoptimizer_createindex",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".dropIndex()",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L349",
       "id": "database_optimizer_databaseoptimizer_dropindex",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".analyzeDatabase()",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L356",
       "id": "database_optimizer_databaseoptimizer_analyzedatabase",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".extractColumnsFromQuery()",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L363",
       "id": "database_optimizer_databaseoptimizer_extractcolumnsfromquery",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".extractColumnFromCondition()",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L389",
       "id": "database_optimizer_databaseoptimizer_extractcolumnfromcondition",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".extractColumnsFromIndexSQL()",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L397",
       "id": "database_optimizer_databaseoptimizer_extractcolumnsfromindexsql",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".generateOptimizationReport()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimizer.ts",
       "source_location": "L408",
       "id": "database_optimizer_databaseoptimizer_generateoptimizationreport",
-      "community": 28
+      "community": 29
     },
     {
       "label": "database-performance.integration.spec.ts",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createBaseSchema()",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 492
+      "community": 493
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 493
+      "community": 494
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "openLockTestDatabase()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 494
+      "community": 495
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createProgress()",
@@ -7105,7 +7105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 495
+      "community": 496
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 496
+      "community": 497
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 497
+      "community": 498
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "init.ts",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createDbPath()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 498
+      "community": 499
     },
     {
       "label": "migrate.spec.ts",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "migrate.ts",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "migrateDatabase()",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_migratedatabase",
-      "community": 499
+      "community": 500
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 685
+      "community": 687
     },
     {
       "label": "migration-runner.ts",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createBaseSchema()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 500
+      "community": 501
     },
     {
       "label": "migration-logger.spec.ts",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "migration-detector.ts",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_ts",
-      "community": 50
+      "community": 51
     },
     {
       "label": "MigrationLogger",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L37",
       "id": "migration_logger_migrationlogger",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".constructor()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L44",
       "id": "migration_logger_migrationlogger_constructor",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".ensureLogDirectory()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L54",
       "id": "migration_logger_migrationlogger_ensurelogdirectory",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".isFileLoggingDisabled()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L73",
       "id": "migration_logger_migrationlogger_isfileloggingdisabled",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".initializeLogFile()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L80",
       "id": "migration_logger_migrationlogger_initializelogfile",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".log()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L102",
       "id": "migration_logger_migrationlogger_log",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".info()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L133",
       "id": "migration_logger_migrationlogger_info",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".warn()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L140",
       "id": "migration_logger_migrationlogger_warn",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".error()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L147",
       "id": "migration_logger_migrationlogger_error",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".debug()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L154",
       "id": "migration_logger_migrationlogger_debug",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".logMigrationResult()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L161",
       "id": "migration_logger_migrationlogger_logmigrationresult",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".writeToFile()",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L184",
       "id": "migration_logger_migrationlogger_writetofile",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".getLogFile()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L203",
       "id": "migration_logger_migrationlogger_getlogfile",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".getEntries()",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L210",
       "id": "migration_logger_migrationlogger_getentries",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".getLogDirectory()",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts",
       "source_location": "L217",
       "id": "migration_logger_migrationlogger_getlogdirectory",
-      "community": 50
+      "community": 51
     },
     {
       "label": "types.ts",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "migration-detector.spec.ts",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "backup-manager.ts",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "dependency-validator.ts",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "schema-version-manager.ts",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createBaseSchema()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 501
+      "community": 502
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_ts",
-      "community": 75
+      "community": 76
     },
     {
       "label": "ConsolidationScoreFieldsMigration",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L26",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".loadSQLFile()",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L34",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_loadsqlfile",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".executeSQL()",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L43",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_executesql",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".tableExists()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L68",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_tableexists",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".columnExists()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L79",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_columnexists",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".indexExists()",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L89",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_indexexists",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".validateBefore()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L100",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_validatebefore",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".calculateS()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L142",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_calculates",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".calculateConsolidationScore()",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L158",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_calculateconsolidationscore",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".getRBaseForType()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L192",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_getrbasefortype",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".up()",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L206",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_up",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".down()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L315",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_down",
-      "community": 75
+      "community": 76
     },
     {
       "label": ".validateAfter()",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts",
       "source_location": "L339",
       "id": "003_consolidation_score_fields_consolidationscorefieldsmigration_validateafter",
-      "community": 75
+      "community": 76
     },
     {
       "label": "012-fix-tfidf-dimension-trigger.ts",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createBaseSchema()",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 502
+      "community": 503
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "createBaseSchema()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 503
+      "community": 504
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_ts",
-      "community": 63
+      "community": 64
     },
     {
       "label": "MetaMemoryStatsSchemaMigration",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L26",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".loadSQLFile()",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L37",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_loadsqlfile",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".executeSQL()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L55",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_executesql",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".tableExists()",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L89",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_tableexists",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".columnExists()",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L106",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_columnexists",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".indexExists()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L119",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_indexexists",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".triggerExists()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L135",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_triggerexists",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".validateBefore()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L148",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_validatebefore",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".up()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L174",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_up",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".down()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L188",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_down",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".verifyTableStructure()",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L222",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_verifytablestructure",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".verifyIndexesAndTrigger()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L260",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_verifyindexesandtrigger",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".verifyForeignKeyConstraint()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L285",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_verifyforeignkeyconstraint",
-      "community": 63
+      "community": 64
     },
     {
       "label": ".validateAfter()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.ts",
       "source_location": "L313",
       "id": "011_meta_memory_stats_schema_metamemorystatsschemamigration_validateafter",
-      "community": 63
+      "community": 64
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createBaseSchema()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 504
+      "community": 505
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createSchemaWith018()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 505
+      "community": 506
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "createBaseSchema()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 506
+      "community": 507
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_006_fts5_reflection_notes_ts",
-      "community": 64
+      "community": 65
     },
     {
       "label": "FTS5ReflectionNotesMigration",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L40",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".loadSQLFile()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L48",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_loadsqlfile",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".executeSQL()",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L57",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_executesql",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".virtualTableExists()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L82",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_virtualtableexists",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".validateBefore()",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L93",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_validatebefore",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".reindexExistingData()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L138",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_reindexexistingdata",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".createDualTriggers()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L249",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_createdualtriggers",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".dropDualTriggers()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L294",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_dropdualtriggers",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".triggerExists()",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L303",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_triggerexists",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".registerNormalizeFunction()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L323",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_registernormalizefunction",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".performAtomicTableReplacement()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L363",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_performatomictablereplacement",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".up()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L419",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_up",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".down()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L462",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_down",
-      "community": 64
+      "community": 65
     },
     {
       "label": ".validateAfter()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.ts",
       "source_location": "L485",
       "id": "006_fts5_reflection_notes_fts5reflectionnotesmigration_validateafter",
-      "community": 64
+      "community": 65
     },
     {
       "label": "024-feedback-event-memory-created-at-index.ts",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "createBaseSchema()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 507
+      "community": 508
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "createBaseSchema()",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 508
+      "community": 509
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createBaseSchema()",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 509
+      "community": 510
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_core_memory_repository_sqlite_impl_ts",
-      "community": 51
+      "community": 52
     },
     {
       "label": "convertAlwaysLoad()",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L17",
       "id": "core_memory_repository_sqlite_impl_convertalwaysload",
-      "community": 51
+      "community": 52
     },
     {
       "label": "CoreMemoryRepositorySqliteImpl",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L27",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".constructor()",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L30",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_constructor",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".create()",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L37",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_create",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".findById()",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L63",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_findbyid",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".findByKey()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L90",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_findbykey",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".findByAgentId()",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L117",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_findbyagentid",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".findAlwaysLoad()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L141",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_findalwaysload",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".update()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L185",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_update",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".updateByKey()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L225",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_updatebykey",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".delete()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L269",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_delete",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".deleteByKey()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L282",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_deletebykey",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".deleteByAgentId()",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L295",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_deletebyagentid",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".findAll()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L308",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_findall",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".count()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts",
       "source_location": "L331",
       "id": "core_memory_repository_sqlite_impl_corememoryrepositorysqliteimpl_count",
-      "community": 51
+      "community": 52
     },
     {
       "label": "process-attribute-repository-sqlite.impl.ts",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_knowledge_vault_repository_sqlite_impl_ts",
-      "community": 34
+      "community": 35
     },
     {
       "label": "KnowledgeVaultRepositorySqlite",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L13",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".constructor()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L16",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_constructor",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".create()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L23",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_create",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findById()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L66",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findbyid",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findActiveByKey()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L99",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findactivebykey",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findByKeyAndVersion()",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L134",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findbykeyandversion",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findAllVersionsByKey()",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L171",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findallversionsbykey",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findActiveByAgentId()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L204",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findactivebyagentid",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findByAgentId()",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L243",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findbyagentid",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".update()",
@@ -11425,7 +11425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L273",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_update",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".delete()",
@@ -11433,7 +11433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L325",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_delete",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".deleteActiveByKey()",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L348",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_deleteactivebykey",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".hardDelete()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L371",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_harddelete",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findAll()",
@@ -11457,7 +11457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L383",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findall",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".findAllActive()",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L412",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_findallactive",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".count()",
@@ -11473,7 +11473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L452",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_count",
-      "community": 34
+      "community": 35
     },
     {
       "label": ".getNextVersion()",
@@ -11481,7 +11481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/knowledge-vault-repository-sqlite.impl.ts",
       "source_location": "L473",
       "id": "knowledge_vault_repository_sqlite_impl_knowledgevaultrepositorysqlite_getnextversion",
-      "community": 34
+      "community": 35
     },
     {
       "label": "kg-triple-repository-sqlite.impl.ts",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "cache-service.ts",
@@ -11865,7 +11865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "batch-scheduler.ts",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 510
+      "community": 511
     },
     {
       "label": "relation-validator-executor.ts",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "validateBatchJobConfig()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 511
+      "community": 512
     },
     {
       "label": "retry-manager.ts",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_job_queue_ts",
-      "community": 76
+      "community": 77
     },
     {
       "label": "JobQueue",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L26",
       "id": "job_queue_jobqueue",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".constructor()",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L31",
       "id": "job_queue_jobqueue_constructor",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".add()",
@@ -12601,7 +12601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L48",
       "id": "job_queue_jobqueue_add",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".getNext()",
@@ -12609,7 +12609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L94",
       "id": "job_queue_jobqueue_getnext",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".peekNext()",
@@ -12617,7 +12617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L110",
       "id": "job_queue_jobqueue_peeknext",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".markRunning()",
@@ -12625,7 +12625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L126",
       "id": "job_queue_jobqueue_markrunning",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".markCompleted()",
@@ -12633,7 +12633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L135",
       "id": "job_queue_jobqueue_markcompleted",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".size()",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L142",
       "id": "job_queue_jobqueue_size",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".runningCount()",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L149",
       "id": "job_queue_jobqueue_runningcount",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".isEmpty()",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L156",
       "id": "job_queue_jobqueue_isempty",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".clear()",
@@ -12665,7 +12665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L163",
       "id": "job_queue_jobqueue_clear",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".isRunning()",
@@ -12673,7 +12673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L172",
       "id": "job_queue_jobqueue_isrunning",
-      "community": 76
+      "community": 77
     },
     {
       "label": ".isQueued()",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/job-queue.ts",
       "source_location": "L181",
       "id": "job_queue_jobqueue_isqueued",
-      "community": 76
+      "community": 77
     },
     {
       "label": "file-logger.spec.ts",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "retry-manager.spec.ts",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "shouldRetry()",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 512
+      "community": 513
     },
     {
       "label": "job-queue.spec.ts",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "initializeTestDatabase()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 513
+      "community": 514
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createQualityTables()",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 514
+      "community": 515
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "stopwords.spec.ts",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "type-guards.ts",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 84
+      "community": 85
     },
     {
       "label": "buildExactMatchQuery()",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L46",
       "id": "procedural_memory_extractor_buildexactmatchquery",
-      "community": 84
+      "community": 85
     },
     {
       "label": "runFallbackSearchAnd()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L67",
       "id": "procedural_memory_extractor_runfallbacksearchand",
-      "community": 84
+      "community": 85
     },
     {
       "label": "runFallbackSearchOr()",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L90",
       "id": "procedural_memory_extractor_runfallbacksearchor",
-      "community": 84
+      "community": 85
     },
     {
       "label": "extractWorkflowName()",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L120",
       "id": "procedural_memory_extractor_extractworkflowname",
-      "community": 84
+      "community": 85
     },
     {
       "label": "extractSkillName()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L237",
       "id": "procedural_memory_extractor_extractskillname",
-      "community": 84
+      "community": 85
     },
     {
       "label": "extractSteps()",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L316",
       "id": "procedural_memory_extractor_extractsteps",
-      "community": 84
+      "community": 85
     },
     {
       "label": "generateTriggerConditions()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L401",
       "id": "procedural_memory_extractor_generatetriggerconditions",
-      "community": 84
+      "community": 85
     },
     {
       "label": "extractProceduralMemory()",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L509",
       "id": "procedural_memory_extractor_extractproceduralmemory",
-      "community": 84
+      "community": 85
     },
     {
       "label": "calculateSimilarity()",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L541",
       "id": "procedural_memory_extractor_calculatesimilarity",
-      "community": 84
+      "community": 85
     },
     {
       "label": "determineMergeStrategy()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L622",
       "id": "procedural_memory_extractor_determinemergestrategy",
-      "community": 84
+      "community": 85
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L704",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 84
+      "community": 85
     },
     {
       "label": ".extract()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L705",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 84
+      "community": 85
     },
     {
       "label": "sql-security-validator.ts",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 515
+      "community": 516
     },
     {
       "label": "environment-check.ts",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 516
+      "community": 517
     },
     {
       "label": "error-handling.spec.ts",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "operation()",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 517
+      "community": 518
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "relation-visualizer.ts",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_ts",
-      "community": 29
+      "community": 30
     },
     {
       "label": "log()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L11",
       "id": "database_log",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getSqliteErrorCode()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L17",
       "id": "database_getsqliteerrorcode",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getErrorMessage()",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L26",
       "id": "database_geterrormessage",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getErrorName()",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L35",
       "id": "database_geterrorname",
-      "community": 29
+      "community": 30
     },
     {
       "label": "DatabaseUtils",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L44",
       "id": "database_databaseutils",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".getTransactionState()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L51",
       "id": "database_databaseutils_gettransactionstate",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".setTransactionState()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L61",
       "id": "database_databaseutils_settransactionstate",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".isOpen()",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L71",
       "id": "database_databaseutils_isopen",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".run()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L93",
       "id": "database_databaseutils_run",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".get()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L125",
       "id": "database_databaseutils_get",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".all()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L156",
       "id": "database_databaseutils_all",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".exec()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L187",
       "id": "database_databaseutils_exec",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".runTransaction()",
@@ -14033,7 +14033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L194",
       "id": "database_databaseutils_runtransaction",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".checkpointWAL()",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L291",
       "id": "database_databaseutils_checkpointwal",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".isInTransaction()",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L304",
       "id": "database_databaseutils_isintransaction",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".forceCleanupTransaction()",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L311",
       "id": "database_databaseutils_forcecleanuptransaction",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".getDatabaseStatus()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L329",
       "id": "database_databaseutils_getdatabasestatus",
-      "community": 29
+      "community": 30
     },
     {
       "label": ".initializeDatabase()",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.ts",
       "source_location": "L370",
       "id": "database_databaseutils_initializedatabase",
-      "community": 29
+      "community": 30
     },
     {
       "label": "configuration-validator.ts",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "cache-key-generator.ts",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "path-validator.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 518
+      "community": 519
     },
     {
       "label": "error-handling.ts",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "withErrorHandling()",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 519
+      "community": 520
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 520
+      "community": 521
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "initializeTestDatabase()",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 521
+      "community": 522
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 522
+      "community": 523
     },
     {
       "label": "logging-helpers.ts",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "pii-masker.ts",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "path-validator.spec.ts",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "triple-cache.spec.ts",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "logger-schema.spec.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "initializeTestDatabase()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 523
+      "community": 524
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "benchmark.types.ts",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "assertMacroCategory()",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 524
+      "community": 525
     },
     {
       "label": "migration.types.ts",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "consolidation-score.types.ts",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "consolidation.types.ts",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 723
+      "community": 725
     },
     {
       "label": "vector-search.types.ts",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "procedural-versioning.ts",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "triple-extraction.ts",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "feedback.types.ts",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "embedding.types.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "relation-graph.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "failure-event.ts",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "index.ts",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "isMemoryItemType()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 525
+      "community": 526
     },
     {
       "label": "error-types.ts",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 732
+      "community": 734
     },
     {
       "label": "ranking.types.ts",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "alerts.types.ts",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "relation.ts",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "index.spec.ts",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "constants.ts",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "environment.ts",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 739
+      "community": 741
     },
     {
       "label": "retry-options-loader.ts",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "validateConfig()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 526
+      "community": 527
     },
     {
       "label": "config-loader-utils.ts",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "constants.spec.ts",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "config-validation.spec.ts",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "environment-paths.spec.ts",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "relation-constants.ts",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "introspection-constants.ts",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "http-bind-policy.ts",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "retry-manager.interface.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "cache.interface.ts",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "error-logging.interface.ts",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "database.interface.ts",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "llm-client-initializer.ts",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_ts",
-      "community": 22
+      "community": 17
     },
     {
       "label": "LLMClientInitializer",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L44",
       "id": "llm_client_initializer_llmclientinitializer",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".constructor()",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L51",
       "id": "llm_client_initializer_llmclientinitializer_constructor",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".initialize()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L72",
       "id": "llm_client_initializer_llmclientinitializer_initialize",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".validateApiKeys()",
@@ -15713,127 +15713,143 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L114",
       "id": "llm_client_initializer_llmclientinitializer_validateapikeys",
-      "community": 22
+      "community": 17
+    },
+    {
+      "label": ".shouldWarnMissingOpenaiKey()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L125",
+      "id": "llm_client_initializer_llmclientinitializer_shouldwarnmissingopenaikey",
+      "community": 17
+    },
+    {
+      "label": ".shouldWarnMissingGeminiKey()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L129",
+      "id": "llm_client_initializer_llmclientinitializer_shouldwarnmissinggeminikey",
+      "community": 17
     },
     {
       "label": ".resolveLlmModelLabel()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L121",
+      "source_location": "L133",
       "id": "llm_client_initializer_llmclientinitializer_resolvellmmodellabel",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".getSelectedProvider()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L133",
+      "source_location": "L145",
       "id": "llm_client_initializer_llmclientinitializer_getselectedprovider",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".getErrorMessage()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L144",
+      "source_location": "L156",
       "id": "llm_client_initializer_llmclientinitializer_geterrormessage",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".addWarning()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L156",
+      "source_location": "L168",
       "id": "llm_client_initializer_llmclientinitializer_addwarning",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".initializeOpenAI()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L173",
+      "source_location": "L185",
       "id": "llm_client_initializer_llmclientinitializer_initializeopenai",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".initializeGemini()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L224",
+      "source_location": "L238",
       "id": "llm_client_initializer_llmclientinitializer_initializegemini",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".handleOllamaResponse()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L273",
+      "source_location": "L289",
       "id": "llm_client_initializer_llmclientinitializer_handleollamaresponse",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".testOllamaConnection()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L321",
+      "source_location": "L337",
       "id": "llm_client_initializer_llmclientinitializer_testollamaconnection",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".shouldRetryOllamaConnection()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L385",
+      "source_location": "L401",
       "id": "llm_client_initializer_llmclientinitializer_shouldretryollamaconnection",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".getOllamaErrorMessage()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L407",
+      "source_location": "L423",
       "id": "llm_client_initializer_llmclientinitializer_getollamaerrormessage",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".determinePreferredProvider()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L429",
+      "source_location": "L445",
       "id": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".determineProviderForOpenAI()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L452",
+      "source_location": "L468",
       "id": "llm_client_initializer_llmclientinitializer_determineproviderforopenai",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".determineProviderForGemini()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L481",
+      "source_location": "L497",
       "id": "llm_client_initializer_llmclientinitializer_determineproviderforgemini",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".determineProviderForOllama()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L510",
+      "source_location": "L526",
       "id": "llm_client_initializer_llmclientinitializer_determineproviderforollama",
-      "community": 22
+      "community": 17
     },
     {
       "label": ".determineProviderForAuto()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L544",
+      "source_location": "L560",
       "id": "llm_client_initializer_llmclientinitializer_determineproviderforauto",
-      "community": 22
+      "community": 17
     },
     {
       "label": "llm-client-initializer.test-setup.ts",
@@ -15865,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "openai-client.spec.ts",
@@ -15873,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -15881,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -15889,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -15897,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -15905,7 +15921,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -15913,7 +15929,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "environment-priority.spec.ts",
@@ -15921,7 +15937,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -15929,7 +15945,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "gemini-client.spec.ts",
@@ -15937,7 +15953,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "search-local-tool.ts",
@@ -16225,7 +16241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "initializeTestDatabase()",
@@ -16233,7 +16249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 527
+      "community": 528
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -16241,7 +16257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "initializeTestDatabase()",
@@ -16249,7 +16265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 528
+      "community": 529
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -16257,7 +16273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "query-filter-strategy.ts",
@@ -16305,7 +16321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -16313,7 +16329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "local-search-service.ts",
@@ -16385,7 +16401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -16393,7 +16409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "anchor-interfaces.ts",
@@ -16401,7 +16417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_interfaces_ts",
-      "community": 65
+      "community": 66
     },
     {
       "label": "AnchorError",
@@ -16409,7 +16425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L154",
       "id": "anchor_interfaces_anchorerror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16417,7 +16433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L155",
       "id": "anchor_interfaces_anchorerror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "MemoryNotFoundError",
@@ -16425,7 +16441,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L164",
       "id": "anchor_interfaces_memorynotfounderror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16433,7 +16449,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L165",
       "id": "anchor_interfaces_memorynotfounderror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "DatabaseValidationError",
@@ -16441,7 +16457,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L175",
       "id": "anchor_interfaces_databasevalidationerror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16449,7 +16465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L176",
       "id": "anchor_interfaces_databasevalidationerror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "AnchorNotFoundError",
@@ -16457,7 +16473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L185",
       "id": "anchor_interfaces_anchornotfounderror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16465,7 +16481,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L186",
       "id": "anchor_interfaces_anchornotfounderror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "EmbeddingNotFoundError",
@@ -16473,7 +16489,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L195",
       "id": "anchor_interfaces_embeddingnotfounderror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16481,7 +16497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L196",
       "id": "anchor_interfaces_embeddingnotfounderror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "ServiceNotInitializedError",
@@ -16489,7 +16505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L205",
       "id": "anchor_interfaces_servicenotinitializederror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16497,7 +16513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L206",
       "id": "anchor_interfaces_servicenotinitializederror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "VectorDimensionMismatchError",
@@ -16505,7 +16521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L215",
       "id": "anchor_interfaces_vectordimensionmismatcherror",
-      "community": 65
+      "community": 66
     },
     {
       "label": ".constructor()",
@@ -16513,7 +16529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-interfaces.ts",
       "source_location": "L216",
       "id": "anchor_interfaces_vectordimensionmismatcherror_constructor",
-      "community": 65
+      "community": 66
     },
     {
       "label": "search-strategy-interfaces.ts",
@@ -16521,7 +16537,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -16529,7 +16545,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -16537,7 +16553,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 529
+      "community": 530
     },
     {
       "label": "embedding-types.ts",
@@ -16545,7 +16561,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -16553,7 +16569,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -16657,7 +16673,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_ts",
-      "community": 85
+      "community": 86
     },
     {
       "label": "AnchorManager",
@@ -16665,7 +16681,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L17",
       "id": "anchor_manager_anchormanager",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".constructor()",
@@ -16673,7 +16689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L35",
       "id": "anchor_manager_anchormanager_constructor",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".setErrorLoggingService()",
@@ -16681,7 +16697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L51",
       "id": "anchor_manager_anchormanager_seterrorloggingservice",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".setDatabase()",
@@ -16689,7 +16705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L58",
       "id": "anchor_manager_anchormanager_setdatabase",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".setAnchor()",
@@ -16697,7 +16713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L87",
       "id": "anchor_manager_anchormanager_setanchor",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".getAnchor()",
@@ -16705,7 +16721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L194",
       "id": "anchor_manager_anchormanager_getanchor",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".clearAnchor()",
@@ -16713,7 +16729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L282",
       "id": "anchor_manager_anchormanager_clearanchor",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".getSlotConfig()",
@@ -16721,7 +16737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L327",
       "id": "anchor_manager_anchormanager_getslotconfig",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".getSearchService()",
@@ -16729,7 +16745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L335",
       "id": "anchor_manager_anchormanager_getsearchservice",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".getCacheService()",
@@ -16737,7 +16753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L343",
       "id": "anchor_manager_anchormanager_getcacheservice",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".restoreCacheFromDB()",
@@ -16745,7 +16761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L351",
       "id": "anchor_manager_anchormanager_restorecachefromdb",
-      "community": 85
+      "community": 86
     },
     {
       "label": ".searchLocal()",
@@ -16753,7 +16769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L363",
       "id": "anchor_manager_anchormanager_searchlocal",
-      "community": 85
+      "community": 86
     },
     {
       "label": "fallback-search-service.ts",
@@ -16801,7 +16817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "fallback-strategy.ts",
@@ -16849,7 +16865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_ts",
-      "community": 38
+      "community": 39
     },
     {
       "label": "AnchorSearchService",
@@ -16857,7 +16873,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L27",
       "id": "anchor_search_service_anchorsearchservice",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".constructor()",
@@ -16865,7 +16881,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L47",
       "id": "anchor_search_service_anchorsearchservice_constructor",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".setErrorLoggingService()",
@@ -16873,7 +16889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L73",
       "id": "anchor_search_service_anchorsearchservice_seterrorloggingservice",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".setRelationGraph()",
@@ -16881,7 +16897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L80",
       "id": "anchor_search_service_anchorsearchservice_setrelationgraph",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".setDatabase()",
@@ -16889,7 +16905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L89",
       "id": "anchor_search_service_anchorsearchservice_setdatabase",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -16897,7 +16913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L130",
       "id": "anchor_search_service_anchorsearchservice_sethybridsearchengine",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".setVectorSearchEngine()",
@@ -16905,7 +16921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L156",
       "id": "anchor_search_service_anchorsearchservice_setvectorsearchengine",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".searchLocal()",
@@ -16913,7 +16929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L188",
       "id": "anchor_search_service_anchorsearchservice_searchlocal",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".getSlotConfig()",
@@ -16921,7 +16937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L332",
       "id": "anchor_search_service_anchorsearchservice_getslotconfig",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".cosineSimilarity()",
@@ -16929,7 +16945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L345",
       "id": "anchor_search_service_anchorsearchservice_cosinesimilarity",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -16937,7 +16953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L386",
       "id": "anchor_search_service_anchorsearchservice_fallbacktoglobalsearch",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".calculateReanchorScore()",
@@ -16945,7 +16961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L397",
       "id": "anchor_search_service_anchorsearchservice_calculatereanchorscore",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".analyzeAnchorUsage()",
@@ -16953,7 +16969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L485",
       "id": "anchor_search_service_anchorsearchservice_analyzeanchorusage",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".generateReanchorReason()",
@@ -16961,7 +16977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L559",
       "id": "anchor_search_service_anchorsearchservice_generatereanchorreason",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".autoReanchor()",
@@ -16969,7 +16985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L581",
       "id": "anchor_search_service_anchorsearchservice_autoreanchor",
-      "community": 38
+      "community": 39
     },
     {
       "label": ".checkAndAutoReanchor()",
@@ -16977,7 +16993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.ts",
       "source_location": "L710",
       "id": "anchor_search_service_anchorsearchservice_checkandautoreanchor",
-      "community": 38
+      "community": 39
     },
     {
       "label": "query-filter-strategy.spec.ts",
@@ -16985,7 +17001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "anchor-cache-service.ts",
@@ -17177,7 +17193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "local-search-service.spec.ts",
@@ -17185,7 +17201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -17193,7 +17209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "vector-search.factory.ts",
@@ -17321,7 +17337,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -17329,7 +17345,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 530
+      "community": 531
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -17337,7 +17353,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "search-result-combiner.ts",
@@ -17377,7 +17393,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_ts",
-      "community": 35
+      "community": 36
     },
     {
       "label": "SearchEngine",
@@ -17385,7 +17401,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L59",
       "id": "search_engine_searchengine",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".constructor()",
@@ -17393,7 +17409,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L65",
       "id": "search_engine_searchengine_constructor",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".isTestEnvironment()",
@@ -17401,7 +17417,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L69",
       "id": "search_engine_searchengine_istestenvironment",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".logFallbackWarning()",
@@ -17409,7 +17425,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L73",
       "id": "search_engine_searchengine_logfallbackwarning",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".logReflectionNotesConfigFallbackWarning()",
@@ -17417,7 +17433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L77",
       "id": "search_engine_searchengine_logreflectionnotesconfigfallbackwarning",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".search()",
@@ -17425,7 +17441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L96",
       "id": "search_engine_searchengine_search",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".buildFTSQuery()",
@@ -17433,7 +17449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L356",
       "id": "search_engine_searchengine_buildftsquery",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".preprocessQuery()",
@@ -17441,7 +17457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L393",
       "id": "search_engine_searchengine_preprocessquery",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".makeFTSSafe()",
@@ -17449,7 +17465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L416",
       "id": "search_engine_searchengine_makeftssafe",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".executeQuery()",
@@ -17457,7 +17473,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L429",
       "id": "search_engine_searchengine_executequery",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".attachBreakdownToDisplayTotal()",
@@ -17465,7 +17481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L435",
       "id": "search_engine_searchengine_attachbreakdowntodisplaytotal",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".applyRanking()",
@@ -17473,7 +17489,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L456",
       "id": "search_engine_searchengine_applyranking",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".checkFTS5Availability()",
@@ -17481,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L640",
       "id": "search_engine_searchengine_checkfts5availability",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".checkReflectionNotesAvailability()",
@@ -17489,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L689",
       "id": "search_engine_searchengine_checkreflectionnotesavailability",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".buildReflectionNotesSearchCondition()",
@@ -17497,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L744",
       "id": "search_engine_searchengine_buildreflectionnotessearchcondition",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".calculateFactMetadataBoost()",
@@ -17505,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L767",
       "id": "search_engine_searchengine_calculatefactmetadataboost",
-      "community": 35
+      "community": 36
     },
     {
       "label": ".generateRecallReason()",
@@ -17513,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine.ts",
       "source_location": "L780",
       "id": "search_engine_searchengine_generaterecallreason",
-      "community": 35
+      "community": 36
     },
     {
       "label": "search-ranking.ts",
@@ -17521,7 +17537,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_ranking_ts",
-      "community": 6
+      "community": 7
     },
     {
       "label": "SearchRanking",
@@ -17529,7 +17545,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L81",
       "id": "search_ranking_searchranking",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".constructor()",
@@ -17537,7 +17553,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L84",
       "id": "search_ranking_searchranking_constructor",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateProceduralMemoryBoost()",
@@ -17545,7 +17561,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L110",
       "id": "search_ranking_searchranking_calculateproceduralmemoryboost",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateFinalScore()",
@@ -17553,7 +17569,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L137",
       "id": "search_ranking_searchranking_calculatefinalscore",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateFinalScoreAndBreakdown()",
@@ -17561,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L190",
       "id": "search_ranking_searchranking_calculatefinalscoreandbreakdown",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".getConsolidationScoreWeights()",
@@ -17569,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L250",
       "id": "search_ranking_searchranking_getconsolidationscoreweights",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateFinalScoreWithConsolidation()",
@@ -17577,7 +17593,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L267",
       "id": "search_ranking_searchranking_calculatefinalscorewithconsolidation",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateRelevance()",
@@ -17585,7 +17601,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L285",
       "id": "search_ranking_searchranking_calculaterelevance",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateEmbeddingSimilarity()",
@@ -17593,7 +17609,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L318",
       "id": "search_ranking_searchranking_calculateembeddingsimilarity",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".normalizeBM25()",
@@ -17601,7 +17617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L334",
       "id": "search_ranking_searchranking_normalizebm25",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateSimpleBM25()",
@@ -17609,7 +17625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L342",
       "id": "search_ranking_searchranking_calculatesimplebm25",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateTagMatch()",
@@ -17617,7 +17633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L377",
       "id": "search_ranking_searchranking_calculatetagmatch",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateTitleHit()",
@@ -17625,7 +17641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L393",
       "id": "search_ranking_searchranking_calculatetitlehit",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".hasNgramMatch()",
@@ -17633,7 +17649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L413",
       "id": "search_ranking_searchranking_hasngrammatch",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".generateNgrams()",
@@ -17641,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L430",
       "id": "search_ranking_searchranking_generatengrams",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".dotProduct()",
@@ -17649,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L442",
       "id": "search_ranking_searchranking_dotproduct",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".magnitude()",
@@ -17657,7 +17673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L449",
       "id": "search_ranking_searchranking_magnitude",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateRecency()",
@@ -17665,7 +17681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L457",
       "id": "search_ranking_searchranking_calculaterecency",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateImportance()",
@@ -17673,7 +17689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L468",
       "id": "search_ranking_searchranking_calculateimportance",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateUsage()",
@@ -17681,7 +17697,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L480",
       "id": "search_ranking_searchranking_calculateusage",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateBatchUsage()",
@@ -17689,7 +17705,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L509",
       "id": "search_ranking_searchranking_calculatebatchusage",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".normalize()",
@@ -17697,7 +17713,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L531",
       "id": "search_ranking_searchranking_normalize",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateDuplicationPenalty()",
@@ -17705,7 +17721,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L540",
       "id": "search_ranking_searchranking_calculateduplicationpenalty",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateTextSimilarity()",
@@ -17713,7 +17729,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L560",
       "id": "search_ranking_searchranking_calculatetextsimilarity",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateRelationWeight()",
@@ -17721,7 +17737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L575",
       "id": "search_ranking_searchranking_calculaterelationweight",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateRelevanceSimple()",
@@ -17729,7 +17745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L615",
       "id": "search_ranking_searchranking_calculaterelevancesimple",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".calculateUsageSimple()",
@@ -17737,7 +17753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L629",
       "id": "search_ranking_searchranking_calculateusagesimple",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".getAgeInDays()",
@@ -17745,7 +17761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L639",
       "id": "search_ranking_searchranking_getageindays",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".getHalfLife()",
@@ -17753,7 +17769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L649",
       "id": "search_ranking_searchranking_gethalflife",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".getTypeBoost()",
@@ -17761,7 +17777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking.ts",
       "source_location": "L663",
       "id": "search_ranking_searchranking_gettypeboost",
-      "community": 6
+      "community": 7
     },
     {
       "label": "hybrid-search-engine.ts",
@@ -18193,7 +18209,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_ts",
-      "community": 52
+      "community": 53
     },
     {
       "label": "VectorSearchEngine",
@@ -18201,7 +18217,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L51",
       "id": "vector_search_engine_vectorsearchengine",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".constructor()",
@@ -18209,7 +18225,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L54",
       "id": "vector_search_engine_vectorsearchengine_constructor",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".initialize()",
@@ -18217,7 +18233,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L61",
       "id": "vector_search_engine_vectorsearchengine_initialize",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".search()",
@@ -18225,7 +18241,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L73",
       "id": "vector_search_engine_vectorsearchengine_search",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".hybridSearch()",
@@ -18233,7 +18249,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L95",
       "id": "vector_search_engine_vectorsearchengine_hybridsearch",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".getIndexStatus()",
@@ -18241,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L119",
       "id": "vector_search_engine_vectorsearchengine_getindexstatus",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".rebuildIndex()",
@@ -18249,7 +18265,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L152",
       "id": "vector_search_engine_vectorsearchengine_rebuildindex",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".performanceTest()",
@@ -18257,7 +18273,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L168",
       "id": "vector_search_engine_vectorsearchengine_performancetest",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".getDimensions()",
@@ -18265,7 +18281,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L202",
       "id": "vector_search_engine_vectorsearchengine_getdimensions",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".getVectorTableName()",
@@ -18273,7 +18289,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L221",
       "id": "vector_search_engine_vectorsearchengine_getvectortablename",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".isAvailable()",
@@ -18281,7 +18297,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L228",
       "id": "vector_search_engine_vectorsearchengine_isavailable",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".isConnected()",
@@ -18289,7 +18305,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L243",
       "id": "vector_search_engine_vectorsearchengine_isconnected",
-      "community": 52
+      "community": 53
     },
     {
       "label": "getVectorSearchEngine()",
@@ -18297,7 +18313,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L251",
       "id": "vector_search_engine_getvectorsearchengine",
-      "community": 52
+      "community": 53
     },
     {
       "label": "createVectorSearchEngine()",
@@ -18305,7 +18321,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L258",
       "id": "vector_search_engine_createvectorsearchengine",
-      "community": 52
+      "community": 53
     },
     {
       "label": "resetVectorSearchEngine()",
@@ -18313,7 +18329,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts",
       "source_location": "L262",
       "id": "vector_search_engine_resetvectorsearchengine",
-      "community": 52
+      "community": 53
     },
     {
       "label": "vector-search-engine-migration.ts",
@@ -18377,7 +18393,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -18385,7 +18401,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 531
+      "community": 532
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -18513,7 +18529,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "search-ranking.spec.ts",
@@ -18521,7 +18537,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -18625,7 +18641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -18633,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "search-engine.spec.ts",
@@ -18673,7 +18689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "vector-search.repository.ts",
@@ -18825,7 +18841,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -18833,7 +18849,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "vector-search.service.ts",
@@ -18929,7 +18945,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -18937,7 +18953,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 532
+      "community": 533
     },
     {
       "label": "vector-performance-tester.ts",
@@ -19001,7 +19017,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createMockRepository()",
@@ -19009,7 +19025,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 533
+      "community": 534
     },
     {
       "label": "vector-index-manager.ts",
@@ -19073,7 +19089,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_ts",
-      "community": 66
+      "community": 67
     },
     {
       "label": "VectorSearchFacade",
@@ -19081,7 +19097,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L25",
       "id": "vector_search_facade_vectorsearchfacade",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".constructor()",
@@ -19089,7 +19105,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L30",
       "id": "vector_search_facade_vectorsearchfacade_constructor",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".search()",
@@ -19097,7 +19113,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L43",
       "id": "vector_search_facade_vectorsearchfacade_search",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".hybridSearch()",
@@ -19105,7 +19121,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L50",
       "id": "vector_search_facade_vectorsearchfacade_hybridsearch",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".providerHybridSearch()",
@@ -19113,7 +19129,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L54",
       "id": "vector_search_facade_vectorsearchfacade_providerhybridsearch",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".unifiedSearch()",
@@ -19121,7 +19137,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L61",
       "id": "vector_search_facade_vectorsearchfacade_unifiedsearch",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".getIndexStatus()",
@@ -19129,7 +19145,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L71",
       "id": "vector_search_facade_vectorsearchfacade_getindexstatus",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".rebuildIndex()",
@@ -19137,7 +19153,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L78",
       "id": "vector_search_facade_vectorsearchfacade_rebuildindex",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".isAvailable()",
@@ -19145,7 +19161,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L85",
       "id": "vector_search_facade_vectorsearchfacade_isavailable",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".runPerformanceTest()",
@@ -19153,7 +19169,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L92",
       "id": "vector_search_facade_vectorsearchfacade_runperformancetest",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".analyzePerformance()",
@@ -19161,7 +19177,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L102",
       "id": "vector_search_facade_vectorsearchfacade_analyzeperformance",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".generatePerformanceReport()",
@@ -19169,7 +19185,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L112",
       "id": "vector_search_facade_vectorsearchfacade_generateperformancereport",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".getStatusSummary()",
@@ -19177,7 +19193,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L119",
       "id": "vector_search_facade_vectorsearchfacade_getstatussummary",
-      "community": 66
+      "community": 67
     },
     {
       "label": ".getSystemStatus()",
@@ -19185,7 +19201,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.ts",
       "source_location": "L126",
       "id": "vector_search_facade_vectorsearchfacade_getsystemstatus",
-      "community": 66
+      "community": 67
     },
     {
       "label": "vector-search-container.ts",
@@ -19313,7 +19329,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createMockRepositories()",
@@ -19321,7 +19337,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 534
+      "community": 535
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -19329,7 +19345,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -19337,7 +19353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createMockIndexRepository()",
@@ -19345,7 +19361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 535
+      "community": 536
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -19353,7 +19369,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_spaced_repetition_factory_ts",
-      "community": 19
+      "community": 21
     },
     {
       "label": "SpacedRepetitionFactory",
@@ -19361,7 +19377,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L36",
       "id": "spaced_repetition_factory_spacedrepetitionfactory",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createDefaultService()",
@@ -19369,7 +19385,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L40",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createdefaultservice",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createService()",
@@ -19377,7 +19393,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L59",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createservice",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createIntervalStrategy()",
@@ -19385,7 +19401,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L83",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createintervalstrategy",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createRecallCalculator()",
@@ -19393,7 +19409,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L97",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createrecallcalculator",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createNecessityChecker()",
@@ -19401,7 +19417,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L111",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createnecessitychecker",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createReviewScheduler()",
@@ -19409,7 +19425,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L123",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createreviewscheduler",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createPerformanceAnalyzer()",
@@ -19417,7 +19433,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L143",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createperformanceanalyzer",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createPriorityCalculator()",
@@ -19425,7 +19441,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L157",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createprioritycalculator",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createOptimalRecommender()",
@@ -19433,7 +19449,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L173",
       "id": "spaced_repetition_factory_spacedrepetitionfactory_createoptimalrecommender",
-      "community": 19
+      "community": 21
     },
     {
       "label": "SpacedRepetitionServiceImpl",
@@ -19441,7 +19457,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L190",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".constructor()",
@@ -19449,7 +19465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L191",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_constructor",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".calculateNextInterval()",
@@ -19457,7 +19473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L201",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_calculatenextinterval",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".calculateRecallProbability()",
@@ -19465,7 +19481,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L206",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_calculaterecallprobability",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".needsReview()",
@@ -19473,7 +19489,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L210",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_needsreview",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createReviewSchedule()",
@@ -19481,7 +19497,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L214",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_createreviewschedule",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -19489,7 +19505,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L223",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_createbatchreviewschedules",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".calculateReviewPriority()",
@@ -19497,7 +19513,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L227",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_calculatereviewpriority",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -19505,7 +19521,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L231",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_analyzereviewperformance",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -19513,7 +19529,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/spaced-repetition.factory.ts",
       "source_location": "L238",
       "id": "spaced_repetition_factory_spacedrepetitionserviceimpl_recommendoptimalinterval",
-      "community": 19
+      "community": 21
     },
     {
       "label": "spaced-repetition.factory.spec.ts",
@@ -19521,7 +19537,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -19529,7 +19545,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -19537,7 +19553,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "spaced-repetition.ts",
@@ -19641,7 +19657,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_ts",
-      "community": 67
+      "community": 68
     },
     {
       "label": "SpacedRepetitionAlgorithmRefactored",
@@ -19649,7 +19665,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L19",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".constructor()",
@@ -19657,7 +19673,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L23",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_constructor",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".calculateNextInterval()",
@@ -19665,7 +19681,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L40",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_calculatenextinterval",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".calculateRecallProbability()",
@@ -19673,7 +19689,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L52",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_calculaterecallprobability",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".needsReview()",
@@ -19681,7 +19697,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L64",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_needsreview",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".createReviewSchedule()",
@@ -19689,7 +19705,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L77",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_createreviewschedule",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -19697,7 +19713,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L91",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_createbatchreviewschedules",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".calculateReviewPriority()",
@@ -19705,7 +19721,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L100",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_calculatereviewpriority",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -19713,7 +19729,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L109",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_analyzereviewperformance",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -19721,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L121",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_recommendoptimalinterval",
-      "community": 67
+      "community": 68
     },
     {
       "label": ".getDaysSince()",
@@ -19729,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L134",
       "id": "spaced_repetition_refactored_spacedrepetitionalgorithmrefactored_getdayssince",
-      "community": 67
+      "community": 68
     },
     {
       "label": "createSpacedRepetitionAlgorithm()",
@@ -19737,7 +19753,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L144",
       "id": "spaced_repetition_refactored_createspacedrepetitionalgorithm",
-      "community": 67
+      "community": 68
     },
     {
       "label": "getSpacedRepetitionAlgorithm()",
@@ -19745,7 +19761,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L148",
       "id": "spaced_repetition_refactored_getspacedrepetitionalgorithm",
-      "community": 67
+      "community": 68
     },
     {
       "label": "resetSpacedRepetitionAlgorithm()",
@@ -19753,7 +19769,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.ts",
       "source_location": "L152",
       "id": "spaced_repetition_refactored_resetspacedrepetitionalgorithm",
-      "community": 67
+      "community": 68
     },
     {
       "label": "forgetting-algorithm.ts",
@@ -19761,7 +19777,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_forgetting_algorithm_ts",
-      "community": 86
+      "community": 87
     },
     {
       "label": "ForgettingAlgorithm",
@@ -19769,7 +19785,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L30",
       "id": "forgetting_algorithm_forgettingalgorithm",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".constructor()",
@@ -19777,7 +19793,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L33",
       "id": "forgetting_algorithm_forgettingalgorithm_constructor",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".calculateForgetScore()",
@@ -19785,7 +19801,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L48",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateforgetscore",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".shouldForget()",
@@ -19793,7 +19809,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L64",
       "id": "forgetting_algorithm_forgettingalgorithm_shouldforget",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".generateForgetReason()",
@@ -19801,7 +19817,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L72",
       "id": "forgetting_algorithm_forgettingalgorithm_generateforgetreason",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".calculateFeatures()",
@@ -19809,7 +19825,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L102",
       "id": "forgetting_algorithm_forgettingalgorithm_calculatefeatures",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".calculateRecency()",
@@ -19817,7 +19833,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L142",
       "id": "forgetting_algorithm_forgettingalgorithm_calculaterecency",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".calculateUsage()",
@@ -19825,7 +19841,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L153",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateusage",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".calculateAccessScore()",
@@ -19833,7 +19849,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L177",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateaccessscore",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".getAgeInDays()",
@@ -19841,7 +19857,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L187",
       "id": "forgetting_algorithm_forgettingalgorithm_getageindays",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".getHalfLife()",
@@ -19849,7 +19865,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L197",
       "id": "forgetting_algorithm_forgettingalgorithm_gethalflife",
-      "community": 86
+      "community": 87
     },
     {
       "label": ".analyzeForgetCandidates()",
@@ -19857,7 +19873,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L211",
       "id": "forgetting_algorithm_forgettingalgorithm_analyzeforgetcandidates",
-      "community": 86
+      "community": 87
     },
     {
       "label": "forgetting-algorithm.spec.ts",
@@ -19865,7 +19881,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -19905,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -19913,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_forgetting_policy_service_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "ForgettingPolicyService",
@@ -19921,7 +19937,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L67",
       "id": "forgetting_policy_service_forgettingpolicyservice",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".constructor()",
@@ -19929,7 +19945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L72",
       "id": "forgetting_policy_service_forgettingpolicyservice_constructor",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".executeMemoryCleanup()",
@@ -19937,7 +19953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L102",
       "id": "forgetting_policy_service_forgettingpolicyservice_executememorycleanup",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".getAllMemories()",
@@ -19945,7 +19961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L190",
       "id": "forgetting_policy_service_forgettingpolicyservice_getallmemories",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".analyzeReviewCandidates()",
@@ -19953,7 +19969,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L221",
       "id": "forgetting_policy_service_forgettingpolicyservice_analyzereviewcandidates",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".calculateUsageScore()",
@@ -19961,7 +19977,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L251",
       "id": "forgetting_policy_service_forgettingpolicyservice_calculateusagescore",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".isSoftDeleteCandidate()",
@@ -19969,7 +19985,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L262",
       "id": "forgetting_policy_service_forgettingpolicyservice_issoftdeletecandidate",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".isHardDeleteCandidate()",
@@ -19977,7 +19993,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L274",
       "id": "forgetting_policy_service_forgettingpolicyservice_isharddeletecandidate",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".getSoftDeleteGracePeriodDays()",
@@ -19985,7 +20001,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L286",
       "id": "forgetting_policy_service_forgettingpolicyservice_getsoftdeletegraceperioddays",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".sweepExpiredSoftDeletes()",
@@ -19993,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L295",
       "id": "forgetting_policy_service_forgettingpolicyservice_sweepexpiredsoftdeletes",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".softDeleteMemory()",
@@ -20001,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L316",
       "id": "forgetting_policy_service_forgettingpolicyservice_softdeletememory",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".hardDeleteMemory()",
@@ -20009,7 +20025,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L336",
       "id": "forgetting_policy_service_forgettingpolicyservice_harddeletememory",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".updateReviewSchedule()",
@@ -20017,7 +20033,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L347",
       "id": "forgetting_policy_service_forgettingpolicyservice_updatereviewschedule",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".getAgeInDays()",
@@ -20025,7 +20041,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L359",
       "id": "forgetting_policy_service_forgettingpolicyservice_getageindays",
-      "community": 53
+      "community": 54
     },
     {
       "label": ".generateForgettingStats()",
@@ -20033,7 +20049,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/forgetting-policy-service.ts",
       "source_location": "L368",
       "id": "forgetting_policy_service_forgettingpolicyservice_generateforgettingstats",
-      "community": 53
+      "community": 54
     },
     {
       "label": "forgetting-policy-service.spec.ts",
@@ -20041,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -20049,7 +20065,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "priority-calculation.service.ts",
@@ -20057,7 +20073,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_priority_calculation_service_ts",
-      "community": 23
+      "community": 24
     },
     {
       "label": "DefaultPriorityCalculator",
@@ -20065,7 +20081,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L16",
       "id": "priority_calculation_service_defaultprioritycalculator",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateReviewPriority()",
@@ -20073,7 +20089,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L17",
       "id": "priority_calculation_service_defaultprioritycalculator_calculatereviewpriority",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateBatchPriorities()",
@@ -20081,7 +20097,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L25",
       "id": "priority_calculation_service_defaultprioritycalculator_calculatebatchpriorities",
-      "community": 23
+      "community": 24
     },
     {
       "label": "WeightedPriorityCalculator",
@@ -20089,7 +20105,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L45",
       "id": "priority_calculation_service_weightedprioritycalculator",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".constructor()",
@@ -20097,7 +20113,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L46",
       "id": "priority_calculation_service_weightedprioritycalculator_constructor",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateReviewPriority()",
@@ -20105,7 +20121,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L52",
       "id": "priority_calculation_service_weightedprioritycalculator_calculatereviewpriority",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateBatchPriorities()",
@@ -20113,7 +20129,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L62",
       "id": "priority_calculation_service_weightedprioritycalculator_calculatebatchpriorities",
-      "community": 23
+      "community": 24
     },
     {
       "label": "AdaptivePriorityCalculator",
@@ -20121,7 +20137,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L82",
       "id": "priority_calculation_service_adaptiveprioritycalculator",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".constructor()",
@@ -20129,7 +20145,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L85",
       "id": "priority_calculation_service_adaptiveprioritycalculator_constructor",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateReviewPriority()",
@@ -20137,7 +20153,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L89",
       "id": "priority_calculation_service_adaptiveprioritycalculator_calculatereviewpriority",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateBatchPriorities()",
@@ -20145,7 +20161,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L96",
       "id": "priority_calculation_service_adaptiveprioritycalculator_calculatebatchpriorities",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateAdaptationFactor()",
@@ -20153,7 +20169,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L111",
       "id": "priority_calculation_service_adaptiveprioritycalculator_calculateadaptationfactor",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".updatePerformancePattern()",
@@ -20161,7 +20177,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L125",
       "id": "priority_calculation_service_adaptiveprioritycalculator_updateperformancepattern",
-      "community": 23
+      "community": 24
     },
     {
       "label": "TimeBasedPriorityCalculator",
@@ -20169,7 +20185,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L142",
       "id": "priority_calculation_service_timebasedprioritycalculator",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".constructor()",
@@ -20177,7 +20193,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L143",
       "id": "priority_calculation_service_timebasedprioritycalculator_constructor",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateReviewPriority()",
@@ -20185,7 +20201,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L151",
       "id": "priority_calculation_service_timebasedprioritycalculator_calculatereviewpriority",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".calculateBatchPriorities()",
@@ -20193,7 +20209,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L158",
       "id": "priority_calculation_service_timebasedprioritycalculator_calculatebatchpriorities",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".getTimeFactor()",
@@ -20201,7 +20217,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L173",
       "id": "priority_calculation_service_timebasedprioritycalculator_gettimefactor",
-      "community": 23
+      "community": 24
     },
     {
       "label": ".initializeTimeWeights()",
@@ -20209,7 +20225,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/priority-calculation.service.ts",
       "source_location": "L178",
       "id": "priority_calculation_service_timebasedprioritycalculator_initializetimeweights",
-      "community": 23
+      "community": 24
     },
     {
       "label": "interval-calculation.service.ts",
@@ -20217,7 +20233,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_ts",
-      "community": 87
+      "community": 88
     },
     {
       "label": "DefaultIntervalStrategy",
@@ -20225,7 +20241,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L17",
       "id": "interval_calculation_service_defaultintervalstrategy",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".constructor()",
@@ -20233,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L18",
       "id": "interval_calculation_service_defaultintervalstrategy_constructor",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".calculateInterval()",
@@ -20241,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L20",
       "id": "interval_calculation_service_defaultintervalstrategy_calculateinterval",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".calculateConfidence()",
@@ -20249,7 +20265,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L42",
       "id": "interval_calculation_service_defaultintervalstrategy_calculateconfidence",
-      "community": 87
+      "community": 88
     },
     {
       "label": "ConservativeIntervalStrategy",
@@ -20257,7 +20273,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L57",
       "id": "interval_calculation_service_conservativeintervalstrategy",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".constructor()",
@@ -20265,7 +20281,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L58",
       "id": "interval_calculation_service_conservativeintervalstrategy_constructor",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".calculateInterval()",
@@ -20273,7 +20289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L60",
       "id": "interval_calculation_service_conservativeintervalstrategy_calculateinterval",
-      "community": 87
+      "community": 88
     },
     {
       "label": "AdaptiveIntervalStrategy",
@@ -20281,7 +20297,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L88",
       "id": "interval_calculation_service_adaptiveintervalstrategy",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".constructor()",
@@ -20289,7 +20305,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L89",
       "id": "interval_calculation_service_adaptiveintervalstrategy_constructor",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".calculateInterval()",
@@ -20297,7 +20313,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L94",
       "id": "interval_calculation_service_adaptiveintervalstrategy_calculateinterval",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".calculatePerformanceAdjustment()",
@@ -20305,7 +20321,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L112",
       "id": "interval_calculation_service_adaptiveintervalstrategy_calculateperformanceadjustment",
-      "community": 87
+      "community": 88
     },
     {
       "label": ".updatePerformanceHistory()",
@@ -20313,7 +20329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L123",
       "id": "interval_calculation_service_adaptiveintervalstrategy_updateperformancehistory",
-      "community": 87
+      "community": 88
     },
     {
       "label": "review-scheduling.service.ts",
@@ -20321,7 +20337,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_ts",
-      "community": 39
+      "community": 40
     },
     {
       "label": "DefaultReviewScheduler",
@@ -20329,7 +20345,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L21",
       "id": "review_scheduling_service_defaultreviewscheduler",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".constructor()",
@@ -20337,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L22",
       "id": "review_scheduling_service_defaultreviewscheduler_constructor",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".createReviewSchedule()",
@@ -20345,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L29",
       "id": "review_scheduling_service_defaultreviewscheduler_createreviewschedule",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -20353,7 +20369,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L57",
       "id": "review_scheduling_service_defaultreviewscheduler_createbatchreviewschedules",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".getDaysSince()",
@@ -20361,7 +20377,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L75",
       "id": "review_scheduling_service_defaultreviewscheduler_getdayssince",
-      "community": 39
+      "community": 40
     },
     {
       "label": "PriorityBasedReviewScheduler",
@@ -20369,7 +20385,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L86",
       "id": "review_scheduling_service_prioritybasedreviewscheduler",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".constructor()",
@@ -20377,7 +20393,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L87",
       "id": "review_scheduling_service_prioritybasedreviewscheduler_constructor",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -20385,7 +20401,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L97",
       "id": "review_scheduling_service_prioritybasedreviewscheduler_createbatchreviewschedules",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".prioritizeAndLimitSchedules()",
@@ -20393,7 +20409,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L104",
       "id": "review_scheduling_service_prioritybasedreviewscheduler_prioritizeandlimitschedules",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".calculatePriority()",
@@ -20401,7 +20417,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L117",
       "id": "review_scheduling_service_prioritybasedreviewscheduler_calculatepriority",
-      "community": 39
+      "community": 40
     },
     {
       "label": "AdaptiveReviewScheduler",
@@ -20409,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L128",
       "id": "review_scheduling_service_adaptivereviewscheduler",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".constructor()",
@@ -20417,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L131",
       "id": "review_scheduling_service_adaptivereviewscheduler_constructor",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".createReviewSchedule()",
@@ -20425,7 +20441,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L140",
       "id": "review_scheduling_service_adaptivereviewscheduler_createreviewschedule",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".adjustThresholdForMemory()",
@@ -20433,7 +20449,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L162",
       "id": "review_scheduling_service_adaptivereviewscheduler_adjustthresholdformemory",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".evaluateReviewNecessity()",
@@ -20441,7 +20457,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L175",
       "id": "review_scheduling_service_adaptivereviewscheduler_evaluatereviewnecessity",
-      "community": 39
+      "community": 40
     },
     {
       "label": ".updatePerformance()",
@@ -20449,7 +20465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.ts",
       "source_location": "L179",
       "id": "review_scheduling_service_adaptivereviewscheduler_updateperformance",
-      "community": 39
+      "community": 40
     },
     {
       "label": "performance-analysis.service.ts",
@@ -20457,7 +20473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_performance_analysis_service_ts",
-      "community": 24
+      "community": 25
     },
     {
       "label": "DefaultPerformanceAnalyzer",
@@ -20465,7 +20481,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L16",
       "id": "performance_analysis_service_defaultperformanceanalyzer",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -20473,7 +20489,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L17",
       "id": "performance_analysis_service_defaultperformanceanalyzer_analyzereviewperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": "DetailedPerformanceAnalyzer",
@@ -20481,7 +20497,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L63",
       "id": "performance_analysis_service_detailedperformanceanalyzer",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -20489,7 +20505,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L64",
       "id": "performance_analysis_service_detailedperformanceanalyzer_analyzereviewperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzePerformanceTrends()",
@@ -20497,7 +20513,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L78",
       "id": "performance_analysis_service_detailedperformanceanalyzer_analyzeperformancetrends",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzeIntervalEffectiveness()",
@@ -20505,7 +20521,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L89",
       "id": "performance_analysis_service_detailedperformanceanalyzer_analyzeintervaleffectiveness",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".calculateWeeklyPerformance()",
@@ -20513,7 +20529,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L99",
       "id": "performance_analysis_service_detailedperformanceanalyzer_calculateweeklyperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".calculateTrendDirection()",
@@ -20521,7 +20537,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L107",
       "id": "performance_analysis_service_detailedperformanceanalyzer_calculatetrenddirection",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".calculateIntervalEffectiveness()",
@@ -20529,7 +20545,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L117",
       "id": "performance_analysis_service_detailedperformanceanalyzer_calculateintervaleffectiveness",
-      "community": 24
+      "community": 25
     },
     {
       "label": "AdaptivePerformanceAnalyzer",
@@ -20537,7 +20553,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L148",
       "id": "performance_analysis_service_adaptiveperformanceanalyzer",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -20545,7 +20561,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L152",
       "id": "performance_analysis_service_adaptiveperformanceanalyzer_analyzereviewperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".updateLearningPatterns()",
@@ -20553,7 +20569,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L166",
       "id": "performance_analysis_service_adaptiveperformanceanalyzer_updatelearningpatterns",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".adjustPerformanceThresholds()",
@@ -20561,7 +20577,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L188",
       "id": "performance_analysis_service_adaptiveperformanceanalyzer_adjustperformancethresholds",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".getPersonalizedThreshold()",
@@ -20569,7 +20585,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L197",
       "id": "performance_analysis_service_adaptiveperformanceanalyzer_getpersonalizedthreshold",
-      "community": 24
+      "community": 25
     },
     {
       "label": "PredictivePerformanceAnalyzer",
@@ -20577,7 +20593,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L206",
       "id": "performance_analysis_service_predictiveperformanceanalyzer",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -20585,7 +20601,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L209",
       "id": "performance_analysis_service_predictiveperformanceanalyzer_analyzereviewperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".predictPerformance()",
@@ -20593,7 +20609,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L222",
       "id": "performance_analysis_service_predictiveperformanceanalyzer_predictperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".calculatePredictedPerformance()",
@@ -20601,7 +20617,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L229",
       "id": "performance_analysis_service_predictiveperformanceanalyzer_calculatepredictedperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".getPredictedPerformance()",
@@ -20609,7 +20625,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/performance-analysis.service.ts",
       "source_location": "L238",
       "id": "performance_analysis_service_predictiveperformanceanalyzer_getpredictedperformance",
-      "community": 24
+      "community": 25
     },
     {
       "label": "spaced-repetition-container.ts",
@@ -20617,7 +20633,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_spaced_repetition_container_ts",
-      "community": 30
+      "community": 31
     },
     {
       "label": "SpacedRepetitionContainer",
@@ -20625,7 +20641,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L17",
       "id": "spaced_repetition_container_spacedrepetitioncontainer",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".constructor()",
@@ -20633,7 +20649,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L22",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_constructor",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".getInstance()",
@@ -20641,7 +20657,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L27",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_getinstance",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".initialize()",
@@ -20649,7 +20665,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L37",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_initialize",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".initializeWithDefaults()",
@@ -20657,7 +20673,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L45",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_initializewithdefaults",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".getService()",
@@ -20665,7 +20681,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L64",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_getservice",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".getConfig()",
@@ -20673,7 +20689,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L74",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_getconfig",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".isInitialized()",
@@ -20681,7 +20697,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L84",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_isinitialized",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".reset()",
@@ -20689,7 +20705,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L91",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_reset",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".updateConfig()",
@@ -20697,7 +20713,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L99",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_updateconfig",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".updateWeights()",
@@ -20705,7 +20721,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L115",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_updateweights",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".updateThreshold()",
@@ -20713,7 +20729,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L131",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_updatethreshold",
-      "community": 30
+      "community": 31
     },
     {
       "label": ".updateDefaultInterval()",
@@ -20721,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L138",
       "id": "spaced_repetition_container_spacedrepetitioncontainer_updatedefaultinterval",
-      "community": 30
+      "community": 31
     },
     {
       "label": "getSpacedRepetitionService()",
@@ -20729,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L146",
       "id": "spaced_repetition_container_getspacedrepetitionservice",
-      "community": 30
+      "community": 31
     },
     {
       "label": "initializeSpacedRepetition()",
@@ -20737,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L150",
       "id": "spaced_repetition_container_initializespacedrepetition",
-      "community": 30
+      "community": 31
     },
     {
       "label": "initializeSpacedRepetitionWithDefaults()",
@@ -20745,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L154",
       "id": "spaced_repetition_container_initializespacedrepetitionwithdefaults",
-      "community": 30
+      "community": 31
     },
     {
       "label": "isSpacedRepetitionInitialized()",
@@ -20753,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L158",
       "id": "spaced_repetition_container_isspacedrepetitioninitialized",
-      "community": 30
+      "community": 31
     },
     {
       "label": "resetSpacedRepetition()",
@@ -20761,7 +20777,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/spaced-repetition-container.ts",
       "source_location": "L162",
       "id": "spaced_repetition_container_resetspacedrepetition",
-      "community": 30
+      "community": 31
     },
     {
       "label": "optimal-interval.service.ts",
@@ -20769,7 +20785,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_optimal_interval_service_ts",
-      "community": 25
+      "community": 26
     },
     {
       "label": "DefaultOptimalIntervalRecommender",
@@ -20777,7 +20793,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L14",
       "id": "optimal_interval_service_defaultoptimalintervalrecommender",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".constructor()",
@@ -20785,7 +20801,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L15",
       "id": "optimal_interval_service_defaultoptimalintervalrecommender_constructor",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -20793,7 +20809,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L20",
       "id": "optimal_interval_service_defaultoptimalintervalrecommender_recommendoptimalinterval",
-      "community": 25
+      "community": 26
     },
     {
       "label": "AdaptiveOptimalIntervalRecommender",
@@ -20801,7 +20817,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L49",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".constructor()",
@@ -20809,7 +20825,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L53",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_constructor",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -20817,7 +20833,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L57",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_recommendoptimalinterval",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".calculatePersonalizedAdjustment()",
@@ -20825,7 +20841,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L77",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_calculatepersonalizedadjustment",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".analyzeLearningSpeed()",
@@ -20833,7 +20849,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L92",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_analyzelearningspeed",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".analyzeRetentionRate()",
@@ -20841,7 +20857,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L105",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_analyzeretentionrate",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".updateLearningProfile()",
@@ -20849,7 +20865,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L114",
       "id": "optimal_interval_service_adaptiveoptimalintervalrecommender_updatelearningprofile",
-      "community": 25
+      "community": 26
     },
     {
       "label": "MLBasedOptimalIntervalRecommender",
@@ -20857,7 +20873,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L131",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -20865,7 +20881,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L134",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender_recommendoptimalinterval",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".predictOptimalInterval()",
@@ -20873,7 +20889,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L149",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender_predictoptimalinterval",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".fallbackRecommendation()",
@@ -20881,7 +20897,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L164",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender_fallbackrecommendation",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".trainModel()",
@@ -20889,7 +20905,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L173",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender_trainmodel",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".trainLinearModel()",
@@ -20897,7 +20913,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L183",
       "id": "optimal_interval_service_mlbasedoptimalintervalrecommender_trainlinearmodel",
-      "community": 25
+      "community": 26
     },
     {
       "label": "EnsembleOptimalIntervalRecommender",
@@ -20905,7 +20921,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L202",
       "id": "optimal_interval_service_ensembleoptimalintervalrecommender",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".constructor()",
@@ -20913,7 +20929,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L205",
       "id": "optimal_interval_service_ensembleoptimalintervalrecommender_constructor",
-      "community": 25
+      "community": 26
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -20921,7 +20937,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts",
       "source_location": "L213",
       "id": "optimal_interval_service_ensembleoptimalintervalrecommender_recommendoptimalinterval",
-      "community": 25
+      "community": 26
     },
     {
       "label": "interval-calculation.service.spec.ts",
@@ -20929,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "recall-probability.service.ts",
@@ -21033,7 +21049,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "telemetry.types.ts",
@@ -21041,7 +21057,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -21049,7 +21065,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "openTelemetryDb()",
@@ -21057,7 +21073,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 536
+      "community": 537
     },
     {
       "label": "telemetry-repository.ts",
@@ -21065,7 +21081,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_ts",
-      "community": 31
+      "community": 32
     },
     {
       "label": "periodCutoffIso()",
@@ -21073,7 +21089,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L94",
       "id": "telemetry_repository_periodcutoffiso",
-      "community": 31
+      "community": 32
     },
     {
       "label": "rolling24hCutoffIso()",
@@ -21081,7 +21097,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L106",
       "id": "telemetry_repository_rolling24hcutoffiso",
-      "community": 31
+      "community": 32
     },
     {
       "label": "percentile95Sorted()",
@@ -21089,7 +21105,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L120",
       "id": "telemetry_repository_percentile95sorted",
-      "community": 31
+      "community": 32
     },
     {
       "label": "TelemetryRepository",
@@ -21097,7 +21113,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L126",
       "id": "telemetry_repository_telemetryrepository",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".constructor()",
@@ -21105,7 +21121,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L127",
       "id": "telemetry_repository_telemetryrepository_constructor",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".avgCandidateCountForPeriod()",
@@ -21113,7 +21129,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L130",
       "id": "telemetry_repository_telemetryrepository_avgcandidatecountforperiod",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".insertEventSync()",
@@ -21121,7 +21137,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L155",
       "id": "telemetry_repository_telemetryrepository_inserteventsync",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".upsertDailyMetricRow()",
@@ -21129,7 +21145,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L179",
       "id": "telemetry_repository_telemetryrepository_upsertdailymetricrow",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".deleteExpiredEvents()",
@@ -21137,7 +21153,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L205",
       "id": "telemetry_repository_telemetryrepository_deleteexpiredevents",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".getBackgroundJobRolling24hStats()",
@@ -21145,7 +21161,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L215",
       "id": "telemetry_repository_telemetryrepository_getbackgroundjobrolling24hstats",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".hasPriorWriteCompletedWithContentHash()",
@@ -21153,7 +21169,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L238",
       "id": "telemetry_repository_telemetryrepository_haspriorwritecompletedwithcontenthash",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".querySearchQuality()",
@@ -21161,7 +21177,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L252",
       "id": "telemetry_repository_telemetryrepository_querysearchquality",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".queryMemoryQuality()",
@@ -21169,7 +21185,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L361",
       "id": "telemetry_repository_telemetryrepository_querymemoryquality",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".queryConsolidationQuality()",
@@ -21177,7 +21193,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L435",
       "id": "telemetry_repository_telemetryrepository_queryconsolidationquality",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".toolBucketFromEvents()",
@@ -21185,7 +21201,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L555",
       "id": "telemetry_repository_telemetryrepository_toolbucketfromevents",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".querySystemMetrics()",
@@ -21193,7 +21209,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L604",
       "id": "telemetry_repository_telemetryrepository_querysystemmetrics",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".queryEvents()",
@@ -21201,7 +21217,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L694",
       "id": "telemetry_repository_telemetryrepository_queryevents",
-      "community": 31
+      "community": 32
     },
     {
       "label": ".listEventsForRequest()",
@@ -21209,7 +21225,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.ts",
       "source_location": "L741",
       "id": "telemetry_repository_telemetryrepository_listeventsforrequest",
-      "community": 31
+      "community": 32
     },
     {
       "label": "get-telemetry-summary-tool.spec.ts",
@@ -21289,7 +21305,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "telemetry-service.ts",
@@ -21297,7 +21313,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_ts",
-      "community": 68
+      "community": 69
     },
     {
       "label": "TelemetryService",
@@ -21305,7 +21321,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L31",
       "id": "telemetry_service_telemetryservice",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".safeParseExtraData()",
@@ -21313,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L35",
       "id": "telemetry_service_telemetryservice_safeparseextradata",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".constructor()",
@@ -21321,7 +21337,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L45",
       "id": "telemetry_service_telemetryservice_constructor",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getContext()",
@@ -21329,7 +21345,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L50",
       "id": "telemetry_service_telemetryservice_getcontext",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".runWithContext()",
@@ -21337,7 +21353,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L54",
       "id": "telemetry_service_telemetryservice_runwithcontext",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".record()",
@@ -21345,7 +21361,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L59",
       "id": "telemetry_service_telemetryservice_record",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getSearchQuality()",
@@ -21353,7 +21369,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L83",
       "id": "telemetry_service_telemetryservice_getsearchquality",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getMemoryQuality()",
@@ -21361,7 +21377,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L87",
       "id": "telemetry_service_telemetryservice_getmemoryquality",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getConsolidationQuality()",
@@ -21369,7 +21385,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L91",
       "id": "telemetry_service_telemetryservice_getconsolidationquality",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getSystemMetrics()",
@@ -21377,7 +21393,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L95",
       "id": "telemetry_service_telemetryservice_getsystemmetrics",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".jobNameToTelemetryEventType()",
@@ -21385,7 +21401,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L105",
       "id": "telemetry_service_telemetryservice_jobnametotelemetryeventtype",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".buildJobSnapshot()",
@@ -21393,7 +21409,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L111",
       "id": "telemetry_service_telemetryservice_buildjobsnapshot",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".getEvents()",
@@ -21401,7 +21417,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L139",
       "id": "telemetry_service_telemetryservice_getevents",
-      "community": 68
+      "community": 69
     },
     {
       "label": ".hasPriorWriteWithContentHash()",
@@ -21409,7 +21425,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.ts",
       "source_location": "L160",
       "id": "telemetry_service_telemetryservice_haspriorwritewithcontenthash",
-      "community": 68
+      "community": 69
     },
     {
       "label": "core-memory-repository.ts",
@@ -21417,7 +21433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "kg-triple-repository.ts",
@@ -21425,7 +21441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "process-attribute-repository.ts",
@@ -21433,7 +21449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -21441,7 +21457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -21449,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "feedback-repository.ts",
@@ -21481,7 +21497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -21489,7 +21505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -21497,7 +21513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -21505,7 +21521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -21513,7 +21529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -21521,7 +21537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createKgTripleTable()",
@@ -21529,7 +21545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 537
+      "community": 538
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -21537,7 +21553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createProcessAttributeTable()",
@@ -21545,7 +21561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 538
+      "community": 539
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -21553,7 +21569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -21561,7 +21577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 539
+      "community": 540
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -21569,7 +21585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -21577,7 +21593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createCoreMemoryTable()",
@@ -21585,7 +21601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 540
+      "community": 541
     },
     {
       "label": "remember-tool.ts",
@@ -22121,7 +22137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_unpin_tool_ts",
-      "community": 77
+      "community": 78
     },
     {
       "label": "isSqliteBusy()",
@@ -22129,7 +22145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L14",
       "id": "unpin_tool_issqlitebusy",
-      "community": 77
+      "community": 78
     },
     {
       "label": "UnpinTool",
@@ -22137,7 +22153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L67",
       "id": "unpin_tool_unpintool",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".constructor()",
@@ -22145,7 +22161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L68",
       "id": "unpin_tool_unpintool_constructor",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".handle()",
@@ -22153,7 +22169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L105",
       "id": "unpin_tool_unpintool_handle",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".handleSingleUnpin()",
@@ -22161,7 +22177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L126",
       "id": "unpin_tool_unpintool_handlesingleunpin",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".handleBatchUnpin()",
@@ -22169,7 +22185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L191",
       "id": "unpin_tool_unpintool_handlebatchunpin",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".getMemoryById()",
@@ -22177,7 +22193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L246",
       "id": "unpin_tool_unpintool_getmemorybyid",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".getMemoriesByIds()",
@@ -22185,7 +22201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L260",
       "id": "unpin_tool_unpintool_getmemoriesbyids",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".logUnpinAction()",
@@ -22193,7 +22209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L277",
       "id": "unpin_tool_unpintool_logunpinaction",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".handleDatabaseLock()",
@@ -22201,7 +22217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L300",
       "id": "unpin_tool_unpintool_handledatabaselock",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".getUnpinnableMemories()",
@@ -22209,7 +22225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L315",
       "id": "unpin_tool_unpintool_getunpinnablememories",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".getUnpinStats()",
@@ -22217,7 +22233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L335",
       "id": "unpin_tool_unpintool_getunpinstats",
-      "community": 77
+      "community": 78
     },
     {
       "label": ".getRecommendedUnpins()",
@@ -22225,7 +22241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/unpin-tool.ts",
       "source_location": "L366",
       "id": "unpin_tool_unpintool_getrecommendedunpins",
-      "community": 77
+      "community": 78
     },
     {
       "label": "get-introspection-summary-tool.ts",
@@ -22337,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_ts",
-      "community": 40
+      "community": 41
     },
     {
       "label": "normalizeProviderFilter()",
@@ -22345,7 +22361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L250",
       "id": "recall_tool_normalizeproviderfilter",
-      "community": 40
+      "community": 41
     },
     {
       "label": "RecallTool",
@@ -22353,7 +22369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L416",
       "id": "recall_tool_recalltool",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".constructor()",
@@ -22361,7 +22377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L417",
       "id": "recall_tool_recalltool_constructor",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".handle()",
@@ -22369,7 +22385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L623",
       "id": "recall_tool_recalltool_handle",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".filterByTriggerConditions()",
@@ -22377,7 +22393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1294",
       "id": "recall_tool_recalltool_filterbytriggerconditions",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".processSearchResults()",
@@ -22385,7 +22401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1374",
       "id": "recall_tool_recalltool_processsearchresults",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".getAppliedFilters()",
@@ -22393,7 +22409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1480",
       "id": "recall_tool_recalltool_getappliedfilters",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".applyVersionFilter()",
@@ -22401,7 +22417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1531",
       "id": "recall_tool_recalltool_applyversionfilter",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".enrichProceduralVersionInfo()",
@@ -22409,7 +22425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1566",
       "id": "recall_tool_recalltool_enrichproceduralversioninfo",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".handleAutoSetAnchor()",
@@ -22417,7 +22433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1614",
       "id": "recall_tool_recalltool_handleautosetanchor",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".handleIncludeNeighbors()",
@@ -22425,7 +22441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1785",
       "id": "recall_tool_recalltool_handleincludeneighbors",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".validateQuery()",
@@ -22433,7 +22449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1918",
       "id": "recall_tool_recalltool_validatequery",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".validateFilters()",
@@ -22441,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1944",
       "id": "recall_tool_recalltool_validatefilters",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".collectMetaMemoryStats()",
@@ -22449,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1977",
       "id": "recall_tool_recalltool_collectmetamemorystats",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".getMetaStatsForResults()",
@@ -22457,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L2022",
       "id": "recall_tool_recalltool_getmetastatsforresults",
-      "community": 40
+      "community": 41
     },
     {
       "label": ".updateConsolidationScoreMetadata()",
@@ -22465,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L2082",
       "id": "recall_tool_recalltool_updateconsolidationscoremetadata",
-      "community": 40
+      "community": 41
     },
     {
       "label": "forget-tool.ts",
@@ -22473,7 +22489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_forget_tool_ts",
-      "community": 41
+      "community": 42
     },
     {
       "label": "ForgetTool",
@@ -22481,7 +22497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L25",
       "id": "forget_tool_forgettool",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".constructor()",
@@ -22489,7 +22505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L26",
       "id": "forget_tool_forgettool_constructor",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".getVectorTableName()",
@@ -22497,7 +22513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L71",
       "id": "forget_tool_forgettool_getvectortablename",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".handle()",
@@ -22505,7 +22521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L75",
       "id": "forget_tool_forgettool_handle",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".handleSingleDelete()",
@@ -22513,7 +22529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L139",
       "id": "forget_tool_forgettool_handlesingledelete",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".handleBatchDelete()",
@@ -22521,7 +22537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L200",
       "id": "forget_tool_forgettool_handlebatchdelete",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".performHardDelete()",
@@ -22529,7 +22545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L235",
       "id": "forget_tool_forgettool_performharddelete",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".performSoftDelete()",
@@ -22537,7 +22553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L272",
       "id": "forget_tool_forgettool_performsoftdelete",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".getMemoryById()",
@@ -22545,7 +22561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L290",
       "id": "forget_tool_forgettool_getmemorybyid",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".validateDeletePermission()",
@@ -22553,7 +22569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L301",
       "id": "forget_tool_forgettool_validatedeletepermission",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".logDeleteAction()",
@@ -22561,7 +22577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L319",
       "id": "forget_tool_forgettool_logdeleteaction",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".deleteEmbedding()",
@@ -22569,7 +22585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L343",
       "id": "forget_tool_forgettool_deleteembedding",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".cleanupRelatedData()",
@@ -22577,7 +22593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L360",
       "id": "forget_tool_forgettool_cleanuprelateddata",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".handleDatabaseLock()",
@@ -22585,7 +22601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L406",
       "id": "forget_tool_forgettool_handledatabaselock",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".getDeletableMemories()",
@@ -22593,7 +22609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L421",
       "id": "forget_tool_forgettool_getdeletablememories",
-      "community": 41
+      "community": 42
     },
     {
       "label": ".getDeleteStats()",
@@ -22601,7 +22617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/forget-tool.ts",
       "source_location": "L438",
       "id": "forget_tool_forgettool_getdeletestats",
-      "community": 41
+      "community": 42
     },
     {
       "label": "procedural-diff-tool.spec.ts",
@@ -22609,7 +22625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createSchema()",
@@ -22617,7 +22633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 541
+      "community": 542
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -22625,7 +22641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "remember-tool.spec.ts",
@@ -22657,7 +22673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -22665,7 +22681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createSchema()",
@@ -22673,7 +22689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 542
+      "community": 543
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -22713,7 +22729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -22721,7 +22737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -22729,7 +22745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "initializeTestDatabase()",
@@ -22737,7 +22753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 543
+      "community": 544
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -22745,7 +22761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "parseData()",
@@ -22753,7 +22769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 544
+      "community": 545
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -22761,7 +22777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "recall-tool.spec.ts",
@@ -22793,7 +22809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -22801,7 +22817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "pin-tool.spec.ts",
@@ -22809,7 +22825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "meta-memory-service.ts",
@@ -22817,7 +22833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_ts",
-      "community": 69
+      "community": 70
     },
     {
       "label": "MetaMemoryService",
@@ -22825,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L45",
       "id": "meta_memory_service_metamemoryservice",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".constructor()",
@@ -22833,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L49",
       "id": "meta_memory_service_metamemoryservice_constructor",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".recordRecall()",
@@ -22841,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L81",
       "id": "meta_memory_service_metamemoryservice_recordrecall",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".addToStatsBuffer()",
@@ -22849,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L173",
       "id": "meta_memory_service_metamemoryservice_addtostatsbuffer",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".scheduleStatsFlush()",
@@ -22857,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L184",
       "id": "meta_memory_service_metamemoryservice_schedulestatsflush",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".flushStats()",
@@ -22865,7 +22881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L199",
       "id": "meta_memory_service_metamemoryservice_flushstats",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".isItemSuccess()",
@@ -22873,7 +22889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L225",
       "id": "meta_memory_service_metamemoryservice_isitemsuccess",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".calculateConfidence()",
@@ -22881,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L237",
       "id": "meta_memory_service_metamemoryservice_calculateconfidence",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".updateAvgConfidence()",
@@ -22889,7 +22905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L262",
       "id": "meta_memory_service_metamemoryservice_updateavgconfidence",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".getStatsById()",
@@ -22897,7 +22913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L281",
       "id": "meta_memory_service_metamemoryservice_getstatsbyid",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".getStats()",
@@ -22905,7 +22921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L342",
       "id": "meta_memory_service_metamemoryservice_getstats",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".mapRowToMetaMemoryStats()",
@@ -22913,7 +22929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L458",
       "id": "meta_memory_service_metamemoryservice_maprowtometamemorystats",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".flushToDatabase()",
@@ -22921,7 +22937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L481",
       "id": "meta_memory_service_metamemoryservice_flushtodatabase",
-      "community": 69
+      "community": 70
     },
     {
       "label": ".destroy()",
@@ -22929,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.ts",
       "source_location": "L550",
       "id": "meta_memory_service_metamemoryservice_destroy",
-      "community": 69
+      "community": 70
     },
     {
       "label": "procedural-memory-diff.ts",
@@ -23041,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createBaseSchema()",
@@ -23049,7 +23065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 545
+      "community": 546
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -23129,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "baseRow()",
@@ -23137,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 546
+      "community": 547
     },
     {
       "label": "procedural-versioning.ts",
@@ -23353,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -23361,7 +23377,23 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 547
+      "community": 548
+    },
+    {
+      "label": "admin-memory-item-preview-service.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
+      "community": 549
+    },
+    {
+      "label": "openDb()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
+      "source_location": "L8",
+      "id": "admin_memory_item_preview_service_spec_opendb",
+      "community": 549
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -23369,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_knowledge_vault_service_ts",
-      "community": 13
+      "community": 14
     },
     {
       "label": "generateVaultId()",
@@ -23377,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L36",
       "id": "knowledge_vault_service_generatevaultid",
-      "community": 13
+      "community": 14
     },
     {
       "label": "ImmutableDataError",
@@ -23385,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L45",
       "id": "knowledge_vault_service_immutabledataerror",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".constructor()",
@@ -23393,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L46",
       "id": "knowledge_vault_service_immutabledataerror_constructor",
-      "community": 13
+      "community": 14
     },
     {
       "label": "KnowledgeVaultService",
@@ -23401,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L55",
       "id": "knowledge_vault_service_knowledgevaultservice",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".constructor()",
@@ -23409,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L56",
       "id": "knowledge_vault_service_knowledgevaultservice_constructor",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".create()",
@@ -23417,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L62",
       "id": "knowledge_vault_service_knowledgevaultservice_create",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findById()",
@@ -23425,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L105",
       "id": "knowledge_vault_service_knowledgevaultservice_findbyid",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findActiveByKey()",
@@ -23433,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L112",
       "id": "knowledge_vault_service_knowledgevaultservice_findactivebykey",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findByKeyAndVersion()",
@@ -23441,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L119",
       "id": "knowledge_vault_service_knowledgevaultservice_findbykeyandversion",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findAllVersionsByKey()",
@@ -23449,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L130",
       "id": "knowledge_vault_service_knowledgevaultservice_findallversionsbykey",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findActiveByAgentId()",
@@ -23457,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L140",
       "id": "knowledge_vault_service_knowledgevaultservice_findactivebyagentid",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findByAgentId()",
@@ -23465,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L147",
       "id": "knowledge_vault_service_knowledgevaultservice_findbyagentid",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".update()",
@@ -23473,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L155",
       "id": "knowledge_vault_service_knowledgevaultservice_update",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".updateActiveByKey()",
@@ -23481,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L200",
       "id": "knowledge_vault_service_knowledgevaultservice_updateactivebykey",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".delete()",
@@ -23489,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L217",
       "id": "knowledge_vault_service_knowledgevaultservice_delete",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".deleteActiveByKey()",
@@ -23497,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L236",
       "id": "knowledge_vault_service_knowledgevaultservice_deleteactivebykey",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".hardDelete()",
@@ -23505,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L256",
       "id": "knowledge_vault_service_knowledgevaultservice_harddelete",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findAllActive()",
@@ -23513,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L275",
       "id": "knowledge_vault_service_knowledgevaultservice_findallactive",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".findAll()",
@@ -23521,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L282",
       "id": "knowledge_vault_service_knowledgevaultservice_findall",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".count()",
@@ -23529,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L289",
       "id": "knowledge_vault_service_knowledgevaultservice_count",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".canUpdate()",
@@ -23537,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L297",
       "id": "knowledge_vault_service_knowledgevaultservice_canupdate",
-      "community": 13
+      "community": 14
     },
     {
       "label": ".canDelete()",
@@ -23545,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L308",
       "id": "knowledge_vault_service_knowledgevaultservice_candelete",
-      "community": 13
+      "community": 14
     },
     {
       "label": "memory-review-candidate-selection-scoring.ts",
@@ -23713,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_embedding_service_ts",
-      "community": 70
+      "community": 71
     },
     {
       "label": "MemoryEmbeddingService",
@@ -23721,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L66",
       "id": "memory_embedding_service_memoryembeddingservice",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".constructor()",
@@ -23729,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L71",
       "id": "memory_embedding_service_memoryembeddingservice_constructor",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".getCurrentProviderName()",
@@ -23737,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L79",
       "id": "memory_embedding_service_memoryembeddingservice_getcurrentprovidername",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".getUnifiedEmbeddingService()",
@@ -23745,7 +23777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L87",
       "id": "memory_embedding_service_memoryembeddingservice_getunifiedembeddingservice",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".loadVecExtension()",
@@ -23753,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L95",
       "id": "memory_embedding_service_memoryembeddingservice_loadvecextension",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".createAndStoreEmbedding()",
@@ -23761,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L117",
       "id": "memory_embedding_service_memoryembeddingservice_createandstoreembedding",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".getVectorTableName()",
@@ -23769,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L238",
       "id": "memory_embedding_service_memoryembeddingservice_getvectortablename",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".searchBySimilarity()",
@@ -23777,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L245",
       "id": "memory_embedding_service_memoryembeddingservice_searchbysimilarity",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".deleteEmbedding()",
@@ -23785,7 +23817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L344",
       "id": "memory_embedding_service_memoryembeddingservice_deleteembedding",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".safeParseTags()",
@@ -23793,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L355",
       "id": "memory_embedding_service_memoryembeddingservice_safeparsetags",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".isAvailable()",
@@ -23801,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L373",
       "id": "memory_embedding_service_memoryembeddingservice_isavailable",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".getEmbeddingStats()",
@@ -23809,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L380",
       "id": "memory_embedding_service_memoryembeddingservice_getembeddingstats",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".normalizeProvider()",
@@ -23817,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L438",
       "id": "memory_embedding_service_memoryembeddingservice_normalizeprovider",
-      "community": 70
+      "community": 71
     },
     {
       "label": ".ensureMetadataDefaults()",
@@ -23825,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-embedding-service.ts",
       "source_location": "L451",
       "id": "memory_embedding_service_memoryembeddingservice_ensuremetadatadefaults",
-      "community": 70
+      "community": 71
     },
     {
       "label": "memory-review-candidate-selection-service.spec.ts",
@@ -23833,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 548
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -23841,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 548
+      "community": 550
     },
     {
       "label": "core-memory-cache-service.ts",
@@ -23849,7 +23881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_core_memory_cache_service_ts",
-      "community": 14
+      "community": 15
     },
     {
       "label": "CoreMemoryCacheService",
@@ -23857,7 +23889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L45",
       "id": "core_memory_cache_service_corememorycacheservice",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".set()",
@@ -23865,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L53",
       "id": "core_memory_cache_service_corememorycacheservice_set",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".get()",
@@ -23873,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L70",
       "id": "core_memory_cache_service_corememorycacheservice_get",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".getWithVersion()",
@@ -23881,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L78",
       "id": "core_memory_cache_service_corememorycacheservice_getwithversion",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".delete()",
@@ -23889,7 +23921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L85",
       "id": "core_memory_cache_service_corememorycacheservice_delete",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".invalidateByVersion()",
@@ -23897,7 +23929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L99",
       "id": "core_memory_cache_service_corememorycacheservice_invalidatebyversion",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".subscribeInvalidation()",
@@ -23905,7 +23937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L125",
       "id": "core_memory_cache_service_corememorycacheservice_subscribeinvalidation",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".unsubscribeInvalidation()",
@@ -23913,7 +23945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L132",
       "id": "core_memory_cache_service_corememorycacheservice_unsubscribeinvalidation",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".notifyInvalidate()",
@@ -23921,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L139",
       "id": "core_memory_cache_service_corememorycacheservice_notifyinvalidate",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".notifyInvalidateAll()",
@@ -23929,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L152",
       "id": "core_memory_cache_service_corememorycacheservice_notifyinvalidateall",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".getAll()",
@@ -23937,7 +23969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L165",
       "id": "core_memory_cache_service_corememorycacheservice_getall",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".clear()",
@@ -23945,7 +23977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L172",
       "id": "core_memory_cache_service_corememorycacheservice_clear",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".has()",
@@ -23953,7 +23985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L181",
       "id": "core_memory_cache_service_corememorycacheservice_has",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".size()",
@@ -23961,7 +23993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L188",
       "id": "core_memory_cache_service_corememorycacheservice_size",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".keys()",
@@ -23969,7 +24001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L195",
       "id": "core_memory_cache_service_corememorycacheservice_keys",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".getByAgentId()",
@@ -23977,7 +24009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L202",
       "id": "core_memory_cache_service_corememorycacheservice_getbyagentid",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".deleteByAgentId()",
@@ -23985,7 +24017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L211",
       "id": "core_memory_cache_service_corememorycacheservice_deletebyagentid",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".getStats()",
@@ -23993,7 +24025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L226",
       "id": "core_memory_cache_service_corememorycacheservice_getstats",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".invalidate()",
@@ -24001,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L246",
       "id": "core_memory_cache_service_corememorycacheservice_invalidate",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getCoreMemoryCache()",
@@ -24009,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L262",
       "id": "core_memory_cache_service_getcorememorycache",
-      "community": 14
+      "community": 15
     },
     {
       "label": "setCoreMemoryCache()",
@@ -24017,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L272",
       "id": "core_memory_cache_service_setcorememorycache",
-      "community": 14
+      "community": 15
     },
     {
       "label": "resetCoreMemoryCache()",
@@ -24025,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-cache-service.ts",
       "source_location": "L279",
       "id": "core_memory_cache_service_resetcorememorycache",
-      "community": 14
+      "community": 15
     },
     {
       "label": "memory-review-candidate-persistence.types.ts",
@@ -24033,7 +24065,31 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 821
+      "community": 823
+    },
+    {
+      "label": "admin-memory-item-preview-service.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
+      "community": 421
+    },
+    {
+      "label": "parseAdminMemoryItemIdParam()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
+      "source_location": "L22",
+      "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
+      "community": 421
+    },
+    {
+      "label": "getAdminMemoryItemPreviewById()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
+      "source_location": "L33",
+      "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
+      "community": 421
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -24041,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -24049,7 +24105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "core-memory-service.ts",
@@ -24057,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_core_memory_service_ts",
-      "community": 32
+      "community": 33
     },
     {
       "label": "generateCoreId()",
@@ -24065,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L62",
       "id": "core_memory_service_generatecoreid",
-      "community": 32
+      "community": 33
     },
     {
       "label": "CoreMemoryService",
@@ -24073,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L71",
       "id": "core_memory_service_corememoryservice",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".constructor()",
@@ -24081,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L74",
       "id": "core_memory_service_corememoryservice_constructor",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".setCache()",
@@ -24089,7 +24145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L84",
       "id": "core_memory_service_corememoryservice_setcache",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".create()",
@@ -24097,7 +24153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L91",
       "id": "core_memory_service_corememoryservice_create",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".findById()",
@@ -24105,7 +24161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L128",
       "id": "core_memory_service_corememoryservice_findbyid",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".findByKey()",
@@ -24113,7 +24169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L135",
       "id": "core_memory_service_corememoryservice_findbykey",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".findByAgentId()",
@@ -24121,7 +24177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L183",
       "id": "core_memory_service_corememoryservice_findbyagentid",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".findAlwaysLoad()",
@@ -24129,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L190",
       "id": "core_memory_service_corememoryservice_findalwaysload",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".update()",
@@ -24137,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L217",
       "id": "core_memory_service_corememoryservice_update",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".updateByKey()",
@@ -24145,7 +24201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L252",
       "id": "core_memory_service_corememoryservice_updatebykey",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".delete()",
@@ -24153,7 +24209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L288",
       "id": "core_memory_service_corememoryservice_delete",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".deleteByKey()",
@@ -24161,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L308",
       "id": "core_memory_service_corememoryservice_deletebykey",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".deleteByAgentId()",
@@ -24169,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L328",
       "id": "core_memory_service_corememoryservice_deletebyagentid",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".findAll()",
@@ -24177,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L349",
       "id": "core_memory_service_corememoryservice_findall",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".count()",
@@ -24185,7 +24241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L356",
       "id": "core_memory_service_corememoryservice_count",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".getCacheKey()",
@@ -24193,7 +24249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L363",
       "id": "core_memory_service_corememoryservice_getcachekey",
-      "community": 32
+      "community": 33
     },
     {
       "label": ".reloadCache()",
@@ -24201,7 +24257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/core-memory-service.ts",
       "source_location": "L370",
       "id": "core_memory_service_corememoryservice_reloadcache",
-      "community": 32
+      "community": 33
     },
     {
       "label": "meta-memory-service.spec.ts",
@@ -24209,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 549
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -24217,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 549
+      "community": 551
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -24225,7 +24281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 550
+      "community": 552
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -24233,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 550
+      "community": 552
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -24313,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -24321,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -24329,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 551
+      "community": 553
     },
     {
       "label": "createSchema()",
@@ -24337,7 +24393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 551
+      "community": 553
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -24345,7 +24401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -24353,7 +24409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 552
+      "community": 554
     },
     {
       "label": "createSchema()",
@@ -24361,7 +24417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 552
+      "community": 554
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -24369,7 +24425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 553
+      "community": 555
     },
     {
       "label": "createBaseSchema()",
@@ -24377,7 +24433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 553
+      "community": 555
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -24385,7 +24441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -24393,7 +24449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 554
+      "community": 556
     },
     {
       "label": "createSchema()",
@@ -24401,7 +24457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 554
+      "community": 556
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -24409,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -24417,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -24425,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_service_spec_ts",
-      "community": 78
+      "community": 79
     },
     {
       "label": "MockCoreMemoryRepository",
@@ -24433,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L10",
       "id": "core_memory_service_spec_mockcorememoryrepository",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".create()",
@@ -24441,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L13",
       "id": "core_memory_service_spec_mockcorememoryrepository_create",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".findById()",
@@ -24449,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L29",
       "id": "core_memory_service_spec_mockcorememoryrepository_findbyid",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".findByKey()",
@@ -24457,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L33",
       "id": "core_memory_service_spec_mockcorememoryrepository_findbykey",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".findByAgentId()",
@@ -24465,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L42",
       "id": "core_memory_service_spec_mockcorememoryrepository_findbyagentid",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".findAlwaysLoad()",
@@ -24473,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L46",
       "id": "core_memory_service_spec_mockcorememoryrepository_findalwaysload",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".update()",
@@ -24481,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L54",
       "id": "core_memory_service_spec_mockcorememoryrepository_update",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".updateByKey()",
@@ -24489,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L68",
       "id": "core_memory_service_spec_mockcorememoryrepository_updatebykey",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".delete()",
@@ -24497,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L74",
       "id": "core_memory_service_spec_mockcorememoryrepository_delete",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".deleteByKey()",
@@ -24505,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L78",
       "id": "core_memory_service_spec_mockcorememoryrepository_deletebykey",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".deleteByAgentId()",
@@ -24513,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L84",
       "id": "core_memory_service_spec_mockcorememoryrepository_deletebyagentid",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".findAll()",
@@ -24521,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L95",
       "id": "core_memory_service_spec_mockcorememoryrepository_findall",
-      "community": 78
+      "community": 79
     },
     {
       "label": ".count()",
@@ -24529,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-service.spec.ts",
       "source_location": "L99",
       "id": "core_memory_service_spec_mockcorememoryrepository_count",
-      "community": 78
+      "community": 79
     },
     {
       "label": "semantic-memory-update-service.spec.ts",
@@ -24537,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -24601,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_ts",
-      "community": 15
+      "community": 16
     },
     {
       "label": "generateId()",
@@ -24609,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L26",
       "id": "semantic_memory_update_service_generateid",
-      "community": 15
+      "community": 16
     },
     {
       "label": "SemanticMemoryUpdateService",
@@ -24617,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L74",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".constructor()",
@@ -24625,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L95",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_constructor",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".ensureRelationTypes()",
@@ -24633,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L138",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_ensurerelationtypes",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".updateSemanticMemory()",
@@ -24641,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L194",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_updatesemanticmemory",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".validateInput()",
@@ -24649,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L238",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_validateinput",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".prepareUpdateData()",
@@ -24657,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L262",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_prepareupdatedata",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".applyUpdates()",
@@ -24665,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L295",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_applyupdates",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".processSingleTriple()",
@@ -24673,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L362",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_processsingletriple",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".notifyListeners()",
@@ -24681,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L468",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_notifylisteners",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".getStatistics()",
@@ -24689,7 +24745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L499",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_getstatistics",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".tripleToNaturalLanguage()",
@@ -24697,7 +24753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L511",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_tripletonaturallanguage",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".createSemanticMemory()",
@@ -24705,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L530",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_createsemanticmemory",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".normalizeTripleForKg()",
@@ -24713,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L599",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_normalizetripleforkg",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".updateExistingSemanticMemory()",
@@ -24721,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L626",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_updateexistingsemanticmemory",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".findDuplicateSemanticMemory()",
@@ -24729,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L696",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_findduplicatesemanticmemory",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".checkSimilarity()",
@@ -24737,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L792",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_checksimilarity",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".cosineSimilarity()",
@@ -24745,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L866",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_cosinesimilarity",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".calculateConfidence()",
@@ -24753,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L912",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_calculateconfidence",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".calculateImportance()",
@@ -24761,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L972",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_calculateimportance",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".validateRelationDirection()",
@@ -24769,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L1005",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_validaterelationdirection",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".createEpisodicEdge()",
@@ -24777,7 +24833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.ts",
       "source_location": "L1066",
       "id": "semantic_memory_update_service_semanticmemoryupdateservice_createepisodicedge",
-      "community": 15
+      "community": 16
     },
     {
       "label": "index.ts",
@@ -24785,7 +24841,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -24793,7 +24849,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 555
+      "community": 557
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -24801,7 +24857,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 555
+      "community": 557
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -24809,7 +24865,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "consolidation-repository.ts",
@@ -25041,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 556
+      "community": 558
     },
     {
       "label": "row()",
@@ -25049,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 556
+      "community": 558
     },
     {
       "label": "summarization-service.ts",
@@ -25145,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 557
+      "community": 559
     },
     {
       "label": "ep()",
@@ -25153,7 +25209,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 557
+      "community": 559
     },
     {
       "label": "relation-graph.port.ts",
@@ -25161,7 +25217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "get-relations-tool.ts",
@@ -25201,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 558
+      "community": 560
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -25209,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 558
+      "community": 560
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -25393,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "createBaseSchema()",
@@ -25401,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 421
+      "community": 422
     },
     {
       "label": "createTestMemory()",
@@ -25409,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 421
+      "community": 422
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -25417,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "createBaseSchema()",
@@ -25425,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 422
+      "community": 423
     },
     {
       "label": "createTestMemory()",
@@ -25433,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 422
+      "community": 423
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -25441,7 +25497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createBaseSchema()",
@@ -25449,7 +25505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createTestMemory()",
@@ -25457,7 +25513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 423
+      "community": 424
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -25465,7 +25521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -25473,7 +25529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createBaseSchema()",
@@ -25481,7 +25537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createTestMemory()",
@@ -25489,7 +25545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 424
+      "community": 425
     },
     {
       "label": "relation-retry-manager.ts",
@@ -25673,7 +25729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_ts",
-      "community": 11
+      "community": 12
     },
     {
       "label": "RelationGraph",
@@ -25681,7 +25737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L40",
       "id": "relation_graph_relationgraph",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".constructor()",
@@ -25689,7 +25745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L50",
       "id": "relation_graph_relationgraph_constructor",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".addRelation()",
@@ -25697,7 +25753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L73",
       "id": "relation_graph_relationgraph_addrelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".addRelationInternal()",
@@ -25705,7 +25761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L139",
       "id": "relation_graph_relationgraph_addrelationinternal",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".handleRelationAddError()",
@@ -25713,7 +25769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L193",
       "id": "relation_graph_relationgraph_handlerelationadderror",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".validateRelationInput()",
@@ -25721,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L239",
       "id": "relation_graph_relationgraph_validaterelationinput",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".checkForCyclicRelation()",
@@ -25729,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L254",
       "id": "relation_graph_relationgraph_checkforcyclicrelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".prepareMetadata()",
@@ -25737,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L275",
       "id": "relation_graph_relationgraph_preparemetadata",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".findExistingRelation()",
@@ -25745,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L297",
       "id": "relation_graph_relationgraph_findexistingrelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".handleExistingRelation()",
@@ -25753,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L338",
       "id": "relation_graph_relationgraph_handleexistingrelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".insertNewRelation()",
@@ -25761,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L396",
       "id": "relation_graph_relationgraph_insertnewrelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".updateCyclicFlag()",
@@ -25769,7 +25825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L428",
       "id": "relation_graph_relationgraph_updatecyclicflag",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".getRelations()",
@@ -25777,7 +25833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L472",
       "id": "relation_graph_relationgraph_getrelations",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".getRelationsBatch()",
@@ -25785,7 +25841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L591",
       "id": "relation_graph_relationgraph_getrelationsbatch",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".getRelatedMemories()",
@@ -25793,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L664",
       "id": "relation_graph_relationgraph_getrelatedmemories",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".removeRelation()",
@@ -25801,7 +25857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L830",
       "id": "relation_graph_relationgraph_removerelation",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".updateConfidence()",
@@ -25809,7 +25865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L860",
       "id": "relation_graph_relationgraph_updateconfidence",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".detectCycleInternal()",
@@ -25817,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L951",
       "id": "relation_graph_relationgraph_detectcycleinternal",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".detectCycle()",
@@ -25825,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1046",
       "id": "relation_graph_relationgraph_detectcycle",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".generateCacheKey()",
@@ -25833,7 +25889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1076",
       "id": "relation_graph_relationgraph_generatecachekey",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".addCacheKeyToIndex()",
@@ -25841,7 +25897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1093",
       "id": "relation_graph_relationgraph_addcachekeytoindex",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".invalidateCache()",
@@ -25849,7 +25905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1115",
       "id": "relation_graph_relationgraph_invalidatecache",
-      "community": 11
+      "community": 12
     },
     {
       "label": ".addRelationsBatch()",
@@ -25857,7 +25913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph.ts",
       "source_location": "L1158",
       "id": "relation_graph_relationgraph_addrelationsbatch",
-      "community": 11
+      "community": 12
     },
     {
       "label": "relation-quality-validator.ts",
@@ -25865,7 +25921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_ts",
-      "community": 79
+      "community": 80
     },
     {
       "label": "RelationQualityValidator",
@@ -25873,7 +25929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L126",
       "id": "relation_quality_validator_relationqualityvalidator",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".matchRelations()",
@@ -25881,7 +25937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L134",
       "id": "relation_quality_validator_relationqualityvalidator_matchrelations",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculatePrecision()",
@@ -25889,7 +25945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L192",
       "id": "relation_quality_validator_relationqualityvalidator_calculateprecision",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateRecall()",
@@ -25897,7 +25953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L219",
       "id": "relation_quality_validator_relationqualityvalidator_calculaterecall",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateF1Score()",
@@ -25905,7 +25961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L239",
       "id": "relation_quality_validator_relationqualityvalidator_calculatef1score",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateTypeMetrics()",
@@ -25913,7 +25969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L254",
       "id": "relation_quality_validator_relationqualityvalidator_calculatetypemetrics",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateConfidenceComplianceRate()",
@@ -25921,7 +25977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L326",
       "id": "relation_quality_validator_relationqualityvalidator_calculateconfidencecompliancerate",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateQualityMetrics()",
@@ -25929,7 +25985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L344",
       "id": "relation_quality_validator_relationqualityvalidator_calculatequalitymetrics",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".validateThresholds()",
@@ -25937,7 +25993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L432",
       "id": "relation_quality_validator_relationqualityvalidator_validatethresholds",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateConfusionMatrix()",
@@ -25945,7 +26001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L483",
       "id": "relation_quality_validator_relationqualityvalidator_calculateconfusionmatrix",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".analyzeRelationType()",
@@ -25953,7 +26009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L544",
       "id": "relation_quality_validator_relationqualityvalidator_analyzerelationtype",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".analyzeAllRelationTypes()",
@@ -25961,7 +26017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L634",
       "id": "relation_quality_validator_relationqualityvalidator_analyzeallrelationtypes",
-      "community": 79
+      "community": 80
     },
     {
       "label": ".calculateQualityMetricsWithAnalysis()",
@@ -25969,7 +26025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator.ts",
       "source_location": "L658",
       "id": "relation_quality_validator_relationqualityvalidator_calculatequalitymetricswithanalysis",
-      "community": 79
+      "community": 80
     },
     {
       "label": "relation-extractor.ts",
@@ -26041,7 +26097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_based_relation_extractor_ts",
-      "community": 9
+      "community": 10
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -26049,7 +26105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L72",
       "id": "llm_based_relation_extractor_tokenbucketratelimiter",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".constructor()",
@@ -26057,7 +26113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L79",
       "id": "llm_based_relation_extractor_tokenbucketratelimiter_constructor",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".consume()",
@@ -26065,7 +26121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L92",
       "id": "llm_based_relation_extractor_tokenbucketratelimiter_consume",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".refill()",
@@ -26073,7 +26129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L127",
       "id": "llm_based_relation_extractor_tokenbucketratelimiter_refill",
-      "community": 9
+      "community": 10
     },
     {
       "label": "LLMBasedRelationExtractor",
@@ -26081,7 +26137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L150",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".constructor()",
@@ -26089,7 +26145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L162",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_constructor",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".initializeClients()",
@@ -26097,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L210",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_initializeclients",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".isAvailable()",
@@ -26105,7 +26161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L231",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_isavailable",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".isOllamaAvailable()",
@@ -26113,7 +26169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L251",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_isollamaavailable",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".determineProvider()",
@@ -26121,7 +26177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L262",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_determineprovider",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".buildPrompt()",
@@ -26129,7 +26185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L308",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_buildprompt",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".filterCandidatesByEmbedding()",
@@ -26137,7 +26193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L349",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_filtercandidatesbyembedding",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".compressMemories()",
@@ -26145,7 +26201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L426",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_compressmemories",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".generateCacheKey()",
@@ -26153,7 +26209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L444",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_generatecachekey",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".calculateAndLogCost()",
@@ -26161,7 +26217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L457",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_calculateandlogcost",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractWithOpenAI()",
@@ -26169,7 +26225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L502",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractwithopenai",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".checkOllamaModel()",
@@ -26177,7 +26233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L585",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_checkollamamodel",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractWithOllama()",
@@ -26185,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L627",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractwithollama",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractWithGemini()",
@@ -26193,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L973",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractwithgemini",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractJSON()",
@@ -26201,7 +26257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1054",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractjson",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".parseLLMResponse()",
@@ -26209,7 +26265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1195",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_parsellmresponse",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractRelations()",
@@ -26217,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1438",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractrelations",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".extractRelationsBatch()",
@@ -26225,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1595",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_extractrelationsbatch",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".getCostMetrics()",
@@ -26233,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1634",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_getcostmetrics",
-      "community": 9
+      "community": 10
     },
     {
       "label": ".resetCostMetrics()",
@@ -26241,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts",
       "source_location": "L1641",
       "id": "llm_based_relation_extractor_llmbasedrelationextractor_resetcostmetrics",
-      "community": 9
+      "community": 10
     },
     {
       "label": "relation-extraction-quality.integration.spec.ts",
@@ -26281,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "relation-graph.spec.ts",
@@ -26289,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createBaseSchema()",
@@ -26297,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L24",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createTestMemory()",
@@ -26305,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L59",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 425
+      "community": 426
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -26313,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 559
+      "community": 561
     },
     {
       "label": "createTestMemory()",
@@ -26321,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 559
+      "community": 561
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -26361,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 560
+      "community": 562
     },
     {
       "label": "createTestMemory()",
@@ -26369,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 560
+      "community": 562
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -26433,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -26441,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -26449,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "getMockMementoConfig()",
@@ -26457,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 426
+      "community": 427
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -26465,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 426
+      "community": 427
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -26473,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "provider-openai.spec.ts",
@@ -26481,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -26489,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -26497,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -26817,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 561
+      "community": 563
     },
     {
       "label": "extract()",
@@ -26825,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 561
+      "community": 563
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -26833,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "tripleDedupeKey()",
@@ -26841,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 427
+      "community": 428
     },
     {
       "label": "mergeTripleLists()",
@@ -26849,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 427
+      "community": 428
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -26857,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "triple-extraction-service.ts",
@@ -26865,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_ts",
-      "community": 54
+      "community": 55
     },
     {
       "label": "TripleExtractionService",
@@ -26873,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L69",
       "id": "triple_extraction_service_tripleextractionservice",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".constructor()",
@@ -26881,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L94",
       "id": "triple_extraction_service_tripleextractionservice_constructor",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".getLlmCallDeps()",
@@ -26889,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L120",
       "id": "triple_extraction_service_tripleextractionservice_getllmcalldeps",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".initializeClients()",
@@ -26897,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L131",
       "id": "triple_extraction_service_tripleextractionservice_initializeclients",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".ensureInitialized()",
@@ -26905,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L166",
       "id": "triple_extraction_service_tripleextractionservice_ensureinitialized",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".determineProvider()",
@@ -26913,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L180",
       "id": "triple_extraction_service_tripleextractionservice_determineprovider",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".isAvailable()",
@@ -26921,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L213",
       "id": "triple_extraction_service_tripleextractionservice_isavailable",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".extractTriples()",
@@ -26929,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L217",
       "id": "triple_extraction_service_tripleextractionservice_extracttriples",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".extractWithLLM()",
@@ -26937,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L320",
       "id": "triple_extraction_service_tripleextractionservice_extractwithllm",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".updateCostMetrics()",
@@ -26945,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L440",
       "id": "triple_extraction_service_tripleextractionservice_updatecostmetrics",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".logExtractionResult()",
@@ -26953,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L458",
       "id": "triple_extraction_service_tripleextractionservice_logextractionresult",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".normalizeExtractionResult()",
@@ -26961,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L490",
       "id": "triple_extraction_service_tripleextractionservice_normalizeextractionresult",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".getCostMetrics()",
@@ -26969,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L496",
       "id": "triple_extraction_service_tripleextractionservice_getcostmetrics",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".getStatistics()",
@@ -26977,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L500",
       "id": "triple_extraction_service_tripleextractionservice_getstatistics",
-      "community": 54
+      "community": 55
     },
     {
       "label": ".getFailureReasonStatistics()",
@@ -26985,7 +27041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts",
       "source_location": "L504",
       "id": "triple_extraction_service_tripleextractionservice_getfailurereasonstatistics",
-      "community": 54
+      "community": 55
     },
     {
       "label": "interfaces.ts",
@@ -26993,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -27001,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -27009,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "triple-extractor.ts",
@@ -27017,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extractor_ts",
-      "community": 42
+      "community": 43
     },
     {
       "label": "TripleExtractor",
@@ -27025,7 +27081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L27",
       "id": "triple_extractor_tripleextractor",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".constructor()",
@@ -27033,7 +27089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L40",
       "id": "triple_extractor_tripleextractor_constructor",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extract()",
@@ -27041,7 +27097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L58",
       "id": "triple_extractor_tripleextractor_extract",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extractWithProvider()",
@@ -27049,7 +27105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L124",
       "id": "triple_extractor_tripleextractor_extractwithprovider",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extractWithOpenAI()",
@@ -27057,7 +27113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L144",
       "id": "triple_extractor_tripleextractor_extractwithopenai",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extractWithGemini()",
@@ -27065,7 +27121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L192",
       "id": "triple_extractor_tripleextractor_extractwithgemini",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extractWithOllama()",
@@ -27073,7 +27129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L239",
       "id": "triple_extractor_tripleextractor_extractwithollama",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".initializeClients()",
@@ -27081,7 +27137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L348",
       "id": "triple_extractor_tripleextractor_initializeclients",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".determineProvider()",
@@ -27089,7 +27145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L383",
       "id": "triple_extractor_tripleextractor_determineprovider",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".isProviderAvailable()",
@@ -27097,7 +27153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L407",
       "id": "triple_extractor_tripleextractor_isprovideravailable",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".getFallbackProvider()",
@@ -27105,7 +27161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L423",
       "id": "triple_extractor_tripleextractor_getfallbackprovider",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".shouldRetry()",
@@ -27113,7 +27169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L446",
       "id": "triple_extractor_tripleextractor_shouldretry",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".checkOllamaModel()",
@@ -27121,7 +27177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L460",
       "id": "triple_extractor_tripleextractor_checkollamamodel",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".parseLLMResponse()",
@@ -27129,7 +27185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L484",
       "id": "triple_extractor_tripleextractor_parsellmresponse",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".extractJSON()",
@@ -27137,7 +27193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L531",
       "id": "triple_extractor_tripleextractor_extractjson",
-      "community": 42
+      "community": 43
     },
     {
       "label": ".isValidTriple()",
@@ -27145,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts",
       "source_location": "L550",
       "id": "triple_extractor_tripleextractor_isvalidtriple",
-      "community": 42
+      "community": 43
     },
     {
       "label": "triple-normalizer.ts",
@@ -27185,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -27225,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "triple-parser.ts",
@@ -27273,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 562
+      "community": 564
     },
     {
       "label": "splitTextIntoChunks()",
@@ -27281,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 562
+      "community": 564
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -27289,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 563
+      "community": 565
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -27297,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 563
+      "community": 565
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -27385,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -27393,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "interfaces.spec.ts",
@@ -27401,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -27409,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "triple-parser.spec.ts",
@@ -27417,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "embedding-provider-factory.ts",
@@ -27425,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_embedding_provider_factory_ts",
-      "community": 36
+      "community": 37
     },
     {
       "label": "EmbeddingProviderFactory",
@@ -27433,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L24",
       "id": "embedding_provider_factory_embeddingproviderfactory",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".constructor()",
@@ -27441,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L29",
       "id": "embedding_provider_factory_embeddingproviderfactory_constructor",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".getInstance()",
@@ -27449,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L40",
       "id": "embedding_provider_factory_embeddingproviderfactory_getinstance",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".initializeProviders()",
@@ -27457,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L51",
       "id": "embedding_provider_factory_embeddingproviderfactory_initializeproviders",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".getProvider()",
@@ -27465,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L62",
       "id": "embedding_provider_factory_embeddingproviderfactory_getprovider",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".getAvailableProviders()",
@@ -27473,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L74",
       "id": "embedding_provider_factory_embeddingproviderfactory_getavailableproviders",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".selectProvider()",
@@ -27481,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L127",
       "id": "embedding_provider_factory_embeddingproviderfactory_selectprovider",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".selectProviderWithHealthCheck()",
@@ -27489,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L163",
       "id": "embedding_provider_factory_embeddingproviderfactory_selectproviderwithhealthcheck",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".registerProvider()",
@@ -27497,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L175",
       "id": "embedding_provider_factory_embeddingproviderfactory_registerprovider",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".unregisterProvider()",
@@ -27505,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L186",
       "id": "embedding_provider_factory_embeddingproviderfactory_unregisterprovider",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".resolveAvailability()",
@@ -27513,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L191",
       "id": "embedding_provider_factory_embeddingproviderfactory_resolveavailability",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".reset()",
@@ -27521,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L205",
       "id": "embedding_provider_factory_embeddingproviderfactory_reset",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".normalizeProviderName()",
@@ -27529,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L210",
       "id": "embedding_provider_factory_embeddingproviderfactory_normalizeprovidername",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".getPriorityProviders()",
@@ -27537,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L231",
       "id": "embedding_provider_factory_embeddingproviderfactory_getpriorityproviders",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".handleProviderFailure()",
@@ -27545,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L235",
       "id": "embedding_provider_factory_embeddingproviderfactory_handleproviderfailure",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".getProviderName()",
@@ -27553,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L244",
       "id": "embedding_provider_factory_embeddingproviderfactory_getprovidername",
-      "community": 36
+      "community": 37
     },
     {
       "label": ".createService()",
@@ -27561,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts",
       "source_location": "L256",
       "id": "embedding_provider_factory_embeddingproviderfactory_createservice",
-      "community": 36
+      "community": 37
     },
     {
       "label": "model-availability-service.ts",
@@ -27689,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "embedding-service.ts",
@@ -27697,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_service_ts",
-      "community": 55
+      "community": 56
     },
     {
       "label": "EmbeddingService",
@@ -27705,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L36",
       "id": "embedding_service_embeddingservice",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".constructor()",
@@ -27713,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L47",
       "id": "embedding_service_embeddingservice_constructor",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".initializeOpenAI()",
@@ -27721,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L57",
       "id": "embedding_service_embeddingservice_initializeopenai",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".generateEmbedding()",
@@ -27729,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L78",
       "id": "embedding_service_embeddingservice_generateembedding",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".generateOpenAIEmbedding()",
@@ -27737,7 +27793,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L127",
       "id": "embedding_service_embeddingservice_generateopenaiembedding",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".generateGeminiEmbedding()",
@@ -27745,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L187",
       "id": "embedding_service_embeddingservice_generategeminiembedding",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".generateLightweightEmbedding()",
@@ -27753,7 +27809,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L203",
       "id": "embedding_service_embeddingservice_generatelightweightembedding",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".searchSimilar()",
@@ -27761,7 +27817,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L219",
       "id": "embedding_service_embeddingservice_searchsimilar",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".cosineSimilarity()",
@@ -27769,7 +27825,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L252",
       "id": "embedding_service_embeddingservice_cosinesimilarity",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".generateCacheKey()",
@@ -27777,7 +27833,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L282",
       "id": "embedding_service_embeddingservice_generatecachekey",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".hashText()",
@@ -27785,7 +27841,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L290",
       "id": "embedding_service_embeddingservice_hashtext",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".cleanupCache()",
@@ -27793,7 +27849,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L303",
       "id": "embedding_service_embeddingservice_cleanupcache",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".truncateText()",
@@ -27801,7 +27857,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L318",
       "id": "embedding_service_embeddingservice_truncatetext",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".isAvailable()",
@@ -27809,7 +27865,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L334",
       "id": "embedding_service_embeddingservice_isavailable",
-      "community": 55
+      "community": 56
     },
     {
       "label": ".getModelInfo()",
@@ -27817,7 +27873,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-service.ts",
       "source_location": "L352",
       "id": "embedding_service_embeddingservice_getmodelinfo",
-      "community": 55
+      "community": 56
     },
     {
       "label": "minilm-embedding-service.ts",
@@ -27825,7 +27881,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_minilm_embedding_service_ts",
-      "community": 43
+      "community": 44
     },
     {
       "label": "MiniLMEmbeddingService",
@@ -27833,7 +27889,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L41",
       "id": "minilm_embedding_service_minilmembeddingservice",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".constructor()",
@@ -27841,7 +27897,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L55",
       "id": "minilm_embedding_service_minilmembeddingservice_constructor",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".generateEmbedding()",
@@ -27849,7 +27905,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L63",
       "id": "minilm_embedding_service_minilmembeddingservice_generateembedding",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".searchSimilar()",
@@ -27857,7 +27913,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L122",
       "id": "minilm_embedding_service_minilmembeddingservice_searchsimilar",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".isAvailable()",
@@ -27865,7 +27921,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L160",
       "id": "minilm_embedding_service_minilmembeddingservice_isavailable",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".getModelInfo()",
@@ -27873,7 +27929,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L170",
       "id": "minilm_embedding_service_minilmembeddingservice_getmodelinfo",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".validateInput()",
@@ -27881,7 +27937,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L182",
       "id": "minilm_embedding_service_minilmembeddingservice_validateinput",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".getModel()",
@@ -27889,7 +27945,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L192",
       "id": "minilm_embedding_service_minilmembeddingservice_getmodel",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".loadModel()",
@@ -27897,7 +27953,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L215",
       "id": "minilm_embedding_service_minilmembeddingservice_loadmodel",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".preprocessText()",
@@ -27905,7 +27961,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L261",
       "id": "minilm_embedding_service_minilmembeddingservice_preprocesstext",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".generateCacheKey()",
@@ -27913,7 +27969,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L272",
       "id": "minilm_embedding_service_minilmembeddingservice_generatecachekey",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".hashText()",
@@ -27921,7 +27977,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L279",
       "id": "minilm_embedding_service_minilmembeddingservice_hashtext",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".estimateTokens()",
@@ -27929,7 +27985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L292",
       "id": "minilm_embedding_service_minilmembeddingservice_estimatetokens",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".calculateCosineSimilarity()",
@@ -27937,7 +27993,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L301",
       "id": "minilm_embedding_service_minilmembeddingservice_calculatecosinesimilarity",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".clearCache()",
@@ -27945,7 +28001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L325",
       "id": "minilm_embedding_service_minilmembeddingservice_clearcache",
-      "community": 43
+      "community": 44
     },
     {
       "label": ".getCacheSize()",
@@ -27953,7 +28009,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts",
       "source_location": "L332",
       "id": "minilm_embedding_service_minilmembeddingservice_getcachesize",
-      "community": 43
+      "community": 44
     },
     {
       "label": "gemini-embedding-service.ts",
@@ -27961,7 +28017,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_gemini_embedding_service_ts",
-      "community": 80
+      "community": 81
     },
     {
       "label": "GeminiEmbeddingService",
@@ -27969,7 +28025,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L32",
       "id": "gemini_embedding_service_geminiembeddingservice",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".constructor()",
@@ -27977,7 +28033,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L42",
       "id": "gemini_embedding_service_geminiembeddingservice_constructor",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".initializeGemini()",
@@ -27985,7 +28041,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L60",
       "id": "gemini_embedding_service_geminiembeddingservice_initializegemini",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".generateEmbedding()",
@@ -27993,7 +28049,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L83",
       "id": "gemini_embedding_service_geminiembeddingservice_generateembedding",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".searchSimilar()",
@@ -28001,7 +28057,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L201",
       "id": "gemini_embedding_service_geminiembeddingservice_searchsimilar",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".cosineSimilarity()",
@@ -28009,7 +28065,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L234",
       "id": "gemini_embedding_service_geminiembeddingservice_cosinesimilarity",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".generateCacheKey()",
@@ -28017,7 +28073,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L264",
       "id": "gemini_embedding_service_geminiembeddingservice_generatecachekey",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".hashText()",
@@ -28025,7 +28081,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L272",
       "id": "gemini_embedding_service_geminiembeddingservice_hashtext",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".cleanupCache()",
@@ -28033,7 +28089,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L285",
       "id": "gemini_embedding_service_geminiembeddingservice_cleanupcache",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".truncateText()",
@@ -28041,7 +28097,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L300",
       "id": "gemini_embedding_service_geminiembeddingservice_truncatetext",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".estimateTokens()",
@@ -28049,7 +28105,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L316",
       "id": "gemini_embedding_service_geminiembeddingservice_estimatetokens",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".isAvailable()",
@@ -28057,7 +28113,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L326",
       "id": "gemini_embedding_service_geminiembeddingservice_isavailable",
-      "community": 80
+      "community": 81
     },
     {
       "label": ".getModelInfo()",
@@ -28065,7 +28121,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts",
       "source_location": "L333",
       "id": "gemini_embedding_service_geminiembeddingservice_getmodelinfo",
-      "community": 80
+      "community": 81
     },
     {
       "label": "unified-embedding-service.ts",
@@ -28073,7 +28129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_unified_embedding_service_ts",
-      "community": 56
+      "community": 57
     },
     {
       "label": "UnifiedEmbeddingService",
@@ -28081,7 +28137,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L27",
       "id": "unified_embedding_service_unifiedembeddingservice",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".constructor()",
@@ -28089,7 +28145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L33",
       "id": "unified_embedding_service_unifiedembeddingservice_constructor",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".generateEmbedding()",
@@ -28097,7 +28153,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L43",
       "id": "unified_embedding_service_unifiedembeddingservice_generateembedding",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".searchSimilar()",
@@ -28105,7 +28161,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L84",
       "id": "unified_embedding_service_unifiedembeddingservice_searchsimilar",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".isAvailable()",
@@ -28113,7 +28169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L130",
       "id": "unified_embedding_service_unifiedembeddingservice_isavailable",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".getModelInfo()",
@@ -28121,7 +28177,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L142",
       "id": "unified_embedding_service_unifiedembeddingservice_getmodelinfo",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".getAvailableProviders()",
@@ -28129,7 +28185,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L172",
       "id": "unified_embedding_service_unifiedembeddingservice_getavailableproviders",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".getCurrentProviderName()",
@@ -28137,7 +28193,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L182",
       "id": "unified_embedding_service_unifiedembeddingservice_getcurrentprovidername",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".setFallbackProviders()",
@@ -28145,7 +28201,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L189",
       "id": "unified_embedding_service_unifiedembeddingservice_setfallbackproviders",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".syncFallbackProviders()",
@@ -28153,7 +28209,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L194",
       "id": "unified_embedding_service_unifiedembeddingservice_syncfallbackproviders",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".validateInput()",
@@ -28161,7 +28217,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L204",
       "id": "unified_embedding_service_unifiedembeddingservice_validateinput",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".selectProvider()",
@@ -28169,7 +28225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L214",
       "id": "unified_embedding_service_unifiedembeddingservice_selectprovider",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".tryFallbackProviders()",
@@ -28177,7 +28233,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L233",
       "id": "unified_embedding_service_unifiedembeddingservice_tryfallbackproviders",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".tryFallbackSearch()",
@@ -28185,7 +28241,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L262",
       "id": "unified_embedding_service_unifiedembeddingservice_tryfallbacksearch",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".handleProviderFailure()",
@@ -28193,7 +28249,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/unified-embedding-service.ts",
       "source_location": "L282",
       "id": "unified_embedding_service_unifiedembeddingservice_handleproviderfailure",
-      "community": 56
+      "community": 57
     },
     {
       "label": "lightweight-embedding-service.ts",
@@ -28201,7 +28257,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_lightweight_embedding_service_ts",
-      "community": 44
+      "community": 45
     },
     {
       "label": "LightweightEmbeddingService",
@@ -28209,7 +28265,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L29",
       "id": "lightweight_embedding_service_lightweightembeddingservice",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".constructor()",
@@ -28217,7 +28273,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L37",
       "id": "lightweight_embedding_service_lightweightembeddingservice_constructor",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".generateEmbedding()",
@@ -28225,7 +28281,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L45",
       "id": "lightweight_embedding_service_lightweightembeddingservice_generateembedding",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".searchSimilar()",
@@ -28233,7 +28289,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L85",
       "id": "lightweight_embedding_service_lightweightembeddingservice_searchsimilar",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".preprocessText()",
@@ -28241,7 +28297,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L118",
       "id": "lightweight_embedding_service_lightweightembeddingservice_preprocesstext",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".createTFIDFVector()",
@@ -28249,7 +28305,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L130",
       "id": "lightweight_embedding_service_lightweightembeddingservice_createtfidfvector",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".calculateIDF()",
@@ -28257,7 +28313,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L156",
       "id": "lightweight_embedding_service_lightweightembeddingservice_calculateidf",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".applyKeywordWeights()",
@@ -28265,7 +28321,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L181",
       "id": "lightweight_embedding_service_lightweightembeddingservice_applykeywordweights",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".isTechnicalTerm()",
@@ -28273,7 +28329,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L220",
       "id": "lightweight_embedding_service_lightweightembeddingservice_istechnicalterm",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".normalizeVector()",
@@ -28281,7 +28337,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L236",
       "id": "lightweight_embedding_service_lightweightembeddingservice_normalizevector",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".adjustDimensions()",
@@ -28289,7 +28345,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L246",
       "id": "lightweight_embedding_service_lightweightembeddingservice_adjustdimensions",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".hashToIndex()",
@@ -28297,7 +28353,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L261",
       "id": "lightweight_embedding_service_lightweightembeddingservice_hashtoindex",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".cosineSimilarity()",
@@ -28305,7 +28361,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L274",
       "id": "lightweight_embedding_service_lightweightembeddingservice_cosinesimilarity",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".estimateTokens()",
@@ -28313,7 +28369,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L304",
       "id": "lightweight_embedding_service_lightweightembeddingservice_estimatetokens",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".isAvailable()",
@@ -28321,7 +28377,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L312",
       "id": "lightweight_embedding_service_lightweightembeddingservice_isavailable",
-      "community": 44
+      "community": 45
     },
     {
       "label": ".getModelInfo()",
@@ -28329,7 +28385,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/lightweight-embedding-service.ts",
       "source_location": "L319",
       "id": "lightweight_embedding_service_lightweightembeddingservice_getmodelinfo",
-      "community": 44
+      "community": 45
     },
     {
       "label": "embedding-migration-service.ts",
@@ -28337,7 +28393,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_ts",
-      "community": 26
+      "community": 27
     },
     {
       "label": "EmbeddingMigrationService",
@@ -28345,7 +28401,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L51",
       "id": "embedding_migration_service_embeddingmigrationservice",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".createSnapshot()",
@@ -28353,7 +28409,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L52",
       "id": "embedding_migration_service_embeddingmigrationservice_createsnapshot",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".resolveRunStatus()",
@@ -28361,7 +28417,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L60",
       "id": "embedding_migration_service_embeddingmigrationservice_resolverunstatus",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".notifyProgress()",
@@ -28369,7 +28425,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L69",
       "id": "embedding_migration_service_embeddingmigrationservice_notifyprogress",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".beginStep()",
@@ -28377,7 +28433,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L90",
       "id": "embedding_migration_service_embeddingmigrationservice_beginstep",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".completeStep()",
@@ -28385,7 +28441,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L102",
       "id": "embedding_migration_service_embeddingmigrationservice_completestep",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".createPlan()",
@@ -28393,7 +28449,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L116",
       "id": "embedding_migration_service_embeddingmigrationservice_createplan",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".listTargets()",
@@ -28401,7 +28457,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L153",
       "id": "embedding_migration_service_embeddingmigrationservice_listtargets",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".initializeProgress()",
@@ -28409,7 +28465,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L191",
       "id": "embedding_migration_service_embeddingmigrationservice_initializeprogress",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".resolveEffectiveMonitor()",
@@ -28417,7 +28473,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L206",
       "id": "embedding_migration_service_embeddingmigrationservice_resolveeffectivemonitor",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".execute()",
@@ -28425,7 +28481,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L212",
       "id": "embedding_migration_service_embeddingmigrationservice_execute",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".processMigrationRow()",
@@ -28433,7 +28489,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L341",
       "id": "embedding_migration_service_embeddingmigrationservice_processmigrationrow",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".runMigrationBatchLoop()",
@@ -28441,7 +28497,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L446",
       "id": "embedding_migration_service_embeddingmigrationservice_runmigrationbatchloop",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".finalizeMigrationExecution()",
@@ -28449,7 +28505,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L472",
       "id": "embedding_migration_service_embeddingmigrationservice_finalizemigrationexecution",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".safeParseEmbedding()",
@@ -28457,7 +28513,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L526",
       "id": "embedding_migration_service_embeddingmigrationservice_safeparseembedding",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".rollback()",
@@ -28465,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L540",
       "id": "embedding_migration_service_embeddingmigrationservice_rollback",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".applyRollbackDelete()",
@@ -28473,7 +28529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L587",
       "id": "embedding_migration_service_embeddingmigrationservice_applyrollbackdelete",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".applyRollbackRestore()",
@@ -28481,7 +28537,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L591",
       "id": "embedding_migration_service_embeddingmigrationservice_applyrollbackrestore",
-      "community": 26
+      "community": 27
     },
     {
       "label": ".listHistory()",
@@ -28489,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service.ts",
       "source_location": "L611",
       "id": "embedding_migration_service_embeddingmigrationservice_listhistory",
-      "community": 26
+      "community": 27
     },
     {
       "label": "openai-embedding-service.ts",
@@ -28497,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_openai_embedding_service_ts",
-      "community": 45
+      "community": 46
     },
     {
       "label": "OpenAIEmbeddingService",
@@ -28505,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L22",
       "id": "openai_embedding_service_openaiembeddingservice",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".constructor()",
@@ -28513,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L31",
       "id": "openai_embedding_service_openaiembeddingservice_constructor",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".initializeClient()",
@@ -28521,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L51",
       "id": "openai_embedding_service_openaiembeddingservice_initializeclient",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".isAvailable()",
@@ -28529,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L70",
       "id": "openai_embedding_service_openaiembeddingservice_isavailable",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".getModelInfo()",
@@ -28537,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L74",
       "id": "openai_embedding_service_openaiembeddingservice_getmodelinfo",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".generateEmbedding()",
@@ -28545,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L82",
       "id": "openai_embedding_service_openaiembeddingservice_generateembedding",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".searchSimilar()",
@@ -28553,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L109",
       "id": "openai_embedding_service_openaiembeddingservice_searchsimilar",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".generateOpenAIEmbedding()",
@@ -28561,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L136",
       "id": "openai_embedding_service_openaiembeddingservice_generateopenaiembedding",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".generateFallbackEmbedding()",
@@ -28569,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L193",
       "id": "openai_embedding_service_openaiembeddingservice_generatefallbackembedding",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".validateInput()",
@@ -28577,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L213",
       "id": "openai_embedding_service_openaiembeddingservice_validateinput",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".truncateText()",
@@ -28585,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L219",
       "id": "openai_embedding_service_openaiembeddingservice_truncatetext",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".estimateTokens()",
@@ -28593,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L228",
       "id": "openai_embedding_service_openaiembeddingservice_estimatetokens",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".cosineSimilarity()",
@@ -28601,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L232",
       "id": "openai_embedding_service_openaiembeddingservice_cosinesimilarity",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".generateCacheKey()",
@@ -28609,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L253",
       "id": "openai_embedding_service_openaiembeddingservice_generatecachekey",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".hashText()",
@@ -28617,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L257",
       "id": "openai_embedding_service_openaiembeddingservice_hashtext",
-      "community": 45
+      "community": 46
     },
     {
       "label": ".cleanupCache()",
@@ -28625,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts",
       "source_location": "L267",
       "id": "openai_embedding_service_openaiembeddingservice_cleanupcache",
-      "community": 45
+      "community": 46
     },
     {
       "label": "vector-compatibility-service.ts",
@@ -28633,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_vector_compatibility_service_ts",
-      "community": 20
+      "community": 22
     },
     {
       "label": "VectorCompatibilityService",
@@ -28641,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L26",
       "id": "vector_compatibility_service_vectorcompatibilityservice",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".project()",
@@ -28649,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L42",
       "id": "vector_compatibility_service_vectorcompatibilityservice_project",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".assessCompatibility()",
@@ -28657,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L51",
       "id": "vector_compatibility_service_vectorcompatibilityservice_assesscompatibility",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".validateCompatibility()",
@@ -28665,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L118",
       "id": "vector_compatibility_service_vectorcompatibilityservice_validatecompatibility",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".assessProviderCompatibility()",
@@ -28673,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L146",
       "id": "vector_compatibility_service_vectorcompatibilityservice_assessprovidercompatibility",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".validateProviderCompatibility()",
@@ -28681,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L170",
       "id": "vector_compatibility_service_vectorcompatibilityservice_validateprovidercompatibility",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".getNativeDimensions()",
@@ -28689,7 +28745,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L195",
       "id": "vector_compatibility_service_vectorcompatibilityservice_getnativedimensions",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".setNativeDimensions()",
@@ -28697,7 +28753,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L202",
       "id": "vector_compatibility_service_vectorcompatibilityservice_setnativedimensions",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".performProjection()",
@@ -28705,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L209",
       "id": "vector_compatibility_service_vectorcompatibilityservice_performprojection",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".expandVector()",
@@ -28713,7 +28769,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L254",
       "id": "vector_compatibility_service_vectorcompatibilityservice_expandvector",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".reduceVector()",
@@ -28721,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L292",
       "id": "vector_compatibility_service_vectorcompatibilityservice_reducevector",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".zeroPad()",
@@ -28729,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L321",
       "id": "vector_compatibility_service_vectorcompatibilityservice_zeropad",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".repeatUpsample()",
@@ -28737,7 +28793,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L332",
       "id": "vector_compatibility_service_vectorcompatibilityservice_repeatupsample",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".interpolate()",
@@ -28745,7 +28801,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L347",
       "id": "vector_compatibility_service_vectorcompatibilityservice_interpolate",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".averagePool()",
@@ -28753,7 +28809,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L379",
       "id": "vector_compatibility_service_vectorcompatibilityservice_averagepool",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".applyNormalization()",
@@ -28761,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L419",
       "id": "vector_compatibility_service_vectorcompatibilityservice_applynormalization",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".l2Normalize()",
@@ -28769,7 +28825,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L431",
       "id": "vector_compatibility_service_vectorcompatibilityservice_l2normalize",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".minMaxNormalize()",
@@ -28777,7 +28833,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L439",
       "id": "vector_compatibility_service_vectorcompatibilityservice_minmaxnormalize",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".sanitizeVector()",
@@ -28785,7 +28841,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L460",
       "id": "vector_compatibility_service_vectorcompatibilityservice_sanitizevector",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".assertValidOptions()",
@@ -28793,7 +28849,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts",
       "source_location": "L467",
       "id": "vector_compatibility_service_vectorcompatibilityservice_assertvalidoptions",
-      "community": 20
+      "community": 22
     },
     {
       "label": "retry-manager-usage.spec.ts",
@@ -28801,7 +28857,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -28809,7 +28865,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -28817,7 +28873,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "createSchema()",
@@ -28825,7 +28881,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 428
+      "community": 429
     },
     {
       "label": "seedMemoryItem()",
@@ -28833,7 +28889,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 428
+      "community": 429
     },
     {
       "label": "embedding-service.spec.ts",
@@ -28841,7 +28897,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -28849,7 +28905,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -28857,7 +28913,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -28977,7 +29033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 564
+      "community": 566
     },
     {
       "label": "executeResolveError()",
@@ -28985,7 +29041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 564
+      "community": 566
     },
     {
       "label": "error-stats.ts",
@@ -28993,7 +29049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 565
+      "community": 567
     },
     {
       "label": "executeErrorStats()",
@@ -29001,7 +29057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 565
+      "community": 567
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -29009,7 +29065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "resolve-error.spec.ts",
@@ -29017,7 +29073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -29025,7 +29081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 566
+      "community": 568
     },
     {
       "label": "createBaseSchema()",
@@ -29033,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 566
+      "community": 568
     },
     {
       "label": "error-stats.spec.ts",
@@ -29041,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "performance-monitor.ts",
@@ -29401,7 +29457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_failure_detector_ts",
-      "community": 46
+      "community": 47
     },
     {
       "label": "FailureDetector",
@@ -29409,7 +29465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L52",
       "id": "failure_detector_failuredetector",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".constructor()",
@@ -29417,7 +29473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L57",
       "id": "failure_detector_failuredetector_constructor",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".detectToolError()",
@@ -29425,7 +29481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L71",
       "id": "failure_detector_failuredetector_detecttoolerror",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".detectUserFeedback()",
@@ -29433,7 +29489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L131",
       "id": "failure_detector_failuredetector_detectuserfeedback",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".detectPerformanceFailure()",
@@ -29441,7 +29497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L191",
       "id": "failure_detector_failuredetector_detectperformancefailure",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".queueFailureEvent()",
@@ -29449,7 +29505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L271",
       "id": "failure_detector_failuredetector_queuefailureevent",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".classifyError()",
@@ -29457,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L312",
       "id": "failure_detector_failuredetector_classifyerror",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".generateEventId()",
@@ -29465,7 +29521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L333",
       "id": "failure_detector_failuredetector_generateeventid",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".hashMessage()",
@@ -29473,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L341",
       "id": "failure_detector_failuredetector_hashmessage",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".calculatePriority()",
@@ -29481,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L356",
       "id": "failure_detector_failuredetector_calculatepriority",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".extractTaskGoal()",
@@ -29489,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L379",
       "id": "failure_detector_failuredetector_extracttaskgoal",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".updateMetrics()",
@@ -29497,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L390",
       "id": "failure_detector_failuredetector_updatemetrics",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".getQueueStats()",
@@ -29505,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L413",
       "id": "failure_detector_failuredetector_getqueuestats",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".startQueue()",
@@ -29513,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L420",
       "id": "failure_detector_failuredetector_startqueue",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".stopQueue()",
@@ -29521,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L427",
       "id": "failure_detector_failuredetector_stopqueue",
-      "community": 46
+      "community": 47
     },
     {
       "label": ".getDetectionMetrics()",
@@ -29529,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/failure-detector.ts",
       "source_location": "L434",
       "id": "failure_detector_failuredetector_getdetectionmetrics",
-      "community": 46
+      "community": 47
     },
     {
       "label": "performance-alert-service.ts",
@@ -29537,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_alert_service_ts",
-      "community": 21
+      "community": 23
     },
     {
       "label": "PerformanceAlertService",
@@ -29545,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L66",
       "id": "performance_alert_service_performancealertservice",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".constructor()",
@@ -29553,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L73",
       "id": "performance_alert_service_performancealertservice_constructor",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".initializeLogDirectory()",
@@ -29561,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L82",
       "id": "performance_alert_service_performancealertservice_initializelogdirectory",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".setupDefaultThresholds()",
@@ -29569,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L98",
       "id": "performance_alert_service_performancealertservice_setupdefaultthresholds",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".checkPerformanceMetric()",
@@ -29577,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L136",
       "id": "performance_alert_service_performancealertservice_checkperformancemetric",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".shouldTriggerAlert()",
@@ -29585,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L160",
       "id": "performance_alert_service_performancealertservice_shouldtriggeralert",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".evaluateThreshold()",
@@ -29593,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L185",
       "id": "performance_alert_service_performancealertservice_evaluatethreshold",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".createAlert()",
@@ -29601,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L199",
       "id": "performance_alert_service_performancealertservice_createalert",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".getMetricName()",
@@ -29609,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L224",
       "id": "performance_alert_service_performancealertservice_getmetricname",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".generateAlertMessage()",
@@ -29617,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L239",
       "id": "performance_alert_service_performancealertservice_generatealertmessage",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".sendAlert()",
@@ -29625,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L260",
       "id": "performance_alert_service_performancealertservice_sendalert",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".logToConsole()",
@@ -29633,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L274",
       "id": "performance_alert_service_performancealertservice_logtoconsole",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".logToFile()",
@@ -29641,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L298",
       "id": "performance_alert_service_performancealertservice_logtofile",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".resolveAlert()",
@@ -29649,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L325",
       "id": "performance_alert_service_performancealertservice_resolvealert",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".getAlertStats()",
@@ -29657,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L342",
       "id": "performance_alert_service_performancealertservice_getalertstats",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".getActiveAlerts()",
@@ -29665,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L390",
       "id": "performance_alert_service_performancealertservice_getactivealerts",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".searchAlerts()",
@@ -29673,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L399",
       "id": "performance_alert_service_performancealertservice_searchalerts",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".updateThreshold()",
@@ -29681,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L441",
       "id": "performance_alert_service_performancealertservice_updatethreshold",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".cleanupOldAlerts()",
@@ -29689,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L468",
       "id": "performance_alert_service_performancealertservice_cleanupoldalerts",
-      "community": 21
+      "community": 23
     },
     {
       "label": ".cleanup()",
@@ -29697,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts",
       "source_location": "L483",
       "id": "performance_alert_service_performancealertservice_cleanup",
-      "community": 21
+      "community": 23
     },
     {
       "label": "alert-notification-service.ts",
@@ -29817,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_error_logging_service_ts",
-      "community": 71
+      "community": 72
     },
     {
       "label": "ErrorLoggingService",
@@ -29825,7 +29881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L63",
       "id": "error_logging_service_errorloggingservice",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".logError()",
@@ -29833,7 +29889,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L78",
       "id": "error_logging_service_errorloggingservice_logerror",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".resolveError()",
@@ -29841,7 +29897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L134",
       "id": "error_logging_service_errorloggingservice_resolveerror",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".getErrorStats()",
@@ -29849,7 +29905,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L150",
       "id": "error_logging_service_errorloggingservice_geterrorstats",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".getActiveAlerts()",
@@ -29857,7 +29913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L210",
       "id": "error_logging_service_errorloggingservice_getactivealerts",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".acknowledgeAlert()",
@@ -29865,7 +29921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L219",
       "id": "error_logging_service_errorloggingservice_acknowledgealert",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".searchErrors()",
@@ -29873,7 +29929,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L235",
       "id": "error_logging_service_errorloggingservice_searcherrors",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".generateErrorId()",
@@ -29881,7 +29937,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L277",
       "id": "error_logging_service_errorloggingservice_generateerrorid",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".cleanupOldErrors()",
@@ -29889,7 +29945,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L284",
       "id": "error_logging_service_errorloggingservice_cleanupolderrors",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".checkAlertThresholds()",
@@ -29897,7 +29953,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L299",
       "id": "error_logging_service_errorloggingservice_checkalertthresholds",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".createAlert()",
@@ -29905,7 +29961,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L319",
       "id": "error_logging_service_errorloggingservice_createalert",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".cleanupOldAlerts()",
@@ -29913,7 +29969,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L338",
       "id": "error_logging_service_errorloggingservice_cleanupoldalerts",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".logToConsole()",
@@ -29921,7 +29977,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L355",
       "id": "error_logging_service_errorloggingservice_logtoconsole",
-      "community": 71
+      "community": 72
     },
     {
       "label": ".cleanup()",
@@ -29929,7 +29985,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
       "source_location": "L387",
       "id": "error_logging_service_errorloggingservice_cleanup",
-      "community": 71
+      "community": 72
     },
     {
       "label": "failure-detector.spec.ts",
@@ -29937,7 +29993,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -29945,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -29953,7 +30009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -29961,7 +30017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -29969,7 +30025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "toBytes()",
@@ -29977,7 +30033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L5",
       "id": "performance_monitor_spec_tobytes",
-      "community": 429
+      "community": 430
     },
     {
       "label": "createMetrics()",
@@ -29985,7 +30041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 429
+      "community": 430
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -29993,7 +30049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 567
+      "community": 569
     },
     {
       "label": "restoreEnvValue()",
@@ -30001,7 +30057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 567
+      "community": 569
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -30105,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 568
+      "community": 570
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30113,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 568
+      "community": 570
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -30193,7 +30249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 569
+      "community": 571
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30201,7 +30257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 569
+      "community": 571
     },
     {
       "label": "quality-reporter.ts",
@@ -30321,7 +30377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "quality-assurance-service.ts",
@@ -30329,7 +30385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_ts",
-      "community": 81
+      "community": 82
     },
     {
       "label": "QualityAssuranceService",
@@ -30337,7 +30393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L94",
       "id": "quality_assurance_service_qualityassuranceservice",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".constructor()",
@@ -30345,7 +30401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L101",
       "id": "quality_assurance_service_qualityassuranceservice_constructor",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".measureQuality()",
@@ -30353,7 +30409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L123",
       "id": "quality_assurance_service_qualityassuranceservice_measurequality",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".generateReport()",
@@ -30361,7 +30417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L224",
       "id": "quality_assurance_service_qualityassuranceservice_generatereport",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".getReportData()",
@@ -30369,7 +30425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L234",
       "id": "quality_assurance_service_qualityassuranceservice_getreportdata",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".initializeDefaultThresholds()",
@@ -30377,7 +30433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L247",
       "id": "quality_assurance_service_qualityassuranceservice_initializedefaultthresholds",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".getThresholds()",
@@ -30385,7 +30441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L258",
       "id": "quality_assurance_service_qualityassuranceservice_getthresholds",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".setThreshold()",
@@ -30393,7 +30449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L273",
       "id": "quality_assurance_service_qualityassuranceservice_setthreshold",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".deleteThreshold()",
@@ -30401,7 +30457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L297",
       "id": "quality_assurance_service_qualityassuranceservice_deletethreshold",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".getMeasurementHistory()",
@@ -30409,7 +30465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L311",
       "id": "quality_assurance_service_qualityassuranceservice_getmeasurementhistory",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".getLatestMetrics()",
@@ -30417,7 +30473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L328",
       "id": "quality_assurance_service_qualityassuranceservice_getlatestmetrics",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".runBatchMeasurement()",
@@ -30425,7 +30481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L340",
       "id": "quality_assurance_service_qualityassuranceservice_runbatchmeasurement",
-      "community": 81
+      "community": 82
     },
     {
       "label": ".runTestMeasurement()",
@@ -30433,7 +30489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.ts",
       "source_location": "L357",
       "id": "quality_assurance_service_qualityassuranceservice_runtestmeasurement",
-      "community": 81
+      "community": 82
     },
     {
       "label": "quality-metrics-collector.ts",
@@ -30681,7 +30737,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_tool_registry_ts",
-      "community": 47
+      "community": 48
     },
     {
       "label": "ToolRegistry",
@@ -30689,7 +30745,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L27",
       "id": "tool_registry_toolregistry",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".constructor()",
@@ -30697,7 +30753,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L33",
       "id": "tool_registry_toolregistry_constructor",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".register()",
@@ -30705,7 +30761,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L44",
       "id": "tool_registry_toolregistry_register",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".registerAll()",
@@ -30713,7 +30769,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L63",
       "id": "tool_registry_toolregistry_registerall",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".get()",
@@ -30721,7 +30777,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L70",
       "id": "tool_registry_toolregistry_get",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".getAll()",
@@ -30729,7 +30785,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L74",
       "id": "tool_registry_toolregistry_getall",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".execute()",
@@ -30737,7 +30793,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L78",
       "id": "tool_registry_toolregistry_execute",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".has()",
@@ -30745,7 +30801,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L117",
       "id": "tool_registry_toolregistry_has",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".remove()",
@@ -30753,7 +30809,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L121",
       "id": "tool_registry_toolregistry_remove",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".clear()",
@@ -30761,7 +30817,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L127",
       "id": "tool_registry_toolregistry_clear",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".size()",
@@ -30769,7 +30825,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L133",
       "id": "tool_registry_toolregistry_size",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".getNames()",
@@ -30777,7 +30833,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L137",
       "id": "tool_registry_toolregistry_getnames",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".updateMetrics()",
@@ -30785,7 +30841,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L141",
       "id": "tool_registry_toolregistry_updatemetrics",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".generateCacheKey()",
@@ -30793,7 +30849,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L153",
       "id": "tool_registry_toolregistry_generatecachekey",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".cacheResult()",
@@ -30801,7 +30857,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L157",
       "id": "tool_registry_toolregistry_cacheresult",
-      "community": 47
+      "community": 48
     },
     {
       "label": ".log()",
@@ -30809,7 +30865,7 @@
       "source_file": "packages/memento-core/src/tools/tool-registry.ts",
       "source_location": "L169",
       "id": "tool_registry_toolregistry_log",
-      "community": 47
+      "community": 48
     },
     {
       "label": "types.ts",
@@ -30817,7 +30873,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "base-tool.ts",
@@ -30825,7 +30881,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_base_tool_ts",
-      "community": 72
+      "community": 73
     },
     {
       "label": "constructor()",
@@ -30833,7 +30889,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L20",
       "id": "base_tool_constructor",
-      "community": 72
+      "community": 73
     },
     {
       "label": "getDefinition()",
@@ -30841,7 +30897,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L29",
       "id": "base_tool_getdefinition",
-      "community": 72
+      "community": 73
     },
     {
       "label": "createSuccessResult()",
@@ -30849,7 +30905,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L46",
       "id": "base_tool_createsuccessresult",
-      "community": 72
+      "community": 73
     },
     {
       "label": "createErrorResult()",
@@ -30857,7 +30913,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L61",
       "id": "base_tool_createerrorresult",
-      "community": 72
+      "community": 73
     },
     {
       "label": "safeJsonParse()",
@@ -30865,7 +30921,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L82",
       "id": "base_tool_safejsonparse",
-      "community": 72
+      "community": 73
     },
     {
       "label": "validateString()",
@@ -30873,7 +30929,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L94",
       "id": "base_tool_validatestring",
-      "community": 72
+      "community": 73
     },
     {
       "label": "validateNumber()",
@@ -30881,7 +30937,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L113",
       "id": "base_tool_validatenumber",
-      "community": 72
+      "community": 73
     },
     {
       "label": "validateArray()",
@@ -30889,7 +30945,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L134",
       "id": "base_tool_validatearray",
-      "community": 72
+      "community": 73
     },
     {
       "label": "logError()",
@@ -30897,7 +30953,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L149",
       "id": "base_tool_logerror",
-      "community": 72
+      "community": 73
     },
     {
       "label": "logWarning()",
@@ -30905,7 +30961,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L165",
       "id": "base_tool_logwarning",
-      "community": 72
+      "community": 73
     },
     {
       "label": "logInfo()",
@@ -30913,7 +30969,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L179",
       "id": "base_tool_loginfo",
-      "community": 72
+      "community": 73
     },
     {
       "label": "validateDatabase()",
@@ -30921,7 +30977,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L193",
       "id": "base_tool_validatedatabase",
-      "community": 72
+      "community": 73
     },
     {
       "label": "validateService()",
@@ -30929,7 +30985,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L202",
       "id": "base_tool_validateservice",
-      "community": 72
+      "community": 73
     },
     {
       "label": "handleFailure()",
@@ -30937,7 +30993,7 @@
       "source_file": "packages/memento-core/src/tools/base-tool.ts",
       "source_location": "L212",
       "id": "base_tool_handlefailure",
-      "community": 72
+      "community": 73
     },
     {
       "label": "index.ts",
@@ -31001,7 +31057,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_performance_benchmark_ts",
-      "community": 82
+      "community": 83
     },
     {
       "label": "PerformanceBenchmark",
@@ -31009,7 +31065,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L38",
       "id": "performance_benchmark_performancebenchmark",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".constructor()",
@@ -31017,7 +31073,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L45",
       "id": "performance_benchmark_performancebenchmark_constructor",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".runFullBenchmark()",
@@ -31025,7 +31081,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L54",
       "id": "performance_benchmark_performancebenchmark_runfullbenchmark",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".benchmarkMemoryOperations()",
@@ -31033,7 +31089,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L86",
       "id": "performance_benchmark_performancebenchmark_benchmarkmemoryoperations",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".benchmarkSearchOperations()",
@@ -31041,7 +31097,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L131",
       "id": "performance_benchmark_performancebenchmark_benchmarksearchoperations",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".benchmarkCacheOperations()",
@@ -31049,7 +31105,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L188",
       "id": "performance_benchmark_performancebenchmark_benchmarkcacheoperations",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".benchmarkAsyncOperations()",
@@ -31057,7 +31113,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L244",
       "id": "performance_benchmark_performancebenchmark_benchmarkasyncoperations",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".benchmarkConcurrentOperations()",
@@ -31065,7 +31121,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L318",
       "id": "performance_benchmark_performancebenchmark_benchmarkconcurrentoperations",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".waitForTaskCompletion()",
@@ -31073,7 +31129,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L431",
       "id": "performance_benchmark_performancebenchmark_waitfortaskcompletion",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".retryOperation()",
@@ -31081,7 +31137,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L448",
       "id": "performance_benchmark_performancebenchmark_retryoperation",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".calculateBenchmarkResult()",
@@ -31089,7 +31145,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L479",
       "id": "performance_benchmark_performancebenchmark_calculatebenchmarkresult",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".printResult()",
@@ -31097,7 +31153,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L526",
       "id": "performance_benchmark_performancebenchmark_printresult",
-      "community": 82
+      "community": 83
     },
     {
       "label": ".generateReport()",
@@ -31105,7 +31161,7 @@
       "source_file": "packages/memento-core/src/test/performance-benchmark.ts",
       "source_location": "L545",
       "id": "performance_benchmark_performancebenchmark_generatereport",
-      "community": 82
+      "community": 83
     },
     {
       "label": "test-bootstrap.ts",
@@ -31113,7 +31169,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 570
+      "community": 572
     },
     {
       "label": "testBootstrapIntegration()",
@@ -31121,7 +31177,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 570
+      "community": 572
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -31129,7 +31185,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 571
+      "community": 573
     },
     {
       "label": "measureRecall()",
@@ -31137,7 +31193,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 571
+      "community": 573
     },
     {
       "label": "test-embedding.ts",
@@ -31145,7 +31201,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 572
+      "community": 574
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -31153,7 +31209,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 572
+      "community": 574
     },
     {
       "label": "test-tool-consistency.ts",
@@ -31161,7 +31217,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "compareToolResults()",
@@ -31169,7 +31225,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 430
+      "community": 431
     },
     {
       "label": "testToolConsistency()",
@@ -31177,7 +31233,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 430
+      "community": 431
     },
     {
       "label": "test-quality-assurance.ts",
@@ -31185,7 +31241,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "createQualityTables()",
@@ -31193,7 +31249,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 431
+      "community": 432
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -31201,7 +31257,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 431
+      "community": 432
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -31249,7 +31305,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 573
+      "community": 575
     },
     {
       "label": "testSearchFunctionality()",
@@ -31257,7 +31313,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 573
+      "community": 575
     },
     {
       "label": "test-forgetting.ts",
@@ -31265,7 +31321,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 574
+      "community": 576
     },
     {
       "label": "testForgettingFunctionality()",
@@ -31273,7 +31329,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 574
+      "community": 576
     },
     {
       "label": "mock-database.spec.ts",
@@ -31281,7 +31337,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "test-m1-completion.ts",
@@ -31289,7 +31345,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 575
+      "community": 577
     },
     {
       "label": "testM1Completion()",
@@ -31297,7 +31353,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 575
+      "community": 577
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -31305,7 +31361,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 576
+      "community": 578
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -31313,7 +31369,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 576
+      "community": 578
     },
     {
       "label": "vitest.setup.ts",
@@ -31321,7 +31377,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -31329,7 +31385,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 577
+      "community": 579
     },
     {
       "label": "parseItems()",
@@ -31337,7 +31393,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 577
+      "community": 579
     },
     {
       "label": "test-memory-resource.ts",
@@ -31345,7 +31401,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "setupResourceHandlers()",
@@ -31353,7 +31409,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 432
+      "community": 433
     },
     {
       "label": "createTestMemories()",
@@ -31361,7 +31417,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 432
+      "community": 433
     },
     {
       "label": "test-regression.ts",
@@ -31369,7 +31425,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 578
+      "community": 580
     },
     {
       "label": "testRegression()",
@@ -31377,7 +31433,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 578
+      "community": 580
     },
     {
       "label": "test-anchor-system.ts",
@@ -31441,7 +31497,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -31513,7 +31569,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 579
+      "community": 581
     },
     {
       "label": "testSingleProviderRegression()",
@@ -31521,7 +31577,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 579
+      "community": 581
     },
     {
       "label": "visualize-recency.ts",
@@ -31585,7 +31641,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -31649,7 +31705,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 580
+      "community": 582
     },
     {
       "label": "constructor()",
@@ -31657,7 +31713,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 580
+      "community": 582
     },
     {
       "label": "mock-database.ts",
@@ -31665,7 +31721,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_ts",
-      "community": 33
+      "community": 34
     },
     {
       "label": "MockPreparedStatement",
@@ -31673,7 +31729,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L10",
       "id": "mock_database_mockpreparedstatement",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".constructor()",
@@ -31681,7 +31737,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L14",
       "id": "mock_database_mockpreparedstatement_constructor",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".all()",
@@ -31689,7 +31745,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L20",
       "id": "mock_database_mockpreparedstatement_all",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".get()",
@@ -31697,7 +31753,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L26",
       "id": "mock_database_mockpreparedstatement_get",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".run()",
@@ -31705,7 +31761,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L32",
       "id": "mock_database_mockpreparedstatement_run",
-      "community": 33
+      "community": 34
     },
     {
       "label": "MockDatabase",
@@ -31713,7 +31769,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L38",
       "id": "mock_database_mockdatabase",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".constructor()",
@@ -31721,7 +31777,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L43",
       "id": "mock_database_mockdatabase_constructor",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".setupDefaultData()",
@@ -31729,7 +31785,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L47",
       "id": "mock_database_mockdatabase_setupdefaultdata",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".prepare()",
@@ -31737,7 +31793,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L101",
       "id": "mock_database_mockdatabase_prepare",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".analyzeQuery()",
@@ -31745,7 +31801,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L111",
       "id": "mock_database_mockdatabase_analyzequery",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".extractTableName()",
@@ -31753,7 +31809,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L172",
       "id": "mock_database_mockdatabase_extracttablename",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".exec()",
@@ -31761,7 +31817,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L178",
       "id": "mock_database_mockdatabase_exec",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".close()",
@@ -31769,7 +31825,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L183",
       "id": "mock_database_mockdatabase_close",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".isOpen()",
@@ -31777,7 +31833,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L187",
       "id": "mock_database_mockdatabase_isopen",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".setMockError()",
@@ -31785,7 +31841,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L192",
       "id": "mock_database_mockdatabase_setmockerror",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".addMockData()",
@@ -31793,7 +31849,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L196",
       "id": "mock_database_mockdatabase_addmockdata",
-      "community": 33
+      "community": 34
     },
     {
       "label": ".clearMockData()",
@@ -31801,7 +31857,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L200",
       "id": "mock_database_mockdatabase_clearmockdata",
-      "community": 33
+      "community": 34
     },
     {
       "label": "createMockDatabase()",
@@ -31809,7 +31865,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.ts",
       "source_location": "L207",
       "id": "mock_database_createmockdatabase",
-      "community": 33
+      "community": 34
     },
     {
       "label": "consolidation-search-quality-benchmark.ts",
@@ -31889,7 +31945,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -31929,7 +31985,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 581
+      "community": 583
     },
     {
       "label": "createTestMemories()",
@@ -31937,7 +31993,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 581
+      "community": 583
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -31945,7 +32001,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 582
+      "community": 584
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -31953,7 +32009,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 582
+      "community": 584
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -31961,7 +32017,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -31969,7 +32025,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 583
+      "community": 585
     },
     {
       "label": "seedCluster()",
@@ -31977,7 +32033,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 583
+      "community": 585
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -31985,7 +32041,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "readSource()",
@@ -31993,7 +32049,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 433
+      "community": 434
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -32001,7 +32057,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 433
+      "community": 434
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -32041,7 +32097,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 584
+      "community": 586
     },
     {
       "label": "writeFixtureDir()",
@@ -32049,7 +32105,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 584
+      "community": 586
     },
     {
       "label": "search-quality-metrics.ts",
@@ -32145,7 +32201,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -32241,7 +32297,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -32249,7 +32305,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "test-database.ts",
@@ -32281,7 +32337,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "mergeCandidateIds()",
@@ -32289,7 +32345,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 585
+      "community": 587
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -32297,7 +32353,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -32305,7 +32361,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 434
+      "community": 435
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -32313,7 +32369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 434
+      "community": 435
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -32321,7 +32377,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -32329,7 +32385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -32409,7 +32465,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_consolidation_test_data_ts",
-      "community": 73
+      "community": 74
     },
     {
       "label": "initializeTestDatabase()",
@@ -32417,7 +32473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L45",
       "id": "consolidation_test_data_initializetestdatabase",
-      "community": 73
+      "community": 74
     },
     {
       "label": "insertMemoryItem()",
@@ -32425,7 +32481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L134",
       "id": "consolidation_test_data_insertmemoryitem",
-      "community": 73
+      "community": 74
     },
     {
       "label": "insertMemoryEmbedding()",
@@ -32433,7 +32489,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L187",
       "id": "consolidation_test_data_insertmemoryembedding",
-      "community": 73
+      "community": 74
     },
     {
       "label": "SeededRandom",
@@ -32441,7 +32497,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L214",
       "id": "consolidation_test_data_seededrandom",
-      "community": 73
+      "community": 74
     },
     {
       "label": ".constructor()",
@@ -32449,7 +32505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L217",
       "id": "consolidation_test_data_seededrandom_constructor",
-      "community": 73
+      "community": 74
     },
     {
       "label": ".random()",
@@ -32457,7 +32513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L224",
       "id": "consolidation_test_data_seededrandom_random",
-      "community": 73
+      "community": 74
     },
     {
       "label": ".randomInt()",
@@ -32465,7 +32521,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L234",
       "id": "consolidation_test_data_seededrandom_randomint",
-      "community": 73
+      "community": 74
     },
     {
       "label": ".randomFloat()",
@@ -32473,7 +32529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L241",
       "id": "consolidation_test_data_seededrandom_randomfloat",
-      "community": 73
+      "community": 74
     },
     {
       "label": "generateSampleMemoryItems()",
@@ -32481,7 +32537,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L249",
       "id": "consolidation_test_data_generatesamplememoryitems",
-      "community": 73
+      "community": 74
     },
     {
       "label": "generateScenarioBasedTestData()",
@@ -32489,7 +32545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L312",
       "id": "consolidation_test_data_generatescenariobasedtestdata",
-      "community": 73
+      "community": 74
     },
     {
       "label": "generateSeededEmbeddings()",
@@ -32497,7 +32553,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L442",
       "id": "consolidation_test_data_generateseededembeddings",
-      "community": 73
+      "community": 74
     },
     {
       "label": "generateSampleEmbeddings()",
@@ -32505,7 +32561,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L483",
       "id": "consolidation_test_data_generatesampleembeddings",
-      "community": 73
+      "community": 74
     },
     {
       "label": "seedTestDatabase()",
@@ -32513,7 +32569,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L506",
       "id": "consolidation_test_data_seedtestdatabase",
-      "community": 73
+      "community": 74
     },
     {
       "label": "cleanupTestDatabase()",
@@ -32521,7 +32577,7 @@
       "source_file": "packages/memento-core/src/test/helpers/consolidation-test-data.ts",
       "source_location": "L541",
       "id": "consolidation_test_data_cleanuptestdatabase",
-      "community": 73
+      "community": 74
     },
     {
       "label": "benchmark-search-database.spec.ts",
@@ -32529,7 +32585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "query-counter.ts",
@@ -32873,7 +32929,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 586
+      "community": 588
     },
     {
       "label": "copyDir()",
@@ -32881,7 +32937,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 586
+      "community": 588
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -32889,7 +32945,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 587
+      "community": 589
     },
     {
       "label": "readRootPackageJson()",
@@ -32897,7 +32953,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 587
+      "community": 589
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -32905,7 +32961,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 588
+      "community": 590
     },
     {
       "label": "readJson()",
@@ -32913,7 +32969,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 588
+      "community": 590
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -32921,7 +32977,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 589
+      "community": 591
     },
     {
       "label": "readWorkflow()",
@@ -32929,7 +32985,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 589
+      "community": 591
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -32993,7 +33049,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 590
+      "community": 592
     },
     {
       "label": "readStaticFile()",
@@ -33001,7 +33057,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 590
+      "community": 592
     },
     {
       "label": "smoke.spec.ts",
@@ -33009,7 +33065,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 591
+      "community": 593
     },
     {
       "label": "extractFencedBlocks()",
@@ -33017,7 +33073,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 591
+      "community": 593
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -33201,7 +33257,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 592
+      "community": 594
     },
     {
       "label": "shouldInclude()",
@@ -33209,7 +33265,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 592
+      "community": 594
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -33217,7 +33273,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 435
+      "community": 436
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -33225,7 +33281,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 435
+      "community": 436
     },
     {
       "label": "readTarString()",
@@ -33233,7 +33289,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 435
+      "community": 436
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -33297,7 +33353,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 593
+      "community": 595
     },
     {
       "label": "fixMigration()",
@@ -33305,7 +33361,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 593
+      "community": 595
     },
     {
       "label": "sync-root-server-dist.js",
@@ -33313,7 +33369,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 880
+      "community": 882
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -33481,7 +33537,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L1",
       "id": "scripts_auto_setup_js",
-      "community": 74
+      "community": 75
     },
     {
       "label": "log()",
@@ -33489,7 +33545,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L24",
       "id": "auto_setup_log",
-      "community": 74
+      "community": 75
     },
     {
       "label": "logStep()",
@@ -33497,7 +33553,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L28",
       "id": "auto_setup_logstep",
-      "community": 74
+      "community": 75
     },
     {
       "label": "logSuccess()",
@@ -33505,7 +33561,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L32",
       "id": "auto_setup_logsuccess",
-      "community": 74
+      "community": 75
     },
     {
       "label": "logWarning()",
@@ -33513,7 +33569,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L36",
       "id": "auto_setup_logwarning",
-      "community": 74
+      "community": 75
     },
     {
       "label": "logError()",
@@ -33521,7 +33577,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L40",
       "id": "auto_setup_logerror",
-      "community": 74
+      "community": 75
     },
     {
       "label": "checkNodeVersion()",
@@ -33529,7 +33585,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L44",
       "id": "auto_setup_checknodeversion",
-      "community": 74
+      "community": 75
     },
     {
       "label": "createEnvFile()",
@@ -33537,7 +33593,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L56",
       "id": "auto_setup_createenvfile",
-      "community": 74
+      "community": 75
     },
     {
       "label": "createDataDirectory()",
@@ -33545,7 +33601,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L84",
       "id": "auto_setup_createdatadirectory",
-      "community": 74
+      "community": 75
     },
     {
       "label": "initializeDatabase()",
@@ -33553,7 +33609,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L99",
       "id": "auto_setup_initializedatabase",
-      "community": 74
+      "community": 75
     },
     {
       "label": "rebuildNativeModules()",
@@ -33561,7 +33617,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L116",
       "id": "auto_setup_rebuildnativemodules",
-      "community": 74
+      "community": 75
     },
     {
       "label": "checkDependencies()",
@@ -33569,7 +33625,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L180",
       "id": "auto_setup_checkdependencies",
-      "community": 74
+      "community": 75
     },
     {
       "label": "createStartScripts()",
@@ -33577,7 +33633,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L201",
       "id": "auto_setup_createstartscripts",
-      "community": 74
+      "community": 75
     },
     {
       "label": "showUsageInstructions()",
@@ -33585,7 +33641,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L236",
       "id": "auto_setup_showusageinstructions",
-      "community": 74
+      "community": 75
     },
     {
       "label": "main()",
@@ -33593,7 +33649,7 @@
       "source_file": "scripts/auto-setup.js",
       "source_location": "L273",
       "id": "auto_setup_main",
-      "community": 74
+      "community": 75
     },
     {
       "label": "quality-thresholds.ts",
@@ -33641,7 +33697,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 594
+      "community": 596
     },
     {
       "label": "updateEmbeddings()",
@@ -33649,7 +33705,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 594
+      "community": 596
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -33817,7 +33873,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 595
+      "community": 597
     },
     {
       "label": "analyzeEmbeddings()",
@@ -33825,7 +33881,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 595
+      "community": 597
     },
     {
       "label": "test-docker.js",
@@ -33833,7 +33889,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 596
+      "community": 598
     },
     {
       "label": "testDockerServer()",
@@ -33841,7 +33897,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 596
+      "community": 598
     },
     {
       "label": "pack-with-restore.js",
@@ -33849,7 +33905,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 881
+      "community": 883
     },
     {
       "label": "run-migration.js",
@@ -33857,7 +33913,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 597
+      "community": 599
     },
     {
       "label": "runMigration()",
@@ -33865,7 +33921,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 597
+      "community": 599
     },
     {
       "label": "safe-migration.js",
@@ -33873,7 +33929,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 598
+      "community": 600
     },
     {
       "label": "safeMigration()",
@@ -33881,7 +33937,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 598
+      "community": 600
     },
     {
       "label": "generate-ground-truth.ts",
@@ -33945,7 +34001,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 599
+      "community": 601
     },
     {
       "label": "saveWorkMemory()",
@@ -33953,7 +34009,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 599
+      "community": 601
     },
     {
       "label": "check-file-sizes.ts",
@@ -34121,7 +34177,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -34129,7 +34185,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 600
+      "community": 602
     },
     {
       "label": "main()",
@@ -34137,7 +34193,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 600
+      "community": 602
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -34177,7 +34233,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 883
+      "community": 885
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -34225,7 +34281,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 601
+      "community": 603
     },
     {
       "label": "analyzeEmbeddings()",
@@ -34233,7 +34289,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 601
+      "community": 603
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -34241,7 +34297,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 602
+      "community": 604
     },
     {
       "label": "fixVectorDimensions()",
@@ -34249,7 +34305,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 602
+      "community": 604
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -34289,7 +34345,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "loadVecExtension()",
@@ -34297,7 +34353,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 436
+      "community": 437
     },
     {
       "label": "fixTfidfDimensions()",
@@ -34305,7 +34361,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 436
+      "community": 437
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -34313,7 +34369,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 603
+      "community": 605
     },
     {
       "label": "runUpdateMigration()",
@@ -34321,7 +34377,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 603
+      "community": 605
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -34329,7 +34385,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "reappearanceRate()",
@@ -34337,7 +34393,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 437
+      "community": 438
     },
     {
       "label": "main()",
@@ -34345,7 +34401,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 437
+      "community": 438
     },
     {
       "label": "regenerate-embeddings.js",
@@ -34353,7 +34409,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 604
+      "community": 606
     },
     {
       "label": "regenerateEmbeddings()",
@@ -34361,7 +34417,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 604
+      "community": 606
     },
     {
       "label": "generate-relation-report.ts",
@@ -34513,7 +34569,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 605
+      "community": 607
     },
     {
       "label": "sampleReport()",
@@ -34521,7 +34577,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 605
+      "community": 607
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -34529,7 +34585,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 884
+      "community": 886
     },
     {
       "label": "debug-embeddings.js",
@@ -34537,7 +34593,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 606
+      "community": 608
     },
     {
       "label": "debugEmbeddings()",
@@ -34545,7 +34601,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 606
+      "community": 608
     },
     {
       "label": "check-db-integrity.js",
@@ -34705,7 +34761,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L1",
       "id": "scripts_migrate_embedding_data_js",
-      "community": 83
+      "community": 84
     },
     {
       "label": "EmbeddingMigration",
@@ -34713,7 +34769,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L26",
       "id": "migrate_embedding_data_embeddingmigration",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".constructor()",
@@ -34721,7 +34777,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L27",
       "id": "migrate_embedding_data_embeddingmigration_constructor",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".connect()",
@@ -34729,7 +34785,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L38",
       "id": "migrate_embedding_data_embeddingmigration_connect",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".createBackup()",
@@ -34737,7 +34793,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L53",
       "id": "migrate_embedding_data_embeddingmigration_createbackup",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".migrate()",
@@ -34745,7 +34801,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L78",
       "id": "migrate_embedding_data_embeddingmigration_migrate",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".updateSchema()",
@@ -34753,7 +34809,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L117",
       "id": "migrate_embedding_data_embeddingmigration_updateschema",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".runDirectMigration()",
@@ -34761,7 +34817,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L149",
       "id": "migrate_embedding_data_embeddingmigration_rundirectmigration",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".analyzeExistingData()",
@@ -34769,7 +34825,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L213",
       "id": "migrate_embedding_data_embeddingmigration_analyzeexistingdata",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".migrateData()",
@@ -34777,7 +34833,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L245",
       "id": "migrate_embedding_data_embeddingmigration_migratedata",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".updateMetadata()",
@@ -34785,7 +34841,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L263",
       "id": "migrate_embedding_data_embeddingmigration_updatemetadata",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".regenerateEmbeddings()",
@@ -34793,7 +34849,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L288",
       "id": "migrate_embedding_data_embeddingmigration_regenerateembeddings",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".validateMigration()",
@@ -34801,7 +34857,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L301",
       "id": "migrate_embedding_data_embeddingmigration_validatemigration",
-      "community": 83
+      "community": 84
     },
     {
       "label": ".rollback()",
@@ -34809,7 +34865,7 @@
       "source_file": "scripts/migrate-embedding-data.js",
       "source_location": "L329",
       "id": "migrate_embedding_data_embeddingmigration_rollback",
-      "community": 83
+      "community": 84
     },
     {
       "label": "backup-embeddings.js",
@@ -34817,7 +34873,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 607
+      "community": 609
     },
     {
       "label": "backupEmbeddings()",
@@ -34825,7 +34881,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 607
+      "community": 609
     },
     {
       "label": "count-any-types.ts",
@@ -34913,7 +34969,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L1",
       "id": "scripts_count_console_logs_ts",
-      "community": 57
+      "community": 58
     },
     {
       "label": "parseArgs()",
@@ -34921,7 +34977,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L73",
       "id": "count_console_logs_parseargs",
-      "community": 57
+      "community": 58
     },
     {
       "label": "printHelp()",
@@ -34929,7 +34985,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L117",
       "id": "count_console_logs_printhelp",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isCoreModule()",
@@ -34937,7 +34993,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L146",
       "id": "count_console_logs_iscoremodule",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isTestFile()",
@@ -34945,7 +35001,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L155",
       "id": "count_console_logs_istestfile",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isCliScript()",
@@ -34953,7 +35009,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L165",
       "id": "count_console_logs_iscliscript",
-      "community": 57
+      "community": 58
     },
     {
       "label": "matchesPattern()",
@@ -34961,7 +35017,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L172",
       "id": "count_console_logs_matchespattern",
-      "community": 57
+      "community": 58
     },
     {
       "label": "shouldExclude()",
@@ -34969,7 +35025,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L191",
       "id": "count_console_logs_shouldexclude",
-      "community": 57
+      "community": 58
     },
     {
       "label": "findFiles()",
@@ -34977,7 +35033,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L203",
       "id": "count_console_logs_findfiles",
-      "community": 57
+      "community": 58
     },
     {
       "label": "findConsoleLogs()",
@@ -34985,7 +35041,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L237",
       "id": "count_console_logs_findconsolelogs",
-      "community": 57
+      "community": 58
     },
     {
       "label": "countConsoleLogs()",
@@ -34993,7 +35049,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L283",
       "id": "count_console_logs_countconsolelogs",
-      "community": 57
+      "community": 58
     },
     {
       "label": "printResultsJSON()",
@@ -35001,7 +35057,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L353",
       "id": "count_console_logs_printresultsjson",
-      "community": 57
+      "community": 58
     },
     {
       "label": "printResultsCSV()",
@@ -35009,7 +35065,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L374",
       "id": "count_console_logs_printresultscsv",
-      "community": 57
+      "community": 58
     },
     {
       "label": "printResultsText()",
@@ -35017,7 +35073,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L391",
       "id": "count_console_logs_printresultstext",
-      "community": 57
+      "community": 58
     },
     {
       "label": "printResults()",
@@ -35025,7 +35081,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L471",
       "id": "count_console_logs_printresults",
-      "community": 57
+      "community": 58
     },
     {
       "label": "main()",
@@ -35033,7 +35089,7 @@
       "source_file": "scripts/count-console-logs.ts",
       "source_location": "L491",
       "id": "count_console_logs_main",
-      "community": 57
+      "community": 58
     },
     {
       "label": "compare-weight-profiles.spec.ts",
@@ -35041,7 +35097,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -35049,7 +35105,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -35057,7 +35113,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -35065,7 +35121,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -35073,7 +35129,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 608
+      "community": 610
     },
     {
       "label": "jsonEmbedding()",
@@ -35081,7 +35137,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 608
+      "community": 610
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -35089,7 +35145,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -35097,7 +35153,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -35105,7 +35161,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -35113,7 +35169,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 609
+      "community": 611
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -35121,7 +35177,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 609
+      "community": 611
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -35129,7 +35185,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -35137,7 +35193,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 610
+      "community": 612
     },
     {
       "label": "jsonEmbedding()",
@@ -35145,7 +35201,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 610
+      "community": 612
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -35153,7 +35209,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 611
+      "community": 613
     },
     {
       "label": "main()",
@@ -35161,7 +35217,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 611
+      "community": 613
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -35169,7 +35225,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 612
+      "community": 614
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -35177,7 +35233,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 612
+      "community": 614
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -35185,7 +35241,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createBackup()",
@@ -35193,7 +35249,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 438
+      "community": 439
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -35201,7 +35257,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 438
+      "community": 439
     },
     {
       "label": "restore-legacy.ps1",
@@ -35209,7 +35265,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 893
+      "community": 895
     },
     {
       "label": "check-retry-usage.ts",
@@ -35329,7 +35385,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 613
+      "community": 615
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -35337,7 +35393,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 613
+      "community": 615
     },
     {
       "label": "check-no-console-violations.ts",
@@ -35433,7 +35489,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 614
+      "community": 616
     },
     {
       "label": "fixVecTableDimensions()",
@@ -35441,7 +35497,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 614
+      "community": 616
     },
     {
       "label": "sources.ts",
@@ -35497,7 +35553,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "issue-body.ts",
@@ -35537,7 +35593,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "normalizeMessage()",
@@ -35545,7 +35601,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createFingerprint()",
@@ -35553,7 +35609,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 439
+      "community": 440
     },
     {
       "label": "sanitizer.ts",
@@ -35561,7 +35617,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "limitUtf8Bytes()",
@@ -35569,7 +35625,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 440
+      "community": 441
     },
     {
       "label": "sanitizeExcerpt()",
@@ -35577,7 +35633,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 440
+      "community": 441
     },
     {
       "label": "parsers.ts",
@@ -35649,7 +35705,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 615
+      "community": 617
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -35657,7 +35713,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 615
+      "community": 617
     },
     {
       "label": "state-store.ts",
@@ -35921,7 +35977,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "issue-body.spec.ts",
@@ -35929,7 +35985,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "github-client.spec.ts",
@@ -35937,7 +35993,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "config.spec.ts",
@@ -35945,7 +36001,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "detectors.spec.ts",
@@ -35953,7 +36009,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "sources.spec.ts",
@@ -35961,7 +36017,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "parsers.spec.ts",
@@ -35969,7 +36025,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "monitor.spec.ts",
@@ -35977,7 +36033,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 616
+      "community": 618
     },
     {
       "label": "config()",
@@ -35985,7 +36041,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 616
+      "community": 618
     },
     {
       "label": "fingerprint.spec.ts",
@@ -35993,7 +36049,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "state-store.spec.ts",
@@ -36001,7 +36057,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "sanitizer.spec.ts",
@@ -36009,7 +36065,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "entrypoint.spec.ts",
@@ -36017,7 +36073,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "index.ts",
@@ -36057,7 +36113,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "memento-admin-fetch.js",
@@ -36113,7 +36169,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_js",
-      "community": 58
+      "community": 59
     },
     {
       "label": "selectFirst()",
@@ -36121,7 +36177,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L23",
       "id": "dashboard_auth_selectfirst",
-      "community": 58
+      "community": 59
     },
     {
       "label": "getElementByIdFallback()",
@@ -36129,7 +36185,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L33",
       "id": "dashboard_auth_getelementbyidfallback",
-      "community": 58
+      "community": 59
     },
     {
       "label": "beginAuthRequest()",
@@ -36137,7 +36193,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L43",
       "id": "dashboard_auth_beginauthrequest",
-      "community": 58
+      "community": 59
     },
     {
       "label": "isCurrentAuthRequest()",
@@ -36145,7 +36201,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L48",
       "id": "dashboard_auth_iscurrentauthrequest",
-      "community": 58
+      "community": 59
     },
     {
       "label": "createSessionGate()",
@@ -36153,7 +36209,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L52",
       "id": "dashboard_auth_createsessiongate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "ensureSessionGate()",
@@ -36161,7 +36217,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L59",
       "id": "dashboard_auth_ensuresessiongate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "unlockSessionGate()",
@@ -36169,7 +36225,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L65",
       "id": "dashboard_auth_unlocksessiongate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "resetSessionGate()",
@@ -36177,7 +36233,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L76",
       "id": "dashboard_auth_resetsessiongate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "setMessage()",
@@ -36185,7 +36241,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L83",
       "id": "dashboard_auth_setmessage",
-      "community": 58
+      "community": 59
     },
     {
       "label": "setAuthState()",
@@ -36193,7 +36249,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L91",
       "id": "dashboard_auth_setauthstate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "readErrorMessage()",
@@ -36201,7 +36257,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L128",
       "id": "dashboard_auth_readerrormessage",
-      "community": 58
+      "community": 59
     },
     {
       "label": "checkSession()",
@@ -36209,7 +36265,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L142",
       "id": "dashboard_auth_checksession",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleSignIn()",
@@ -36217,7 +36273,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L184",
       "id": "dashboard_auth_handlesignin",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleSignOut()",
@@ -36225,7 +36281,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L235",
       "id": "dashboard_auth_handlesignout",
-      "community": 58
+      "community": 59
     },
     {
       "label": "bindDom()",
@@ -36233,7 +36289,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L247",
       "id": "dashboard_auth_binddom",
-      "community": 58
+      "community": 59
     },
     {
       "label": "anchor-map.js",
@@ -36241,7 +36297,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_js",
-      "community": 12
+      "community": 13
     },
     {
       "label": "readAnchorMapToken()",
@@ -36249,7 +36305,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L23",
       "id": "anchor_map_readanchormaptoken",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getAnchorMapPalette()",
@@ -36257,7 +36313,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L34",
       "id": "anchor_map_getanchormappalette",
-      "community": 12
+      "community": 13
     },
     {
       "label": "escapeHtml()",
@@ -36265,7 +36321,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L49",
       "id": "anchor_map_escapehtml",
-      "community": 12
+      "community": 13
     },
     {
       "label": "debugAnchorMap()",
@@ -36273,7 +36329,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L60",
       "id": "anchor_map_debuganchormap",
-      "community": 12
+      "community": 13
     },
     {
       "label": "initializeMap()",
@@ -36281,7 +36337,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L82",
       "id": "anchor_map_initializemap",
-      "community": 12
+      "community": 13
     },
     {
       "label": "setupEventListeners()",
@@ -36289,7 +36345,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L125",
       "id": "anchor_map_setupeventlisteners",
-      "community": 12
+      "community": 13
     },
     {
       "label": "loadMapData()",
@@ -36297,7 +36353,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L176",
       "id": "anchor_map_loadmapdata",
-      "community": 12
+      "community": 13
     },
     {
       "label": "renderMap()",
@@ -36305,7 +36361,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L215",
       "id": "anchor_map_rendermap",
-      "community": 12
+      "community": 13
     },
     {
       "label": "layoutNodesByHop()",
@@ -36313,7 +36369,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L338",
       "id": "anchor_map_layoutnodesbyhop",
-      "community": 12
+      "community": 13
     },
     {
       "label": "drag()",
@@ -36321,7 +36377,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L385",
       "id": "anchor_map_drag",
-      "community": 12
+      "community": 13
     },
     {
       "label": "selectNode()",
@@ -36329,7 +36385,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L412",
       "id": "anchor_map_selectnode",
-      "community": 12
+      "community": 13
     },
     {
       "label": "displayMemoryDetails()",
@@ -36337,7 +36393,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L425",
       "id": "anchor_map_displaymemorydetails",
-      "community": 12
+      "community": 13
     },
     {
       "label": "updateAnchorList()",
@@ -36345,7 +36401,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L510",
       "id": "anchor_map_updateanchorlist",
-      "community": 12
+      "community": 13
     },
     {
       "label": "selectAnchorNode()",
@@ -36353,7 +36409,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L540",
       "id": "anchor_map_selectanchornode",
-      "community": 12
+      "community": 13
     },
     {
       "label": "changeAnchor()",
@@ -36361,7 +36417,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L566",
       "id": "anchor_map_changeanchor",
-      "community": 12
+      "community": 13
     },
     {
       "label": "performSearch()",
@@ -36369,7 +36425,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L574",
       "id": "anchor_map_performsearch",
-      "community": 12
+      "community": 13
     },
     {
       "label": "highlightSearchResults()",
@@ -36377,7 +36433,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L630",
       "id": "anchor_map_highlightsearchresults",
-      "community": 12
+      "community": 13
     },
     {
       "label": "updateNodeHighlight()",
@@ -36385,7 +36441,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L671",
       "id": "anchor_map_updatenodehighlight",
-      "community": 12
+      "community": 13
     },
     {
       "label": "clearSearch()",
@@ -36393,7 +36449,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L727",
       "id": "anchor_map_clearsearch",
-      "community": 12
+      "community": 13
     },
     {
       "label": "startAutoRefresh()",
@@ -36401,7 +36457,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L742",
       "id": "anchor_map_startautorefresh",
-      "community": 12
+      "community": 13
     },
     {
       "label": "stopAutoRefresh()",
@@ -36409,7 +36465,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L756",
       "id": "anchor_map_stopautorefresh",
-      "community": 12
+      "community": 13
     },
     {
       "label": "tryConnectWebSocket()",
@@ -36417,7 +36473,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L767",
       "id": "anchor_map_tryconnectwebsocket",
-      "community": 12
+      "community": 13
     },
     {
       "label": "disconnectWebSocket()",
@@ -36425,7 +36481,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L847",
       "id": "anchor_map_disconnectwebsocket",
-      "community": 12
+      "community": 13
     },
     {
       "label": "review-candidates-panel.js",
@@ -36433,103 +36489,287 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 88
+      "community": 6
     },
     {
       "label": "$()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L13",
+      "source_location": "L20",
       "id": "review_candidates_panel",
-      "community": 88
+      "community": 6
     },
     {
       "label": "setHidden()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L17",
+      "source_location": "L24",
       "id": "review_candidates_panel_sethidden",
-      "community": 88
+      "community": 6
     },
     {
       "label": "clearStatus()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L24",
+      "source_location": "L31",
       "id": "review_candidates_panel_clearstatus",
-      "community": 88
+      "community": 6
     },
     {
       "label": "truncateReason()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L31",
+      "source_location": "L38",
       "id": "review_candidates_panel_truncatereason",
-      "community": 88
+      "community": 6
     },
     {
-      "label": "renderTable()",
+      "label": "formatDue()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L41",
-      "id": "review_candidates_panel_rendertable",
-      "community": 88
+      "source_location": "L48",
+      "id": "review_candidates_panel_formatdue",
+      "community": 6
     },
     {
       "label": "escapeHtml()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L71",
+      "source_location": "L59",
       "id": "review_candidates_panel_escapehtml",
-      "community": 88
+      "community": 6
+    },
+    {
+      "label": "escapeAttr()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L67",
+      "id": "review_candidates_panel_escapeattr",
+      "community": 6
+    },
+    {
+      "label": "previewUrl()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L71",
+      "id": "review_candidates_panel_previewurl",
+      "community": 6
+    },
+    {
+      "label": "reviewCandidatePostUrl()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L75",
+      "id": "review_candidates_panel_reviewcandidateposturl",
+      "community": 6
+    },
+    {
+      "label": "getPreviewActionsEl()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L79",
+      "id": "review_candidates_panel_getpreviewactionsel",
+      "community": 6
+    },
+    {
+      "label": "setPreviewActionsBusy()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L83",
+      "id": "review_candidates_panel_setpreviewactionsbusy",
+      "community": 6
+    },
+    {
+      "label": "syncReviewDismissButtons()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L90",
+      "id": "review_candidates_panel_syncreviewdismissbuttons",
+      "community": 6
+    },
+    {
+      "label": "showActionToast()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L105",
+      "id": "review_candidates_panel_showactiontoast",
+      "community": 6
+    },
+    {
+      "label": "postCandidateAction()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L122",
+      "id": "review_candidates_panel_postcandidateaction",
+      "community": 6
+    },
+    {
+      "label": "clearRowSelection()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L164",
+      "id": "review_candidates_panel_clearrowselection",
+      "community": 6
+    },
+    {
+      "label": "resetPreviewPanel()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L172",
+      "id": "review_candidates_panel_resetpreviewpanel",
+      "community": 6
+    },
+    {
+      "label": "setPreviewCandidateFields()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L192",
+      "id": "review_candidates_panel_setpreviewcandidatefields",
+      "community": 6
+    },
+    {
+      "label": "loadMemoryPreview()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L211",
+      "id": "review_candidates_panel_loadmemorypreview",
+      "community": 6
+    },
+    {
+      "label": "onRowActivate()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L248",
+      "id": "review_candidates_panel_onrowactivate",
+      "community": 6
+    },
+    {
+      "label": "wireTableBody()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L270",
+      "id": "review_candidates_panel_wiretablebody",
+      "community": 6
+    },
+    {
+      "label": "renderTable()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L296",
+      "id": "review_candidates_panel_rendertable",
+      "community": 6
     },
     {
       "label": "showLoading()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L79",
+      "source_location": "L344",
       "id": "review_candidates_panel_showloading",
-      "community": 88
+      "community": 6
     },
     {
       "label": "showError()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L83",
+      "source_location": "L348",
       "id": "review_candidates_panel_showerror",
-      "community": 88
+      "community": 6
     },
     {
       "label": "showEmpty()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L91",
+      "source_location": "L356",
       "id": "review_candidates_panel_showempty",
-      "community": 88
+      "community": 6
     },
     {
       "label": "hideTable()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L95",
+      "source_location": "L360",
       "id": "review_candidates_panel_hidetable",
-      "community": 88
+      "community": 6
+    },
+    {
+      "label": "clearReviewTabBadge()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L364",
+      "id": "review_candidates_panel_clearreviewtabbadge",
+      "community": 6
+    },
+    {
+      "label": "setReviewTabBadge()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L373",
+      "id": "review_candidates_panel_setreviewtabbadge",
+      "community": 6
+    },
+    {
+      "label": "showNewCandidatesToast()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L383",
+      "id": "review_candidates_panel_shownewcandidatestoast",
+      "community": 6
+    },
+    {
+      "label": "registerVisibilityForPoll()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L405",
+      "id": "review_candidates_panel_registervisibilityforpoll",
+      "community": 6
+    },
+    {
+      "label": "startPollingIfNeeded()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L417",
+      "id": "review_candidates_panel_startpollingifneeded",
+      "community": 6
+    },
+    {
+      "label": "fetchReviewCandidateListJson()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L430",
+      "id": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "community": 6
+    },
+    {
+      "label": "applyListSuccess()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L439",
+      "id": "review_candidates_panel_applylistsuccess",
+      "community": 6
+    },
+    {
+      "label": "runPollTick()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L455",
+      "id": "review_candidates_panel_runpolltick",
+      "community": 6
     },
     {
       "label": "loadList()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L99",
+      "source_location": "L490",
       "id": "review_candidates_panel_loadlist",
-      "community": 88
+      "community": 6
     },
     {
       "label": "initReviewCandidatesPanel()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L137",
+      "source_location": "L517",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 88
+      "community": 6
     },
     {
       "label": "graph.js",
@@ -36537,7 +36777,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L1",
       "id": "static_js_graph_js",
-      "community": 59
+      "community": 60
     },
     {
       "label": "readGraphToken()",
@@ -36545,7 +36785,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L1",
       "id": "graph_readgraphtoken",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getGraphPalette()",
@@ -36553,7 +36793,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L12",
       "id": "graph_getgraphpalette",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getNodeFillColor()",
@@ -36561,7 +36801,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L31",
       "id": "graph_getnodefillcolor",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getNodeStrokeColor()",
@@ -36569,7 +36809,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L35",
       "id": "graph_getnodestrokecolor",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getTypeBadgeClass()",
@@ -36577,7 +36817,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L41",
       "id": "graph_gettypebadgeclass",
-      "community": 59
+      "community": 60
     },
     {
       "label": "buildUrl()",
@@ -36585,7 +36825,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L67",
       "id": "graph_buildurl",
-      "community": 59
+      "community": 60
     },
     {
       "label": "renderGraph()",
@@ -36593,7 +36833,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L88",
       "id": "graph_rendergraph",
-      "community": 59
+      "community": 60
     },
     {
       "label": "showDetail()",
@@ -36601,7 +36841,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L206",
       "id": "graph_showdetail",
-      "community": 59
+      "community": 60
     },
     {
       "label": "closePanel()",
@@ -36609,7 +36849,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L247",
       "id": "graph_closepanel",
-      "community": 59
+      "community": 60
     },
     {
       "label": "escHtml()",
@@ -36617,7 +36857,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L251",
       "id": "graph_eschtml",
-      "community": 59
+      "community": 60
     },
     {
       "label": "showLoading()",
@@ -36625,7 +36865,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L260",
       "id": "graph_showloading",
-      "community": 59
+      "community": 60
     },
     {
       "label": "showEmpty()",
@@ -36633,7 +36873,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L261",
       "id": "graph_showempty",
-      "community": 59
+      "community": 60
     },
     {
       "label": "showError()",
@@ -36641,7 +36881,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L262",
       "id": "graph_showerror",
-      "community": 59
+      "community": 60
     },
     {
       "label": "clearStatus()",
@@ -36649,7 +36889,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L266",
       "id": "graph_clearstatus",
-      "community": 59
+      "community": 60
     },
     {
       "label": "loadGraph()",
@@ -36657,7 +36897,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L273",
       "id": "graph_loadgraph",
-      "community": 59
+      "community": 60
     },
     {
       "label": "embedding-map.js",
@@ -36665,7 +36905,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 60
+      "community": 61
     },
     {
       "label": "readParams()",
@@ -36673,7 +36913,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_readparams",
-      "community": 60
+      "community": 61
     },
     {
       "label": "clusterColor()",
@@ -36681,7 +36921,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L35",
       "id": "embedding_map_clustercolor",
-      "community": 60
+      "community": 61
     },
     {
       "label": "ensureTooltip()",
@@ -36689,7 +36929,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L45",
       "id": "embedding_map_ensuretooltip",
-      "community": 60
+      "community": 61
     },
     {
       "label": "showTooltip()",
@@ -36697,7 +36937,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L56",
       "id": "embedding_map_showtooltip",
-      "community": 60
+      "community": 61
     },
     {
       "label": "hideTooltip()",
@@ -36705,7 +36945,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L73",
       "id": "embedding_map_hidetooltip",
-      "community": 60
+      "community": 61
     },
     {
       "label": "closeSidePanel()",
@@ -36713,7 +36953,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L79",
       "id": "embedding_map_closesidepanel",
-      "community": 60
+      "community": 61
     },
     {
       "label": "appendLabeledLine()",
@@ -36721,7 +36961,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L87",
       "id": "embedding_map_appendlabeledline",
-      "community": 60
+      "community": 61
     },
     {
       "label": "openSidePanel()",
@@ -36729,7 +36969,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L96",
       "id": "embedding_map_opensidepanel",
-      "community": 60
+      "community": 61
     },
     {
       "label": "setupChart()",
@@ -36737,7 +36977,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L144",
       "id": "embedding_map_setupchart",
-      "community": 60
+      "community": 61
     },
     {
       "label": "renderScatter()",
@@ -36745,7 +36985,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L201",
       "id": "embedding_map_renderscatter",
-      "community": 60
+      "community": 61
     },
     {
       "label": "setLoading()",
@@ -36753,7 +36993,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L292",
       "id": "embedding_map_setloading",
-      "community": 60
+      "community": 61
     },
     {
       "label": "setError()",
@@ -36761,7 +37001,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L299",
       "id": "embedding_map_seterror",
-      "community": 60
+      "community": 61
     },
     {
       "label": "updateCacheInfo()",
@@ -36769,7 +37009,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L327",
       "id": "embedding_map_updatecacheinfo",
-      "community": 60
+      "community": 61
     },
     {
       "label": "loadEmbeddingMap()",
@@ -36777,7 +37017,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L341",
       "id": "embedding_map_loadembeddingmap",
-      "community": 60
+      "community": 61
     },
     {
       "label": "initEmbeddingMap()",
@@ -36785,7 +37025,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L382",
       "id": "embedding_map_initembeddingmap",
-      "community": 60
+      "community": 61
     },
     {
       "label": "dashboard-tabs.js",
@@ -42029,7 +42269,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L37",
+      "source_location": "L39",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_admin_routes_ts",
       "_tgt": "admin_routes_parsecleanupparams",
@@ -42041,7 +42281,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L65",
+      "source_location": "L67",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_admin_routes_ts",
       "_tgt": "admin_routes_parsereviewcandidatestatusquery",
@@ -42053,7 +42293,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
-      "source_location": "L81",
+      "source_location": "L83",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_admin_routes_ts",
       "_tgt": "admin_routes_createadminrouter",
@@ -42233,7 +42473,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
-      "source_location": "L977",
+      "source_location": "L978",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_admin_routes_spec_ts",
       "_tgt": "admin_routes_spec_makeapp",
@@ -64421,7 +64661,31 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L121",
+      "source_location": "L125",
+      "weight": 1.0,
+      "_src": "llm_client_initializer_llmclientinitializer",
+      "_tgt": "llm_client_initializer_llmclientinitializer_shouldwarnmissingopenaikey",
+      "source": "llm_client_initializer_llmclientinitializer",
+      "target": "llm_client_initializer_llmclientinitializer_shouldwarnmissingopenaikey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L129",
+      "weight": 1.0,
+      "_src": "llm_client_initializer_llmclientinitializer",
+      "_tgt": "llm_client_initializer_llmclientinitializer_shouldwarnmissinggeminikey",
+      "source": "llm_client_initializer_llmclientinitializer",
+      "target": "llm_client_initializer_llmclientinitializer_shouldwarnmissinggeminikey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L133",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_resolvellmmodellabel",
@@ -64433,7 +64697,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L133",
+      "source_location": "L145",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_getselectedprovider",
@@ -64445,7 +64709,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L144",
+      "source_location": "L156",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_geterrormessage",
@@ -64457,7 +64721,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L156",
+      "source_location": "L168",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_addwarning",
@@ -64469,7 +64733,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L173",
+      "source_location": "L185",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_initializeopenai",
@@ -64481,7 +64745,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L224",
+      "source_location": "L238",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_initializegemini",
@@ -64493,7 +64757,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L273",
+      "source_location": "L289",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_handleollamaresponse",
@@ -64505,7 +64769,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L321",
+      "source_location": "L337",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_testollamaconnection",
@@ -64517,7 +64781,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L385",
+      "source_location": "L401",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_shouldretryollamaconnection",
@@ -64529,7 +64793,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L407",
+      "source_location": "L423",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_getollamaerrormessage",
@@ -64541,7 +64805,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L429",
+      "source_location": "L445",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
@@ -64553,7 +64817,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L452",
+      "source_location": "L468",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforopenai",
@@ -64565,7 +64829,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L481",
+      "source_location": "L497",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforgemini",
@@ -64577,7 +64841,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L510",
+      "source_location": "L526",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforollama",
@@ -64589,7 +64853,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L544",
+      "source_location": "L560",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforauto",
@@ -64673,7 +64937,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L196",
+      "source_location": "L190",
+      "weight": 1.0,
+      "_src": "llm_client_initializer_llmclientinitializer_initializeopenai",
+      "_tgt": "llm_client_initializer_llmclientinitializer_shouldwarnmissingopenaikey",
+      "source": "llm_client_initializer_llmclientinitializer_shouldwarnmissingopenaikey",
+      "target": "llm_client_initializer_llmclientinitializer_initializeopenai",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L243",
+      "weight": 1.0,
+      "_src": "llm_client_initializer_llmclientinitializer_initializegemini",
+      "_tgt": "llm_client_initializer_llmclientinitializer_shouldwarnmissinggeminikey",
+      "source": "llm_client_initializer_llmclientinitializer_shouldwarnmissinggeminikey",
+      "target": "llm_client_initializer_llmclientinitializer_initializegemini",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
+      "source_location": "L210",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_initializeopenai",
       "_tgt": "llm_client_initializer_llmclientinitializer_geterrormessage",
@@ -64685,7 +64973,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L250",
+      "source_location": "L266",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_initializegemini",
       "_tgt": "llm_client_initializer_llmclientinitializer_geterrormessage",
@@ -64697,7 +64985,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L285",
+      "source_location": "L301",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_handleollamaresponse",
       "_tgt": "llm_client_initializer_llmclientinitializer_geterrormessage",
@@ -64709,7 +64997,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L363",
+      "source_location": "L379",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_testollamaconnection",
       "_tgt": "llm_client_initializer_llmclientinitializer_geterrormessage",
@@ -64721,7 +65009,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L179",
+      "source_location": "L192",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_initializeopenai",
       "_tgt": "llm_client_initializer_llmclientinitializer_addwarning",
@@ -64733,7 +65021,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L230",
+      "source_location": "L245",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_initializegemini",
       "_tgt": "llm_client_initializer_llmclientinitializer_addwarning",
@@ -64745,7 +65033,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L287",
+      "source_location": "L303",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_handleollamaresponse",
       "_tgt": "llm_client_initializer_llmclientinitializer_addwarning",
@@ -64757,7 +65045,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L366",
+      "source_location": "L382",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_testollamaconnection",
       "_tgt": "llm_client_initializer_llmclientinitializer_addwarning",
@@ -64769,7 +65057,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L360",
+      "source_location": "L376",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_testollamaconnection",
       "_tgt": "llm_client_initializer_llmclientinitializer_handleollamaresponse",
@@ -64781,7 +65069,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L364",
+      "source_location": "L380",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_testollamaconnection",
       "_tgt": "llm_client_initializer_llmclientinitializer_getollamaerrormessage",
@@ -64793,7 +65081,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L434",
+      "source_location": "L450",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforopenai",
@@ -64805,7 +65093,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L436",
+      "source_location": "L452",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforgemini",
@@ -64817,7 +65105,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L438",
+      "source_location": "L454",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforollama",
@@ -64829,7 +65117,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
-      "source_location": "L441",
+      "source_location": "L457",
       "weight": 1.0,
       "_src": "llm_client_initializer_llmclientinitializer_determinepreferredprovider",
       "_tgt": "llm_client_initializer_llmclientinitializer_determineproviderforauto",
@@ -77716,6 +78004,18 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
+      "source_location": "L8",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
+      "_tgt": "admin_memory_item_preview_service_spec_opendb",
+      "source": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
+      "target": "admin_memory_item_preview_service_spec_opendb",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-vault-service.ts",
       "source_location": "L36",
       "weight": 1.0,
@@ -79127,6 +79427,30 @@
       "_tgt": "core_memory_cache_service_corememorycacheservice_keys",
       "source": "core_memory_cache_service_corememorycacheservice_keys",
       "target": "core_memory_cache_service_corememorycacheservice_getstats",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
+      "_tgt": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
+      "source": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
+      "target": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
+      "_tgt": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
+      "source": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
+      "target": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
       "confidence_score": 1.0
     },
     {
@@ -103073,7 +103397,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L13",
+      "source_location": "L20",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel",
@@ -103085,7 +103409,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L17",
+      "source_location": "L24",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103097,7 +103421,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L24",
+      "source_location": "L31",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_clearstatus",
@@ -103109,7 +103433,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L31",
+      "source_location": "L38",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_truncatereason",
@@ -103121,19 +103445,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L41",
+      "source_location": "L48",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
-      "_tgt": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_formatdue",
       "source": "static_js_review_candidates_panel_js",
-      "target": "review_candidates_panel_rendertable",
+      "target": "review_candidates_panel_formatdue",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L71",
+      "source_location": "L59",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_escapehtml",
@@ -103145,7 +103469,187 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L67",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_escapeattr",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_escapeattr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L71",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_previewurl",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_previewurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L75",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_reviewcandidateposturl",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_reviewcandidateposturl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L79",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_getpreviewactionsel",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_getpreviewactionsel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L83",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_setpreviewactionsbusy",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_setpreviewactionsbusy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L90",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_syncreviewdismissbuttons",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_syncreviewdismissbuttons",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L105",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_showactiontoast",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_showactiontoast",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L122",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_postcandidateaction",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_postcandidateaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L164",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_clearrowselection",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_clearrowselection",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L172",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_resetpreviewpanel",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_resetpreviewpanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L192",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_setpreviewcandidatefields",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_setpreviewcandidatefields",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L211",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_loadmemorypreview",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_loadmemorypreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L248",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_onrowactivate",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L270",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_wiretablebody",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_wiretablebody",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L296",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_rendertable",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L344",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_showloading",
@@ -103157,7 +103661,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L83",
+      "source_location": "L348",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_showerror",
@@ -103169,7 +103673,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L91",
+      "source_location": "L356",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_showempty",
@@ -103181,7 +103685,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L95",
+      "source_location": "L360",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_hidetable",
@@ -103193,7 +103697,103 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L99",
+      "source_location": "L364",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_clearreviewtabbadge",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_clearreviewtabbadge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L373",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_setreviewtabbadge",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_setreviewtabbadge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L383",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_shownewcandidatestoast",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_shownewcandidatestoast",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L405",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_registervisibilityforpoll",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_registervisibilityforpoll",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L417",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_startpollingifneeded",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_startpollingifneeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L430",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L439",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_applylistsuccess",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_applylistsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L455",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_runpolltick",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L490",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_loadlist",
@@ -103205,7 +103805,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L137",
+      "source_location": "L517",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_initreviewcandidatespanel",
@@ -103217,7 +103817,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L25",
+      "source_location": "L32",
       "weight": 1.0,
       "_src": "review_candidates_panel_clearstatus",
       "_tgt": "review_candidates_panel",
@@ -103229,7 +103829,103 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L42",
+      "source_location": "L80",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_getpreviewactionsel",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_getpreviewactionsel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L91",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_syncreviewdismissbuttons",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_syncreviewdismissbuttons",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L106",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_showactiontoast",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_showactiontoast",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L173",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_resetpreviewpanel",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_resetpreviewpanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L193",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_setpreviewcandidatefields",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_setpreviewcandidatefields",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L213",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadmemorypreview",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_loadmemorypreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L257",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L271",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_wiretablebody",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_wiretablebody",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L297",
       "weight": 1.0,
       "_src": "review_candidates_panel_rendertable",
       "_tgt": "review_candidates_panel",
@@ -103241,7 +103937,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L80",
+      "source_location": "L345",
       "weight": 1.0,
       "_src": "review_candidates_panel_showloading",
       "_tgt": "review_candidates_panel",
@@ -103253,7 +103949,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L84",
+      "source_location": "L349",
       "weight": 1.0,
       "_src": "review_candidates_panel_showerror",
       "_tgt": "review_candidates_panel",
@@ -103265,7 +103961,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L92",
+      "source_location": "L357",
       "weight": 1.0,
       "_src": "review_candidates_panel_showempty",
       "_tgt": "review_candidates_panel",
@@ -103277,7 +103973,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L96",
+      "source_location": "L361",
       "weight": 1.0,
       "_src": "review_candidates_panel_hidetable",
       "_tgt": "review_candidates_panel",
@@ -103289,19 +103985,67 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L122",
+      "source_location": "L365",
       "weight": 1.0,
-      "_src": "review_candidates_panel_loadlist",
+      "_src": "review_candidates_panel_clearreviewtabbadge",
       "_tgt": "review_candidates_panel",
       "source": "review_candidates_panel",
-      "target": "review_candidates_panel_loadlist",
+      "target": "review_candidates_panel_clearreviewtabbadge",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L140",
+      "source_location": "L374",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_setreviewtabbadge",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_setreviewtabbadge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L384",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_shownewcandidatestoast",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_shownewcandidatestoast",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L442",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_applylistsuccess",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_applylistsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L476",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel",
+      "source": "review_candidates_panel",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L521",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel",
@@ -103313,7 +104057,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L68",
+      "source_location": "L178",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_resetpreviewpanel",
+      "_tgt": "review_candidates_panel_sethidden",
+      "source": "review_candidates_panel_sethidden",
+      "target": "review_candidates_panel_resetpreviewpanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L260",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel_sethidden",
+      "source": "review_candidates_panel_sethidden",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L341",
       "weight": 1.0,
       "_src": "review_candidates_panel_rendertable",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103325,7 +104093,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L80",
+      "source_location": "L345",
       "weight": 1.0,
       "_src": "review_candidates_panel_showloading",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103337,7 +104105,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L88",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "review_candidates_panel_showerror",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103349,7 +104117,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L92",
+      "source_location": "L357",
       "weight": 1.0,
       "_src": "review_candidates_panel_showempty",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103361,7 +104129,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L96",
+      "source_location": "L361",
       "weight": 1.0,
       "_src": "review_candidates_panel_hidetable",
       "_tgt": "review_candidates_panel_sethidden",
@@ -103373,7 +104141,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L105",
+      "source_location": "L495",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_clearstatus",
@@ -103385,7 +104153,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L60",
+      "source_location": "L332",
       "weight": 1.0,
       "_src": "review_candidates_panel_rendertable",
       "_tgt": "review_candidates_panel_truncatereason",
@@ -103397,12 +104165,156 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L54",
+      "source_location": "L204",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_setpreviewcandidatefields",
+      "_tgt": "review_candidates_panel_formatdue",
+      "source": "review_candidates_panel_formatdue",
+      "target": "review_candidates_panel_setpreviewcandidatefields",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L334",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_formatdue",
+      "source": "review_candidates_panel_formatdue",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L68",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_escapeattr",
+      "_tgt": "review_candidates_panel_escapehtml",
+      "source": "review_candidates_panel_escapehtml",
+      "target": "review_candidates_panel_escapeattr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L324",
       "weight": 1.0,
       "_src": "review_candidates_panel_rendertable",
       "_tgt": "review_candidates_panel_escapehtml",
-      "source": "review_candidates_panel_rendertable",
-      "target": "review_candidates_panel_escapehtml",
+      "source": "review_candidates_panel_escapehtml",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L330",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_escapeattr",
+      "source": "review_candidates_panel_escapeattr",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L222",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadmemorypreview",
+      "_tgt": "review_candidates_panel_previewurl",
+      "source": "review_candidates_panel_previewurl",
+      "target": "review_candidates_panel_loadmemorypreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L132",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_reviewcandidateposturl",
+      "source": "review_candidates_panel_reviewcandidateposturl",
+      "target": "review_candidates_panel_postcandidateaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L84",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_setpreviewactionsbusy",
+      "_tgt": "review_candidates_panel_getpreviewactionsel",
+      "source": "review_candidates_panel_getpreviewactionsel",
+      "target": "review_candidates_panel_setpreviewactionsbusy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L128",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_setpreviewactionsbusy",
+      "source": "review_candidates_panel_setpreviewactionsbusy",
+      "target": "review_candidates_panel_postcandidateaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L129",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_syncreviewdismissbuttons",
+      "source": "review_candidates_panel_syncreviewdismissbuttons",
+      "target": "review_candidates_panel_postcandidateaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L189",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_resetpreviewpanel",
+      "_tgt": "review_candidates_panel_syncreviewdismissbuttons",
+      "source": "review_candidates_panel_syncreviewdismissbuttons",
+      "target": "review_candidates_panel_resetpreviewpanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L267",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel_syncreviewdismissbuttons",
+      "source": "review_candidates_panel_syncreviewdismissbuttons",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L153",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_showactiontoast",
+      "source": "review_candidates_panel_showactiontoast",
+      "target": "review_candidates_panel_postcandidateaction",
       "confidence_score": 1.0
     },
     {
@@ -103411,9 +104323,21 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L130",
       "weight": 1.0,
-      "_src": "review_candidates_panel_loadlist",
-      "_tgt": "review_candidates_panel_rendertable",
-      "source": "review_candidates_panel_rendertable",
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_showerror",
+      "source": "review_candidates_panel_postcandidateaction",
+      "target": "review_candidates_panel_showerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L154",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_postcandidateaction",
+      "_tgt": "review_candidates_panel_loadlist",
+      "source": "review_candidates_panel_postcandidateaction",
       "target": "review_candidates_panel_loadlist",
       "confidence_score": 1.0
     },
@@ -103421,7 +104345,139 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L102",
+      "source_location": "L531",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_initreviewcandidatespanel",
+      "_tgt": "review_candidates_panel_postcandidateaction",
+      "source": "review_candidates_panel_postcandidateaction",
+      "target": "review_candidates_panel_initreviewcandidatespanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L252",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel_clearrowselection",
+      "source": "review_candidates_panel_clearrowselection",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L303",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_clearrowselection",
+      "source": "review_candidates_panel_clearrowselection",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L496",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadlist",
+      "_tgt": "review_candidates_panel_clearrowselection",
+      "source": "review_candidates_panel_clearrowselection",
+      "target": "review_candidates_panel_loadlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L304",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_resetpreviewpanel",
+      "source": "review_candidates_panel_resetpreviewpanel",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L497",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadlist",
+      "_tgt": "review_candidates_panel_resetpreviewpanel",
+      "source": "review_candidates_panel_resetpreviewpanel",
+      "target": "review_candidates_panel_loadlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L265",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel_setpreviewcandidatefields",
+      "source": "review_candidates_panel_setpreviewcandidatefields",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L266",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_onrowactivate",
+      "_tgt": "review_candidates_panel_loadmemorypreview",
+      "source": "review_candidates_panel_loadmemorypreview",
+      "target": "review_candidates_panel_onrowactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L281",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_wiretablebody",
+      "_tgt": "review_candidates_panel_onrowactivate",
+      "source": "review_candidates_panel_onrowactivate",
+      "target": "review_candidates_panel_wiretablebody",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L340",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_rendertable",
+      "_tgt": "review_candidates_panel_wiretablebody",
+      "source": "review_candidates_panel_wiretablebody",
+      "target": "review_candidates_panel_rendertable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L452",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_applylistsuccess",
+      "_tgt": "review_candidates_panel_rendertable",
+      "source": "review_candidates_panel_rendertable",
+      "target": "review_candidates_panel_applylistsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L492",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showloading",
@@ -103433,7 +104489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L101",
+      "source_location": "L491",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showerror",
@@ -103445,7 +104501,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L104",
+      "source_location": "L448",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_applylistsuccess",
+      "_tgt": "review_candidates_panel_showempty",
+      "source": "review_candidates_panel_showempty",
+      "target": "review_candidates_panel_applylistsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L494",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showempty",
@@ -103457,7 +104525,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L103",
+      "source_location": "L449",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_applylistsuccess",
+      "_tgt": "review_candidates_panel_hidetable",
+      "source": "review_candidates_panel_hidetable",
+      "target": "review_candidates_panel_applylistsuccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L493",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_hidetable",
@@ -103469,7 +104549,139 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L144",
+      "source_location": "L518",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_initreviewcandidatespanel",
+      "_tgt": "review_candidates_panel_clearreviewtabbadge",
+      "source": "review_candidates_panel_clearreviewtabbadge",
+      "target": "review_candidates_panel_initreviewcandidatespanel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L480",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_setreviewtabbadge",
+      "source": "review_candidates_panel_setreviewtabbadge",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L478",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_shownewcandidatestoast",
+      "source": "review_candidates_panel_shownewcandidatestoast",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L412",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_registervisibilityforpoll",
+      "_tgt": "review_candidates_panel_runpolltick",
+      "source": "review_candidates_panel_registervisibilityforpoll",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L421",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_startpollingifneeded",
+      "_tgt": "review_candidates_panel_registervisibilityforpoll",
+      "source": "review_candidates_panel_registervisibilityforpoll",
+      "target": "review_candidates_panel_startpollingifneeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L426",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_startpollingifneeded",
+      "_tgt": "review_candidates_panel_runpolltick",
+      "source": "review_candidates_panel_startpollingifneeded",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L510",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadlist",
+      "_tgt": "review_candidates_panel_startpollingifneeded",
+      "source": "review_candidates_panel_startpollingifneeded",
+      "target": "review_candidates_panel_loadlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L462",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "source": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L500",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadlist",
+      "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "source": "review_candidates_panel_fetchreviewcandidatelistjson",
+      "target": "review_candidates_panel_loadlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L483",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_applylistsuccess",
+      "source": "review_candidates_panel_applylistsuccess",
+      "target": "review_candidates_panel_runpolltick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L509",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_loadlist",
+      "_tgt": "review_candidates_panel_applylistsuccess",
+      "source": "review_candidates_panel_applylistsuccess",
+      "target": "review_candidates_panel_loadlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L525",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel_loadlist",

--- a/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
+++ b/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
@@ -32,6 +32,16 @@ describe('dashboard review candidates panel (#252, #253)', () => {
     expect(panelJs).toContain('/admin/memory/items/');
     expect(panelJs).toContain('initReviewCandidatesPanel');
   });
+
+  it('review-candidates-panel.js POST review/dismiss paths and dashboard preview actions (#254)', () => {
+    expect(panelJs).toContain('/admin/memory/review-candidates/');
+    expect(panelJs).toContain('encodeURIComponent');
+    expect(panelJs).toContain("postCandidateAction('review')");
+    expect(panelJs).toContain("postCandidateAction('dismiss')");
+    expect(dashboardHtml).toContain('id="rc-preview-actions"');
+    expect(dashboardHtml).toContain('id="rc-btn-review"');
+    expect(dashboardHtml).toContain('id="rc-btn-dismiss"');
+  });
 });
 
 describe('dashboard review queue poll notify (#255)', () => {

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -849,6 +849,18 @@ body {
   overflow: auto;
 }
 
+.rc-preview-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.rc-preview-actions[aria-busy='true'] {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
 .review-candidates-table tbody tr.rc-row--selected {
   box-shadow: inset 3px 0 0 0 var(--color-brand-primary);
   background: var(--color-bg-card);

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -200,6 +200,10 @@
                 </dl>
                 <p id="rc-preview-memory-status" class="rc-preview-memory-status" aria-live="polite"></p>
                 <pre id="rc-preview-content" class="rc-preview-content"></pre>
+                <div id="rc-preview-actions" class="rc-preview-actions" aria-busy="false">
+                  <button type="button" id="rc-btn-review" class="m-button m-button--secondary" disabled>Review</button>
+                  <button type="button" id="rc-btn-dismiss" class="m-button m-button--secondary" disabled>Dismiss</button>
+                </div>
               </div>
             </div>
           </aside>

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -15,6 +15,7 @@
   let visListenerRegistered = false;
   let lastPendingCount = -1;
   let toastHideTimer = null;
+  let actionInFlight = false;
 
   function $(id) {
     return document.getElementById(id);
@@ -71,6 +72,104 @@
     return '/admin/memory/items/' + encodeURIComponent(memoryId);
   }
 
+  function reviewCandidatePostUrl(id, action) {
+    return '/admin/memory/review-candidates/' + encodeURIComponent(id) + '/' + encodeURIComponent(action);
+  }
+
+  function getPreviewActionsEl() {
+    return $('rc-preview-actions');
+  }
+
+  function setPreviewActionsBusy(busy) {
+    const review = $('rc-btn-review');
+    const dismiss = $('rc-btn-dismiss');
+    if (review) {
+      review.disabled = !!busy;
+    }
+    if (dismiss) {
+      dismiss.disabled = !!busy;
+    }
+  }
+
+  function syncReviewDismissButtons() {
+    const wrap = getPreviewActionsEl();
+    if (!wrap) {
+      return;
+    }
+    const cid = selectedRow && selectedRow.dataset ? selectedRow.dataset.candidateId : '';
+    const has = !!cid;
+    setHidden(wrap, !has);
+    const busy = actionInFlight;
+    const review = $('rc-btn-review');
+    const dismiss = $('rc-btn-dismiss');
+    if (review) {
+      review.disabled = !has || busy;
+    }
+    if (dismiss) {
+      dismiss.disabled = !has || busy;
+    }
+  }
+
+  function showActionToast(message, _ok) {
+    const t = $('rc-toast');
+    if (!t) {
+      return;
+    }
+    t.textContent = message;
+    t.classList.remove('hidden');
+    if (toastHideTimer) {
+      clearTimeout(toastHideTimer);
+    }
+    toastHideTimer = setTimeout(function () {
+      t.classList.add('hidden');
+      t.textContent = '';
+      toastHideTimer = null;
+    }, 8000);
+  }
+
+  async function postCandidateAction(action) {
+    if (actionInFlight) {
+      return;
+    }
+    const tr = selectedRow;
+    const id = tr && tr.dataset ? tr.dataset.candidateId : '';
+    if (!id) {
+      showActionToast('No candidate selected.', false);
+      return;
+    }
+    actionInFlight = true;
+    setPreviewActionsBusy(true);
+    try {
+      const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+      const url = reviewCandidatePostUrl(id, action);
+      const res = await fetchFn(url, {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const body = await res.json().catch(function () {
+        return {};
+      });
+      if (!res.ok) {
+        const msg = (body && (body.error || body.message)) || 'HTTP ' + res.status;
+        showActionToast(String(msg), false);
+        return;
+      }
+      showActionToast(action === 'review' ? 'Marked reviewed.' : 'Dismissed.', true);
+      clearRowSelection();
+      resetPreviewPanel();
+      syncReviewDismissButtons();
+      loadedOnce = true;
+      await loadList();
+    } catch (e) {
+      showActionToast(e instanceof Error ? e.message : 'Network error', false);
+    } finally {
+      actionInFlight = false;
+      setPreviewActionsBusy(false);
+      syncReviewDismissButtons();
+    }
+  }
+
   function clearRowSelection() {
     if (selectedRow) {
       selectedRow.classList.remove('rc-row--selected');
@@ -96,6 +195,7 @@
     if (content) {
       content.textContent = '';
     }
+    syncReviewDismissButtons();
   }
 
   function setPreviewCandidateFields(priority, reason, due, memoryId) {
@@ -173,6 +273,7 @@
     }
     setPreviewCandidateFields(tr.dataset.priority, tr.dataset.reason, tr.dataset.due, tr.dataset.memoryId);
     loadMemoryPreview(tr.dataset.memoryId);
+    syncReviewDismissButtons();
   }
 
   function wireTableBody() {
@@ -217,6 +318,8 @@
       const memoryId = String(c.memory_id ?? '');
       const reasonFull = String(c.reason ?? '');
       const dueRaw = String(c.due_at ?? '');
+      const candidateId = String(c.id ?? '');
+      tr.dataset.candidateId = candidateId;
       tr.className = 'rc-row--clickable';
       tr.setAttribute('role', 'button');
       tr.setAttribute('tabindex', '0');
@@ -429,6 +532,18 @@
         btn.addEventListener('click', function () {
           loadedOnce = true;
           loadList();
+        });
+      }
+      const btnReview = $('rc-btn-review');
+      if (btnReview) {
+        btnReview.addEventListener('click', function () {
+          void postCandidateAction('review');
+        });
+      }
+      const btnDismiss = $('rc-btn-dismiss');
+      if (btnDismiss) {
+        btnDismiss.addEventListener('click', function () {
+          void postCandidateAction('dismiss');
         });
       }
     }

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -73,7 +73,7 @@
   }
 
   function reviewCandidatePostUrl(id, action) {
-    return '/admin/memory/review-candidates/' + encodeURIComponent(id) + '/' + encodeURIComponent(action);
+    return '/admin/memory/review-candidates/' + encodeURIComponent(id) + '/' + action;
   }
 
   function getPreviewActionsEl() {
@@ -81,36 +81,28 @@
   }
 
   function setPreviewActionsBusy(busy) {
-    const review = $('rc-btn-review');
-    const dismiss = $('rc-btn-dismiss');
-    if (review) {
-      review.disabled = !!busy;
-    }
-    if (dismiss) {
-      dismiss.disabled = !!busy;
+    const wrap = getPreviewActionsEl();
+    if (wrap) {
+      wrap.setAttribute('aria-busy', busy ? 'true' : 'false');
     }
   }
 
   function syncReviewDismissButtons() {
-    const wrap = getPreviewActionsEl();
-    if (!wrap) {
-      return;
+    const reviewBtn = $('rc-btn-review');
+    const dismissBtn = $('rc-btn-dismiss');
+    const id = selectedRow && selectedRow.dataset.candidateId ? String(selectedRow.dataset.candidateId) : '';
+    const detail = $('rc-preview-detail');
+    const visible = detail && !detail.classList.contains('hidden');
+    const enable = !!(id && visible && !actionInFlight);
+    if (reviewBtn) {
+      reviewBtn.disabled = !enable;
     }
-    const cid = selectedRow && selectedRow.dataset ? selectedRow.dataset.candidateId : '';
-    const has = !!cid;
-    setHidden(wrap, !has);
-    const busy = actionInFlight;
-    const review = $('rc-btn-review');
-    const dismiss = $('rc-btn-dismiss');
-    if (review) {
-      review.disabled = !has || busy;
-    }
-    if (dismiss) {
-      dismiss.disabled = !has || busy;
+    if (dismissBtn) {
+      dismissBtn.disabled = !enable;
     }
   }
 
-  function showActionToast(message, _ok) {
+  function showActionToast(message) {
     const t = $('rc-toast');
     if (!t) {
       return;
@@ -124,24 +116,21 @@
       t.classList.add('hidden');
       t.textContent = '';
       toastHideTimer = null;
-    }, 8000);
+    }, 4000);
   }
 
   async function postCandidateAction(action) {
-    if (actionInFlight) {
-      return;
-    }
-    const tr = selectedRow;
-    const id = tr && tr.dataset ? tr.dataset.candidateId : '';
-    if (!id) {
-      showActionToast('No candidate selected.', false);
+    const id = selectedRow && selectedRow.dataset.candidateId ? String(selectedRow.dataset.candidateId) : '';
+    if (!id || actionInFlight) {
       return;
     }
     actionInFlight = true;
     setPreviewActionsBusy(true);
+    syncReviewDismissButtons();
+    showError('');
+    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+    const url = reviewCandidatePostUrl(id, action);
     try {
-      const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
-      const url = reviewCandidatePostUrl(id, action);
       const res = await fetchFn(url, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
@@ -151,18 +140,20 @@
         return {};
       });
       if (!res.ok) {
-        const msg = (body && (body.error || body.message)) || 'HTTP ' + res.status;
-        showActionToast(String(msg), false);
+        const msg =
+          (body && (body.error || body.message)) ||
+          (res.status === 409
+            ? 'This candidate can no longer be updated (conflict).'
+            : res.status === 404
+              ? 'Review candidate not found.'
+              : 'HTTP ' + res.status);
+        showError(String(msg));
         return;
       }
-      showActionToast(action === 'review' ? 'Marked reviewed.' : 'Dismissed.', true);
-      clearRowSelection();
-      resetPreviewPanel();
-      syncReviewDismissButtons();
-      loadedOnce = true;
+      showActionToast(action === 'review' ? 'Marked as reviewed.' : 'Dismissed.');
       await loadList();
     } catch (e) {
-      showActionToast(e instanceof Error ? e.message : 'Network error', false);
+      showError(e instanceof Error ? e.message : 'Network error');
     } finally {
       actionInFlight = false;
       setPreviewActionsBusy(false);


### PR DESCRIPTION
## 변경 사항

대시보드 **Review Queue** 탭에서 pending 후보 행을 선택한 뒤, 프리뷰 패널의 **Review** / **Dismiss** 버튼으로 `POST /admin/memory/review-candidates/:id/review|dismiss`를 호출할 수 있게 했습니다. 성공 시에는 기존과 동일하게 `GET ...?status=pending`으로 **목록 전량 재조회**합니다. 실패 시에는 `#rc-error`에 서버 메시지(또는 404/409 기본 문구)를 표시하고, 요청 중에는 `aria-busy`와 버튼 비활성으로 중복 제출을 막습니다.

## 변경 유형

- [x] ✨ 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능)
- [x] ✅ 테스트 추가/수정

## 관련 이슈

- Closes #254
- Related to #245 #252 #253

## 설계·계획

- `docs/superpowers/specs/2026-05-04-issue-254-review-dismiss-ui-design.md`
- `docs/superpowers/plans/2026-05-04-issue-254-review-dismiss-ui.md`

## 테스트

1. `npm run dev:http` 등으로 HTTP 대시보드 실행 후 Review Queue 탭에서 행 선택 → Review 또는 Dismiss 클릭.
2. 자동: `npx vitest run packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts`

### 테스트 결과

- [x] `dashboard-review-candidates-panel.spec.ts` 통과 (Vitest)
- [ ] 수동 UI 확인 (Draft — 리뷰어 확인 권장)

## 지식 복리

해당 없음 (요청 범위 내 UI 연동 및 정적 회귀 테스트).
