### PR TITLE
feat(dashboard): Review Queue 폴링·오류 백오프 설정화 (#274)

### DIFF
--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -853,6 +853,17 @@ Content-Type: application/json
 | `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` (24h) | Scheduler interval for `memory_review_candidates` in ms (minimum `60000`) |
 | `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | Days added to “now” when the batch computes each row’s `due_at` (1–366) |
 
+
+The dashboard **Review Queue** tab reads polling options from an inline `window.__MEMENTO_REVIEW_QUEUE__` object injected on `GET /dashboard` (GitHub #274).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS` | `60000` | Delay between successful background polls (ms). Invalid/absent values behave like `60000`. The server **clamps** to **10000**–**86400000** (1 day). |
+| `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS` | (empty) | Backoff delays after a failed poll attempt, comma-separated (e.g. `60000,120000`). When empty, failures retry on the same interval as successes. Each step is **clamped** to **10000**–**86400000**. |
+
+**Recommendation:** keep the default 60s or increase it for quieter traffic; add gentle error backoff only if your environment sees intermittent admin errors (for example `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS=60000,120000`). Do not confuse this with the batch scheduler variable `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS`.
+
+
 Tune **selection sensitivity** with the first three variables; tune **schedule cadence and due dates** with the last two.
 
 ### Performance Monitoring API

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -975,6 +975,17 @@ Content-Type: application/json
 
 운영 시 **후보 선정 민감도**는 위 표의 앞 세 변수로, **스케줄 간격·마감 시각**은 마지막 두 변수로 조정합니다.
 
+대시보드 **Review Queue** 탭의 백그라운드 폴링은 HTTP 서버가 `GET /dashboard` HTML에 `window.__MEMENTO_REVIEW_QUEUE__`를 인라인으로 주입해 적용합니다(GitHub #274).
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS` | `60000` | 성공한 폴링 사이의 대기 시간(ms). 잘못된 값·미설정은 `60000`과 동일하게 취급. 서버는 **10000**~**86400000**(1일)로 클램프 |
+| `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS` | (비어 있음) | 연속 폴링 실패 시 대기(ms). 쉼표 구분 목록(예: `60000,120000`). 비어 있으면 실패 후에도 성공 시와 동일 간격(`MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS`)으로만 재시도. 각 값도 **10000**~**86400000**로 클램프 |
+
+**권장:** 운영에서는 기본 60초를 유지하거나 늘리고, 오류 시에만 완만한 백오프를 두려면 `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS=60000,120000`처럼 설정합니다(배치 `memory_review_candidates`와 혼동하지 말 것).
+
+
+
 ### 성능 모니터링 API
 
 #### 성능 통계

--- a/docs/superpowers/specs/2026-05-03-issue-255-review-notify-polling-design.md
+++ b/docs/superpowers/specs/2026-05-03-issue-255-review-notify-polling-design.md
@@ -49,7 +49,7 @@
 
 **상수**
 
-- `POLL_INTERVAL_MS = 60_000` (1분). 필요 시 환경별 조정은 후속 이슈.
+- 기본 폴링 간격은 **60초**(클라이언트 폴백 및 서버 미주입 시). 운영 조정은 **#274**: `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS`, `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS`(선택) 및 `docs/api/*/api-reference.md` 참고.
 
 **제한**
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-05)
 
 ## Corpus Check
-- 912 files · ~1,343,689 words
+- 914 files · ~1,345,425 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4636 nodes · 5710 edges · 909 communities detected
+- 4648 nodes · 5732 edges · 911 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -919,6 +919,8 @@
 - [[_COMMUNITY_Community 906|Community 906]]
 - [[_COMMUNITY_Community 907|Community 907]]
 - [[_COMMUNITY_Community 908|Community 908]]
+- [[_COMMUNITY_Community 909|Community 909]]
+- [[_COMMUNITY_Community 910|Community 910]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -958,12 +960,12 @@ Cohesion: 0.1
 Nodes (3): CacheService, EmbeddingCacheService, SearchCacheService
 
 ### Community 5 - "Community 5"
-Cohesion: 0.08
-Nodes (22): calculateKendallTau(), calculateQualityDegradation(), calculateRanks(), calculateSpearmanRho(), calculateTopKRetention(), compareQualityWithGroundTruth(), detectAndAlertQualityDegradation(), detectQualityDegradation() (+14 more)
+Cohesion: 0.15
+Nodes (39): $(), applyListSuccess(), clearPollTimer(), clearReviewTabBadge(), clearRowSelection(), clearStatus(), escapeAttr(), escapeHtml() (+31 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.17
-Nodes (35): $(), applyListSuccess(), clearReviewTabBadge(), clearRowSelection(), clearStatus(), escapeAttr(), escapeHtml(), fetchReviewCandidateListJson() (+27 more)
+Cohesion: 0.08
+Nodes (22): calculateKendallTau(), calculateQualityDegradation(), calculateRanks(), calculateSpearmanRho(), calculateTopKRetention(), compareQualityWithGroundTruth(), detectAndAlertQualityDegradation(), detectQualityDegradation() (+14 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.11
@@ -1794,128 +1796,128 @@ Cohesion: 0.29
 Nodes (0): 
 
 ### Community 214 - "Community 214"
-Cohesion: 0.29
-Nodes (0): 
+Cohesion: 0.52
+Nodes (6): buildReviewQueueBootInjectionHtml(), clampIntervalMs(), injectReviewQueueBootIntoDashboardHtml(), parseBackoffCsv(), parsePositiveIntMs(), resolveReviewQueueDashboardBootFromEnv()
 
 ### Community 215 - "Community 215"
-Cohesion: 0.43
-Nodes (1): MigrationDetector
+Cohesion: 0.29
+Nodes (0): 
 
 ### Community 216 - "Community 216"
 Cohesion: 0.43
-Nodes (1): BackfillKgTripleFromMemoryItemMigration
+Nodes (1): MigrationDetector
 
 ### Community 217 - "Community 217"
+Cohesion: 0.43
+Nodes (1): BackfillKgTripleFromMemoryItemMigration
+
+### Community 218 - "Community 218"
 Cohesion: 0.38
 Nodes (3): parseJsonArray(), ProcessAttributeRepositorySqlite, stringifyJsonArray()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.48
 Nodes (6): computeJsonHash(), computeReflectionNotesCount(), createProceduralMemorySnapshot(), hasProceduralMemoryChanged(), isEqual(), normalizeJson()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.48
 Nodes (5): containsPathTraversal(), getAllowedDirs(), isAbsolutePath(), isWithinAllowedDirs(), validateFilePath()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.38
 Nodes (1): PromptTemplateLoader
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.29
 Nodes (1): QueryFilterService
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (2): MigrationValidator, VectorSearchEngineMigration
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.38
 Nodes (1): VectorPerformanceTester
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (1): VectorIndexManager
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.38
 Nodes (1): SemanticMemoryStatisticsService
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.48
 Nodes (1): ClusteringService
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (2): createMockEmbeddingService(), getMockEmbeddingFunctions()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.48
 Nodes (4): checkOllamaModelInstalled(), extractRawWithOllama(), getStringField(), isRecord()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.38
 Nodes (3): executeTool(), resolveTelemetryOwnerId(), telemetryParamsContext()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.71
 Nodes (6): createAnchorTable(), expect(), runAllTests(), testAnchorSystemWorkflow(), testFallbackMechanism(), testMultiClientScenario()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.52
 Nodes (6): calculateRecency(), generateRecencyData(), main(), printConsoleGraph(), printCSV(), printKeyPoints()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.57
 Nodes (6): compareWithAndWithoutConsolidation(), convertToSearchResults(), generateGroundTruth(), measureSearchQuality(), testConsolidationSearchQuality(), verifyRankingOrder()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.57
 Nodes (6): buildReviewChecklistMarkdown(), findGroundTruth(), loadLabelCandidates(), renderCandidate(), renderRelevantEntry(), summarizeContent()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.48
 Nodes (4): expectExactScript(), normalizeCommand(), readScript(), splitSequentialCommands()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.48
 Nodes (5): buildMemoryIdToBenchmarkIdMap(), main(), parseArgs(), printHelp(), sampleDeterministicNegatives()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.52
 Nodes (6): assertRankingProfileFilesExist(), main(), mean(), pairedPermutationPValue(), parseArgs(), runProfile()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.52
 Nodes (6): extractKeywordsFromMemories(), generateGroundTruthFromSearch(), getMemoryIds(), main(), parseArgs(), printHelp()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.48
 Nodes (6): callHttpTool(), checkServerHealth(), getHttpTools(), handleRequest(), main(), sendResponse()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.52
 Nodes (6): booleanFromEnv(), defaultLogsRoot(), labelsFromEnv(), loadMonitorConfig(), numberFromEnv(), optionalString()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (1): CircuitBreaker
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.6
 Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkLinks(), buildNetworkNodesAndLinks()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (4): errorHandler(), isAppErrorContract(), resolveSeverityAndCategory(), resolveStatusCode()
-
-### Community 244 - "Community 244"
-Cohesion: 0.47
-Nodes (3): cleanupTestDatabase(), createTestDatabaseWithoutServices(), setupTestDatabase()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.4
@@ -2026,44 +2028,44 @@ Cohesion: 0.47
 Nodes (1): MigrateEmbeddingsTool
 
 ### Community 272 - "Community 272"
-Cohesion: 0.6
-Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
+Cohesion: 0.47
+Nodes (3): cleanupTestDatabase(), createTestDatabaseWithoutServices(), setupTestDatabase()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.6
-Nodes (5): readDockerLogs(), readJsonlFiles(), resolveDockerLogsRef(), runDocker(), splitJsonlLines()
+Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
 
 ### Community 274 - "Community 274"
+Cohesion: 0.6
+Nodes (5): readDockerLogs(), readJsonlFiles(), resolveDockerLogsRef(), runDocker(), splitJsonlLines()
+
+### Community 275 - "Community 275"
 Cohesion: 0.4
 Nodes (2): emptyState(), loadState()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.6
 Nodes (5): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), truncateTitle()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.8
 Nodes (5): buildRequestOptions(), getDashboardAuth(), mementoAdminFetch(), performFetch(), waitForSession()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.6
 Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 280 - "Community 280"
-Cohesion: 0.4
-Nodes (1): SseServer
-
 ### Community 281 - "Community 281"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): SseServer
 
 ### Community 282 - "Community 282"
 Cohesion: 0.4
@@ -2094,20 +2096,20 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 289 - "Community 289"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 290 - "Community 290"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 291 - "Community 291"
-Cohesion: 0.5
-Nodes (2): getStopWords(), isStopWord()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): getStopWords(), isStopWord()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
@@ -2118,88 +2120,88 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 295 - "Community 295"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 296 - "Community 296"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 297 - "Community 297"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 298 - "Community 298"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 302 - "Community 302"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 303 - "Community 303"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 304 - "Community 304"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 306 - "Community 306"
+Cohesion: 0.4
+Nodes (1): TokenBucketRateLimiter
+
+### Community 307 - "Community 307"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.7
 Nodes (4): recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 315 - "Community 315"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 316 - "Community 316"
 Cohesion: 0.5
@@ -2215,23 +2217,23 @@ Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 320 - "Community 320"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): BraveSearchProvider
 
 ### Community 321 - "Community 321"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 322 - "Community 322"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 322 - "Community 322"
-Cohesion: 0.5
-Nodes (1): DatabaseOptimizeTool
-
 ### Community 323 - "Community 323"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): DatabaseOptimizeTool
 
 ### Community 324 - "Community 324"
 Cohesion: 0.5
@@ -2251,155 +2253,155 @@ Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.5
-Nodes (1): RelationValidatorExecutor
+Nodes (0): 
 
 ### Community 329 - "Community 329"
 Cohesion: 0.5
-Nodes (1): QualityMeasurementBatchJob
+Nodes (1): RelationValidatorExecutor
 
 ### Community 330 - "Community 330"
 Cohesion: 0.5
-Nodes (1): SleepConsolidationBatchJob
+Nodes (1): QualityMeasurementBatchJob
 
 ### Community 331 - "Community 331"
 Cohesion: 0.5
-Nodes (1): TelemetryCleanupBatchJob
+Nodes (1): SleepConsolidationBatchJob
 
 ### Community 332 - "Community 332"
+Cohesion: 0.5
+Nodes (1): TelemetryCleanupBatchJob
+
+### Community 333 - "Community 333"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 334 - "Community 334"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 335 - "Community 335"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 336 - "Community 336"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 337 - "Community 337"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 338 - "Community 338"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 339 - "Community 339"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 340 - "Community 340"
 Cohesion: 0.5
-Nodes (1): SearchResultCombiner
+Nodes (1): RestoreAnchorsTool
 
 ### Community 341 - "Community 341"
+Cohesion: 0.5
+Nodes (1): SearchResultCombiner
+
+### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (2): computeProcessAttributeFit(), toSet()
 
-### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 343 - "Community 343"
 Cohesion: 0.5
-Nodes (1): ForgettingStatsTool
+Nodes (0): 
 
 ### Community 344 - "Community 344"
 Cohesion: 0.5
-Nodes (1): GetTelemetrySummaryTool
+Nodes (1): ForgettingStatsTool
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): GetTelemetrySummaryTool
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 348 - "Community 348"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 349 - "Community 349"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 352 - "Community 352"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 353 - "Community 353"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 356 - "Community 356"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 358 - "Community 358"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 362 - "Community 362"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 363 - "Community 363"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 363 - "Community 363"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 364 - "Community 364"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 366 - "Community 366"
 Cohesion: 0.5
@@ -2407,15 +2409,15 @@ Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 368 - "Community 368"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
@@ -2430,20 +2432,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 373 - "Community 373"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 374 - "Community 374"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 376 - "Community 376"
+### Community 374 - "Community 374"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 375 - "Community 375"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 376 - "Community 376"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 377 - "Community 377"
 Cohesion: 0.83
@@ -2455,79 +2457,79 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 380 - "Community 380"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 381 - "Community 381"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 382 - "Community 382"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 386 - "Community 386"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 387 - "Community 387"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 390 - "Community 390"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 391 - "Community 391"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 392 - "Community 392"
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 395 - "Community 395"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 396 - "Community 396"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
@@ -2535,27 +2537,27 @@ Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 400 - "Community 400"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 401 - "Community 401"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 403 - "Community 403"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
-
-### Community 404 - "Community 404"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 404 - "Community 404"
+Cohesion: 1.0
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
@@ -2570,16 +2572,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 408 - "Community 408"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 409 - "Community 409"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 410 - "Community 410"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
@@ -2599,11 +2601,11 @@ Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Nodes (0): 
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
@@ -2611,19 +2613,19 @@ Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 419 - "Community 419"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 420 - "Community 420"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 421 - "Community 421"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
@@ -2650,28 +2652,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 428 - "Community 428"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 429 - "Community 429"
 Cohesion: 1.0
 Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): createMetrics(), toBytes()
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Nodes (2): createMetrics(), toBytes()
 
 ### Community 432 - "Community 432"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 433 - "Community 433"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
@@ -2682,32 +2684,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 436 - "Community 436"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 437 - "Community 437"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 438 - "Community 438"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 439 - "Community 439"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 440 - "Community 440"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 441 - "Community 441"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 442 - "Community 442"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 443 - "Community 443"
 Cohesion: 1.0
@@ -4573,942 +4575,952 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 909 - "Community 909"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 910 - "Community 910"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 442`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 443`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 444`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 445`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 446`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 447`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 448`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 449`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 450`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 451`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 452`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 453`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 454`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 455`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 456`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 457`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 458`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 459`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 460`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 461`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 462`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 463`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 464`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 465`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 466`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 467`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 468`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 469`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 470`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 471`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 472`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 473`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 474`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 475`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 476`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 477`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 478`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 479`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 480`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 481`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 482`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 483`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 484`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 485`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 486`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 487`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 488`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 489`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 490`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 491`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 492`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 493`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 494`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 495`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 496`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 497`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 498`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 499`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 500`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `migrateDatabase()`, `migrate.ts`
+- **Thin community `Community 501`** (2 nodes): `migrateDatabase()`, `migrate.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 502`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 503`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 504`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 505`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 506`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 507`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 508`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 509`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 510`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 511`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 512`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 513`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 514`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 515`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 516`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 517`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 518`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 519`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 520`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 521`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 522`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 523`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 524`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 525`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 526`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `isMemoryItemType()`, `index.ts`
+- **Thin community `Community 527`** (2 nodes): `isMemoryItemType()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 528`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 529`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 530`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 531`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 532`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 533`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 534`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 535`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 536`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 537`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 538`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 539`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 540`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 543`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 544`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 545`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 549`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 554`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 555`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 557`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 558`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 559`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 560`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 561`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 562`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 563`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 564`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 565`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 566`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 567`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 568`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 569`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 570`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 571`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 572`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 573`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 574`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 575`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 576`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 577`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 578`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 579`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 580`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 581`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 582`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 583`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 584`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 585`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 586`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 587`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 588`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 589`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 591`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 592`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 594`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 595`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 596`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 597`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 598`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 599`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 600`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 601`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 602`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 603`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 604`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 605`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 606`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 607`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 608`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 609`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 610`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 612`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 613`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 614`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 615`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 616`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 617`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 618`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 619`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 620`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 621`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `types.ts`
+- **Thin community `Community 622`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 623`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `index.ts`
+- **Thin community `Community 624`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 625`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 626`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 627`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 628`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 629`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 630`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `transport.ts`
+- **Thin community `Community 631`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `index.ts`
+- **Thin community `Community 632`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 633`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 634`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 635`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 636`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 637`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 638`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 639`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 640`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 641`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 642`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 643`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 644`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 645`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 646`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 647`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 648`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 649`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 650`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 651`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 652`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 653`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 654`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 655`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 656`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 657`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 658`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `context.ts`
+- **Thin community `Community 659`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 660`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 661`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 662`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 663`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `index.ts`
+- **Thin community `Community 664`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 665`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 666`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `types.ts`
+- **Thin community `Community 667`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 668`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 669`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 670`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 671`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 672`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 673`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 674`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 675`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 676`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 677`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 678`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `index.ts`
+- **Thin community `Community 679`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `types.ts`
+- **Thin community `Community 689`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 696`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 706`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 723`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 724`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 725`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 726`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 727`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 728`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 729`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 730`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 731`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 732`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 733`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `error-types.ts`
+- **Thin community `Community 734`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 735`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 736`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `search.types.ts`
+- **Thin community `Community 737`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 739`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `constants.ts`
+- **Thin community `Community 740`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 741`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 748`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 749`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 751`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 752`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 753`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 754`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 755`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 756`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 757`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 758`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 759`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 760`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 776`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 777`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `index.ts`
+- **Thin community `Community 779`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `database-types.ts`
+- **Thin community `Community 781`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 784`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 785`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 786`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 787`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 790`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 792`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 797`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `index.ts`
+- **Thin community `Community 801`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 802`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 804`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 805`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 806`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 807`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 808`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 812`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 814`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 816`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 823`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 824`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `index.ts`
+- **Thin community `Community 833`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 835`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 845`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `types.ts`
+- **Thin community `Community 869`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 871`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 873`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 874`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 875`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 882`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 883`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 885`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 886`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 895`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `types.ts`
+- **Thin community `Community 896`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 909`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 910`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -5526,5 +5538,5 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.07 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
+- **Should `Community 6` be split into smaller, more focused modules?**
   _Cohesion score 0.08 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "vitest.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "assistant.spec.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "types.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "types.spec.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "assistant.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "SlowTransport",
@@ -137,7 +137,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".recall()",
@@ -145,7 +145,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 385
+      "community": 386
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "after-assistant-turn.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "afterAssistantTurn()",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 442
+      "community": 443
     },
     {
       "label": "before-user-turn.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "beforeUserTurn()",
@@ -185,7 +185,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 386
+      "community": 387
     },
     {
       "label": "withTimeout()",
@@ -193,7 +193,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 386
+      "community": 387
     },
     {
       "label": "auto-recall-policy.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "shouldAutoRecall()",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 443
+      "community": 444
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "auto-remember-policy.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "rememberDispatch()",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 444
+      "community": 445
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "channel-scope.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "scopeRecallFilters()",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 387
+      "community": 388
     },
     {
       "label": "scopeRememberTags()",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 387
+      "community": 388
     },
     {
       "label": "channel-scope.spec.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "http-transport.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "mock-transport.spec.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "transport.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "http-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "factory.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createTransportFromEnv()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 445
+      "community": 446
     },
     {
       "label": "stdio-transport.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "mock-transport.ts",
@@ -529,7 +529,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_ts",
-      "community": 240
+      "community": 241
     },
     {
       "label": "CircuitBreaker",
@@ -537,7 +537,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L8",
       "id": "circuit_breaker_circuitbreaker",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".constructor()",
@@ -545,7 +545,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L12",
       "id": "circuit_breaker_circuitbreaker_constructor",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".canPass()",
@@ -553,7 +553,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L14",
       "id": "circuit_breaker_circuitbreaker_canpass",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".recordSuccess()",
@@ -561,7 +561,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L27",
       "id": "circuit_breaker_circuitbreaker_recordsuccess",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".recordFailure()",
@@ -569,7 +569,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L32",
       "id": "circuit_breaker_circuitbreaker_recordfailure",
-      "community": 240
+      "community": 241
     },
     {
       "label": "logger.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "createRateLimitedLogger()",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 312
+      "community": 313
     },
     {
       "label": "levelFromEnv()",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 312
+      "community": 313
     },
     {
       "label": "consoleSink()",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 312
+      "community": 313
     },
     {
       "label": "logger.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "retry-queue.spec.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "retry-queue.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "http.integration.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "start-http-server.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "startTestHttpServer()",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 313
+      "community": 314
     },
     {
       "label": "findFreePort()",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 313
+      "community": 314
     },
     {
       "label": "waitForHealth()",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 313
+      "community": 314
     },
     {
       "label": "http-server-runner.js",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 645
+      "community": 646
     },
     {
       "label": "test-integration.js",
@@ -905,7 +905,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 446
+      "community": 447
     },
     {
       "label": "testBasicFunctionality()",
@@ -913,7 +913,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 446
+      "community": 447
     },
     {
       "label": "performance-optimizer.js",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "basicUsageExample()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 447
+      "community": 448
     },
     {
       "label": "performance-examples.ts",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "advancedUsageExample()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 448
+      "community": 449
     },
     {
       "label": "migration-guide.ts",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "makeNullRunner()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 449
+      "community": 450
     },
     {
       "label": "telemetry-cli.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "getRepoRoot()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 314
+      "community": 315
     },
     {
       "label": "collectEnvKeys()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 314
+      "community": 315
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 314
+      "community": 315
     },
     {
       "label": "server-info.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createMockResponse()",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 388
+      "community": 389
     },
     {
       "label": "sendOptions()",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 388
+      "community": 389
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "index-factory.spec.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "context.spec.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "server-factory.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "createServerFactory()",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 450
+      "community": 451
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "readRepoFile()",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 389
+      "community": 390
     },
     {
       "label": "sectionBetween()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 389
+      "community": 390
     },
     {
       "label": "http-server.spec.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2153,7 +2153,63 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 653
+      "community": 654
+    },
+    {
+      "label": "review-queue-dashboard-boot.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "community": 214
+    },
+    {
+      "label": "parsePositiveIntMs()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L22",
+      "id": "review_queue_dashboard_boot_parsepositiveintms",
+      "community": 214
+    },
+    {
+      "label": "clampIntervalMs()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L33",
+      "id": "review_queue_dashboard_boot_clampintervalms",
+      "community": 214
+    },
+    {
+      "label": "parseBackoffCsv()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L37",
+      "id": "review_queue_dashboard_boot_parsebackoffcsv",
+      "community": 214
+    },
+    {
+      "label": "resolveReviewQueueDashboardBootFromEnv()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L52",
+      "id": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "community": 214
+    },
+    {
+      "label": "buildReviewQueueBootInjectionHtml()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L66",
+      "id": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
+      "community": 214
+    },
+    {
+      "label": "injectReviewQueueBootIntoDashboardHtml()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L71",
+      "id": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
+      "community": 214
     },
     {
       "label": "stdio-server-impl.ts",
@@ -2161,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "startStdioServer()",
@@ -2169,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 451
+      "community": 452
     },
     {
       "label": "server-factory.spec.ts",
@@ -2177,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "server-state.spec.ts",
@@ -2185,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2193,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_integration_spec_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "postJson()",
@@ -2201,7 +2257,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L11",
       "id": "auth_session_integration_spec_postjson",
-      "community": 277
+      "community": 278
     },
     {
       "label": "getJson()",
@@ -2209,7 +2265,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L52",
       "id": "auth_session_integration_spec_getjson",
-      "community": 277
+      "community": 278
     },
     {
       "label": "deleteRequest()",
@@ -2217,7 +2273,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L87",
       "id": "auth_session_integration_spec_deleterequest",
-      "community": 277
+      "community": 278
     },
     {
       "label": "startRealHttpServer()",
@@ -2225,7 +2281,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L126",
       "id": "auth_session_integration_spec_startrealhttpserver",
-      "community": 277
+      "community": 278
     },
     {
       "label": "mcp.routes.streamable-http.spec.ts",
@@ -2233,7 +2289,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2241,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 315
+      "community": 316
     },
     {
       "label": "postJsonRpc()",
@@ -2249,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 315
+      "community": 316
     },
     {
       "label": "openSse()",
@@ -2257,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 315
+      "community": 316
     },
     {
       "label": "index.ts",
@@ -2337,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2345,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2353,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 452
+      "community": 453
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2361,7 +2417,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createMockResponse()",
@@ -2369,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 390
+      "community": 391
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2377,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 390
+      "community": 391
     },
     {
       "label": "server-state.ts",
@@ -2508,12 +2564,20 @@
       "community": 50
     },
     {
+      "label": "review-queue-dashboard-boot.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
+      "community": 658
+    },
+    {
       "label": "bootstrap.ts",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 657
+      "community": 659
     },
     {
       "label": "index.spec.ts",
@@ -2521,7 +2585,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "sse-server-impl.ts",
@@ -2529,7 +2593,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "startSseServer()",
@@ -2537,7 +2601,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 316
+      "community": 317
     },
     {
       "label": "stopSseServer()",
@@ -2545,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 316
+      "community": 317
     },
     {
       "label": "cleanupSseServer()",
@@ -2553,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 316
+      "community": 317
     },
     {
       "label": "http-server.ts",
@@ -2567,7 +2631,7 @@
       "label": "setTestDependencies()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L71",
+      "source_location": "L75",
       "id": "http_server_settestdependencies",
       "community": 103
     },
@@ -2575,7 +2639,7 @@
       "label": "writeRuntimeDiagnosticsEvent()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L88",
+      "source_location": "L92",
       "id": "http_server_writeruntimediagnosticsevent",
       "community": 103
     },
@@ -2583,7 +2647,7 @@
       "label": "resolveStaticRoot()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L112",
+      "source_location": "L116",
       "id": "http_server_resolvestaticroot",
       "community": 103
     },
@@ -2591,7 +2655,7 @@
       "label": "isProtectedMcpProgrammaticPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L205",
+      "source_location": "L209",
       "id": "http_server_isprotectedmcpprogrammaticpath",
       "community": 103
     },
@@ -2599,7 +2663,7 @@
       "label": "getHttpAuthTrustModelNotice()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L209",
+      "source_location": "L213",
       "id": "http_server_gethttpauthtrustmodelnotice",
       "community": 103
     },
@@ -2607,7 +2671,7 @@
       "label": "getHttpAuthMissingAdminKeyWarning()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L213",
+      "source_location": "L217",
       "id": "http_server_gethttpauthmissingadminkeywarning",
       "community": 103
     },
@@ -2615,7 +2679,7 @@
       "label": "initializeServer()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L243",
+      "source_location": "L252",
       "id": "http_server_initializeserver",
       "community": 103
     },
@@ -2623,7 +2687,7 @@
       "label": "cleanup()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L362",
+      "source_location": "L371",
       "id": "http_server_cleanup",
       "community": 103
     },
@@ -2631,7 +2695,7 @@
       "label": "registerCleanupHandlers()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L434",
+      "source_location": "L443",
       "id": "http_server_registercleanuphandlers",
       "community": 103
     },
@@ -2639,7 +2703,7 @@
       "label": "startServer()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L616",
+      "source_location": "L625",
       "id": "http_server_startserver",
       "community": 103
     },
@@ -2649,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 659
+      "community": 661
     },
     {
       "label": "mcp-logger.ts",
@@ -2737,7 +2801,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_instance_lock_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "isProcessAlive()",
@@ -2745,7 +2809,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L21",
       "id": "instance_lock_isprocessalive",
-      "community": 278
+      "community": 279
     },
     {
       "label": "getLockFilePath()",
@@ -2753,7 +2817,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L33",
       "id": "instance_lock_getlockfilepath",
-      "community": 278
+      "community": 279
     },
     {
       "label": "tryAcquireLock()",
@@ -2761,7 +2825,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L45",
       "id": "instance_lock_tryacquirelock",
-      "community": 278
+      "community": 279
     },
     {
       "label": "releaseLock()",
@@ -2769,7 +2833,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L70",
       "id": "instance_lock_releaselock",
-      "community": 278
+      "community": 279
     },
     {
       "label": "cors-policy.ts",
@@ -2777,7 +2841,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -2785,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 391
+      "community": 392
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -2793,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 391
+      "community": 392
     },
     {
       "label": "cors-policy.spec.ts",
@@ -2801,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 660
+      "community": 662
     },
     {
       "label": "anchor-map.handler.ts",
@@ -2809,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "community": 241
+      "community": 242
     },
     {
       "label": "buildAnchorMapData()",
@@ -2817,7 +2881,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L57",
       "id": "anchor_map_handler_buildanchormapdata",
-      "community": 241
+      "community": 242
     },
     {
       "label": "buildNetworkNodesAndLinks()",
@@ -2825,7 +2889,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L101",
       "id": "anchor_map_handler_buildnetworknodesandlinks",
-      "community": 241
+      "community": 242
     },
     {
       "label": "buildNetworkLinks()",
@@ -2833,7 +2897,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L201",
       "id": "anchor_map_handler_buildnetworklinks",
-      "community": 241
+      "community": 242
     },
     {
       "label": "broadcastToSubscribers()",
@@ -2841,7 +2905,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L249",
       "id": "anchor_map_handler_broadcasttosubscribers",
-      "community": 241
+      "community": 242
     },
     {
       "label": "broadcastAnchorMapUpdate()",
@@ -2849,7 +2913,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L272",
       "id": "anchor_map_handler_broadcastanchormapupdate",
-      "community": 241
+      "community": 242
     },
     {
       "label": "tool-context-meta-memory-injection.spec.ts",
@@ -2857,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -2865,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 662
+      "community": 664
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -2873,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -2881,7 +2945,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "makeMocks()",
@@ -2889,7 +2953,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 453
+      "community": 454
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -2897,7 +2961,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
-      "community": 242
+      "community": 243
     },
     {
       "label": "writeDisabledResponse()",
@@ -2905,7 +2969,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L7",
       "id": "programmatic_auth_middleware_writedisabledresponse",
-      "community": 242
+      "community": 243
     },
     {
       "label": "writeUnauthorized()",
@@ -2913,7 +2977,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L15",
       "id": "programmatic_auth_middleware_writeunauthorized",
-      "community": 242
+      "community": 243
     },
     {
       "label": "readBearerToken()",
@@ -2921,7 +2985,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L23",
       "id": "programmatic_auth_middleware_readbearertoken",
-      "community": 242
+      "community": 243
     },
     {
       "label": "readApiKeyHeader()",
@@ -2929,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L33",
       "id": "programmatic_auth_middleware_readapikeyheader",
-      "community": 242
+      "community": 243
     },
     {
       "label": "createProgrammaticAuthMiddleware()",
@@ -2937,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L43",
       "id": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
-      "community": 242
+      "community": 243
     },
     {
       "label": "error-handler.middleware.ts",
@@ -2945,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_error_handler_middleware_ts",
-      "community": 243
+      "community": 244
     },
     {
       "label": "isAppErrorContract()",
@@ -2953,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L21",
       "id": "error_handler_middleware_isapperrorcontract",
-      "community": 243
+      "community": 244
     },
     {
       "label": "resolveSeverityAndCategory()",
@@ -2961,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L26",
       "id": "error_handler_middleware_resolveseverityandcategory",
-      "community": 243
+      "community": 244
     },
     {
       "label": "resolveStatusCode()",
@@ -2969,7 +3033,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L64",
       "id": "error_handler_middleware_resolvestatuscode",
-      "community": 243
+      "community": 244
     },
     {
       "label": "errorHandler()",
@@ -2977,7 +3041,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L84",
       "id": "error_handler_middleware_errorhandler",
-      "community": 243
+      "community": 244
     },
     {
       "label": "asyncHandler()",
@@ -2985,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L135",
       "id": "error_handler_middleware_asynchandler",
-      "community": 243
+      "community": 244
     },
     {
       "label": "tool-context.middleware.ts",
@@ -2993,7 +3057,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3001,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 454
+      "community": 455
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3009,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "createMockResponse()",
@@ -3017,7 +3081,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 455
+      "community": 456
     },
     {
       "label": "index.ts",
@@ -3025,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3033,7 +3097,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 317
+      "community": 318
     },
     {
       "label": "readCookie()",
@@ -3041,7 +3105,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 317
+      "community": 318
     },
     {
       "label": "writeUnauthorized()",
@@ -3049,7 +3113,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 317
+      "community": 318
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3057,7 +3121,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 317
+      "community": 318
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3065,7 +3129,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "createServiceInjector()",
@@ -3073,7 +3137,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 456
+      "community": 457
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3081,7 +3145,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3089,7 +3153,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 457
+      "community": 458
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3097,7 +3161,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createMockResponse()",
@@ -3105,7 +3169,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 458
+      "community": 459
     },
     {
       "label": "session-store.spec.ts",
@@ -3113,7 +3177,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "session-store.ts",
@@ -3121,7 +3185,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createSessionStore()",
@@ -3129,7 +3193,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 459
+      "community": 460
     },
     {
       "label": "stdio-server.ts",
@@ -3137,7 +3201,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "StdioServer",
@@ -3145,7 +3209,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".start()",
@@ -3153,7 +3217,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".stop()",
@@ -3161,7 +3225,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".cleanup()",
@@ -3169,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 279
+      "community": 280
     },
     {
       "label": "sse-server.ts",
@@ -3177,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "SseServer",
@@ -3185,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".start()",
@@ -3193,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".stop()",
@@ -3201,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".cleanup()",
@@ -3209,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 280
+      "community": 281
     },
     {
       "label": "test-database.ts",
@@ -3217,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_test_helpers_test_database_ts",
-      "community": 244
+      "community": 272
     },
     {
       "label": "setupTestDatabase()",
@@ -3225,7 +3289,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L14",
       "id": "test_database_setuptestdatabase",
-      "community": 244
+      "community": 272
     },
     {
       "label": "cleanupTestDatabase()",
@@ -3233,7 +3297,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L263",
       "id": "test_database_cleanuptestdatabase",
-      "community": 244
+      "community": 272
     },
     {
       "label": "quality.routes.spec.ts",
@@ -3241,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "admin.routes.ts",
@@ -3249,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 318
+      "community": 319
     },
     {
       "label": "parseCleanupParams()",
@@ -3257,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L39",
       "id": "admin_routes_parsecleanupparams",
-      "community": 318
+      "community": 319
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3265,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L67",
       "id": "admin_routes_parsereviewcandidatestatusquery",
-      "community": 318
+      "community": 319
     },
     {
       "label": "createAdminRouter()",
@@ -3273,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L83",
       "id": "admin_routes_createadminrouter",
-      "community": 318
+      "community": 319
     },
     {
       "label": "auth.routes.ts",
@@ -3281,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "readBearerToken()",
@@ -3289,7 +3353,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 281
+      "community": 282
     },
     {
       "label": "readApiKeyHeader()",
@@ -3297,7 +3361,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 281
+      "community": 282
     },
     {
       "label": "readCookie()",
@@ -3305,7 +3369,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 281
+      "community": 282
     },
     {
       "label": "createAuthRouter()",
@@ -3313,7 +3377,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 281
+      "community": 282
     },
     {
       "label": "mcp.routes.ts",
@@ -3369,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_spec_ts",
-      "community": 214
+      "community": 215
     },
     {
       "label": "listen()",
@@ -3377,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L25",
       "id": "admin_routes_spec_listen",
-      "community": 214
+      "community": 215
     },
     {
       "label": "postAdminJson()",
@@ -3385,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L40",
       "id": "admin_routes_spec_postadminjson",
-      "community": 214
+      "community": 215
     },
     {
       "label": "getAdmin()",
@@ -3393,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L76",
       "id": "admin_routes_spec_getadmin",
-      "community": 214
+      "community": 215
     },
     {
       "label": "deleteAdmin()",
@@ -3401,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L102",
       "id": "admin_routes_spec_deleteadmin",
-      "community": 214
+      "community": 215
     },
     {
       "label": "makeApp()",
@@ -3409,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L594",
       "id": "admin_routes_spec_makeapp",
-      "community": 214
+      "community": 215
     },
     {
       "label": "createBaseSchema()",
@@ -3417,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L946",
       "id": "admin_routes_spec_createbaseschema",
-      "community": 214
+      "community": 215
     },
     {
       "label": "tools.routes.ts",
@@ -3425,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createToolsRouter()",
@@ -3433,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 460
+      "community": 461
     },
     {
       "label": "api.routes.ts",
@@ -3441,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createApiRouter()",
@@ -3449,7 +3513,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 461
+      "community": 462
     },
     {
       "label": "quality.routes.ts",
@@ -3457,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createQualityRouter()",
@@ -3465,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 462
+      "community": 463
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3521,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "parseParams()",
@@ -3529,7 +3593,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 392
+      "community": 393
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -3537,7 +3601,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 392
+      "community": 393
     },
     {
       "label": "admin-graph-response.ts",
@@ -3545,7 +3609,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "buildGraphResponse()",
@@ -3553,7 +3617,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 463
+      "community": 464
     },
     {
       "label": "admin-graph.routes.ts",
@@ -3561,7 +3625,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -3569,7 +3633,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 464
+      "community": 465
     },
     {
       "label": "admin-relations.routes.ts",
@@ -3577,7 +3641,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -3585,7 +3649,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 465
+      "community": 466
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -3593,7 +3657,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -3601,7 +3665,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 466
+      "community": 467
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -3609,7 +3673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -3617,7 +3681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 467
+      "community": 468
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -3713,7 +3777,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "resolveEnvPath()",
@@ -3721,7 +3785,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 393
+      "community": 394
     },
     {
       "label": "loadEnv()",
@@ -3729,7 +3793,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 393
+      "community": 394
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -3737,7 +3801,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "runCli()",
@@ -3745,7 +3809,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 468
+      "community": 469
     },
     {
       "label": "option-map.ts",
@@ -3801,7 +3865,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -3809,7 +3873,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -3817,7 +3881,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 394
+      "community": 395
     },
     {
       "label": "runQualityMeasurement()",
@@ -3825,7 +3889,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 394
+      "community": 395
     },
     {
       "label": "test-simple-alerts.ts",
@@ -3833,7 +3897,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "testSimpleAlerts()",
@@ -3841,7 +3905,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -3849,7 +3913,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "testBasicFunctionality()",
@@ -3857,7 +3921,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 470
+      "community": 471
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -3865,7 +3929,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -3873,7 +3937,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 471
+      "community": 472
     },
     {
       "label": "test-server-synchronization.ts",
@@ -3881,7 +3945,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "compareServices()",
@@ -3889,7 +3953,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 395
+      "community": 396
     },
     {
       "label": "testServerSynchronization()",
@@ -3897,7 +3961,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 395
+      "community": 396
     },
     {
       "label": "test-error-logging.ts",
@@ -3905,7 +3969,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "testErrorLogging()",
@@ -3913,7 +3977,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 472
+      "community": 473
     },
     {
       "label": "debug-http-v2.ts",
@@ -3921,7 +3985,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "testFetch()",
@@ -3929,7 +3993,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 473
+      "community": 474
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -3937,7 +4001,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "initializeTestDatabase()",
@@ -3945,7 +4009,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 474
+      "community": 475
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -3953,7 +4017,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -3961,7 +4025,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -3969,7 +4033,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "testReflexionE2E()",
@@ -3977,7 +4041,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 475
+      "community": 476
     },
     {
       "label": "test-alerts-direct.ts",
@@ -3985,7 +4049,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "testAlertsDirect()",
@@ -3993,7 +4057,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 476
+      "community": 477
     },
     {
       "label": "test-client.ts",
@@ -4001,7 +4065,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "assert()",
@@ -4009,7 +4073,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 396
+      "community": 397
     },
     {
       "label": "testMementoClient()",
@@ -4017,7 +4081,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 396
+      "community": 397
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4025,7 +4089,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4097,7 +4161,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4105,7 +4169,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4113,7 +4177,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4121,7 +4185,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 478
+      "community": 479
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4129,7 +4193,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4137,7 +4201,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 479
+      "community": 480
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4145,7 +4209,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4153,7 +4217,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createBaseSchema()",
@@ -4161,7 +4225,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createTestMemory()",
@@ -4169,7 +4233,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 397
+      "community": 398
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4177,7 +4241,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4185,7 +4249,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 398
+      "community": 399
     },
     {
       "label": "findNodeForAnchor()",
@@ -4193,7 +4257,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 398
+      "community": 399
     },
     {
       "label": "vitest.config.ts",
@@ -4201,7 +4265,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4209,7 +4273,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "brave-search-provider.ts",
@@ -4217,7 +4281,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 319
+      "community": 320
     },
     {
       "label": "BraveSearchProvider",
@@ -4225,7 +4289,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".constructor()",
@@ -4233,7 +4297,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".search()",
@@ -4241,7 +4305,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 319
+      "community": 320
     },
     {
       "label": "noop-search-provider.ts",
@@ -4249,7 +4313,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "NoopSearchProvider",
@@ -4257,7 +4321,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 399
+      "community": 400
     },
     {
       "label": ".search()",
@@ -4265,7 +4329,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 399
+      "community": 400
     },
     {
       "label": "search-factory.ts",
@@ -4273,7 +4337,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "createSearchProvider()",
@@ -4281,7 +4345,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 480
+      "community": 481
     },
     {
       "label": "search-provider.ts",
@@ -4289,7 +4353,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "llm-provider.ts",
@@ -4297,7 +4361,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "claude-provider.spec.ts",
@@ -4305,7 +4369,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "types.ts",
@@ -4313,7 +4377,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "loadAgentConfig()",
@@ -4321,7 +4385,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 481
+      "community": 482
     },
     {
       "label": "system-prompt.ts",
@@ -4329,7 +4393,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "vitest.config.ts",
@@ -4337,7 +4401,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "utils.spec.ts",
@@ -4345,7 +4409,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "buildMemory()",
@@ -4353,7 +4417,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 482
+      "community": 483
     },
     {
       "label": "context-injector.ts",
@@ -5177,7 +5241,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "logger.ts",
@@ -5185,7 +5249,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "shouldLog()",
@@ -5193,7 +5257,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 400
+      "community": 401
     },
     {
       "label": "log()",
@@ -5201,7 +5265,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 400
+      "community": 401
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5209,7 +5273,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 320
+      "community": 321
     },
     {
       "label": "constructor()",
@@ -5217,7 +5281,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L231",
       "id": "bootstrap_spec_constructor",
-      "community": 320
+      "community": 321
     },
     {
       "label": "loadBootstrap()",
@@ -5225,7 +5289,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L254",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 320
+      "community": 321
     },
     {
       "label": "installTimeoutSpy()",
@@ -5233,7 +5297,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L258",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 320
+      "community": 321
     },
     {
       "label": "index.ts",
@@ -5241,7 +5305,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createMementoCore()",
@@ -5249,7 +5313,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 401
+      "community": 402
     },
     {
       "label": "closeDatabase()",
@@ -5257,7 +5321,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 401
+      "community": 402
     },
     {
       "label": "bootstrap.ts",
@@ -5265,7 +5329,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "initializeServices()",
@@ -5273,7 +5337,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 483
+      "community": 484
     },
     {
       "label": "context.ts",
@@ -5281,7 +5345,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "createServerContext()",
@@ -5289,7 +5353,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L15",
       "id": "context_createservercontext",
-      "community": 321
+      "community": 322
     },
     {
       "label": "createToolContext()",
@@ -5297,7 +5361,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L24",
       "id": "context_createtoolcontext",
-      "community": 321
+      "community": 322
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -5305,7 +5369,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L37",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 321
+      "community": 322
     },
     {
       "label": "write-and-meta.ts",
@@ -5313,7 +5377,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -5321,7 +5385,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 484
+      "community": 485
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -5329,7 +5393,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -5337,7 +5401,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 485
+      "community": 486
     },
     {
       "label": "anchor-stack.ts",
@@ -5345,7 +5409,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "createAnchorStack()",
@@ -5353,7 +5417,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 486
+      "community": 487
     },
     {
       "label": "failure-reflexion.ts",
@@ -5361,7 +5425,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "startFailureAndReflexion()",
@@ -5369,7 +5433,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 487
+      "community": 488
     },
     {
       "label": "search-and-embedding.ts",
@@ -5377,7 +5441,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -5385,7 +5449,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 488
+      "community": 489
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -5393,7 +5457,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -5401,7 +5465,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 489
+      "community": 490
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -5409,7 +5473,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -5417,7 +5481,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 490
+      "community": 491
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6225,7 +6289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createInput()",
@@ -6233,7 +6297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 491
+      "community": 492
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -6241,7 +6305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "extract()",
@@ -6249,7 +6313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 282
+      "community": 283
     },
     {
       "label": "waitForEventProcessing()",
@@ -6257,7 +6321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 282
+      "community": 283
     },
     {
       "label": "createProceduralMemory()",
@@ -6265,7 +6329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 282
+      "community": 283
     },
     {
       "label": "createFailureEvent()",
@@ -6273,7 +6337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 282
+      "community": 283
     },
     {
       "label": "relation-graph-factory.ts",
@@ -6281,7 +6345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createRelationGraph()",
@@ -6289,7 +6353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 492
+      "community": 493
     },
     {
       "label": "consolidation-score-service.ts",
@@ -6377,7 +6441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -6457,7 +6521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -6465,7 +6529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".constructor()",
@@ -6473,7 +6537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".handle()",
@@ -6481,7 +6545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 322
+      "community": 323
     },
     {
       "label": "migration-history-service.ts",
@@ -6801,7 +6865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createBaseSchema()",
@@ -6809,7 +6873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 402
+      "community": 403
     },
     {
       "label": "measureTime()",
@@ -6817,7 +6881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 402
+      "community": 403
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -6825,7 +6889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createBaseSchema()",
@@ -6833,7 +6897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 493
+      "community": 494
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -6937,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -6945,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 494
+      "community": 495
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7049,7 +7113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "openLockTestDatabase()",
@@ -7057,7 +7121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 495
+      "community": 496
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7065,7 +7129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 323
+      "community": 324
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -7073,7 +7137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 323
+      "community": 324
     },
     {
       "label": "createPlan()",
@@ -7081,7 +7145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 323
+      "community": 324
     },
     {
       "label": "createResult()",
@@ -7089,7 +7153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 323
+      "community": 324
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -7097,7 +7161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createProgress()",
@@ -7105,7 +7169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 496
+      "community": 497
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7113,7 +7177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7121,7 +7185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7129,7 +7193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7137,7 +7201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 497
+      "community": 498
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7145,7 +7209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7153,7 +7217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7161,7 +7225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 498
+      "community": 499
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7169,7 +7233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "addMissingColumn()",
@@ -7177,7 +7241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 403
+      "community": 404
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7185,7 +7249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 403
+      "community": 404
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7193,7 +7257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -7289,7 +7353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 685
+      "community": 687
     },
     {
       "label": "init.ts",
@@ -7361,7 +7425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createDbPath()",
@@ -7369,7 +7433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 499
+      "community": 500
     },
     {
       "label": "migrate.spec.ts",
@@ -7377,7 +7441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "migrate.ts",
@@ -7385,7 +7449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "migrateDatabase()",
@@ -7393,7 +7457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_migratedatabase",
-      "community": 500
+      "community": 501
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -7401,7 +7465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "migration-runner.ts",
@@ -7481,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createBaseSchema()",
@@ -7489,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 501
+      "community": 502
     },
     {
       "label": "migration-logger.spec.ts",
@@ -7497,7 +7561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "migration-detector.ts",
@@ -7505,7 +7569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_ts",
-      "community": 215
+      "community": 216
     },
     {
       "label": "MigrationDetector",
@@ -7513,7 +7577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L63",
       "id": "migration_detector_migrationdetector",
-      "community": 215
+      "community": 216
     },
     {
       "label": ".constructor()",
@@ -7521,7 +7585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L66",
       "id": "migration_detector_migrationdetector_constructor",
-      "community": 215
+      "community": 216
     },
     {
       "label": ".detectAllMigrations()",
@@ -7529,7 +7593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L73",
       "id": "migration_detector_migrationdetector_detectallmigrations",
-      "community": 215
+      "community": 216
     },
     {
       "label": ".detectPendingMigrations()",
@@ -7537,7 +7601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L177",
       "id": "migration_detector_migrationdetector_detectpendingmigrations",
-      "community": 215
+      "community": 216
     },
     {
       "label": ".parseVersionNumber()",
@@ -7545,7 +7609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L208",
       "id": "migration_detector_migrationdetector_parseversionnumber",
-      "community": 215
+      "community": 216
     },
     {
       "label": ".findMigrationByVersion()",
@@ -7553,7 +7617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L222",
       "id": "migration_detector_migrationdetector_findmigrationbyversion",
-      "community": 215
+      "community": 216
     },
     {
       "label": "migration-logger.ts",
@@ -7689,7 +7753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "migration-detector.spec.ts",
@@ -7697,7 +7761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "backup-manager.ts",
@@ -7777,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "dependency-validator.ts",
@@ -7881,7 +7945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "schema-version-manager.ts",
@@ -7969,7 +8033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 324
+      "community": 325
     },
     {
       "label": "createMemoryItemTable()",
@@ -7977,7 +8041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 324
+      "community": 325
     },
     {
       "label": "columnExists()",
@@ -7985,7 +8049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 324
+      "community": 325
     },
     {
       "label": "indexExists()",
@@ -7993,7 +8057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 324
+      "community": 325
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -8361,7 +8425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 283
+      "community": 284
     },
     {
       "label": "createMemoryItemTable()",
@@ -8369,7 +8433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 283
+      "community": 284
     },
     {
       "label": "createSchemaVersionTable()",
@@ -8377,7 +8441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 283
+      "community": 284
     },
     {
       "label": "columnExists()",
@@ -8385,7 +8449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 283
+      "community": 284
     },
     {
       "label": "indexExists()",
@@ -8393,7 +8457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 283
+      "community": 284
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -8473,7 +8537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 284
+      "community": 285
     },
     {
       "label": "createMemoryItemTable()",
@@ -8481,7 +8545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 284
+      "community": 285
     },
     {
       "label": "createSchemaVersionTable()",
@@ -8489,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 284
+      "community": 285
     },
     {
       "label": "columnExists()",
@@ -8497,7 +8561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 284
+      "community": 285
     },
     {
       "label": "indexExists()",
@@ -8505,7 +8569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 284
+      "community": 285
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -8737,7 +8801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createBaseSchema()",
@@ -8745,7 +8809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 502
+      "community": 503
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -8929,7 +8993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "createBaseSchema()",
@@ -8937,7 +9001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 503
+      "community": 504
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -9025,7 +9089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_ts",
-      "community": 216
+      "community": 217
     },
     {
       "label": "BackfillKgTripleFromMemoryItemMigration",
@@ -9033,7 +9097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".tableExists()",
@@ -9041,7 +9105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L23",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_tableexists",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".validateBefore()",
@@ -9049,7 +9113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L30",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validatebefore",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".up()",
@@ -9057,7 +9121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L47",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_up",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".down()",
@@ -9065,7 +9129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L94",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_down",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".validateAfter()",
@@ -9073,7 +9137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L101",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validateafter",
-      "community": 216
+      "community": 217
     },
     {
       "label": "023-feedback-event-score-breakdown.ts",
@@ -9233,7 +9297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createBaseSchema()",
@@ -9241,7 +9305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 504
+      "community": 505
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -9249,7 +9313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 285
+      "community": 286
     },
     {
       "label": "createMemoryItemTable()",
@@ -9257,7 +9321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 285
+      "community": 286
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9265,7 +9329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 285
+      "community": 286
     },
     {
       "label": "columnExists()",
@@ -9273,7 +9337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 285
+      "community": 286
     },
     {
       "label": "indexExists()",
@@ -9281,7 +9345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 285
+      "community": 286
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -9609,7 +9673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "createMemoryItemTable()",
@@ -9617,7 +9681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 404
+      "community": 405
     },
     {
       "label": "tableExists()",
@@ -9625,7 +9689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 404
+      "community": 405
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -9937,7 +10001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createBaseSchema()",
@@ -9945,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 505
+      "community": 506
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10049,7 +10113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "createSchemaWith018()",
@@ -10057,7 +10121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 506
+      "community": 507
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10065,7 +10129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "createBaseSchema()",
@@ -10073,7 +10137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 507
+      "community": 508
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -10081,7 +10145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 325
+      "community": 326
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -10089,7 +10153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 325
+      "community": 326
     },
     {
       "label": "createMemoryLinkTable()",
@@ -10097,7 +10161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 325
+      "community": 326
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10105,7 +10169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 325
+      "community": 326
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -10297,7 +10361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 286
+      "community": 287
     },
     {
       "label": "createMemoryItemTable()",
@@ -10305,7 +10369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 286
+      "community": 287
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10313,7 +10377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 286
+      "community": 287
     },
     {
       "label": "columnExists()",
@@ -10321,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 286
+      "community": 287
     },
     {
       "label": "indexExists()",
@@ -10329,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 286
+      "community": 287
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -10409,7 +10473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 287
+      "community": 288
     },
     {
       "label": "createMemoryItemTable()",
@@ -10417,7 +10481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 287
+      "community": 288
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10425,7 +10489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 287
+      "community": 288
     },
     {
       "label": "columnExists()",
@@ -10433,7 +10497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 287
+      "community": 288
     },
     {
       "label": "indexExists()",
@@ -10441,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 287
+      "community": 288
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -10633,7 +10697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "createBaseSchema()",
@@ -10641,7 +10705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 508
+      "community": 509
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -10769,7 +10833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createBaseSchema()",
@@ -10777,7 +10841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 509
+      "community": 510
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -10785,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "createBaseSchema()",
@@ -10793,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 405
+      "community": 406
     },
     {
       "label": "createMemoryLinkTable()",
@@ -10801,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 405
+      "community": 406
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -10881,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createBaseSchema()",
@@ -10889,7 +10953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 510
+      "community": 511
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -10897,7 +10961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 326
+      "community": 327
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -10905,7 +10969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 326
+      "community": 327
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10913,7 +10977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 326
+      "community": 327
     },
     {
       "label": "getIndexNames()",
@@ -10921,7 +10985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 326
+      "community": 327
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -10929,7 +10993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "createSchemaWith019()",
@@ -10937,7 +11001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 327
+      "community": 328
     },
     {
       "label": "tableExists()",
@@ -10945,7 +11009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 327
+      "community": 328
     },
     {
       "label": "columnExists()",
@@ -10953,7 +11017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 327
+      "community": 328
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -11105,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -11289,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_process_attribute_repository_sqlite_impl_ts",
-      "community": 217
+      "community": 218
     },
     {
       "label": "parseJsonArray()",
@@ -11297,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L14",
       "id": "process_attribute_repository_sqlite_impl_parsejsonarray",
-      "community": 217
+      "community": 218
     },
     {
       "label": "stringifyJsonArray()",
@@ -11305,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L24",
       "id": "process_attribute_repository_sqlite_impl_stringifyjsonarray",
-      "community": 217
+      "community": 218
     },
     {
       "label": "ProcessAttributeRepositorySqlite",
@@ -11313,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L32",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".constructor()",
@@ -11321,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L35",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_constructor",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".getByProcessId()",
@@ -11329,7 +11393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L42",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_getbyprocessid",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".upsert()",
@@ -11337,7 +11401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L63",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_upsert",
-      "community": 217
+      "community": 218
     },
     {
       "label": "knowledge-vault-repository-sqlite.impl.ts",
@@ -11537,7 +11601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "cache-service.ts",
@@ -11865,7 +11929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "batch-scheduler.ts",
@@ -12297,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -12305,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 511
+      "community": 512
     },
     {
       "label": "relation-validator-executor.ts",
@@ -12313,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_relation_validator_executor_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "RelationValidatorExecutor",
@@ -12321,7 +12385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L31",
       "id": "relation_validator_executor_relationvalidatorexecutor",
-      "community": 328
+      "community": 329
     },
     {
       "label": ".constructor()",
@@ -12329,7 +12393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L34",
       "id": "relation_validator_executor_relationvalidatorexecutor_constructor",
-      "community": 328
+      "community": 329
     },
     {
       "label": ".execute()",
@@ -12337,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L49",
       "id": "relation_validator_executor_relationvalidatorexecutor_execute",
-      "community": 328
+      "community": 329
     },
     {
       "label": "batch-scheduler-types.ts",
@@ -12345,7 +12409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -12353,7 +12417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "validateBatchJobConfig()",
@@ -12361,7 +12425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 512
+      "community": 513
     },
     {
       "label": "retry-manager.ts",
@@ -12689,7 +12753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -12761,7 +12825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "retry-manager.spec.ts",
@@ -12769,7 +12833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "shouldRetry()",
@@ -12777,7 +12841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 513
+      "community": 514
     },
     {
       "label": "job-queue.spec.ts",
@@ -12785,7 +12849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 288
+      "community": 289
     },
     {
       "label": "job()",
@@ -12793,7 +12857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 288
+      "community": 289
     },
     {
       "label": "job1()",
@@ -12801,7 +12865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 288
+      "community": 289
     },
     {
       "label": "job2()",
@@ -12809,7 +12873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 288
+      "community": 289
     },
     {
       "label": "job3()",
@@ -12817,7 +12881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 288
+      "community": 289
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -12825,7 +12889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -12833,7 +12897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "initializeTestDatabase()",
@@ -12841,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 514
+      "community": 515
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -12937,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -12945,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -12953,7 +13017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 329
+      "community": 330
     },
     {
       "label": ".constructor()",
@@ -12961,7 +13025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 329
+      "community": 330
     },
     {
       "label": ".execute()",
@@ -12969,7 +13033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 329
+      "community": 330
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -12977,7 +13041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -12985,7 +13049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -12993,7 +13057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 330
+      "community": 331
     },
     {
       "label": ".constructor()",
@@ -13001,7 +13065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 330
+      "community": 331
     },
     {
       "label": ".execute()",
@@ -13009,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 330
+      "community": 331
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -13017,7 +13081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -13025,7 +13089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 331
+      "community": 332
     },
     {
       "label": ".constructor()",
@@ -13033,7 +13097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 331
+      "community": 332
     },
     {
       "label": ".execute()",
@@ -13041,7 +13105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 331
+      "community": 332
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -13049,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "generateId()",
@@ -13057,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 406
+      "community": 407
     },
     {
       "label": "initializeTestDatabase()",
@@ -13065,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 406
+      "community": 407
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -13073,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "createQualityTables()",
@@ -13081,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 515
+      "community": 516
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -13089,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "generateId()",
@@ -13097,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 407
+      "community": 408
     },
     {
       "label": "initializeTestDatabase()",
@@ -13105,7 +13169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 407
+      "community": 408
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -13113,7 +13177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "stopwords.spec.ts",
@@ -13121,7 +13185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "type-guards.ts",
@@ -13305,7 +13369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "validateTableName()",
@@ -13313,7 +13377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 408
+      "community": 409
     },
     {
       "label": "getVectorTableName()",
@@ -13321,7 +13385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 408
+      "community": 409
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -13329,7 +13393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -13337,7 +13401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 516
+      "community": 517
     },
     {
       "label": "environment-check.ts",
@@ -13345,7 +13409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "isTestEnvironment()",
@@ -13353,7 +13417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 332
+      "community": 333
     },
     {
       "label": "isValidationDisabled()",
@@ -13361,7 +13425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 332
+      "community": 333
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -13369,7 +13433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 332
+      "community": 333
     },
     {
       "label": "db-path.spec.ts",
@@ -13377,7 +13441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -13385,7 +13449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -13393,7 +13457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 289
+      "community": 290
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -13401,7 +13465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 289
+      "community": 290
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -13409,7 +13473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 289
+      "community": 290
     },
     {
       "label": "extractKeyTokens()",
@@ -13417,7 +13481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 289
+      "community": 290
     },
     {
       "label": "getSearchQueryExamples()",
@@ -13425,7 +13489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 289
+      "community": 290
     },
     {
       "label": "relation-type-converter.ts",
@@ -13433,7 +13497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 290
+      "community": 291
     },
     {
       "label": "toDbRelationType()",
@@ -13441,7 +13505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 290
+      "community": 291
     },
     {
       "label": "fromDbRelationType()",
@@ -13449,7 +13513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 290
+      "community": 291
     },
     {
       "label": "isValidDbRelationType()",
@@ -13457,7 +13521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 290
+      "community": 291
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -13465,7 +13529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 290
+      "community": 291
     },
     {
       "label": "db-path.ts",
@@ -13473,7 +13537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -13481,7 +13545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 517
+      "community": 518
     },
     {
       "label": "error-handling.spec.ts",
@@ -13489,7 +13553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "operation()",
@@ -13497,7 +13561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 518
+      "community": 519
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -13505,7 +13569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_ts",
-      "community": 218
+      "community": 219
     },
     {
       "label": "normalizeJson()",
@@ -13513,7 +13577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L104",
       "id": "procedural_memory_change_detector_normalizejson",
-      "community": 218
+      "community": 219
     },
     {
       "label": "computeJsonHash()",
@@ -13521,7 +13585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L168",
       "id": "procedural_memory_change_detector_computejsonhash",
-      "community": 218
+      "community": 219
     },
     {
       "label": "computeReflectionNotesCount()",
@@ -13529,7 +13593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L221",
       "id": "procedural_memory_change_detector_computereflectionnotescount",
-      "community": 218
+      "community": 219
     },
     {
       "label": "createProceduralMemorySnapshot()",
@@ -13537,7 +13601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L254",
       "id": "procedural_memory_change_detector_createproceduralmemorysnapshot",
-      "community": 218
+      "community": 219
     },
     {
       "label": "isEqual()",
@@ -13545,7 +13609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L325",
       "id": "procedural_memory_change_detector_isequal",
-      "community": 218
+      "community": 219
     },
     {
       "label": "hasProceduralMemoryChanged()",
@@ -13553,7 +13617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L357",
       "id": "procedural_memory_change_detector_hasproceduralmemorychanged",
-      "community": 218
+      "community": 219
     },
     {
       "label": "logging-rate-limiter.ts",
@@ -13681,7 +13745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "relation-visualizer.ts",
@@ -14081,7 +14145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "issue()",
@@ -14089,7 +14153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 409
+      "community": 410
     },
     {
       "label": "validateConfiguration()",
@@ -14097,7 +14161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 409
+      "community": 410
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -14105,7 +14169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "cache-key-generator.ts",
@@ -14161,7 +14225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "transactionFn()",
@@ -14169,7 +14233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 410
+      "community": 411
     },
     {
       "label": "outerTransaction()",
@@ -14177,7 +14241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 410
+      "community": 411
     },
     {
       "label": "write-coalescing.ts",
@@ -14265,7 +14329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "validateReflectionNote()",
@@ -14273,7 +14337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 333
+      "community": 334
     },
     {
       "label": "validateReflectionNotes()",
@@ -14281,7 +14345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 333
+      "community": 334
     },
     {
       "label": "formatValidationErrors()",
@@ -14289,7 +14353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 333
+      "community": 334
     },
     {
       "label": "environment-check.spec.ts",
@@ -14297,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "path-validator.ts",
@@ -14305,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_path_validator_ts",
-      "community": 219
+      "community": 220
     },
     {
       "label": "getAllowedDirs()",
@@ -14313,7 +14377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L22",
       "id": "path_validator_getalloweddirs",
-      "community": 219
+      "community": 220
     },
     {
       "label": "isAbsolutePath()",
@@ -14321,7 +14385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L45",
       "id": "path_validator_isabsolutepath",
-      "community": 219
+      "community": 220
     },
     {
       "label": "containsPathTraversal()",
@@ -14329,7 +14393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L55",
       "id": "path_validator_containspathtraversal",
-      "community": 219
+      "community": 220
     },
     {
       "label": "isWithinAllowedDirs()",
@@ -14337,7 +14401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L78",
       "id": "path_validator_iswithinalloweddirs",
-      "community": 219
+      "community": 220
     },
     {
       "label": "validateFilePath()",
@@ -14345,7 +14409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L117",
       "id": "path_validator_validatefilepath",
-      "community": 219
+      "community": 220
     },
     {
       "label": "sanitizeFileName()",
@@ -14353,7 +14417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L159",
       "id": "path_validator_sanitizefilename",
-      "community": 219
+      "community": 220
     },
     {
       "label": "ensure-memory-review-candidate-schema.ts",
@@ -14361,7 +14425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -14369,7 +14433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 519
+      "community": 520
     },
     {
       "label": "error-handling.ts",
@@ -14377,7 +14441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "withErrorHandling()",
@@ -14385,7 +14449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 520
+      "community": 521
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -14393,7 +14457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -14401,7 +14465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -14473,7 +14537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_prompt_template_loader_ts",
-      "community": 220
+      "community": 221
     },
     {
       "label": "PromptTemplateLoader",
@@ -14481,7 +14545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L29",
       "id": "prompt_template_loader_prompttemplateloader",
-      "community": 220
+      "community": 221
     },
     {
       "label": ".loadTemplate()",
@@ -14489,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L40",
       "id": "prompt_template_loader_prompttemplateloader_loadtemplate",
-      "community": 220
+      "community": 221
     },
     {
       "label": ".renderTemplate()",
@@ -14497,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L76",
       "id": "prompt_template_loader_prompttemplateloader_rendertemplate",
-      "community": 220
+      "community": 221
     },
     {
       "label": ".loadAndRender()",
@@ -14505,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L95",
       "id": "prompt_template_loader_prompttemplateloader_loadandrender",
-      "community": 220
+      "community": 221
     },
     {
       "label": ".clearCache()",
@@ -14513,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L103",
       "id": "prompt_template_loader_prompttemplateloader_clearcache",
-      "community": 220
+      "community": 221
     },
     {
       "label": ".getTemplatePath()",
@@ -14521,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L113",
       "id": "prompt_template_loader_prompttemplateloader_gettemplatepath",
-      "community": 220
+      "community": 221
     },
     {
       "label": "logger.ts",
@@ -14601,7 +14665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -14609,7 +14673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 521
+      "community": 522
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -14617,7 +14681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "createValidReflectionNote()",
@@ -14625,7 +14689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 411
+      "community": 412
     },
     {
       "label": "createLargeNote()",
@@ -14633,7 +14697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 411
+      "community": 412
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -14641,7 +14705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "initializeTestDatabase()",
@@ -14649,7 +14713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 522
+      "community": 523
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -14657,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -14665,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 523
+      "community": 524
     },
     {
       "label": "logging-helpers.ts",
@@ -14761,7 +14825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "pii-masker.ts",
@@ -14833,7 +14897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 291
+      "community": 292
     },
     {
       "label": "getStopWords()",
@@ -14841,7 +14905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 291
+      "community": 292
     },
     {
       "label": "getEnglishStopWords()",
@@ -14849,7 +14913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 291
+      "community": 292
     },
     {
       "label": "getKoreanStopWords()",
@@ -14857,7 +14921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 291
+      "community": 292
     },
     {
       "label": "isStopWord()",
@@ -14865,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 291
+      "community": 292
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -14873,7 +14937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -14881,7 +14945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "path-validator.spec.ts",
@@ -14889,7 +14953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "triple-cache.spec.ts",
@@ -14897,7 +14961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -14905,7 +14969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -14913,7 +14977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -14921,7 +14985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "logger-schema.spec.ts",
@@ -14929,7 +14993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -14937,7 +15001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -14945,7 +15009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "initializeTestDatabase()",
@@ -14953,7 +15017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 524
+      "community": 525
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -14961,7 +15025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -14969,7 +15033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "benchmark.types.ts",
@@ -14977,7 +15041,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "assertMacroCategory()",
@@ -14985,7 +15049,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 525
+      "community": 526
     },
     {
       "label": "migration.types.ts",
@@ -14993,7 +15057,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 723
+      "community": 725
     },
     {
       "label": "consolidation-score.types.ts",
@@ -15001,7 +15065,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "consolidation.types.ts",
@@ -15009,7 +15073,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "vector-search.types.ts",
@@ -15017,7 +15081,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -15025,7 +15089,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "procedural-versioning.ts",
@@ -15033,7 +15097,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "triple-extraction.ts",
@@ -15041,7 +15105,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "feedback.types.ts",
@@ -15049,7 +15113,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "embedding.types.ts",
@@ -15057,7 +15121,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "relation-graph.ts",
@@ -15065,7 +15129,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 732
+      "community": 734
     },
     {
       "label": "failure-event.ts",
@@ -15073,7 +15137,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "index.ts",
@@ -15081,7 +15145,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "isMemoryItemType()",
@@ -15089,7 +15153,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 526
+      "community": 527
     },
     {
       "label": "error-types.ts",
@@ -15097,7 +15161,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "ranking.types.ts",
@@ -15105,7 +15169,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "alerts.types.ts",
@@ -15113,7 +15177,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "relation.ts",
@@ -15121,7 +15185,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 334
+      "community": 335
     },
     {
       "label": "isApplicableRelationType()",
@@ -15129,7 +15193,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L151",
       "id": "relation_isapplicablerelationtype",
-      "community": 334
+      "community": 335
     },
     {
       "label": "getRelationCategory()",
@@ -15137,7 +15201,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L161",
       "id": "relation_getrelationcategory",
-      "community": 334
+      "community": 335
     },
     {
       "label": "getRelationBoost()",
@@ -15145,7 +15209,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L168",
       "id": "relation_getrelationboost",
-      "community": 334
+      "community": 335
     },
     {
       "label": "search.types.ts",
@@ -15153,7 +15217,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "index.spec.ts",
@@ -15161,7 +15225,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -15169,7 +15233,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 739
+      "community": 741
     },
     {
       "label": "constants.ts",
@@ -15177,7 +15241,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "environment.ts",
@@ -15321,7 +15385,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "retry-options-loader.ts",
@@ -15377,7 +15441,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "validateConfig()",
@@ -15385,7 +15449,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 527
+      "community": 528
     },
     {
       "label": "config-loader-utils.ts",
@@ -15457,7 +15521,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "constants.spec.ts",
@@ -15465,7 +15529,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "config-validation.spec.ts",
@@ -15473,7 +15537,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -15481,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "environment-paths.spec.ts",
@@ -15489,7 +15553,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -15497,7 +15561,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "relation-constants.ts",
@@ -15505,7 +15569,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "introspection-constants.ts",
@@ -15513,7 +15577,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -15521,7 +15585,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "http-bind-policy.ts",
@@ -15601,7 +15665,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "retry-manager.interface.ts",
@@ -15609,7 +15673,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "cache.interface.ts",
@@ -15617,7 +15681,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -15625,7 +15689,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "error-logging.interface.ts",
@@ -15633,7 +15697,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -15641,7 +15705,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -15649,7 +15713,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "database.interface.ts",
@@ -15657,7 +15721,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -15665,7 +15729,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -15673,7 +15737,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "llm-client-initializer.ts",
@@ -15857,7 +15921,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "getMockMementoConfig()",
@@ -15865,7 +15929,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 412
+      "community": 413
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -15873,7 +15937,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 412
+      "community": 413
     },
     {
       "label": "initialize.spec.ts",
@@ -15881,7 +15945,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "openai-client.spec.ts",
@@ -15889,7 +15953,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -15897,7 +15961,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -15905,7 +15969,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -15913,7 +15977,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -15921,7 +15985,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -15929,7 +15993,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "environment-priority.spec.ts",
@@ -15937,7 +16001,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -15945,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "gemini-client.spec.ts",
@@ -15953,7 +16017,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "search-local-tool.ts",
@@ -15961,7 +16025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "SearchLocalTool",
@@ -15969,7 +16033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 335
+      "community": 336
     },
     {
       "label": ".constructor()",
@@ -15977,7 +16041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 335
+      "community": 336
     },
     {
       "label": ".handle()",
@@ -15985,7 +16049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 335
+      "community": 336
     },
     {
       "label": "get-anchor-tool.ts",
@@ -15993,7 +16057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "GetAnchorTool",
@@ -16001,7 +16065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 336
+      "community": 337
     },
     {
       "label": ".constructor()",
@@ -16009,7 +16073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 336
+      "community": 337
     },
     {
       "label": ".handle()",
@@ -16017,7 +16081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 336
+      "community": 337
     },
     {
       "label": "set-anchor-tool.ts",
@@ -16025,7 +16089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "SetAnchorTool",
@@ -16033,7 +16097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 337
+      "community": 338
     },
     {
       "label": ".constructor()",
@@ -16041,7 +16105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 337
+      "community": 338
     },
     {
       "label": ".handle()",
@@ -16049,7 +16113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 337
+      "community": 338
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -16057,7 +16121,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "ClearAnchorTool",
@@ -16065,7 +16129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 338
+      "community": 339
     },
     {
       "label": ".constructor()",
@@ -16073,7 +16137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 338
+      "community": 339
     },
     {
       "label": ".handle()",
@@ -16081,7 +16145,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 338
+      "community": 339
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -16089,7 +16153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "RestoreAnchorsTool",
@@ -16097,7 +16161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 339
+      "community": 340
     },
     {
       "label": ".constructor()",
@@ -16105,7 +16169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 339
+      "community": 340
     },
     {
       "label": ".handle()",
@@ -16113,7 +16177,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 339
+      "community": 340
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -16121,7 +16185,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 292
+      "community": 293
     },
     {
       "label": "initializeTestDatabase()",
@@ -16129,7 +16193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createMockEmbeddingService()",
@@ -16137,7 +16201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -16145,7 +16209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -16153,7 +16217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 292
+      "community": 293
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -16161,7 +16225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 293
+      "community": 294
     },
     {
       "label": "initializeTestDatabase()",
@@ -16169,7 +16233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createMockEmbeddingService()",
@@ -16177,7 +16241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -16185,7 +16249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -16193,7 +16257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 293
+      "community": 294
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -16201,7 +16265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 294
+      "community": 295
     },
     {
       "label": "initializeTestDatabase()",
@@ -16209,7 +16273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createMockEmbeddingService()",
@@ -16217,7 +16281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -16225,7 +16289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -16233,7 +16297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 294
+      "community": 295
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -16241,7 +16305,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "initializeTestDatabase()",
@@ -16249,7 +16313,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 528
+      "community": 529
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -16257,7 +16321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "initializeTestDatabase()",
@@ -16265,7 +16329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 529
+      "community": 530
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -16273,7 +16337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "query-filter-strategy.ts",
@@ -16281,7 +16345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "QueryFilterStrategy",
@@ -16289,7 +16353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".constructor()",
@@ -16297,7 +16361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".filter()",
@@ -16305,7 +16369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".execute()",
@@ -16313,7 +16377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 295
+      "community": 296
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -16321,7 +16385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -16329,7 +16393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "local-search-service.ts",
@@ -16401,7 +16465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -16409,7 +16473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "anchor-interfaces.ts",
@@ -16537,7 +16601,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -16545,7 +16609,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -16553,7 +16617,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 530
+      "community": 531
     },
     {
       "label": "embedding-types.ts",
@@ -16561,7 +16625,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -16569,7 +16633,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -16577,7 +16641,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "NHopSearchStrategy",
@@ -16585,7 +16649,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".constructor()",
@@ -16593,7 +16657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".search()",
@@ -16601,7 +16665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".execute()",
@@ -16609,7 +16673,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 296
+      "community": 297
     },
     {
       "label": "query-filter-service.ts",
@@ -16617,7 +16681,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_ts",
-      "community": 221
+      "community": 222
     },
     {
       "label": "QueryFilterService",
@@ -16625,7 +16689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L41",
       "id": "query_filter_service_queryfilterservice",
-      "community": 221
+      "community": 222
     },
     {
       "label": ".constructor()",
@@ -16633,7 +16697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L45",
       "id": "query_filter_service_queryfilterservice_constructor",
-      "community": 221
+      "community": 222
     },
     {
       "label": ".filterByQuery()",
@@ -16641,7 +16705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L53",
       "id": "query_filter_service_queryfilterservice_filterbyquery",
-      "community": 221
+      "community": 222
     },
     {
       "label": ".cosineSimilarity()",
@@ -16649,7 +16713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L151",
       "id": "query_filter_service_queryfilterservice_cosinesimilarity",
-      "community": 221
+      "community": 222
     },
     {
       "label": ".calculateTextSimilarity()",
@@ -16657,7 +16721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L175",
       "id": "query_filter_service_queryfilterservice_calculatetextsimilarity",
-      "community": 221
+      "community": 222
     },
     {
       "label": ".calculateBaseRankingScore()",
@@ -16665,7 +16729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L186",
       "id": "query_filter_service_queryfilterservice_calculatebaserankingscore",
-      "community": 221
+      "community": 222
     },
     {
       "label": "anchor-manager.ts",
@@ -16777,7 +16841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "FallbackSearchService",
@@ -16785,7 +16849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".setDatabase()",
@@ -16793,7 +16857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -16801,7 +16865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -16809,7 +16873,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 297
+      "community": 298
     },
     {
       "label": "index.ts",
@@ -16817,7 +16881,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "fallback-strategy.ts",
@@ -16825,7 +16889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "FallbackStrategy",
@@ -16833,7 +16897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".constructor()",
@@ -16841,7 +16905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".fallback()",
@@ -16849,7 +16913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".execute()",
@@ -16857,7 +16921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 298
+      "community": 299
     },
     {
       "label": "anchor-search-service.ts",
@@ -17001,7 +17065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "anchor-cache-service.ts",
@@ -17193,7 +17257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "local-search-service.spec.ts",
@@ -17201,7 +17265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -17209,7 +17273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "vector-search.factory.ts",
@@ -17337,7 +17401,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -17345,7 +17409,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 531
+      "community": 532
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -17353,7 +17417,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "search-result-combiner.ts",
@@ -17361,7 +17425,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "SearchResultCombiner",
@@ -17369,7 +17433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L19",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 340
+      "community": 341
     },
     {
       "label": ".combine()",
@@ -17377,7 +17441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L31",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 340
+      "community": 341
     },
     {
       "label": ".generateHybridReason()",
@@ -17385,7 +17449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L100",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 340
+      "community": 341
     },
     {
       "label": "search-engine.ts",
@@ -18337,7 +18401,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_migration_ts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "VectorSearchEngineMigration",
@@ -18345,7 +18409,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L16",
       "id": "vector_search_engine_migration_vectorsearchenginemigration",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".migrate()",
@@ -18353,7 +18417,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L23",
       "id": "vector_search_engine_migration_vectorsearchenginemigration_migrate",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".createAdapter()",
@@ -18361,7 +18425,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L43",
       "id": "vector_search_engine_migration_vectorsearchenginemigration_createadapter",
-      "community": 222
+      "community": 223
     },
     {
       "label": "MigrationValidator",
@@ -18369,7 +18433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L137",
       "id": "vector_search_engine_migration_migrationvalidator",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".validateCompatibility()",
@@ -18377,7 +18441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L141",
       "id": "vector_search_engine_migration_migrationvalidator_validatecompatibility",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".comparePerformance()",
@@ -18385,7 +18449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L180",
       "id": "vector_search_engine_migration_migrationvalidator_compareperformance",
-      "community": 222
+      "community": 223
     },
     {
       "label": "hybrid-search-outcome-utils.ts",
@@ -18393,7 +18457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -18401,7 +18465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 532
+      "community": 533
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -18409,7 +18473,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_spec_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "createMockVectorRows()",
@@ -18417,7 +18481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L14",
       "id": "vector_search_engine_spec_createmockvectorrows",
-      "community": 413
+      "community": 414
     },
     {
       "label": "createMockImplementation()",
@@ -18425,7 +18489,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L28",
       "id": "vector_search_engine_spec_createmockimplementation",
-      "community": 413
+      "community": 414
     },
     {
       "label": "procedural-memory-matcher.ts",
@@ -18497,7 +18561,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "normalize()",
@@ -18505,7 +18569,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 341
+      "community": 342
     },
     {
       "label": "toSet()",
@@ -18513,7 +18577,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 341
+      "community": 342
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -18521,7 +18585,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 341
+      "community": 342
     },
     {
       "label": "procedural-memory-matcher.spec.ts",
@@ -18529,7 +18593,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "search-ranking.spec.ts",
@@ -18537,7 +18601,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -18545,7 +18609,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "initializeTestDatabase()",
@@ -18553,7 +18617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 414
+      "community": 415
     },
     {
       "label": "createValidReflectionNote()",
@@ -18561,7 +18625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 414
+      "community": 415
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -18641,7 +18705,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -18649,7 +18713,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "search-engine.spec.ts",
@@ -18657,7 +18721,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createCountingSearchDb()",
@@ -18665,7 +18729,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -18673,7 +18737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createSearchRows()",
@@ -18681,7 +18745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 342
+      "community": 343
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -18689,7 +18753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "vector-search.repository.ts",
@@ -18865,7 +18929,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -18873,7 +18937,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "vector-search.service.ts",
@@ -18969,7 +19033,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -18977,7 +19041,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 533
+      "community": 534
     },
     {
       "label": "vector-performance-tester.ts",
@@ -18985,7 +19049,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_ts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "VectorPerformanceTester",
@@ -18993,7 +19057,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L12",
       "id": "vector_performance_tester_vectorperformancetester",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".constructor()",
@@ -19001,7 +19065,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L13",
       "id": "vector_performance_tester_vectorperformancetester_constructor",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".runPerformanceTest()",
@@ -19009,7 +19073,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L18",
       "id": "vector_performance_tester_vectorperformancetester_runperformancetest",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".validateTestParameters()",
@@ -19017,7 +19081,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L44",
       "id": "vector_performance_tester_vectorperformancetester_validatetestparameters",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".analyzeResults()",
@@ -19025,7 +19089,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L57",
       "id": "vector_performance_tester_vectorperformancetester_analyzeresults",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".generateReport()",
@@ -19033,7 +19097,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L87",
       "id": "vector_performance_tester_vectorperformancetester_generatereport",
-      "community": 223
+      "community": 224
     },
     {
       "label": "vector-search.service.spec.ts",
@@ -19041,7 +19105,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createMockRepository()",
@@ -19049,7 +19113,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 534
+      "community": 535
     },
     {
       "label": "vector-index-manager.ts",
@@ -19057,7 +19121,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_ts",
-      "community": 224
+      "community": 225
     },
     {
       "label": "VectorIndexManager",
@@ -19065,7 +19129,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L12",
       "id": "vector_index_manager_vectorindexmanager",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".constructor()",
@@ -19073,7 +19137,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L13",
       "id": "vector_index_manager_vectorindexmanager_constructor",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".getIndexStatus()",
@@ -19081,7 +19145,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L21",
       "id": "vector_index_manager_vectorindexmanager_getindexstatus",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".rebuildIndex()",
@@ -19089,7 +19153,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L54",
       "id": "vector_index_manager_vectorindexmanager_rebuildindex",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".isAvailable()",
@@ -19097,7 +19161,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L72",
       "id": "vector_index_manager_vectorindexmanager_isavailable",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".getStatusSummary()",
@@ -19105,7 +19169,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L87",
       "id": "vector_index_manager_vectorindexmanager_getstatussummary",
-      "community": 224
+      "community": 225
     },
     {
       "label": "vector-search-facade.ts",
@@ -19313,7 +19377,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "selectScore()",
@@ -19321,7 +19385,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 299
+      "community": 300
     },
     {
       "label": "computeNormalizationRange()",
@@ -19329,7 +19393,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 299
+      "community": 300
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -19337,7 +19401,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 299
+      "community": 300
     },
     {
       "label": ".normalize()",
@@ -19345,7 +19409,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 299
+      "community": 300
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -19353,7 +19417,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createMockRepositories()",
@@ -19361,7 +19425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 535
+      "community": 536
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -19369,7 +19433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -19377,7 +19441,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createMockIndexRepository()",
@@ -19385,7 +19449,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 536
+      "community": 537
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -19561,7 +19625,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -19569,7 +19633,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -19577,7 +19641,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "spaced-repetition.ts",
@@ -19905,7 +19969,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -19913,7 +19977,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "ForgettingStatsTool",
@@ -19921,7 +19985,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".constructor()",
@@ -19929,7 +19993,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".handle()",
@@ -19937,7 +20001,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 343
+      "community": 344
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -19945,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -20081,7 +20145,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -20089,7 +20153,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "priority-calculation.service.ts",
@@ -20969,7 +21033,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "recall-probability.service.ts",
@@ -21073,7 +21137,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "telemetry.types.ts",
@@ -21081,7 +21145,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -21089,7 +21153,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "openTelemetryDb()",
@@ -21097,7 +21161,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 537
+      "community": 538
     },
     {
       "label": "telemetry-repository.ts",
@@ -21257,7 +21321,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "makeSearchQuality()",
@@ -21265,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 300
+      "community": 301
     },
     {
       "label": "makeMemoryQuality()",
@@ -21273,7 +21337,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 300
+      "community": 301
     },
     {
       "label": "makeConsolidationQuality()",
@@ -21281,7 +21345,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 300
+      "community": 301
     },
     {
       "label": "makeContext()",
@@ -21289,7 +21353,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 300
+      "community": 301
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -21297,7 +21361,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -21305,7 +21369,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 344
+      "community": 345
     },
     {
       "label": ".constructor()",
@@ -21313,7 +21377,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 344
+      "community": 345
     },
     {
       "label": ".handle()",
@@ -21321,7 +21385,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 344
+      "community": 345
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -21329,7 +21393,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "telemetry-service.ts",
@@ -21457,7 +21521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "kg-triple-repository.ts",
@@ -21465,7 +21529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "process-attribute-repository.ts",
@@ -21473,7 +21537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -21481,7 +21545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -21489,7 +21553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "feedback-repository.ts",
@@ -21497,7 +21561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -21505,7 +21569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 415
+      "community": 416
     },
     {
       "label": "FeedbackRepository",
@@ -21513,7 +21577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 415
+      "community": 416
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -21521,7 +21585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -21529,7 +21593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -21537,7 +21601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -21545,7 +21609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -21553,7 +21617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -21561,7 +21625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createKgTripleTable()",
@@ -21569,7 +21633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 538
+      "community": 539
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -21577,7 +21641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createProcessAttributeTable()",
@@ -21585,7 +21649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 539
+      "community": 540
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -21593,7 +21657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -21601,7 +21665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 540
+      "community": 541
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -21609,7 +21673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -21617,7 +21681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createCoreMemoryTable()",
@@ -21625,7 +21689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 541
+      "community": 542
     },
     {
       "label": "remember-tool.ts",
@@ -21793,7 +21857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -21801,7 +21865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 345
+      "community": 346
     },
     {
       "label": ".constructor()",
@@ -21809,7 +21873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 345
+      "community": 346
     },
     {
       "label": ".handle()",
@@ -21817,7 +21881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 345
+      "community": 346
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -21825,7 +21889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "ProceduralRollbackTool",
@@ -21833,7 +21897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".constructor()",
@@ -21841,7 +21905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".handle()",
@@ -21849,7 +21913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 346
+      "community": 347
     },
     {
       "label": "feedback-tool.ts",
@@ -21905,7 +21969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "CleanupMemoryTool",
@@ -21913,7 +21977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".constructor()",
@@ -21921,7 +21985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".handle()",
@@ -21929,7 +21993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 347
+      "community": 348
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -22129,7 +22193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "ProceduralDiffTool",
@@ -22137,7 +22201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 348
+      "community": 349
     },
     {
       "label": ".constructor()",
@@ -22145,7 +22209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 348
+      "community": 349
     },
     {
       "label": ".handle()",
@@ -22153,7 +22217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 348
+      "community": 349
     },
     {
       "label": "unpin-tool.ts",
@@ -22273,7 +22337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -22281,7 +22345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 349
+      "community": 350
     },
     {
       "label": ".constructor()",
@@ -22289,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 349
+      "community": 350
     },
     {
       "label": ".handle()",
@@ -22297,7 +22361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 349
+      "community": 350
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -22305,7 +22369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "RememberProcedureTool",
@@ -22313,7 +22377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 350
+      "community": 351
     },
     {
       "label": ".constructor()",
@@ -22321,7 +22385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 350
+      "community": 351
     },
     {
       "label": ".handle()",
@@ -22329,7 +22393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 350
+      "community": 351
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -22337,7 +22401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -22345,7 +22409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 301
+      "community": 302
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -22353,7 +22417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 301
+      "community": 302
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -22361,7 +22425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 301
+      "community": 302
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -22369,7 +22433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 301
+      "community": 302
     },
     {
       "label": "recall-tool.ts",
@@ -22649,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createSchema()",
@@ -22657,7 +22721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 542
+      "community": 543
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -22665,7 +22729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "remember-tool.spec.ts",
@@ -22673,7 +22737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "initializeTestDatabase()",
@@ -22681,7 +22745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 416
+      "community": 417
     },
     {
       "label": "createValidReflectionNote()",
@@ -22689,7 +22753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 416
+      "community": 417
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -22697,7 +22761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -22705,7 +22769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createSchema()",
@@ -22713,7 +22777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 543
+      "community": 544
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -22721,7 +22785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "generateId()",
@@ -22729,7 +22793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 351
+      "community": 352
     },
     {
       "label": "initializeTestDatabase()",
@@ -22737,7 +22801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 351
+      "community": 352
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -22745,7 +22809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 351
+      "community": 352
     },
     {
       "label": "forget-tool.spec.ts",
@@ -22753,7 +22817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -22761,7 +22825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -22769,7 +22833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "initializeTestDatabase()",
@@ -22777,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 544
+      "community": 545
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -22785,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "parseData()",
@@ -22793,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 545
+      "community": 546
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -22801,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "recall-tool.spec.ts",
@@ -22809,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "initializeTestDatabase()",
@@ -22817,7 +22881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 417
+      "community": 418
     },
     {
       "label": "createValidReflectionNote()",
@@ -22825,7 +22889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1354",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 417
+      "community": 418
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -22833,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -22841,7 +22905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "pin-tool.spec.ts",
@@ -22849,7 +22913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "meta-memory-service.ts",
@@ -22977,7 +23041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "fieldDiff()",
@@ -22985,7 +23049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 352
+      "community": 353
     },
     {
       "label": "parseStepsJson()",
@@ -22993,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 352
+      "community": 353
     },
     {
       "label": "computeProceduralDiff()",
@@ -23001,7 +23065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 352
+      "community": 353
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -23009,7 +23073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -23017,7 +23081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 302
+      "community": 303
     },
     {
       "label": ".constructor()",
@@ -23025,7 +23089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 302
+      "community": 303
     },
     {
       "label": ".notFound()",
@@ -23033,7 +23097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 302
+      "community": 303
     },
     {
       "label": ".notActionable()",
@@ -23041,7 +23105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 302
+      "community": 303
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -23049,7 +23113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "parseImportanceThreshold()",
@@ -23057,7 +23121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 353
+      "community": 354
     },
     {
       "label": "parsePositiveInt()",
@@ -23065,7 +23129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 353
+      "community": 354
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -23073,7 +23137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 353
+      "community": 354
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -23081,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -23089,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 546
+      "community": 547
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -23169,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "baseRow()",
@@ -23177,7 +23241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 547
+      "community": 548
     },
     {
       "label": "procedural-versioning.ts",
@@ -23185,7 +23249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "getVersionChain()",
@@ -23193,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 354
+      "community": 355
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -23201,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 354
+      "community": 355
     },
     {
       "label": "getNextVersionNumber()",
@@ -23209,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 354
+      "community": 355
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -23217,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -23225,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 418
+      "community": 419
     },
     {
       "label": ".runScan()",
@@ -23233,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 418
+      "community": 419
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -23241,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "generateMemoryId()",
@@ -23249,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 419
+      "community": 420
     },
     {
       "label": "rollbackToVersion()",
@@ -23257,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 419
+      "community": 420
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -23329,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "selectionWindowLimit()",
@@ -23337,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 420
+      "community": 421
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -23345,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 420
+      "community": 421
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -23353,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "IntrospectionScanCache",
@@ -23361,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".set()",
@@ -23369,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".get()",
@@ -23377,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".clear()",
@@ -23385,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 303
+      "community": 304
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -23393,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -23401,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 548
+      "community": 549
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -23409,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "openDb()",
@@ -23417,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 549
+      "community": 550
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -23889,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -23897,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "core-memory-cache-service.ts",
@@ -24089,7 +24153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -24097,7 +24161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -24105,7 +24169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 421
+      "community": 422
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -24113,7 +24177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 421
+      "community": 422
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -24121,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -24129,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "core-memory-service.ts",
@@ -24289,7 +24353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -24297,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -24305,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -24313,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 552
+      "community": 553
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -24393,7 +24457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -24401,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -24409,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createSchema()",
@@ -24417,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 553
+      "community": 554
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -24425,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -24433,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "createSchema()",
@@ -24441,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 554
+      "community": 555
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -24449,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "createBaseSchema()",
@@ -24457,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 555
+      "community": 556
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -24465,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -24473,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "createSchema()",
@@ -24481,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 556
+      "community": 557
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -24489,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -24497,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -24617,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -24625,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_statistics_ts",
-      "community": 225
+      "community": 226
     },
     {
       "label": "SemanticMemoryStatisticsService",
@@ -24633,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L43",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice",
-      "community": 225
+      "community": 226
     },
     {
       "label": ".constructor()",
@@ -24641,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L48",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_constructor",
-      "community": 225
+      "community": 226
     },
     {
       "label": ".initializeStatistics()",
@@ -24649,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L55",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_initializestatistics",
-      "community": 225
+      "community": 226
     },
     {
       "label": ".recordUpdate()",
@@ -24657,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L86",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_recordupdate",
-      "community": 225
+      "community": 226
     },
     {
       "label": ".getStatistics()",
@@ -24665,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L154",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_getstatistics",
-      "community": 225
+      "community": 226
     },
     {
       "label": ".reset()",
@@ -24673,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L161",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_reset",
-      "community": 225
+      "community": 226
     },
     {
       "label": "semantic-memory-update-service.ts",
@@ -24865,7 +24929,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -24873,7 +24937,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -24881,7 +24945,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 557
+      "community": 558
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -24889,7 +24953,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "consolidation-repository.ts",
@@ -25065,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_ts",
-      "community": 226
+      "community": 227
     },
     {
       "label": "ClusteringService",
@@ -25073,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L16",
       "id": "clustering_service_clusteringservice",
-      "community": 226
+      "community": 227
     },
     {
       "label": ".getSimilarityThreshold()",
@@ -25081,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L17",
       "id": "clustering_service_clusteringservice_getsimilaritythreshold",
-      "community": 226
+      "community": 227
     },
     {
       "label": ".getMinClusterSize()",
@@ -25089,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L23",
       "id": "clustering_service_clusteringservice_getminclustersize",
-      "community": 226
+      "community": 227
     },
     {
       "label": ".cosineSimilarity()",
@@ -25097,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L29",
       "id": "clustering_service_clusteringservice_cosinesimilarity",
-      "community": 226
+      "community": 227
     },
     {
       "label": ".clusterGroup()",
@@ -25105,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L50",
       "id": "clustering_service_clusteringservice_clustergroup",
-      "community": 226
+      "community": 227
     },
     {
       "label": ".buildClusters()",
@@ -25113,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L117",
       "id": "clustering_service_clusteringservice_buildclusters",
-      "community": 226
+      "community": 227
     },
     {
       "label": "summarization-service.spec.ts",
@@ -25121,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "row()",
@@ -25129,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 558
+      "community": 559
     },
     {
       "label": "summarization-service.ts",
@@ -25185,7 +25249,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "insertEpisodic()",
@@ -25193,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 304
+      "community": 305
     },
     {
       "label": "insertEmbedding()",
@@ -25201,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 304
+      "community": 305
     },
     {
       "label": "FailingRepo",
@@ -25209,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 304
+      "community": 305
     },
     {
       "label": ".insertSemanticMemory()",
@@ -25217,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 304
+      "community": 305
     },
     {
       "label": "clustering-service.spec.ts",
@@ -25225,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "ep()",
@@ -25233,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 559
+      "community": 560
     },
     {
       "label": "relation-graph.port.ts",
@@ -25241,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "get-relations-tool.ts",
@@ -25249,7 +25313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "GetRelationsTool",
@@ -25257,7 +25321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".constructor()",
@@ -25265,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".handle()",
@@ -25273,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 355
+      "community": 356
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -25281,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -25289,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 560
+      "community": 561
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -25297,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "VisualizeRelationsTool",
@@ -25305,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".constructor()",
@@ -25313,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".handle()",
@@ -25321,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 356
+      "community": 357
     },
     {
       "label": "remove-relation-tool.ts",
@@ -25329,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "RemoveRelationTool",
@@ -25337,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".constructor()",
@@ -25345,7 +25409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".handle()",
@@ -25353,7 +25417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 357
+      "community": 358
     },
     {
       "label": "extract-relations-tool.ts",
@@ -25361,7 +25425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "ExtractRelationsTool",
@@ -25369,7 +25433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 358
+      "community": 359
     },
     {
       "label": ".constructor()",
@@ -25377,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 358
+      "community": 359
     },
     {
       "label": ".handle()",
@@ -25385,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 358
+      "community": 359
     },
     {
       "label": "add-relation-tool.ts",
@@ -25393,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "AddRelationTool",
@@ -25401,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L18",
       "id": "add_relation_tool_addrelationtool",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".constructor()",
@@ -25409,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".handle()",
@@ -25417,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L57",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 359
+      "community": 360
     },
     {
       "label": "extract-triples-tool.ts",
@@ -25473,7 +25537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "createBaseSchema()",
@@ -25481,7 +25545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 422
+      "community": 423
     },
     {
       "label": "createTestMemory()",
@@ -25489,7 +25553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 422
+      "community": 423
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -25497,7 +25561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createBaseSchema()",
@@ -25505,7 +25569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createTestMemory()",
@@ -25513,7 +25577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 423
+      "community": 424
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -25521,7 +25585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createBaseSchema()",
@@ -25529,7 +25593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createTestMemory()",
@@ -25537,7 +25601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 424
+      "community": 425
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -25545,7 +25609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -25553,7 +25617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createBaseSchema()",
@@ -25561,7 +25625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createTestMemory()",
@@ -25569,7 +25633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 425
+      "community": 426
     },
     {
       "label": "relation-retry-manager.ts",
@@ -25577,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "RelationRetryManager",
@@ -25585,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".constructor()",
@@ -25593,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".retry()",
@@ -25601,7 +25665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 360
+      "community": 361
     },
     {
       "label": "rule-based-relation-extractor.ts",
@@ -26329,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "loadTestDataset()",
@@ -26337,7 +26401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 361
+      "community": 362
     },
     {
       "label": "createBaseSchema()",
@@ -26345,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 361
+      "community": 362
     },
     {
       "label": "createTestMemory()",
@@ -26353,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 361
+      "community": 362
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -26361,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "relation-graph.spec.ts",
@@ -26369,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createBaseSchema()",
@@ -26377,7 +26441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L24",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createTestMemory()",
@@ -26385,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L59",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 426
+      "community": 427
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -26393,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "createTestMemory()",
@@ -26401,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 561
+      "community": 562
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -26409,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "createBaseSchema()",
@@ -26417,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 362
+      "community": 363
     },
     {
       "label": "createTestMemory()",
@@ -26425,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 362
+      "community": 363
     },
     {
       "label": "createBulkMemories()",
@@ -26433,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 362
+      "community": 363
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -26441,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "createTestMemory()",
@@ -26449,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 562
+      "community": 563
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -26457,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_based_relation_extractor_spec_ts",
-      "community": 227
+      "community": 228
     },
     {
       "label": "getMockEmbeddingFunctions()",
@@ -26465,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L97",
       "id": "llm_based_relation_extractor_spec_getmockembeddingfunctions",
-      "community": 227
+      "community": 228
     },
     {
       "label": "createMockConfig()",
@@ -26473,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L106",
       "id": "llm_based_relation_extractor_spec_createmockconfig",
-      "community": 227
+      "community": 228
     },
     {
       "label": "createTestMemory()",
@@ -26481,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L161",
       "id": "llm_based_relation_extractor_spec_createtestmemory",
-      "community": 227
+      "community": 228
     },
     {
       "label": "createMockEmbeddingService()",
@@ -26489,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L182",
       "id": "llm_based_relation_extractor_spec_createmockembeddingservice",
-      "community": 227
+      "community": 228
     },
     {
       "label": "generateEmbedding()",
@@ -26497,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L231",
       "id": "llm_based_relation_extractor_spec_generateembedding",
-      "community": 227
+      "community": 228
     },
     {
       "label": "searchSimilar()",
@@ -26505,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L232",
       "id": "llm_based_relation_extractor_spec_searchsimilar",
-      "community": 227
+      "community": 228
     },
     {
       "label": "provider-auto.spec.ts",
@@ -26513,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -26521,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -26529,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "getMockMementoConfig()",
@@ -26537,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 427
+      "community": 428
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -26545,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 427
+      "community": 428
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -26553,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "provider-openai.spec.ts",
@@ -26561,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -26569,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -26577,7 +26641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -26585,7 +26649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -26593,7 +26657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".constructor()",
@@ -26601,7 +26665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".consume()",
@@ -26609,7 +26673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".refill()",
@@ -26617,7 +26681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 305
+      "community": 306
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -26625,7 +26689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 363
+      "community": 364
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -26633,7 +26697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 363
+      "community": 364
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -26641,7 +26705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 363
+      "community": 364
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -26649,7 +26713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 363
+      "community": 364
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -26841,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_providers_ts",
-      "community": 228
+      "community": 229
     },
     {
       "label": "isRecord()",
@@ -26849,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L25",
       "id": "triple_extraction_llm_providers_isrecord",
-      "community": 228
+      "community": 229
     },
     {
       "label": "getStringField()",
@@ -26857,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L29",
       "id": "triple_extraction_llm_providers_getstringfield",
-      "community": 228
+      "community": 229
     },
     {
       "label": "extractRawWithOpenAI()",
@@ -26865,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L34",
       "id": "triple_extraction_llm_providers_extractrawwithopenai",
-      "community": 228
+      "community": 229
     },
     {
       "label": "extractRawWithGemini()",
@@ -26873,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L92",
       "id": "triple_extraction_llm_providers_extractrawwithgemini",
-      "community": 228
+      "community": 229
     },
     {
       "label": "extractRawWithOllama()",
@@ -26881,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L148",
       "id": "triple_extraction_llm_providers_extractrawwithollama",
-      "community": 228
+      "community": 229
     },
     {
       "label": "checkOllamaModelInstalled()",
@@ -26889,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L275",
       "id": "triple_extraction_llm_providers_checkollamamodelinstalled",
-      "community": 228
+      "community": 229
     },
     {
       "label": "triple-pipeline-orchestrator.spec.ts",
@@ -26897,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "extract()",
@@ -26905,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 563
+      "community": 564
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -26913,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "tripleDedupeKey()",
@@ -26921,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 428
+      "community": 429
     },
     {
       "label": "mergeTripleLists()",
@@ -26929,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 428
+      "community": 429
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -26937,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "triple-extraction-service.ts",
@@ -27073,7 +27137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -27081,7 +27145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -27089,7 +27153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "triple-extractor.ts",
@@ -27233,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 364
+      "community": 365
     },
     {
       "label": "TripleNormalizer",
@@ -27241,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".constructor()",
@@ -27249,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".normalize()",
@@ -27257,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 364
+      "community": 365
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -27265,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -27273,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 365
+      "community": 366
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -27281,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 365
+      "community": 366
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -27289,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 365
+      "community": 366
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -27297,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 365
+      "community": 366
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -27305,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "triple-parser.ts",
@@ -27313,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "TripleParser",
@@ -27321,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".parse()",
@@ -27329,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".extractJSON()",
@@ -27337,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".isValidTriple()",
@@ -27345,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 306
+      "community": 307
     },
     {
       "label": "triple-text-chunker.ts",
@@ -27353,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "splitTextIntoChunks()",
@@ -27361,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 564
+      "community": 565
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -27369,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -27377,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 565
+      "community": 566
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -27465,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -27473,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "interfaces.spec.ts",
@@ -27481,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -27489,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "triple-parser.spec.ts",
@@ -27497,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "embedding-provider-factory.ts",
@@ -27737,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 366
+      "community": 367
     },
     {
       "label": "createMockService()",
@@ -27745,7 +27809,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 366
+      "community": 367
     },
     {
       "label": "resolver()",
@@ -27753,7 +27817,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 366
+      "community": 367
     },
     {
       "label": "priority()",
@@ -27761,7 +27825,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 366
+      "community": 367
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -27769,7 +27833,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "embedding-service.ts",
@@ -28881,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -28889,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -28897,7 +28961,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "createSchema()",
@@ -28905,7 +28969,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 429
+      "community": 430
     },
     {
       "label": "seedMemoryItem()",
@@ -28913,7 +28977,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 429
+      "community": 430
     },
     {
       "label": "embedding-service.spec.ts",
@@ -28921,7 +28985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -28929,7 +28993,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -28937,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -28945,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 367
+      "community": 368
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -28953,7 +29017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".constructor()",
@@ -28961,7 +29025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".handle()",
@@ -28969,7 +29033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 367
+      "community": 368
     },
     {
       "label": "performance-alerts.ts",
@@ -29025,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 368
+      "community": 369
     },
     {
       "label": "PerformanceStatsTool",
@@ -29033,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".constructor()",
@@ -29041,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".handle()",
@@ -29049,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 368
+      "community": 369
     },
     {
       "label": "resolve-error.ts",
@@ -29057,7 +29121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "executeResolveError()",
@@ -29065,7 +29129,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 566
+      "community": 567
     },
     {
       "label": "error-stats.ts",
@@ -29073,7 +29137,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "executeErrorStats()",
@@ -29081,7 +29145,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 567
+      "community": 568
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -29089,7 +29153,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "resolve-error.spec.ts",
@@ -29097,7 +29161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -29105,7 +29169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "createBaseSchema()",
@@ -29113,7 +29177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 568
+      "community": 569
     },
     {
       "label": "error-stats.spec.ts",
@@ -29121,7 +29185,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "performance-monitor.ts",
@@ -30017,7 +30081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -30025,7 +30089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -30033,7 +30097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -30041,7 +30105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -30049,7 +30113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "toBytes()",
@@ -30057,7 +30121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L5",
       "id": "performance_monitor_spec_tobytes",
-      "community": 430
+      "community": 431
     },
     {
       "label": "createMetrics()",
@@ -30065,7 +30129,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 430
+      "community": 431
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -30073,7 +30137,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "restoreEnvValue()",
@@ -30081,7 +30145,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 569
+      "community": 570
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -30089,7 +30153,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 369
+      "community": 370
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -30097,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 369
+      "community": 370
     },
     {
       "label": "createQualityMetricsTable()",
@@ -30105,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 369
+      "community": 370
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30113,7 +30177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 369
+      "community": 370
     },
     {
       "label": "quality-recorder.ts",
@@ -30185,7 +30249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30193,7 +30257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 570
+      "community": 571
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -30273,7 +30337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30281,7 +30345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 571
+      "community": 572
     },
     {
       "label": "quality-reporter.ts",
@@ -30369,7 +30433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 370
+      "community": 371
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -30377,7 +30441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 370
+      "community": 371
     },
     {
       "label": "createQualityMetricsTable()",
@@ -30385,7 +30449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 370
+      "community": 371
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30393,7 +30457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 370
+      "community": 371
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -30401,7 +30465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "quality-assurance-service.ts",
@@ -30681,7 +30745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 371
+      "community": 372
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -30689,7 +30753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 371
+      "community": 372
     },
     {
       "label": "createQualityMetricsTable()",
@@ -30697,7 +30761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 371
+      "community": 372
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -30705,7 +30769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 371
+      "community": 372
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -30897,7 +30961,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "base-tool.ts",
@@ -31025,7 +31089,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_index_ts",
-      "community": 229
+      "community": 230
     },
     {
       "label": "getToolRegistry()",
@@ -31033,7 +31097,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L58",
       "id": "index_gettoolregistry",
-      "community": 229
+      "community": 230
     },
     {
       "label": "getTool()",
@@ -31041,7 +31105,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L62",
       "id": "index_gettool",
-      "community": 229
+      "community": 230
     },
     {
       "label": "getAllTools()",
@@ -31049,7 +31113,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L66",
       "id": "index_getalltools",
-      "community": 229
+      "community": 230
     },
     {
       "label": "telemetryParamsContext()",
@@ -31057,7 +31121,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L71",
       "id": "index_telemetryparamscontext",
-      "community": 229
+      "community": 230
     },
     {
       "label": "resolveTelemetryOwnerId()",
@@ -31065,7 +31129,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L89",
       "id": "index_resolvetelemetryownerid",
-      "community": 229
+      "community": 230
     },
     {
       "label": "executeTool()",
@@ -31073,7 +31137,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L110",
       "id": "index_executetool",
-      "community": 229
+      "community": 230
     },
     {
       "label": "performance-benchmark.ts",
@@ -31193,7 +31257,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "testBootstrapIntegration()",
@@ -31201,7 +31265,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 572
+      "community": 573
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -31209,7 +31273,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "measureRecall()",
@@ -31217,7 +31281,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 573
+      "community": 574
     },
     {
       "label": "test-embedding.ts",
@@ -31225,7 +31289,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -31233,7 +31297,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 574
+      "community": 575
     },
     {
       "label": "test-tool-consistency.ts",
@@ -31241,7 +31305,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "compareToolResults()",
@@ -31249,7 +31313,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 431
+      "community": 432
     },
     {
       "label": "testToolConsistency()",
@@ -31257,7 +31321,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 431
+      "community": 432
     },
     {
       "label": "test-quality-assurance.ts",
@@ -31265,7 +31329,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "createQualityTables()",
@@ -31273,7 +31337,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 432
+      "community": 433
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -31281,7 +31345,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 432
+      "community": 433
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -31289,7 +31353,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "PerformanceBenchmark",
@@ -31297,7 +31361,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".measureOperation()",
@@ -31305,7 +31369,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".getResults()",
@@ -31313,7 +31377,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".getSummary()",
@@ -31321,7 +31385,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 307
+      "community": 308
     },
     {
       "label": "test-search.ts",
@@ -31329,7 +31393,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "testSearchFunctionality()",
@@ -31337,7 +31401,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 575
+      "community": 576
     },
     {
       "label": "test-forgetting.ts",
@@ -31345,7 +31409,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "testForgettingFunctionality()",
@@ -31353,7 +31417,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 576
+      "community": 577
     },
     {
       "label": "mock-database.spec.ts",
@@ -31361,7 +31425,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "test-m1-completion.ts",
@@ -31369,7 +31433,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "testM1Completion()",
@@ -31377,7 +31441,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 577
+      "community": 578
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -31385,7 +31449,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -31393,7 +31457,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vitest.setup.ts",
@@ -31401,7 +31465,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -31409,7 +31473,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "parseItems()",
@@ -31417,7 +31481,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 579
+      "community": 580
     },
     {
       "label": "test-memory-resource.ts",
@@ -31425,7 +31489,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "setupResourceHandlers()",
@@ -31433,7 +31497,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 433
+      "community": 434
     },
     {
       "label": "createTestMemories()",
@@ -31441,7 +31505,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 433
+      "community": 434
     },
     {
       "label": "test-regression.ts",
@@ -31449,7 +31513,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "testRegression()",
@@ -31457,7 +31521,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 580
+      "community": 581
     },
     {
       "label": "test-anchor-system.ts",
@@ -31465,7 +31529,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_anchor_system_ts",
-      "community": 230
+      "community": 231
     },
     {
       "label": "createAnchorTable()",
@@ -31473,7 +31537,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L16",
       "id": "test_anchor_system_createanchortable",
-      "community": 230
+      "community": 231
     },
     {
       "label": "testAnchorSystemWorkflow()",
@@ -31481,7 +31545,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L35",
       "id": "test_anchor_system_testanchorsystemworkflow",
-      "community": 230
+      "community": 231
     },
     {
       "label": "testMultiClientScenario()",
@@ -31489,7 +31553,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L179",
       "id": "test_anchor_system_testmulticlientscenario",
-      "community": 230
+      "community": 231
     },
     {
       "label": "testFallbackMechanism()",
@@ -31497,7 +31561,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L316",
       "id": "test_anchor_system_testfallbackmechanism",
-      "community": 230
+      "community": 231
     },
     {
       "label": "expect()",
@@ -31505,7 +31569,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L431",
       "id": "test_anchor_system_expect",
-      "community": 230
+      "community": 231
     },
     {
       "label": "runAllTests()",
@@ -31513,7 +31577,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L471",
       "id": "test_anchor_system_runalltests",
-      "community": 230
+      "community": 231
     },
     {
       "label": "test-vector-search-quality-with-consolidation.spec.ts",
@@ -31521,7 +31585,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -31593,7 +31657,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "testSingleProviderRegression()",
@@ -31601,7 +31665,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 581
+      "community": 582
     },
     {
       "label": "visualize-recency.ts",
@@ -31609,7 +31673,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_visualize_recency_ts",
-      "community": 231
+      "community": 232
     },
     {
       "label": "calculateRecency()",
@@ -31617,7 +31681,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L21",
       "id": "visualize_recency_calculaterecency",
-      "community": 231
+      "community": 232
     },
     {
       "label": "generateRecencyData()",
@@ -31625,7 +31689,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L28",
       "id": "visualize_recency_generaterecencydata",
-      "community": 231
+      "community": 232
     },
     {
       "label": "printConsoleGraph()",
@@ -31633,7 +31697,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L55",
       "id": "visualize_recency_printconsolegraph",
-      "community": 231
+      "community": 232
     },
     {
       "label": "printKeyPoints()",
@@ -31641,7 +31705,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L133",
       "id": "visualize_recency_printkeypoints",
-      "community": 231
+      "community": 232
     },
     {
       "label": "printCSV()",
@@ -31649,7 +31713,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L164",
       "id": "visualize_recency_printcsv",
-      "community": 231
+      "community": 232
     },
     {
       "label": "main()",
@@ -31657,7 +31721,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L180",
       "id": "visualize_recency_main",
-      "community": 231
+      "community": 232
     },
     {
       "label": "embedding-integration-test.ts",
@@ -31665,7 +31729,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -31673,7 +31737,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_consolidation_search_quality_ts",
-      "community": 232
+      "community": 233
     },
     {
       "label": "generateGroundTruth()",
@@ -31681,7 +31745,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L44",
       "id": "test_consolidation_search_quality_generategroundtruth",
-      "community": 232
+      "community": 233
     },
     {
       "label": "convertToSearchResults()",
@@ -31689,7 +31753,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L67",
       "id": "test_consolidation_search_quality_converttosearchresults",
-      "community": 232
+      "community": 233
     },
     {
       "label": "measureSearchQuality()",
@@ -31697,7 +31761,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L79",
       "id": "test_consolidation_search_quality_measuresearchquality",
-      "community": 232
+      "community": 233
     },
     {
       "label": "compareWithAndWithoutConsolidation()",
@@ -31705,7 +31769,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L130",
       "id": "test_consolidation_search_quality_comparewithandwithoutconsolidation",
-      "community": 232
+      "community": 233
     },
     {
       "label": "verifyRankingOrder()",
@@ -31713,7 +31777,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L174",
       "id": "test_consolidation_search_quality_verifyrankingorder",
-      "community": 232
+      "community": 233
     },
     {
       "label": "testConsolidationSearchQuality()",
@@ -31721,7 +31785,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L197",
       "id": "test_consolidation_search_quality_testconsolidationsearchquality",
-      "community": 232
+      "community": 233
     },
     {
       "label": "test-vector-search-engine.ts",
@@ -31729,7 +31793,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "constructor()",
@@ -31737,7 +31801,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 582
+      "community": 583
     },
     {
       "label": "mock-database.ts",
@@ -31969,7 +32033,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -31977,7 +32041,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 372
+      "community": 373
     },
     {
       "label": "telemetryDb()",
@@ -31985,7 +32049,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 372
+      "community": 373
     },
     {
       "label": "percentile95()",
@@ -31993,7 +32057,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 372
+      "community": 373
     },
     {
       "label": "run()",
@@ -32001,7 +32065,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 372
+      "community": 373
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -32009,7 +32073,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "createTestMemories()",
@@ -32017,7 +32081,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 583
+      "community": 584
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -32025,7 +32089,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -32033,7 +32097,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 584
+      "community": 585
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -32041,7 +32105,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -32049,7 +32113,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "seedCluster()",
@@ -32057,7 +32121,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 585
+      "community": 586
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -32065,7 +32129,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "readSource()",
@@ -32073,7 +32137,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 434
+      "community": 435
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -32081,7 +32145,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 434
+      "community": 435
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -32089,7 +32153,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -32097,7 +32161,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 373
+      "community": 374
     },
     {
       "label": "normalizeTags()",
@@ -32105,7 +32169,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 373
+      "community": 374
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -32113,7 +32177,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 373
+      "community": 374
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -32121,7 +32185,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "writeFixtureDir()",
@@ -32129,7 +32193,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 586
+      "community": 587
     },
     {
       "label": "search-quality-metrics.ts",
@@ -32225,7 +32289,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -32233,7 +32297,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_ts",
-      "community": 233
+      "community": 234
     },
     {
       "label": "loadLabelCandidates()",
@@ -32241,7 +32305,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L19",
       "id": "search_quality_review_checklist_loadlabelcandidates",
-      "community": 233
+      "community": 234
     },
     {
       "label": "summarizeContent()",
@@ -32249,7 +32313,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L33",
       "id": "search_quality_review_checklist_summarizecontent",
-      "community": 233
+      "community": 234
     },
     {
       "label": "findGroundTruth()",
@@ -32257,7 +32321,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L42",
       "id": "search_quality_review_checklist_findgroundtruth",
-      "community": 233
+      "community": 234
     },
     {
       "label": "renderCandidate()",
@@ -32265,7 +32329,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L48",
       "id": "search_quality_review_checklist_rendercandidate",
-      "community": 233
+      "community": 234
     },
     {
       "label": "renderRelevantEntry()",
@@ -32273,7 +32337,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L65",
       "id": "search_quality_review_checklist_renderrelevantentry",
-      "community": 233
+      "community": 234
     },
     {
       "label": "buildReviewChecklistMarkdown()",
@@ -32281,7 +32345,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L82",
       "id": "search_quality_review_checklist_buildreviewchecklistmarkdown",
-      "community": 233
+      "community": 234
     },
     {
       "label": "benchmark-search-database.ts",
@@ -32289,7 +32353,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "normalizeMemoryType()",
@@ -32297,7 +32361,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 374
+      "community": 375
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -32305,7 +32369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 374
+      "community": 375
     },
     {
       "label": "seedOneCorpusRow()",
@@ -32313,7 +32377,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 374
+      "community": 375
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -32321,7 +32385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -32329,7 +32393,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "test-database.ts",
@@ -32337,7 +32401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_test_database_ts",
-      "community": 244
+      "community": 272
     },
     {
       "label": "createTestDatabaseWithoutServices()",
@@ -32345,7 +32409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L198",
       "id": "test_database_createtestdatabasewithoutservices",
-      "community": 244
+      "community": 272
     },
     {
       "label": "createTestMemory()",
@@ -32353,7 +32417,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L209",
       "id": "test_database_createtestmemory",
-      "community": 244
+      "community": 272
     },
     {
       "label": "search-quality-candidate-builder.ts",
@@ -32361,7 +32425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "mergeCandidateIds()",
@@ -32369,7 +32433,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 587
+      "community": 588
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -32377,7 +32441,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -32385,7 +32449,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 435
+      "community": 436
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -32393,7 +32457,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 435
+      "community": 436
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -32401,7 +32465,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -32409,7 +32473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -32609,7 +32673,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "query-counter.ts",
@@ -32617,7 +32681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "extractQueryType()",
@@ -32625,7 +32689,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 375
+      "community": 376
     },
     {
       "label": "isExcluded()",
@@ -32633,7 +32697,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 375
+      "community": 376
     },
     {
       "label": "createQueryCounter()",
@@ -32641,7 +32705,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 375
+      "community": 376
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -32649,7 +32713,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_ts",
-      "community": 5
+      "community": 6
     },
     {
       "label": "calculateKendallTau()",
@@ -32657,7 +32721,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L158",
       "id": "vector_search_quality_metrics_calculatekendalltau",
-      "community": 5
+      "community": 6
     },
     {
       "label": "calculateSpearmanRho()",
@@ -32665,7 +32729,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L281",
       "id": "vector_search_quality_metrics_calculatespearmanrho",
-      "community": 5
+      "community": 6
     },
     {
       "label": "calculateRanks()",
@@ -32673,7 +32737,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L335",
       "id": "vector_search_quality_metrics_calculateranks",
-      "community": 5
+      "community": 6
     },
     {
       "label": "calculateTopKRetention()",
@@ -32681,7 +32745,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L381",
       "id": "vector_search_quality_metrics_calculatetopkretention",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateVectorOnlySearchResults()",
@@ -32689,7 +32753,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L433",
       "id": "vector_search_quality_metrics_generatevectoronlysearchresults",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateConsolidationSearchResults()",
@@ -32697,7 +32761,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L500",
       "id": "vector_search_quality_metrics_generateconsolidationsearchresults",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateOrderPreservationReport()",
@@ -32705,7 +32769,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L571",
       "id": "vector_search_quality_metrics_generateorderpreservationreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "measureVectorOnlyQuality()",
@@ -32713,7 +32777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L700",
       "id": "vector_search_quality_metrics_measurevectoronlyquality",
-      "community": 5
+      "community": 6
     },
     {
       "label": "measureConsolidationQuality()",
@@ -32721,7 +32785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L737",
       "id": "vector_search_quality_metrics_measureconsolidationquality",
-      "community": 5
+      "community": 6
     },
     {
       "label": "calculateQualityDegradation()",
@@ -32729,7 +32793,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L802",
       "id": "vector_search_quality_metrics_calculatequalitydegradation",
-      "community": 5
+      "community": 6
     },
     {
       "label": "validateQualityThresholds()",
@@ -32737,7 +32801,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L910",
       "id": "vector_search_quality_metrics_validatequalitythresholds",
-      "community": 5
+      "community": 6
     },
     {
       "label": "compareQualityWithGroundTruth()",
@@ -32745,7 +32809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1022",
       "id": "vector_search_quality_metrics_comparequalitywithgroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateQualityComparisonReport()",
@@ -32753,7 +32817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1144",
       "id": "vector_search_quality_metrics_generatequalitycomparisonreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "visualizeQualityComparison()",
@@ -32761,7 +32825,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1188",
       "id": "vector_search_quality_metrics_visualizequalitycomparison",
-      "community": 5
+      "community": 6
     },
     {
       "label": "validateLowVectorHighConsolidation()",
@@ -32769,7 +32833,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1384",
       "id": "vector_search_quality_metrics_validatelowvectorhighconsolidation",
-      "community": 5
+      "community": 6
     },
     {
       "label": "validateHighVectorLowConsolidation()",
@@ -32777,7 +32841,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1486",
       "id": "vector_search_quality_metrics_validatehighvectorlowconsolidation",
-      "community": 5
+      "community": 6
     },
     {
       "label": "validateW2UpperBound()",
@@ -32785,7 +32849,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1634",
       "id": "vector_search_quality_metrics_validatew2upperbound",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateExtremeScenarioReport()",
@@ -32793,7 +32857,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1796",
       "id": "vector_search_quality_metrics_generateextremescenarioreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveBaselineSnapshot()",
@@ -32801,7 +32865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1965",
       "id": "vector_search_quality_metrics_savebaselinesnapshot",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadBaselineSnapshot()",
@@ -32809,7 +32873,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2008",
       "id": "vector_search_quality_metrics_loadbaselinesnapshot",
-      "community": 5
+      "community": 6
     },
     {
       "label": "compareWithBaseline()",
@@ -32817,7 +32881,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2144",
       "id": "vector_search_quality_metrics_comparewithbaseline",
-      "community": 5
+      "community": 6
     },
     {
       "label": "detectQualityDegradation()",
@@ -32825,7 +32889,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2308",
       "id": "vector_search_quality_metrics_detectqualitydegradation",
-      "community": 5
+      "community": 6
     },
     {
       "label": "printQualityAlert()",
@@ -32833,7 +32897,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2495",
       "id": "vector_search_quality_metrics_printqualityalert",
-      "community": 5
+      "community": 6
     },
     {
       "label": "detectAndAlertQualityDegradation()",
@@ -32841,7 +32905,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2645",
       "id": "vector_search_quality_metrics_detectandalertqualitydegradation",
-      "community": 5
+      "community": 6
     },
     {
       "label": "GroundTruthSeededRandom",
@@ -32849,7 +32913,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2663",
       "id": "vector_search_quality_metrics_groundtruthseededrandom",
-      "community": 5
+      "community": 6
     },
     {
       "label": ".constructor()",
@@ -32857,7 +32921,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2666",
       "id": "vector_search_quality_metrics_groundtruthseededrandom_constructor",
-      "community": 5
+      "community": 6
     },
     {
       "label": ".random()",
@@ -32865,7 +32929,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2673",
       "id": "vector_search_quality_metrics_groundtruthseededrandom_random",
-      "community": 5
+      "community": 6
     },
     {
       "label": ".randomInt()",
@@ -32873,7 +32937,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2683",
       "id": "vector_search_quality_metrics_groundtruthseededrandom_randomint",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateGroundTruth()",
@@ -32881,7 +32945,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2737",
       "id": "vector_search_quality_metrics_generategroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveGroundTruth()",
@@ -32889,7 +32953,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2807",
       "id": "vector_search_quality_metrics_savegroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadGroundTruth()",
@@ -32897,7 +32961,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2849",
       "id": "vector_search_quality_metrics_loadgroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateOrLoadGroundTruth()",
@@ -32905,7 +32969,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2903",
       "id": "vector_search_quality_metrics_generateorloadgroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadStrictBenchmarkGroundTruth()",
@@ -32913,7 +32977,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2930",
       "id": "vector_search_quality_metrics_loadstrictbenchmarkgroundtruth",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveOrderPreservationReport()",
@@ -32921,7 +32985,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L2971",
       "id": "vector_search_quality_metrics_saveorderpreservationreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveQualityComparisonReport()",
@@ -32929,7 +32993,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L3102",
       "id": "vector_search_quality_metrics_savequalitycomparisonreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveExtremeScenarioReport()",
@@ -32937,7 +33001,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L3181",
       "id": "vector_search_quality_metrics_saveextremescenarioreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "saveIntegratedReport()",
@@ -32945,7 +33009,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L3365",
       "id": "vector_search_quality_metrics_saveintegratedreport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "copy-assets.js",
@@ -32953,7 +33017,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 588
+      "community": 589
     },
     {
       "label": "copyDir()",
@@ -32961,7 +33025,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 588
+      "community": 589
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -32969,7 +33033,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "readRootPackageJson()",
@@ -32977,7 +33041,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 589
+      "community": 590
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -32985,7 +33049,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "readJson()",
@@ -32993,7 +33057,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 590
+      "community": 591
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -33001,7 +33065,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "readWorkflow()",
@@ -33009,7 +33073,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 591
+      "community": 592
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -33017,7 +33081,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L1",
       "id": "tests_root_quality_gates_spec_ts",
-      "community": 234
+      "community": 235
     },
     {
       "label": "readJson()",
@@ -33025,7 +33089,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L21",
       "id": "root_quality_gates_spec_readjson",
-      "community": 234
+      "community": 235
     },
     {
       "label": "normalizeCommand()",
@@ -33033,7 +33097,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L27",
       "id": "root_quality_gates_spec_normalizecommand",
-      "community": 234
+      "community": 235
     },
     {
       "label": "readScript()",
@@ -33041,7 +33105,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L31",
       "id": "root_quality_gates_spec_readscript",
-      "community": 234
+      "community": 235
     },
     {
       "label": "expectExactScript()",
@@ -33049,7 +33113,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L39",
       "id": "root_quality_gates_spec_expectexactscript",
-      "community": 234
+      "community": 235
     },
     {
       "label": "splitSequentialCommands()",
@@ -33057,7 +33121,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L43",
       "id": "root_quality_gates_spec_splitsequentialcommands",
-      "community": 234
+      "community": 235
     },
     {
       "label": "ruleSeverity()",
@@ -33065,7 +33129,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L47",
       "id": "root_quality_gates_spec_ruleseverity",
-      "community": 234
+      "community": 235
     },
     {
       "label": "static-design-contracts.spec.ts",
@@ -33073,7 +33137,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "readStaticFile()",
@@ -33081,7 +33145,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 592
+      "community": 593
     },
     {
       "label": "smoke.spec.ts",
@@ -33089,7 +33153,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "extractFencedBlocks()",
@@ -33097,7 +33161,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 593
+      "community": 594
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -33169,7 +33233,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "parseArgs()",
@@ -33177,7 +33241,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 376
+      "community": 377
     },
     {
       "label": "printHelp()",
@@ -33185,7 +33249,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 376
+      "community": 377
     },
     {
       "label": "main()",
@@ -33193,7 +33257,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 376
+      "community": 377
     },
     {
       "label": "check-magic-numbers.ts",
@@ -33281,7 +33345,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 594
+      "community": 595
     },
     {
       "label": "shouldInclude()",
@@ -33289,7 +33353,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 594
+      "community": 595
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -33297,7 +33361,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 436
+      "community": 437
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -33305,7 +33369,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 436
+      "community": 437
     },
     {
       "label": "readTarString()",
@@ -33313,7 +33377,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 436
+      "community": 437
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -33321,7 +33385,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_candidates_ts",
-      "community": 235
+      "community": 236
     },
     {
       "label": "parseArgs()",
@@ -33329,7 +33393,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L23",
       "id": "generate_search_quality_candidates_parseargs",
-      "community": 235
+      "community": 236
     },
     {
       "label": "printHelp()",
@@ -33337,7 +33401,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L63",
       "id": "generate_search_quality_candidates_printhelp",
-      "community": 235
+      "community": 236
     },
     {
       "label": "buildMemoryIdToBenchmarkIdMap()",
@@ -33345,7 +33409,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L83",
       "id": "generate_search_quality_candidates_buildmemoryidtobenchmarkidmap",
-      "community": 235
+      "community": 236
     },
     {
       "label": "hashString()",
@@ -33353,7 +33417,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L91",
       "id": "generate_search_quality_candidates_hashstring",
-      "community": 235
+      "community": 236
     },
     {
       "label": "sampleDeterministicNegatives()",
@@ -33361,7 +33425,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L100",
       "id": "generate_search_quality_candidates_sampledeterministicnegatives",
-      "community": 235
+      "community": 236
     },
     {
       "label": "main()",
@@ -33369,7 +33433,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L123",
       "id": "generate_search_quality_candidates_main",
-      "community": 235
+      "community": 236
     },
     {
       "label": "fix-migration.js",
@@ -33377,7 +33441,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 595
+      "community": 596
     },
     {
       "label": "fixMigration()",
@@ -33385,7 +33449,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 595
+      "community": 596
     },
     {
       "label": "sync-root-server-dist.js",
@@ -33393,7 +33457,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 882
+      "community": 884
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -33401,7 +33465,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_ts",
-      "community": 236
+      "community": 237
     },
     {
       "label": "mean()",
@@ -33409,7 +33473,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L44",
       "id": "compare_weight_profiles_mean",
-      "community": 236
+      "community": 237
     },
     {
       "label": "pairedPermutationPValue()",
@@ -33417,7 +33481,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L51",
       "id": "compare_weight_profiles_pairedpermutationpvalue",
-      "community": 236
+      "community": 237
     },
     {
       "label": "runProfile()",
@@ -33425,7 +33489,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L75",
       "id": "compare_weight_profiles_runprofile",
-      "community": 236
+      "community": 237
     },
     {
       "label": "assertRankingProfileFilesExist()",
@@ -33433,7 +33497,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L149",
       "id": "compare_weight_profiles_assertrankingprofilefilesexist",
-      "community": 236
+      "community": 237
     },
     {
       "label": "parseArgs()",
@@ -33441,7 +33505,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L158",
       "id": "compare_weight_profiles_parseargs",
-      "community": 236
+      "community": 237
     },
     {
       "label": "main()",
@@ -33449,7 +33513,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L173",
       "id": "compare_weight_profiles_main",
-      "community": 236
+      "community": 237
     },
     {
       "label": "verify-search-quality-benchmark-review.ts",
@@ -33457,7 +33521,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "parseArgs()",
@@ -33465,7 +33529,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 377
+      "community": 378
     },
     {
       "label": "printHelp()",
@@ -33473,7 +33537,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 377
+      "community": 378
     },
     {
       "label": "main()",
@@ -33481,7 +33545,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 377
+      "community": 378
     },
     {
       "label": "check-path-traversal.ts",
@@ -33681,7 +33745,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "parseArgs()",
@@ -33689,7 +33753,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 308
+      "community": 309
     },
     {
       "label": "printHelp()",
@@ -33697,7 +33761,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 308
+      "community": 309
     },
     {
       "label": "printThresholds()",
@@ -33705,7 +33769,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 308
+      "community": 309
     },
     {
       "label": "main()",
@@ -33713,7 +33777,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 308
+      "community": 309
     },
     {
       "label": "simple-update.js",
@@ -33721,7 +33785,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 596
+      "community": 597
     },
     {
       "label": "updateEmbeddings()",
@@ -33729,7 +33793,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 596
+      "community": 597
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -33897,7 +33961,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "analyzeEmbeddings()",
@@ -33905,7 +33969,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 597
+      "community": 598
     },
     {
       "label": "test-docker.js",
@@ -33913,7 +33977,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 598
+      "community": 599
     },
     {
       "label": "testDockerServer()",
@@ -33921,7 +33985,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 598
+      "community": 599
     },
     {
       "label": "pack-with-restore.js",
@@ -33929,7 +33993,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 883
+      "community": 885
     },
     {
       "label": "run-migration.js",
@@ -33937,7 +34001,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 599
+      "community": 600
     },
     {
       "label": "runMigration()",
@@ -33945,7 +34009,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 599
+      "community": 600
     },
     {
       "label": "safe-migration.js",
@@ -33953,7 +34017,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 600
+      "community": 601
     },
     {
       "label": "safeMigration()",
@@ -33961,7 +34025,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 600
+      "community": 601
     },
     {
       "label": "generate-ground-truth.ts",
@@ -33969,7 +34033,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L1",
       "id": "scripts_generate_ground_truth_ts",
-      "community": 237
+      "community": 238
     },
     {
       "label": "parseArgs()",
@@ -33977,7 +34041,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L53",
       "id": "generate_ground_truth_parseargs",
-      "community": 237
+      "community": 238
     },
     {
       "label": "printHelp()",
@@ -33985,7 +34049,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L92",
       "id": "generate_ground_truth_printhelp",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getMemoryIds()",
@@ -33993,7 +34057,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L129",
       "id": "generate_ground_truth_getmemoryids",
-      "community": 237
+      "community": 238
     },
     {
       "label": "extractKeywordsFromMemories()",
@@ -34001,7 +34065,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L143",
       "id": "generate_ground_truth_extractkeywordsfrommemories",
-      "community": 237
+      "community": 238
     },
     {
       "label": "generateGroundTruthFromSearch()",
@@ -34009,7 +34073,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L186",
       "id": "generate_ground_truth_generategroundtruthfromsearch",
-      "community": 237
+      "community": 238
     },
     {
       "label": "main()",
@@ -34017,7 +34081,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L226",
       "id": "generate_ground_truth_main",
-      "community": 237
+      "community": 238
     },
     {
       "label": "save-work-memory.ts",
@@ -34025,7 +34089,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "saveWorkMemory()",
@@ -34033,7 +34097,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 601
+      "community": 602
     },
     {
       "label": "check-file-sizes.ts",
@@ -34201,7 +34265,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -34209,7 +34273,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "main()",
@@ -34217,7 +34281,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 602
+      "community": 603
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -34225,7 +34289,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "parseArgs()",
@@ -34233,7 +34297,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 378
+      "community": 379
     },
     {
       "label": "printHelp()",
@@ -34241,7 +34305,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 378
+      "community": 379
     },
     {
       "label": "main()",
@@ -34249,7 +34313,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 378
+      "community": 379
     },
     {
       "label": "verify-bin.js",
@@ -34257,7 +34321,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 885
+      "community": 887
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -34265,7 +34329,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "getTriggerInfo()",
@@ -34273,7 +34337,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 309
+      "community": 310
     },
     {
       "label": "fixTriggers()",
@@ -34281,7 +34345,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 309
+      "community": 310
     },
     {
       "label": "checkMigrationVersion()",
@@ -34289,7 +34353,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 309
+      "community": 310
     },
     {
       "label": "main()",
@@ -34297,7 +34361,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 309
+      "community": 310
     },
     {
       "label": "simple-migrate.js",
@@ -34305,7 +34369,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 603
+      "community": 604
     },
     {
       "label": "analyzeEmbeddings()",
@@ -34313,7 +34377,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 603
+      "community": 604
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -34321,7 +34385,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 604
+      "community": 605
     },
     {
       "label": "fixVectorDimensions()",
@@ -34329,7 +34393,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 604
+      "community": 605
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -34337,7 +34401,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "formatCategoryReportLine()",
@@ -34345,7 +34409,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 379
+      "community": 380
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -34353,7 +34417,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 379
+      "community": 380
     },
     {
       "label": "main()",
@@ -34361,7 +34425,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 379
+      "community": 380
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -34369,7 +34433,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "loadVecExtension()",
@@ -34377,7 +34441,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 437
+      "community": 438
     },
     {
       "label": "fixTfidfDimensions()",
@@ -34385,7 +34449,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 437
+      "community": 438
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -34393,7 +34457,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "runUpdateMigration()",
@@ -34401,7 +34465,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 605
+      "community": 606
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -34409,7 +34473,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "reappearanceRate()",
@@ -34417,7 +34481,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 438
+      "community": 439
     },
     {
       "label": "main()",
@@ -34425,7 +34489,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 438
+      "community": 439
     },
     {
       "label": "regenerate-embeddings.js",
@@ -34433,7 +34497,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 606
+      "community": 607
     },
     {
       "label": "regenerateEmbeddings()",
@@ -34441,7 +34505,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 606
+      "community": 607
     },
     {
       "label": "generate-relation-report.ts",
@@ -34593,7 +34657,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "sampleReport()",
@@ -34601,7 +34665,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 607
+      "community": 608
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -34609,7 +34673,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 886
+      "community": 888
     },
     {
       "label": "debug-embeddings.js",
@@ -34617,7 +34681,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 608
+      "community": 609
     },
     {
       "label": "debugEmbeddings()",
@@ -34625,7 +34689,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 608
+      "community": 609
     },
     {
       "label": "check-db-integrity.js",
@@ -34633,7 +34697,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 380
+      "community": 381
     },
     {
       "label": "log()",
@@ -34641,7 +34705,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 380
+      "community": 381
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -34649,7 +34713,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 380
+      "community": 381
     },
     {
       "label": "main()",
@@ -34657,7 +34721,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 380
+      "community": 381
     },
     {
       "label": "mcp-http-client.js",
@@ -34665,7 +34729,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L1",
       "id": "scripts_mcp_http_client_js",
-      "community": 238
+      "community": 239
     },
     {
       "label": "callHttpTool()",
@@ -34673,7 +34737,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L15",
       "id": "mcp_http_client_callhttptool",
-      "community": 238
+      "community": 239
     },
     {
       "label": "getHttpTools()",
@@ -34681,7 +34745,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L38",
       "id": "mcp_http_client_gethttptools",
-      "community": 238
+      "community": 239
     },
     {
       "label": "sendResponse()",
@@ -34689,7 +34753,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L61",
       "id": "mcp_http_client_sendresponse",
-      "community": 238
+      "community": 239
     },
     {
       "label": "handleRequest()",
@@ -34697,7 +34761,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L77",
       "id": "mcp_http_client_handlerequest",
-      "community": 238
+      "community": 239
     },
     {
       "label": "checkServerHealth()",
@@ -34705,7 +34769,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L143",
       "id": "mcp_http_client_checkserverhealth",
-      "community": 238
+      "community": 239
     },
     {
       "label": "main()",
@@ -34713,7 +34777,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L158",
       "id": "mcp_http_client_main",
-      "community": 238
+      "community": 239
     },
     {
       "label": "weekly-relation-validation.ts",
@@ -34897,7 +34961,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 609
+      "community": 610
     },
     {
       "label": "backupEmbeddings()",
@@ -34905,7 +34969,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 609
+      "community": 610
     },
     {
       "label": "count-any-types.ts",
@@ -35121,7 +35185,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -35129,7 +35193,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -35137,7 +35201,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -35145,7 +35209,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -35153,7 +35217,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "jsonEmbedding()",
@@ -35161,7 +35225,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 610
+      "community": 611
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -35169,7 +35233,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -35177,7 +35241,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -35185,7 +35249,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -35193,7 +35257,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -35201,7 +35265,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 611
+      "community": 612
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -35209,7 +35273,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -35217,7 +35281,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "jsonEmbedding()",
@@ -35225,7 +35289,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 612
+      "community": 613
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -35233,7 +35297,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "main()",
@@ -35241,7 +35305,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 613
+      "community": 614
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -35249,7 +35313,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -35257,7 +35321,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 614
+      "community": 615
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -35265,7 +35329,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createBackup()",
@@ -35273,7 +35337,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 439
+      "community": 440
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -35281,7 +35345,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 439
+      "community": 440
     },
     {
       "label": "restore-legacy.ps1",
@@ -35289,7 +35353,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 895
+      "community": 897
     },
     {
       "label": "check-retry-usage.ts",
@@ -35361,7 +35425,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_simple_throws_ts",
-      "community": 272
+      "community": 273
     },
     {
       "label": "isTestFile()",
@@ -35369,7 +35433,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L29",
       "id": "analyze_simple_throws_istestfile",
-      "community": 272
+      "community": 273
     },
     {
       "label": "shouldExcludeDir()",
@@ -35377,7 +35441,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L38",
       "id": "analyze_simple_throws_shouldexcludedir",
-      "community": 272
+      "community": 273
     },
     {
       "label": "findThrows()",
@@ -35385,7 +35449,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L45",
       "id": "analyze_simple_throws_findthrows",
-      "community": 272
+      "community": 273
     },
     {
       "label": "scanDirectory()",
@@ -35393,7 +35457,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L102",
       "id": "analyze_simple_throws_scandirectory",
-      "community": 272
+      "community": 273
     },
     {
       "label": "main()",
@@ -35401,7 +35465,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L126",
       "id": "analyze_simple_throws_main",
-      "community": 272
+      "community": 273
     },
     {
       "label": "analyze-benchmark-test-data.ts",
@@ -35409,7 +35473,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -35417,7 +35481,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 615
+      "community": 616
     },
     {
       "label": "check-no-console-violations.ts",
@@ -35513,7 +35577,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "fixVecTableDimensions()",
@@ -35521,7 +35585,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 616
+      "community": 617
     },
     {
       "label": "sources.ts",
@@ -35529,7 +35593,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 273
+      "community": 274
     },
     {
       "label": "splitJsonlLines()",
@@ -35537,7 +35601,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L13",
       "id": "sources_splitjsonllines",
-      "community": 273
+      "community": 274
     },
     {
       "label": "runDocker()",
@@ -35545,7 +35609,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L22",
       "id": "sources_rundocker",
-      "community": 273
+      "community": 274
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -35553,7 +35617,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L42",
       "id": "sources_resolvedockerlogsref",
-      "community": 273
+      "community": 274
     },
     {
       "label": "readDockerLogs()",
@@ -35561,7 +35625,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L89",
       "id": "sources_readdockerlogs",
-      "community": 273
+      "community": 274
     },
     {
       "label": "readJsonlFiles()",
@@ -35569,7 +35633,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L118",
       "id": "sources_readjsonlfiles",
-      "community": 273
+      "community": 274
     },
     {
       "label": "types.ts",
@@ -35577,7 +35641,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "issue-body.ts",
@@ -35585,7 +35649,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "startMarker()",
@@ -35593,7 +35657,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 381
+      "community": 382
     },
     {
       "label": "renderManagedIssueBody()",
@@ -35601,7 +35665,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 381
+      "community": 382
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -35609,7 +35673,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 381
+      "community": 382
     },
     {
       "label": "fingerprint.ts",
@@ -35617,7 +35681,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "normalizeMessage()",
@@ -35625,7 +35689,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createFingerprint()",
@@ -35633,7 +35697,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 440
+      "community": 441
     },
     {
       "label": "sanitizer.ts",
@@ -35641,7 +35705,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "limitUtf8Bytes()",
@@ -35649,7 +35713,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 441
+      "community": 442
     },
     {
       "label": "sanitizeExcerpt()",
@@ -35657,7 +35721,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 441
+      "community": 442
     },
     {
       "label": "parsers.ts",
@@ -35665,7 +35729,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "inferLevel()",
@@ -35673,7 +35737,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parseAppLogLine()",
@@ -35681,7 +35745,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parseJsonlRecord()",
@@ -35689,7 +35753,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 382
+      "community": 383
     },
     {
       "label": "index.ts",
@@ -35697,7 +35761,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -35705,7 +35769,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 383
+      "community": 384
     },
     {
       "label": "createMonitorRuntime()",
@@ -35713,7 +35777,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 383
+      "community": 384
     },
     {
       "label": "runForever()",
@@ -35721,7 +35785,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 383
+      "community": 384
     },
     {
       "label": "promotion.ts",
@@ -35729,7 +35793,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -35737,7 +35801,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 617
+      "community": 618
     },
     {
       "label": "state-store.ts",
@@ -35745,7 +35809,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_state_store_ts",
-      "community": 274
+      "community": 275
     },
     {
       "label": "emptyState()",
@@ -35753,7 +35817,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L5",
       "id": "state_store_emptystate",
-      "community": 274
+      "community": 275
     },
     {
       "label": "loadState()",
@@ -35761,7 +35825,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L9",
       "id": "state_store_loadstate",
-      "community": 274
+      "community": 275
     },
     {
       "label": "saveState()",
@@ -35769,7 +35833,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L20",
       "id": "state_store_savestate",
-      "community": 274
+      "community": 275
     },
     {
       "label": "upsertOccurrence()",
@@ -35777,7 +35841,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L27",
       "id": "state_store_upsertoccurrence",
-      "community": 274
+      "community": 275
     },
     {
       "label": "appendOccurrence()",
@@ -35785,7 +35849,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L55",
       "id": "state_store_appendoccurrence",
-      "community": 274
+      "community": 275
     },
     {
       "label": "monitor.ts",
@@ -35793,7 +35857,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "recordMonitorError()",
@@ -35801,7 +35865,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L20",
       "id": "monitor_recordmonitorerror",
-      "community": 310
+      "community": 311
     },
     {
       "label": "withFingerprint()",
@@ -35809,7 +35873,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L29",
       "id": "monitor_withfingerprint",
-      "community": 310
+      "community": 311
     },
     {
       "label": "syncFingerprint()",
@@ -35817,7 +35881,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_syncfingerprint",
-      "community": 310
+      "community": 311
     },
     {
       "label": "runMonitorCycle()",
@@ -35825,7 +35889,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L103",
       "id": "monitor_runmonitorcycle",
-      "community": 310
+      "community": 311
     },
     {
       "label": "github-client.ts",
@@ -35897,7 +35961,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_detectors_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "nowIso()",
@@ -35905,7 +35969,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L6",
       "id": "detectors_nowiso",
-      "community": 275
+      "community": 276
     },
     {
       "label": "truncateTitle()",
@@ -35913,7 +35977,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L10",
       "id": "detectors_truncatetitle",
-      "community": 275
+      "community": 276
     },
     {
       "label": "detectAppLogEvent()",
@@ -35921,7 +35985,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L14",
       "id": "detectors_detectapplogevent",
-      "community": 275
+      "community": 276
     },
     {
       "label": "detectRuntimeAnomaly()",
@@ -35929,7 +35993,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L62",
       "id": "detectors_detectruntimeanomaly",
-      "community": 275
+      "community": 276
     },
     {
       "label": "detectDockerAnomaly()",
@@ -35937,7 +36001,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L85",
       "id": "detectors_detectdockeranomaly",
-      "community": 275
+      "community": 276
     },
     {
       "label": "config.ts",
@@ -35945,7 +36009,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_config_ts",
-      "community": 239
+      "community": 240
     },
     {
       "label": "defaultLogsRoot()",
@@ -35953,7 +36017,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L5",
       "id": "config_defaultlogsroot",
-      "community": 239
+      "community": 240
     },
     {
       "label": "optionalString()",
@@ -35961,7 +36025,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L7",
       "id": "config_optionalstring",
-      "community": 239
+      "community": 240
     },
     {
       "label": "numberFromEnv()",
@@ -35969,7 +36033,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L12",
       "id": "config_numberfromenv",
-      "community": 239
+      "community": 240
     },
     {
       "label": "booleanFromEnv()",
@@ -35977,7 +36041,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L19",
       "id": "config_booleanfromenv",
-      "community": 239
+      "community": 240
     },
     {
       "label": "labelsFromEnv()",
@@ -35985,7 +36049,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L27",
       "id": "config_labelsfromenv",
-      "community": 239
+      "community": 240
     },
     {
       "label": "loadMonitorConfig()",
@@ -35993,7 +36057,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L32",
       "id": "config_loadmonitorconfig",
-      "community": 239
+      "community": 240
     },
     {
       "label": "promotion.spec.ts",
@@ -36001,7 +36065,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "issue-body.spec.ts",
@@ -36009,7 +36073,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "github-client.spec.ts",
@@ -36017,7 +36081,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "config.spec.ts",
@@ -36025,7 +36089,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "detectors.spec.ts",
@@ -36033,7 +36097,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "sources.spec.ts",
@@ -36041,7 +36105,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "parsers.spec.ts",
@@ -36049,7 +36113,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "monitor.spec.ts",
@@ -36057,7 +36121,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "config()",
@@ -36065,7 +36129,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 618
+      "community": 619
     },
     {
       "label": "fingerprint.spec.ts",
@@ -36073,7 +36137,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "state-store.spec.ts",
@@ -36081,7 +36145,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "sanitizer.spec.ts",
@@ -36089,7 +36153,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "entrypoint.spec.ts",
@@ -36097,7 +36161,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "index.ts",
@@ -36105,7 +36169,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "main()",
@@ -36113,7 +36177,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 384
+      "community": 385
     },
     {
       "label": "index.ts",
@@ -36121,7 +36185,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "runExample()",
@@ -36129,7 +36193,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 384
+      "community": 385
     },
     {
       "label": "index.spec.ts",
@@ -36137,7 +36201,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "memento-admin-fetch.js",
@@ -36145,7 +36209,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L1",
       "id": "static_js_memento_admin_fetch_js",
-      "community": 276
+      "community": 277
     },
     {
       "label": "getDashboardAuth()",
@@ -36153,7 +36217,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L8",
       "id": "memento_admin_fetch_getdashboardauth",
-      "community": 276
+      "community": 277
     },
     {
       "label": "waitForSession()",
@@ -36161,7 +36225,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L12",
       "id": "memento_admin_fetch_waitforsession",
-      "community": 276
+      "community": 277
     },
     {
       "label": "buildRequestOptions()",
@@ -36169,7 +36233,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L20",
       "id": "memento_admin_fetch_buildrequestoptions",
-      "community": 276
+      "community": 277
     },
     {
       "label": "performFetch()",
@@ -36177,7 +36241,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L28",
       "id": "memento_admin_fetch_performfetch",
-      "community": 276
+      "community": 277
     },
     {
       "label": "mementoAdminFetch()",
@@ -36185,7 +36249,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L51",
       "id": "memento_admin_fetch_mementoadminfetch",
-      "community": 276
+      "community": 277
     },
     {
       "label": "dashboard-auth.js",
@@ -36513,7 +36577,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 6
+      "community": 5
     },
     {
       "label": "$()",
@@ -36521,7 +36585,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L20",
       "id": "review_candidates_panel",
-      "community": 6
+      "community": 5
     },
     {
       "label": "setHidden()",
@@ -36529,7 +36593,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L24",
       "id": "review_candidates_panel_sethidden",
-      "community": 6
+      "community": 5
     },
     {
       "label": "clearStatus()",
@@ -36537,7 +36601,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L31",
       "id": "review_candidates_panel_clearstatus",
-      "community": 6
+      "community": 5
     },
     {
       "label": "truncateReason()",
@@ -36545,7 +36609,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L38",
       "id": "review_candidates_panel_truncatereason",
-      "community": 6
+      "community": 5
     },
     {
       "label": "formatDue()",
@@ -36553,7 +36617,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L48",
       "id": "review_candidates_panel_formatdue",
-      "community": 6
+      "community": 5
     },
     {
       "label": "escapeHtml()",
@@ -36561,7 +36625,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L59",
       "id": "review_candidates_panel_escapehtml",
-      "community": 6
+      "community": 5
     },
     {
       "label": "escapeAttr()",
@@ -36569,7 +36633,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L67",
       "id": "review_candidates_panel_escapeattr",
-      "community": 6
+      "community": 5
     },
     {
       "label": "previewUrl()",
@@ -36577,7 +36641,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L71",
       "id": "review_candidates_panel_previewurl",
-      "community": 6
+      "community": 5
     },
     {
       "label": "reviewCandidatePostUrl()",
@@ -36585,7 +36649,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L75",
       "id": "review_candidates_panel_reviewcandidateposturl",
-      "community": 6
+      "community": 5
     },
     {
       "label": "getPreviewActionsEl()",
@@ -36593,7 +36657,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L79",
       "id": "review_candidates_panel_getpreviewactionsel",
-      "community": 6
+      "community": 5
     },
     {
       "label": "setPreviewActionsBusy()",
@@ -36601,7 +36665,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L83",
       "id": "review_candidates_panel_setpreviewactionsbusy",
-      "community": 6
+      "community": 5
     },
     {
       "label": "syncReviewDismissButtons()",
@@ -36609,7 +36673,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L90",
       "id": "review_candidates_panel_syncreviewdismissbuttons",
-      "community": 6
+      "community": 5
     },
     {
       "label": "showActionToast()",
@@ -36617,7 +36681,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L105",
       "id": "review_candidates_panel_showactiontoast",
-      "community": 6
+      "community": 5
     },
     {
       "label": "postCandidateAction()",
@@ -36625,7 +36689,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L122",
       "id": "review_candidates_panel_postcandidateaction",
-      "community": 6
+      "community": 5
     },
     {
       "label": "clearRowSelection()",
@@ -36633,7 +36697,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L164",
       "id": "review_candidates_panel_clearrowselection",
-      "community": 6
+      "community": 5
     },
     {
       "label": "resetPreviewPanel()",
@@ -36641,7 +36705,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L172",
       "id": "review_candidates_panel_resetpreviewpanel",
-      "community": 6
+      "community": 5
     },
     {
       "label": "setPreviewCandidateFields()",
@@ -36649,7 +36713,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L192",
       "id": "review_candidates_panel_setpreviewcandidatefields",
-      "community": 6
+      "community": 5
     },
     {
       "label": "loadMemoryPreview()",
@@ -36657,7 +36721,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L211",
       "id": "review_candidates_panel_loadmemorypreview",
-      "community": 6
+      "community": 5
     },
     {
       "label": "onRowActivate()",
@@ -36665,7 +36729,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L248",
       "id": "review_candidates_panel_onrowactivate",
-      "community": 6
+      "community": 5
     },
     {
       "label": "wireTableBody()",
@@ -36673,7 +36737,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L270",
       "id": "review_candidates_panel_wiretablebody",
-      "community": 6
+      "community": 5
     },
     {
       "label": "renderTable()",
@@ -36681,7 +36745,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L296",
       "id": "review_candidates_panel_rendertable",
-      "community": 6
+      "community": 5
     },
     {
       "label": "showLoading()",
@@ -36689,7 +36753,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L344",
       "id": "review_candidates_panel_showloading",
-      "community": 6
+      "community": 5
     },
     {
       "label": "showError()",
@@ -36697,7 +36761,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L348",
       "id": "review_candidates_panel_showerror",
-      "community": 6
+      "community": 5
     },
     {
       "label": "showEmpty()",
@@ -36705,7 +36769,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L356",
       "id": "review_candidates_panel_showempty",
-      "community": 6
+      "community": 5
     },
     {
       "label": "hideTable()",
@@ -36713,7 +36777,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L360",
       "id": "review_candidates_panel_hidetable",
-      "community": 6
+      "community": 5
     },
     {
       "label": "clearReviewTabBadge()",
@@ -36721,7 +36785,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L364",
       "id": "review_candidates_panel_clearreviewtabbadge",
-      "community": 6
+      "community": 5
     },
     {
       "label": "setReviewTabBadge()",
@@ -36729,7 +36793,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L373",
       "id": "review_candidates_panel_setreviewtabbadge",
-      "community": 6
+      "community": 5
     },
     {
       "label": "showNewCandidatesToast()",
@@ -36737,63 +36801,95 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L383",
       "id": "review_candidates_panel_shownewcandidatestoast",
-      "community": 6
+      "community": 5
+    },
+    {
+      "label": "getReviewQueueBoot()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L405",
+      "id": "review_candidates_panel_getreviewqueueboot",
+      "community": 5
+    },
+    {
+      "label": "clearPollTimer()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L424",
+      "id": "review_candidates_panel_clearpolltimer",
+      "community": 5
+    },
+    {
+      "label": "schedulePollAfterMs()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L431",
+      "id": "review_candidates_panel_schedulepollafterms",
+      "community": 5
     },
     {
       "label": "registerVisibilityForPoll()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L405",
+      "source_location": "L442",
       "id": "review_candidates_panel_registervisibilityforpoll",
-      "community": 6
+      "community": 5
     },
     {
       "label": "startPollingIfNeeded()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L417",
+      "source_location": "L454",
       "id": "review_candidates_panel_startpollingifneeded",
-      "community": 6
+      "community": 5
     },
     {
       "label": "fetchReviewCandidateListJson()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L430",
+      "source_location": "L462",
       "id": "review_candidates_panel_fetchreviewcandidatelistjson",
-      "community": 6
+      "community": 5
     },
     {
       "label": "applyListSuccess()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L439",
+      "source_location": "L471",
       "id": "review_candidates_panel_applylistsuccess",
-      "community": 6
+      "community": 5
     },
     {
-      "label": "runPollTick()",
+      "label": "scheduleAfterPollFailure()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L455",
-      "id": "review_candidates_panel_runpolltick",
-      "community": 6
+      "source_location": "L487",
+      "id": "review_candidates_panel_scheduleafterpollfailure",
+      "community": 5
+    },
+    {
+      "label": "runPollCycle()",
+      "file_type": "code",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L498",
+      "id": "review_candidates_panel_runpollcycle",
+      "community": 5
     },
     {
       "label": "loadList()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L490",
+      "source_location": "L547",
       "id": "review_candidates_panel_loadlist",
-      "community": 6
+      "community": 5
     },
     {
       "label": "initReviewCandidatesPanel()",
       "file_type": "code",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L517",
+      "source_location": "L575",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 6
+      "community": 5
     },
     {
       "label": "graph.js",
@@ -37057,7 +37153,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 311
+      "community": 312
     },
     {
       "label": "getTabButtons()",
@@ -37065,7 +37161,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 311
+      "community": 312
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -37073,7 +37169,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 311
+      "community": 312
     },
     {
       "label": "setRovingTabindex()",
@@ -37081,7 +37177,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 311
+      "community": 312
     },
     {
       "label": "activateTab()",
@@ -37089,7 +37185,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 311
+      "community": 312
     }
   ],
   "links": [
@@ -40636,6 +40732,138 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_parsepositiveintms",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_parsepositiveintms",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_clampintervalms",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_clampintervalms",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_parsebackoffcsv",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_parsebackoffcsv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L52",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L66",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L71",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "_tgt": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
+      "source": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
+      "target": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L56",
+      "weight": 1.0,
+      "_src": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "_tgt": "review_queue_dashboard_boot_parsepositiveintms",
+      "source": "review_queue_dashboard_boot_parsepositiveintms",
+      "target": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "_src": "review_queue_dashboard_boot_parsebackoffcsv",
+      "_tgt": "review_queue_dashboard_boot_clampintervalms",
+      "source": "review_queue_dashboard_boot_clampintervalms",
+      "target": "review_queue_dashboard_boot_parsebackoffcsv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "_src": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "_tgt": "review_queue_dashboard_boot_clampintervalms",
+      "source": "review_queue_dashboard_boot_clampintervalms",
+      "target": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L61",
+      "weight": 1.0,
+      "_src": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "_tgt": "review_queue_dashboard_boot_parsebackoffcsv",
+      "source": "review_queue_dashboard_boot_parsebackoffcsv",
+      "target": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
+      "source_location": "L78",
+      "weight": 1.0,
+      "_src": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
+      "_tgt": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
+      "source": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
+      "target": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "weight": 1.0,
@@ -41117,7 +41345,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L71",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_settestdependencies",
@@ -41129,7 +41357,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L88",
+      "source_location": "L92",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_writeruntimediagnosticsevent",
@@ -41141,7 +41369,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L112",
+      "source_location": "L116",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_resolvestaticroot",
@@ -41153,7 +41381,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L205",
+      "source_location": "L209",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_isprotectedmcpprogrammaticpath",
@@ -41165,7 +41393,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L209",
+      "source_location": "L213",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_gethttpauthtrustmodelnotice",
@@ -41177,7 +41405,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L213",
+      "source_location": "L217",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_gethttpauthmissingadminkeywarning",
@@ -41189,7 +41417,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L243",
+      "source_location": "L252",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_initializeserver",
@@ -41201,7 +41429,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L362",
+      "source_location": "L371",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_cleanup",
@@ -41213,7 +41441,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L434",
+      "source_location": "L443",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_registercleanuphandlers",
@@ -41225,7 +41453,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L616",
+      "source_location": "L625",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_startserver",
@@ -41237,7 +41465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L329",
+      "source_location": "L338",
       "weight": 1.0,
       "_src": "http_server_initializeserver",
       "_tgt": "http_server_writeruntimediagnosticsevent",
@@ -41249,7 +41477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L378",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "http_server_cleanup",
       "_tgt": "http_server_writeruntimediagnosticsevent",
@@ -41261,7 +41489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L653",
+      "source_location": "L662",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_gethttpauthtrustmodelnotice",
@@ -41273,7 +41501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L646",
+      "source_location": "L655",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_gethttpauthmissingadminkeywarning",
@@ -41285,7 +41513,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L656",
+      "source_location": "L665",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_initializeserver",
@@ -41297,7 +41525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L659",
+      "source_location": "L668",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_cleanup",
@@ -41309,7 +41537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L664",
+      "source_location": "L673",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_registercleanuphandlers",
@@ -103868,6 +104096,42 @@
       "source_location": "L405",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_getreviewqueueboot",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_getreviewqueueboot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L424",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_clearpolltimer",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_clearpolltimer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L431",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_schedulepollafterms",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_schedulepollafterms",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L442",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_registervisibilityforpoll",
       "source": "static_js_review_candidates_panel_js",
       "target": "review_candidates_panel_registervisibilityforpoll",
@@ -103877,7 +104141,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L417",
+      "source_location": "L454",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_startpollingifneeded",
@@ -103889,7 +104153,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L430",
+      "source_location": "L462",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
@@ -103901,7 +104165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L439",
+      "source_location": "L471",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_applylistsuccess",
@@ -103913,19 +104177,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L455",
+      "source_location": "L487",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
-      "_tgt": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_scheduleafterpollfailure",
       "source": "static_js_review_candidates_panel_js",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_scheduleafterpollfailure",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L490",
+      "source_location": "L498",
+      "weight": 1.0,
+      "_src": "static_js_review_candidates_panel_js",
+      "_tgt": "review_candidates_panel_runpollcycle",
+      "source": "static_js_review_candidates_panel_js",
+      "target": "review_candidates_panel_runpollcycle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L547",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_loadlist",
@@ -103937,7 +104213,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L517",
+      "source_location": "L575",
       "weight": 1.0,
       "_src": "static_js_review_candidates_panel_js",
       "_tgt": "review_candidates_panel_initreviewcandidatespanel",
@@ -104153,7 +104429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L442",
+      "source_location": "L474",
       "weight": 1.0,
       "_src": "review_candidates_panel_applylistsuccess",
       "_tgt": "review_candidates_panel",
@@ -104165,19 +104441,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L476",
+      "source_location": "L528",
       "weight": 1.0,
-      "_src": "review_candidates_panel_runpolltick",
+      "_src": "review_candidates_panel_runpollcycle",
       "_tgt": "review_candidates_panel",
       "source": "review_candidates_panel",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L521",
+      "source_location": "L579",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel",
@@ -104273,7 +104549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L495",
+      "source_location": "L552",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_clearstatus",
@@ -104477,7 +104753,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L531",
+      "source_location": "L589",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel_postcandidateaction",
@@ -104513,7 +104789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L496",
+      "source_location": "L553",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_clearrowselection",
@@ -104537,7 +104813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L497",
+      "source_location": "L554",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_resetpreviewpanel",
@@ -104597,7 +104873,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L452",
+      "source_location": "L484",
       "weight": 1.0,
       "_src": "review_candidates_panel_applylistsuccess",
       "_tgt": "review_candidates_panel_rendertable",
@@ -104609,7 +104885,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L492",
+      "source_location": "L549",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showloading",
@@ -104621,7 +104897,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L491",
+      "source_location": "L548",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showerror",
@@ -104633,7 +104909,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L448",
+      "source_location": "L480",
       "weight": 1.0,
       "_src": "review_candidates_panel_applylistsuccess",
       "_tgt": "review_candidates_panel_showempty",
@@ -104645,7 +104921,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L494",
+      "source_location": "L551",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_showempty",
@@ -104657,7 +104933,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L449",
+      "source_location": "L481",
       "weight": 1.0,
       "_src": "review_candidates_panel_applylistsuccess",
       "_tgt": "review_candidates_panel_hidetable",
@@ -104669,7 +104945,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L493",
+      "source_location": "L550",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_hidetable",
@@ -104681,7 +104957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L518",
+      "source_location": "L576",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel_clearreviewtabbadge",
@@ -104693,43 +104969,127 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L480",
+      "source_location": "L532",
       "weight": 1.0,
-      "_src": "review_candidates_panel_runpolltick",
+      "_src": "review_candidates_panel_runpollcycle",
       "_tgt": "review_candidates_panel_setreviewtabbadge",
       "source": "review_candidates_panel_setreviewtabbadge",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L478",
+      "source_location": "L530",
       "weight": 1.0,
-      "_src": "review_candidates_panel_runpolltick",
+      "_src": "review_candidates_panel_runpollcycle",
       "_tgt": "review_candidates_panel_shownewcandidatestoast",
       "source": "review_candidates_panel_shownewcandidatestoast",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L412",
+      "source_location": "L433",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_schedulepollafterms",
+      "_tgt": "review_candidates_panel_getreviewqueueboot",
+      "source": "review_candidates_panel_getreviewqueueboot",
+      "target": "review_candidates_panel_schedulepollafterms",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L459",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_startpollingifneeded",
+      "_tgt": "review_candidates_panel_getreviewqueueboot",
+      "source": "review_candidates_panel_getreviewqueueboot",
+      "target": "review_candidates_panel_startpollingifneeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L499",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpollcycle",
+      "_tgt": "review_candidates_panel_getreviewqueueboot",
+      "source": "review_candidates_panel_getreviewqueueboot",
+      "target": "review_candidates_panel_runpollcycle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L432",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_schedulepollafterms",
+      "_tgt": "review_candidates_panel_clearpolltimer",
+      "source": "review_candidates_panel_clearpolltimer",
+      "target": "review_candidates_panel_schedulepollafterms",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L501",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpollcycle",
+      "_tgt": "review_candidates_panel_schedulepollafterms",
+      "source": "review_candidates_panel_schedulepollafterms",
+      "target": "review_candidates_panel_runpollcycle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L459",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_startpollingifneeded",
+      "_tgt": "review_candidates_panel_schedulepollafterms",
+      "source": "review_candidates_panel_schedulepollafterms",
+      "target": "review_candidates_panel_startpollingifneeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L495",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_scheduleafterpollfailure",
+      "_tgt": "review_candidates_panel_schedulepollafterms",
+      "source": "review_candidates_panel_schedulepollafterms",
+      "target": "review_candidates_panel_scheduleafterpollfailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L449",
       "weight": 1.0,
       "_src": "review_candidates_panel_registervisibilityforpoll",
-      "_tgt": "review_candidates_panel_runpolltick",
+      "_tgt": "review_candidates_panel_runpollcycle",
       "source": "review_candidates_panel_registervisibilityforpoll",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L421",
+      "source_location": "L458",
       "weight": 1.0,
       "_src": "review_candidates_panel_startpollingifneeded",
       "_tgt": "review_candidates_panel_registervisibilityforpoll",
@@ -104741,19 +105101,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L426",
-      "weight": 1.0,
-      "_src": "review_candidates_panel_startpollingifneeded",
-      "_tgt": "review_candidates_panel_runpolltick",
-      "source": "review_candidates_panel_startpollingifneeded",
-      "target": "review_candidates_panel_runpolltick",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L510",
+      "source_location": "L568",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_startpollingifneeded",
@@ -104765,19 +105113,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L462",
+      "source_location": "L511",
       "weight": 1.0,
-      "_src": "review_candidates_panel_runpolltick",
+      "_src": "review_candidates_panel_runpollcycle",
       "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
       "source": "review_candidates_panel_fetchreviewcandidatelistjson",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L500",
+      "source_location": "L557",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_fetchreviewcandidatelistjson",
@@ -104789,19 +105137,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L483",
+      "source_location": "L535",
       "weight": 1.0,
-      "_src": "review_candidates_panel_runpolltick",
+      "_src": "review_candidates_panel_runpollcycle",
       "_tgt": "review_candidates_panel_applylistsuccess",
       "source": "review_candidates_panel_applylistsuccess",
-      "target": "review_candidates_panel_runpolltick",
+      "target": "review_candidates_panel_runpollcycle",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L509",
+      "source_location": "L566",
       "weight": 1.0,
       "_src": "review_candidates_panel_loadlist",
       "_tgt": "review_candidates_panel_applylistsuccess",
@@ -104813,7 +105161,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "static/js/review-candidates-panel.js",
-      "source_location": "L525",
+      "source_location": "L515",
+      "weight": 1.0,
+      "_src": "review_candidates_panel_runpollcycle",
+      "_tgt": "review_candidates_panel_scheduleafterpollfailure",
+      "source": "review_candidates_panel_scheduleafterpollfailure",
+      "target": "review_candidates_panel_runpollcycle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "static/js/review-candidates-panel.js",
+      "source_location": "L583",
       "weight": 1.0,
       "_src": "review_candidates_panel_initreviewcandidatespanel",
       "_tgt": "review_candidates_panel_loadlist",

--- a/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
+++ b/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
@@ -3,6 +3,8 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { REVIEW_QUEUE_DASHBOARD_BOOT_MARKER } from './review-queue-dashboard-boot.js';
+
 const root = resolve(process.cwd());
 const dashboardHtml = readFileSync(resolve(root, 'static/dashboard.html'), 'utf8');
 const tabsJs = readFileSync(resolve(root, 'static/js/dashboard-tabs.js'), 'utf8');
@@ -14,6 +16,7 @@ describe('dashboard review candidates panel (#252, #253)', () => {
     expect(dashboardHtml).toContain('data-tab="review"');
     expect(dashboardHtml).toContain('id="tab-review-candidates"');
     expect(dashboardHtml).toContain('/static/js/review-candidates-panel.js');
+    expect(dashboardHtml).toContain(REVIEW_QUEUE_DASHBOARD_BOOT_MARKER);
     expect(dashboardHtml).toContain('id="rc-refresh-btn"');
     expect(dashboardHtml).toContain('id="rc-preview-aside"');
     expect(dashboardHtml).toContain('review-candidates-body');
@@ -50,9 +53,10 @@ describe('dashboard review queue poll notify (#255)', () => {
     expect(dashboardHtml).toContain('id="rc-tab-badge"');
   });
 
-  it('review-candidates-panel.js includes polling helpers', () => {
-    expect(panelJs).toContain('POLL_INTERVAL_MS');
-    expect(panelJs).toContain('runPollTick');
+  it('review-candidates-panel.js includes polling helpers (#255, #274)', () => {
+    expect(panelJs).toContain('getReviewQueueBoot');
+    expect(panelJs).toContain('__MEMENTO_REVIEW_QUEUE__');
+    expect(panelJs).toContain('runPollCycle');
     expect(panelJs).toContain('startPollingIfNeeded');
   });
 });

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -25,10 +25,14 @@ type ServerServices
 import Database from 'better-sqlite3';
 import cors from 'cors';
 import express from 'express';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import helmet from 'helmet';
 import { createServer } from 'http';
 import { join } from 'path';
+import {
+  injectReviewQueueBootIntoDashboardHtml,
+  resolveReviewQueueDashboardBootFromEnv
+} from './review-queue-dashboard-boot.js';
 import type { WebSocket } from 'ws';
 import { WebSocketServer } from 'ws';
 import packageJson from '../../package.json' with { type: 'json' };
@@ -217,14 +221,19 @@ export function getHttpAuthMissingAdminKeyWarning(): string {
 // Phase 1.2: 기존 엔드포인트는 모두 라우터로 이동됨
 // 주석 처리된 기존 코드는 제거됨 (tools.routes.ts, admin.routes.ts, api.routes.ts, mcp.routes.ts로 이동)
 
-// 대시보드 라우트 (정적 파일 서빙)
+// 대시보드 라우트: Review Queue 폴링 부트를 환경 변수 기준으로 인라인 주입 (#274)
 app.get('/dashboard', (req, res) => {
-  res.sendFile('dashboard.html', { root: staticRoot }, (err) => {
-    if (err) {
-      logger.error('대시보드 파일 로드 실패', { error: err });
-      res.status(404).send('Dashboard not found');
-    }
-  });
+  const dashboardPath = join(staticRoot, 'dashboard.html');
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- staticRoot 하위 고정 파일 dashboard.html
+    const raw = readFileSync(dashboardPath, 'utf8');
+    const boot = resolveReviewQueueDashboardBootFromEnv();
+    const html = injectReviewQueueBootIntoDashboardHtml(raw, boot);
+    res.type('html').send(html);
+  } catch (err) {
+    logger.error('대시보드 파일 로드 실패', { error: err });
+    res.status(404).send('Dashboard not found');
+  }
 });
 
 // 기억 관계 그래프 뷰 (009-memory-graph-view)

--- a/packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts
+++ b/packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_REVIEW_QUEUE_DASHBOARD_BOOT,
+  buildReviewQueueBootInjectionHtml,
+  injectReviewQueueBootIntoDashboardHtml,
+  resolveReviewQueueDashboardBootFromEnv,
+  REVIEW_QUEUE_DASHBOARD_BOOT_MARKER
+} from './review-queue-dashboard-boot.js';
+
+describe('review-queue-dashboard-boot (#274)', () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('defaults match legacy 60s poll and empty backoff', () => {
+    delete process.env.MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS;
+    delete process.env.MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS;
+    expect(resolveReviewQueueDashboardBootFromEnv()).toEqual(DEFAULT_REVIEW_QUEUE_DASHBOARD_BOOT);
+  });
+
+  it('parses poll interval and clamps to bounds', () => {
+    process.env.MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS = '120000';
+    expect(resolveReviewQueueDashboardBootFromEnv().pollIntervalMs).toBe(120_000);
+
+    process.env.MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS = '1000';
+    expect(resolveReviewQueueDashboardBootFromEnv().pollIntervalMs).toBe(10_000);
+
+    process.env.MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS = 'not-a-number';
+    expect(resolveReviewQueueDashboardBootFromEnv().pollIntervalMs).toBe(60_000);
+  });
+
+  it('parses comma-separated backoff steps', () => {
+    process.env.MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS = '30000, 90000';
+    expect(resolveReviewQueueDashboardBootFromEnv().pollErrorBackoffMs).toEqual([30_000, 90_000]);
+  });
+
+  it('injects boot script at marker', () => {
+    const html = `<head>${REVIEW_QUEUE_DASHBOARD_BOOT_MARKER}</head>`;
+    const boot = { pollIntervalMs: 45_000, pollErrorBackoffMs: [20_000] };
+    const out = injectReviewQueueBootIntoDashboardHtml(html, boot);
+    expect(out).toContain('window.__MEMENTO_REVIEW_QUEUE__=');
+    expect(out).not.toContain(REVIEW_QUEUE_DASHBOARD_BOOT_MARKER);
+    expect(out).toContain('"pollIntervalMs":45000');
+  });
+
+  it('buildReviewQueueBootInjectionHtml wraps JSON in one script tag', () => {
+    const html = buildReviewQueueBootInjectionHtml({
+      pollIntervalMs: 60_000,
+      pollErrorBackoffMs: [30_000]
+    });
+    expect(html.startsWith('<script>window.__MEMENTO_REVIEW_QUEUE__=')).toBe(true);
+    expect(html.endsWith(';</script>')).toBe(true);
+  });
+});

--- a/packages/memento-server/src/server/review-queue-dashboard-boot.ts
+++ b/packages/memento-server/src/server/review-queue-dashboard-boot.ts
@@ -1,0 +1,79 @@
+/**
+ * HTTP 대시보드 Review Queue 패널 폴링 부트 설정 (#274).
+ * `GET /dashboard` 응답에 인라인 스크립트로 `window.__MEMENTO_REVIEW_QUEUE__`를 주입한다.
+ */
+
+export type ReviewQueueDashboardBoot = {
+  pollIntervalMs: number;
+  pollErrorBackoffMs: number[];
+};
+
+export const DEFAULT_REVIEW_QUEUE_DASHBOARD_BOOT: ReviewQueueDashboardBoot = {
+  pollIntervalMs: 60_000,
+  pollErrorBackoffMs: []
+};
+
+/** dashboard.html에 두는 플레이스홀더(서버가 치환). */
+export const REVIEW_QUEUE_DASHBOARD_BOOT_MARKER = '<!--MEMENTO_REVIEW_QUEUE_BOOT-->';
+
+const MIN_POLL_MS = 10_000;
+const MAX_POLL_MS = 24 * 60 * 60 * 1000;
+
+function parsePositiveIntMs(raw: string | undefined, fallback: number): number {
+  if (raw == null || raw.trim() === '') {
+    return fallback;
+  }
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return fallback;
+  }
+  return n;
+}
+
+function clampIntervalMs(n: number): number {
+  return Math.min(MAX_POLL_MS, Math.max(MIN_POLL_MS, n));
+}
+
+function parseBackoffCsv(raw: string | undefined): number[] {
+  if (raw == null || raw.trim() === '') {
+    return [];
+  }
+  const out: number[] = [];
+  for (const part of raw.split(',')) {
+    const n = Number.parseInt(part.trim(), 10);
+    if (Number.isFinite(n) && n > 0) {
+      out.push(clampIntervalMs(n));
+    }
+  }
+  return out;
+}
+
+/** 환경 변수에서 Review Queue 대시보드 부트 설정을 해석한다. */
+export function resolveReviewQueueDashboardBootFromEnv(
+  env: NodeJS.ProcessEnv = process.env
+): ReviewQueueDashboardBoot {
+  const pollIntervalMs = clampIntervalMs(
+    parsePositiveIntMs(
+      env.MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS,
+      DEFAULT_REVIEW_QUEUE_DASHBOARD_BOOT.pollIntervalMs
+    )
+  );
+  const pollErrorBackoffMs = parseBackoffCsv(env.MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS);
+  return { pollIntervalMs, pollErrorBackoffMs };
+}
+
+/** 인라인 스크립트(한 줄). JSON은 `<`를 이스케이프해 `</script>` 조각 주입을 방지한다. */
+export function buildReviewQueueBootInjectionHtml(boot: ReviewQueueDashboardBoot): string {
+  const json = JSON.stringify(boot).replace(/</g, '\\u003c');
+  return `<script>window.__MEMENTO_REVIEW_QUEUE__=${json};</script>`;
+}
+
+export function injectReviewQueueBootIntoDashboardHtml(
+  dashboardHtml: string,
+  boot: ReviewQueueDashboardBoot
+): string {
+  if (!dashboardHtml.includes(REVIEW_QUEUE_DASHBOARD_BOOT_MARKER)) {
+    return dashboardHtml;
+  }
+  return dashboardHtml.replace(REVIEW_QUEUE_DASHBOARD_BOOT_MARKER, buildReviewQueueBootInjectionHtml(boot));
+}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -219,6 +219,7 @@
   <script src="/static/js/anchor-map.js"></script>
   <script src="/static/js/dashboard-tabs.js"></script>
   <script src="/static/js/embedding-map.js"></script>
+  <!--MEMENTO_REVIEW_QUEUE_BOOT-->
   <script src="/static/js/review-candidates-panel.js"></script>
 </body>
 </html>

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -1,12 +1,11 @@
 /**
- * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify)
+ * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify, #274 configurable poll)
  */
 (function (global) {
   'use strict';
 
   const LIST_URL = '/admin/memory/review-candidates?status=pending';
   const REASON_TABLE_MAX = 120;
-  const POLL_INTERVAL_MS = 60 * 1000;
 
   let wired = false;
   let loadedOnce = false;
@@ -16,6 +15,7 @@
   let lastPendingCount = -1;
   let toastHideTimer = null;
   let actionInFlight = false;
+  let pollFailureStreak = 0;
 
   function $(id) {
     return document.getElementById(id);
@@ -402,6 +402,43 @@
     }, 8000);
   }
 
+  function getReviewQueueBoot() {
+    const b = global.__MEMENTO_REVIEW_QUEUE__;
+    const fallbackPoll = 60 * 1000;
+    const pollRaw = b && Number(b.pollIntervalMs);
+    const pollIntervalMs =
+      Number.isFinite(pollRaw) && pollRaw > 0 ? pollRaw : fallbackPoll;
+    const backoffRaw = b && b.pollErrorBackoffMs;
+    const pollErrorBackoffMs = Array.isArray(backoffRaw)
+      ? backoffRaw
+          .map(function (x) {
+            return Number(x);
+          })
+          .filter(function (n) {
+            return Number.isFinite(n) && n > 0;
+          })
+      : [];
+    return { pollIntervalMs: pollIntervalMs, pollErrorBackoffMs: pollErrorBackoffMs };
+  }
+
+  function clearPollTimer() {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function schedulePollAfterMs(delayMs) {
+    clearPollTimer();
+    const boot = getReviewQueueBoot();
+    const d = Number(delayMs);
+    const safe = Number.isFinite(d) && d > 0 ? d : boot.pollIntervalMs;
+    pollTimer = setTimeout(function () {
+      pollTimer = null;
+      void runPollCycle();
+    }, safe);
+  }
+
   function registerVisibilityForPoll() {
     if (visListenerRegistered) {
       return;
@@ -409,7 +446,7 @@
     visListenerRegistered = true;
     document.addEventListener('visibilitychange', function () {
       if (document.visibilityState === 'visible') {
-        runPollTick();
+        void runPollCycle();
       }
     });
   }
@@ -419,12 +456,7 @@
       return;
     }
     registerVisibilityForPoll();
-    pollTimer = setInterval(function () {
-      if (document.visibilityState === 'hidden') {
-        return;
-      }
-      runPollTick();
-    }, POLL_INTERVAL_MS);
+    schedulePollAfterMs(getReviewQueueBoot().pollIntervalMs);
   }
 
   async function fetchReviewCandidateListJson() {
@@ -452,8 +484,25 @@
     renderTable(candidates);
   }
 
-  async function runPollTick() {
+  function scheduleAfterPollFailure(boot) {
+    pollFailureStreak += 1;
+    let delayMs = boot.pollIntervalMs;
+    const steps = boot.pollErrorBackoffMs;
+    if (steps.length > 0) {
+      const idx = Math.min(pollFailureStreak - 1, steps.length - 1);
+      delayMs = steps[idx];
+    }
+    schedulePollAfterMs(delayMs);
+  }
+
+  async function runPollCycle() {
+    const boot = getReviewQueueBoot();
+    if (document.visibilityState === 'hidden') {
+      schedulePollAfterMs(boot.pollIntervalMs);
+      return;
+    }
     if (lastPendingCount < 0) {
+      schedulePollAfterMs(boot.pollIntervalMs);
       return;
     }
     let res;
@@ -463,11 +512,14 @@
       res = r.res;
       body = r.body;
     } catch {
+      scheduleAfterPollFailure(boot);
       return;
     }
     if (!res.ok) {
+      scheduleAfterPollFailure(boot);
       return;
     }
+    pollFailureStreak = 0;
     const candidates = (body && body.candidates) || [];
     const n = candidates.length;
     const prev = lastPendingCount;
@@ -481,10 +533,15 @@
       }
       if (onReview) {
         applyListSuccess(body);
+        schedulePollAfterMs(boot.pollIntervalMs);
         return;
       }
+      lastPendingCount = n;
+      schedulePollAfterMs(boot.pollIntervalMs);
+      return;
     }
     lastPendingCount = n;
+    schedulePollAfterMs(boot.pollIntervalMs);
   }
 
   async function loadList() {
@@ -507,6 +564,7 @@
         return;
       }
       applyListSuccess(body);
+      pollFailureStreak = 0;
       startPollingIfNeeded();
     } catch (e) {
       showLoading(false);


### PR DESCRIPTION
## 요약
- Review Queue 패널 백그라운드 폴링 간격을 `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS`로 조정 가능 (기본 60s, 서버 클램프 10s–24h).
- 연속 폴링 실패 시 `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS`(쉼표 구분)로 선택적 백오프; 미설정 시 기존과 동일하게 성공 시와 동일 간격으로 재시도.
- `GET /dashboard` 응답 HTML에 `window.__MEMENTO_REVIEW_QUEUE__` 인라인 주입; 정적 HTML만 열면 JS 폴백으로 60s 유지.

## 관련 이슈
Closes #274

## 문서
- `docs/api/ko/api-reference.md`, `docs/api/en/api-reference.md` — 키·기본값·권장 범위
- `docs/superpowers/specs/2026-05-03-issue-255-review-notify-polling-design.md` — #274 연계 문구

## 검증
- `npm run lint`, `npm run type-check`, `npm test`

## 지식 복리
- (해당 없음 — 설정 노출 및 문서화 중심 변경)

Made with [Cursor](https://cursor.com)