### PR TITLE
feat(dashboard): Review Queue optional OS notifications (#275)

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -688,6 +688,36 @@ body {
   color: var(--color-text-muted);
 }
 
+/* Review queue optional OS notifications (#275) */
+.rc-notify-prompt {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: var(--color-status-loading-bg);
+  color: var(--color-status-loading-text);
+  border: 1px solid var(--color-border-light);
+  font-size: var(--font-size-sm);
+}
+
+.rc-notify-prompt__text {
+  margin: 0;
+  flex: 1 1 12rem;
+  min-width: 0;
+  line-height: var(--line-height-relaxed, 1.45);
+}
+
+.rc-notify-prompt__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
 .rc-banner {
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -165,6 +165,23 @@
           <button type="button" id="rc-refresh-btn" class="m-button m-button--secondary">Refresh</button>
         </header>
         <p id="rc-status-line" class="review-candidates-status" aria-live="polite"></p>
+        <div
+          id="rc-notify-prompt"
+          class="rc-notify-prompt hidden"
+          role="region"
+          aria-label="Desktop notifications for the review queue"
+        >
+          <p id="rc-notify-prompt-text" class="rc-notify-prompt__text">
+            Optional: get a system notification when the pending queue grows while this tab is in the
+            background. Alerts only include counts, not memory content.
+          </p>
+          <div class="rc-notify-prompt__actions">
+            <button type="button" id="rc-notify-enable-btn" class="m-button m-button--secondary">
+              Enable system alerts
+            </button>
+            <button type="button" id="rc-notify-dismiss-btn" class="m-button m-button--ghost">Not now</button>
+          </div>
+        </div>
         <div id="rc-loading" class="rc-banner hidden">Loading…</div>
         <div id="rc-error" class="rc-banner rc-banner--error hidden" role="alert"></div>
         <div id="rc-empty" class="rc-banner hidden">No pending review candidates.</div>

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -1,5 +1,5 @@
 /**
- * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify, #274 configurable poll)
+ * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify, #274 configurable poll, #275 optional Notification API)
  */
 (function (global) {
   'use strict';
@@ -16,6 +16,11 @@
   let toastHideTimer = null;
   let actionInFlight = false;
   let pollFailureStreak = 0;
+  let notifyPromptWired = false;
+
+  /** @type {string} */
+  const LS_NOTIFY_PROMPT_DISMISSED = 'memento_review_queue_notify_prompt_dismissed_v1';
+  const OS_NOTIFY_TAG = 'memento-review-queue-pending-grow';
 
   function $(id) {
     return document.getElementById(id);
@@ -380,6 +385,113 @@
     b.setAttribute('aria-hidden', 'false');
   }
 
+
+  function reviewOsNotifyAvailable() {
+    if (!global.isSecureContext) {
+      return false;
+    }
+    return typeof Notification === 'function';
+  }
+
+  function isReviewNotifyPromptDismissed() {
+    try {
+      return !!(global.localStorage && localStorage.getItem(LS_NOTIFY_PROMPT_DISMISSED) === '1');
+    } catch {
+      return true;
+    }
+  }
+
+  function dismissReviewNotifyPrompt() {
+    try {
+      if (global.localStorage) {
+        localStorage.setItem(LS_NOTIFY_PROMPT_DISMISSED, '1');
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function syncReviewNotifyPromptUI() {
+    const wrap = $('rc-notify-prompt');
+    if (!wrap) {
+      return;
+    }
+    if (!reviewOsNotifyAvailable()) {
+      setHidden(wrap, true);
+      return;
+    }
+    if (Notification.permission !== 'default') {
+      setHidden(wrap, true);
+      return;
+    }
+    if (isReviewNotifyPromptDismissed()) {
+      setHidden(wrap, true);
+      return;
+    }
+    setHidden(wrap, false);
+  }
+
+  function wireReviewNotifyPrompt() {
+    if (notifyPromptWired) {
+      return;
+    }
+    notifyPromptWired = true;
+    const enable = $('rc-notify-enable-btn');
+    const dismiss = $('rc-notify-dismiss-btn');
+    if (enable) {
+      enable.addEventListener('click', function () {
+        void (async function () {
+          try {
+            await Notification.requestPermission();
+          } catch {
+            /* ignore */
+          }
+          syncReviewNotifyPromptUI();
+        })();
+      });
+    }
+    if (dismiss) {
+      dismiss.addEventListener('click', function () {
+        dismissReviewNotifyPrompt();
+        syncReviewNotifyPromptUI();
+      });
+    }
+  }
+
+  function tryOsNotifyReviewQueueGrowth(delta) {
+    if (!reviewOsNotifyAvailable()) {
+      return;
+    }
+    if (Notification.permission !== 'granted') {
+      return;
+    }
+    if (document.visibilityState !== 'hidden') {
+      return;
+    }
+    const title = 'Memento — Review queue';
+    const body =
+      delta === 1
+        ? 'The pending review queue has 1 new item.'
+        : 'The pending review queue has ' + String(delta) + ' new items.';
+    try {
+      const n = new Notification(title, { body: body, tag: OS_NOTIFY_TAG });
+      n.onclick = function () {
+        try {
+          global.focus();
+        } catch {
+          /* ignore */
+        }
+        try {
+          n.close();
+        } catch {
+          /* ignore */
+        }
+      };
+    } catch {
+      /* OS or browser blocked notification */
+    }
+  }
+
   function showNewCandidatesToast(delta, onReviewTab) {
     const t = $('rc-toast');
     if (!t) {
@@ -497,7 +609,9 @@
 
   async function runPollCycle() {
     const boot = getReviewQueueBoot();
-    if (document.visibilityState === 'hidden') {
+    const allowPollWhenHidden =
+      reviewOsNotifyAvailable() && Notification.permission === 'granted';
+    if (document.visibilityState === 'hidden' && !allowPollWhenHidden) {
       schedulePollAfterMs(boot.pollIntervalMs);
       return;
     }
@@ -528,6 +642,7 @@
       const reviewPanel = $('tab-review-candidates');
       const onReview = !!(reviewPanel && reviewPanel.classList.contains('active'));
       showNewCandidatesToast(delta, onReview);
+      tryOsNotifyReviewQueueGrowth(delta);
       if (!onReview) {
         setReviewTabBadge(n);
       }
@@ -595,10 +710,12 @@
           void postCandidateAction('dismiss');
         });
       }
+      wireReviewNotifyPrompt();
     }
     if (!loadedOnce) {
       loadedOnce = true;
     }
+    syncReviewNotifyPromptUI();
     loadList();
   }
 


### PR DESCRIPTION
## 변경 사항
- Review Queue 패널에 **시스템 알림 옵트인** 배너 추가(명시적 버튼 클릭 시에만 `Notification.requestPermission()`).
- `Not now`는 `localStorage`로 재노출하지 않음.
- 권한 **granted**이고 탭이 **hidden**일 때만 `new Notification`(제목·건수 문구만, 메모리 본문 없음). `try/catch`로 실패 무시.
- **granted**인 경우에만 백그라운드에서도 기존 폴링을 유지해(미허용·거부 시 기존 #255와 동일) 큐 증가를 감지.
- #255 토스트·탭 뱃지 동작 유지.

## 변경 유형
- [x] 새로운 기능

## 관련 이슈
- Closes #275

## 테스트
- `npm test`, `npm run lint` 통과(워크트리에서 실행).

## 문서
- [x] 문서 업데이트 불필요

## 지식 복리
- 단순 프런트 옵션 추가 수준으로 `/ce-compound` 문서는 생략.

Made with [Cursor](https://cursor.com)