### PR TITLE
feat(server): Admin 리뷰 큐 SSE + 폴링 폴백 (#276)

### DIFF
--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -741,6 +741,21 @@ Each element of `candidates` contains only queue metadata (`id`, `memory_id`, `s
 - `400`: invalid `status` value
 - `500`: database not connected or other server error
 
+##### Review queue SSE (optional real-time)
+
+```http
+GET /admin/memory/review-candidates/stream
+```
+
+Same **browser session** cookie as other `/admin` routes. Returns **`text/event-stream`** with:
+
+- `retry:` reconnection hint for the browser `EventSource` client
+- `event: ready` — connection established (payload `{"ok":true}`)
+- `: ping` comment frames periodically to keep the connection warm
+- `event: changed` — queue may have changed; payload includes `reason` (`review`, `dismiss`, or `batch_memory_review_candidates`)
+
+The dashboard client opens this stream after the pending list loads successfully; if `EventSource` is unavailable or the stream errors, it **falls back to the existing polling** from issue #255. **Single-process only** (no cross-replica fan-out without Redis or similar).
+
 ##### Single memory preview (Admin)
 
 When the review queue list omits body text, fetch one `memory_item` row by `memory_id` (e.g. for the dashboard preview pane).

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -861,6 +861,21 @@ GET /admin/memory/review-candidates?status=pending
 - `400`: 잘못된 `status` 값
 - `500`: DB 미연결 등 서버 오류
 
+##### 리뷰 큐 SSE (선택 실시간)
+
+```http
+GET /admin/memory/review-candidates/stream
+```
+
+다른 `/admin` 경로와 동일한 **브라우저 세션 쿠키**가 필요합니다. 응답은 **`text/event-stream`**이며, 다음을 포함합니다.
+
+- `retry:` — 브라우저 `EventSource` 재연결 힌트
+- `event: ready` — 연결 수립(본문 `{"ok":true}`)
+- 주기적 `: ping` 코멘트(연결 유지)
+- `event: changed` — 큐가 바뀌었을 수 있음; 본문에 `reason` (`review`, `dismiss`, `batch_memory_review_candidates`)
+
+대시보드는 pending 목록 로드 성공 후 스트림을 연고, `EventSource` 미지원·오류 시 **#255 폴링으로 폴백**합니다. **단일 프로세스** 전제(레플리카 간 브로드캐스트 없음).
+
 ##### 단일 기억 프리뷰 (Admin)
 
 리뷰 후보 목록에 본문이 없을 때, 대시보드 등에서 `memory_id`로 **`memory_item` 한 행**을 조회합니다.

--- a/docs/superpowers/plans/2026-05-05-issue-276-review-queue-sse.md
+++ b/docs/superpowers/plans/2026-05-05-issue-276-review-queue-sse.md
@@ -1,0 +1,39 @@
+# Issue #276 — Review queue SSE + poll fallback
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `GET /admin/memory/review-candidates/stream` (SSE) with in-process `changed` notifications, and dashboard `EventSource` with **automatic fallback** to existing #255 polling.
+
+**Architecture:** `review-candidates-sse-hub.ts` holds connected `express.Response` clients; `admin.routes` attaches SSE and calls `notifyReviewCandidatesChanged` after mutating routes and `memory_review_candidates` batch. Static panel mirrors anchor-map philosophy: **stream first, poll on failure**.
+
+**Tech Stack:** Express 5, Vitest (`admin.routes.spec`, string regression spec), static IIFE `review-candidates-panel.js`.
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `packages/memento-server/src/server/review-candidates-sse-hub.ts` | SSE attach, ping, fan-out, test reset |
+| `packages/memento-server/src/server/routes/admin.routes.ts` | Route + notify hooks |
+| `static/js/review-candidates-panel.js` | `EventSource`, `schedulePollAfterMsUnlessSse`, fallback |
+| `packages/memento-server/src/server/routes/admin.routes.spec.ts` | SSE integration tests |
+| `packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts` | Static string checks |
+| `docs/api/en/api-reference.md`, `docs/api/ko/api-reference.md` | Admin SSE section |
+| `docs/superpowers/specs/2026-05-05-issue-276-review-queue-sse-design.md` | Design record |
+
+---
+
+## Tasks
+
+- [x] Hub module + admin route + notify on review/dismiss/batch
+- [x] Client stream + poll coordination + unload cleanup
+- [x] Vitest + API docs + design/plan docs
+- [x] `npm run test:ci:server` + `npm run lint` + graphify code rebuild
+
+## Verification
+
+```bash
+npm test && npm run lint
+python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+```

--- a/docs/superpowers/specs/2026-05-05-issue-276-review-queue-sse-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-276-review-queue-sse-design.md
@@ -1,0 +1,36 @@
+# 설계: 이슈 #276 — Admin 리뷰 후보 SSE + 폴링 폴백
+
+**상태**: 구현 반영  
+**날짜**: 2026-05-05  
+**이슈**: GitHub #276  
+**선행**: [#255 폴링 설계](./2026-05-03-issue-255-review-notify-polling-design.md)
+
+## 목표
+
+- Review Queue pending 목록이 **실시간에 가깝게** 갱신되도록 **SSE**를 제공한다.
+- **Admin 브라우저 세션**(`memento_admin_session`)은 기존 `GET /admin/memory/review-candidates`와 **동일 경로·동일 미들웨어**로 적용한다.
+- `EventSource` 실패·오류 시 **#255 폴링**으로 안전하게 폴백한다.
+- **1차 파동**: Redis·외부 브로커 없이 **프로세스 내** `Set<Response>` 팬아웃만 사용한다.
+
+## 비목표
+
+- nginx 등 **리버스 프록시 전제** 문서화(사용자 확인: 직접 바인딩 위주).
+- 기존 **루트 WebSocket**에 리뷰 채널을 합치지 않는다(세션 모델 불일치).
+- 멀티 레플리카 간 이벤트 전파.
+
+## 서버
+
+- `GET /admin/memory/review-candidates/stream` — `text/event-stream`, `retry:`, `event: ready`, `: ping`, `event: changed` + `data: {"reason":...}`.
+- `notifyReviewCandidatesChanged` 호출: `POST .../review`·`.../dismiss` 성공 시, `POST /admin/batch/run`의 `memory_review_candidates` 완료 시.
+
+## 클라이언트
+
+- 초기 목록 로드 성공 후 `EventSource(STREAM_URL)`; `open` 시 폴링 타이머 정지.
+- `changed` 수신 시 `GET` 목록으로 동기화(Review 탭 활성 시 표 갱신, 비활성 시 뱃지·토스트 규칙 유지).
+- `onerror` → 스트림 종료 후 `startPollingIfNeeded()`.
+- `beforeunload`에서 스트림 정리.
+
+## 리스크·한계
+
+- **단일 노드**에서만 모든 대시보드 클라이언트에 푸시가 도달한다.
+- 장기 SSE가 세션 `touch`를 유발할 수 있으나, 운영자 수·단일 노드 MVP에서는 허용 범위로 둔다.

--- a/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
+++ b/packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts
@@ -61,3 +61,16 @@ describe('dashboard review queue poll notify (#255)', () => {
   });
 });
 
+describe('dashboard review queue SSE (#276)', () => {
+  const root = resolve(process.cwd());
+  const panelJs = readFileSync(resolve(root, 'static/js/review-candidates-panel.js'), 'utf8');
+
+  it('review-candidates-panel.js wires EventSource stream URL and fallback helpers', () => {
+    expect(panelJs).toContain('/admin/memory/review-candidates/stream');
+    expect(panelJs).toContain('EventSource');
+    expect(panelJs).toContain('maybeStartReviewCandidatesEventSource');
+    expect(panelJs).toContain('resumePollingAfterStreamLoss');
+    expect(panelJs).toContain('schedulePollAfterMsUnlessSse');
+  });
+});
+

--- a/packages/memento-server/src/server/review-candidates-sse-hub.ts
+++ b/packages/memento-server/src/server/review-candidates-sse-hub.ts
@@ -1,0 +1,79 @@
+/**
+ * In-process SSE fan-out for Admin review queue (#276). Single-node only; no Redis.
+ */
+import type { Response } from 'express';
+
+const clients = new Set<Response>();
+
+const PING_MS = 25_000;
+
+/** Test helper: close all connections and clear registry. */
+export function resetReviewCandidatesSseHubForTests(): void {
+  for (const res of clients) {
+    try {
+      res.end();
+    } catch {
+      /* ignore */
+    }
+  }
+  clients.clear();
+}
+
+function writeSafe(res: Response, chunk: string): boolean {
+  try {
+    if (res.writableEnded) {
+      return false;
+    }
+    res.write(chunk);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Starts SSE response: headers, retry hint, `ready` event, periodic comment ping.
+ * Caller must mount this only behind the same auth as other `/admin` JSON routes.
+ */
+export function attachReviewCandidatesSse(res: Response): void {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  if (typeof res.flushHeaders === 'function') {
+    res.flushHeaders();
+  }
+
+  clients.add(res);
+
+  const ping = setInterval(() => {
+    if (!writeSafe(res, ': ping\n\n')) {
+      clearInterval(ping);
+      clients.delete(res);
+    }
+  }, PING_MS);
+
+  const cleanup = (): void => {
+    clearInterval(ping);
+    clients.delete(res);
+  };
+
+  res.on('close', cleanup);
+
+  writeSafe(res, 'retry: 3000\n\n');
+  writeSafe(res, `event: ready\ndata: ${JSON.stringify({ ok: true })}\n\n`);
+}
+
+export function notifyReviewCandidatesChanged(reason: string): void {
+  const frame = `event: changed\ndata: ${JSON.stringify({ reason })}\n\n`;
+  const dead: Response[] = [];
+  for (const res of clients) {
+    if (!writeSafe(res, frame)) {
+      dead.push(res);
+    }
+  }
+  for (const r of dead) {
+    clients.delete(r);
+  }
+}

--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import http from 'http';
 import Database from 'better-sqlite3';
 import { createAdminRouter } from './admin.routes.js';
+import { resetReviewCandidatesSseHubForTests } from '../review-candidates-sse-hub.js';
 import type { ServerServices } from '../bootstrap.js';
 import {
   type SleepConsolidationRunResult,
@@ -983,6 +984,7 @@ describe('admin.routes memory review candidates', () => {
   }
 
   beforeEach(async () => {
+    resetReviewCandidatesSseHubForTests();
     db = new Database(':memory:');
     createBaseSchema(db);
     await new MetaMemoryStatsSchemaMigration().up(db);
@@ -1034,12 +1036,59 @@ describe('admin.routes memory review candidates', () => {
   });
 
   afterEach(() => {
+    resetReviewCandidatesSseHubForTests();
     try {
       db.close();
     } catch {
       /* ignore */
     }
   });
+
+  function readStreamUntil(
+    port: number,
+    path: string,
+    needle: string,
+    timeoutMs: number
+  ): Promise<{ statusCode: number; contentType: string; text: string }> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        req.destroy();
+        reject(new Error(`stream read timeout waiting for: ${needle}`));
+      }, timeoutMs);
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path,
+          method: 'GET',
+          headers: { Connection: 'close' }
+        },
+        res => {
+          const statusCode = res.statusCode ?? 0;
+          const rawCt = res.headers['content-type'];
+          const contentType = Array.isArray(rawCt) ? rawCt[0] : (rawCt ?? '');
+          let buf = '';
+          res.on('data', (c: Buffer) => {
+            buf += c.toString('utf8');
+            if (buf.includes(needle)) {
+              clearTimeout(timer);
+              req.destroy();
+              resolve({ statusCode, contentType, text: buf });
+            }
+          });
+          res.on('end', () => {
+            clearTimeout(timer);
+            reject(new Error(`stream ended without needle; got: ${buf.slice(0, 200)}`));
+          });
+        }
+      );
+      req.on('error', err => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      req.end();
+    });
+  }
 
   it('GET /admin/memory/items/mem_stale returns 200 with memory.content', async () => {
     const { server, port } = await listen(makeApp(db));
@@ -1153,6 +1202,94 @@ describe('admin.routes memory review candidates', () => {
     } finally {
       await scheduler.stop();
       resetBatchScheduler();
+    }
+  });
+
+  it('GET /admin/memory/review-candidates/stream returns SSE ready (#276)', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const { statusCode, contentType, text } = await readStreamUntil(
+        port,
+        '/admin/memory/review-candidates/stream',
+        'event: ready',
+        3000
+      );
+      expect(statusCode).toBe(200);
+      expect(contentType).toContain('text/event-stream');
+      expect(text).toContain('retry:');
+      expect(text).toContain('event: ready');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('SSE stream receives changed after POST review (#276)', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          req.destroy();
+          reject(new Error('timeout waiting for SSE changed'));
+        }, 8000);
+        let posted = false;
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port,
+            path: '/admin/memory/review-candidates/stream',
+            method: 'GET',
+            headers: { Connection: 'close' }
+          },
+          res => {
+            try {
+              expect(res.statusCode).toBe(200);
+              const rawCt = res.headers['content-type'];
+              const ct = Array.isArray(rawCt) ? rawCt[0] : (rawCt ?? '');
+              expect(ct).toContain('text/event-stream');
+            } catch (e) {
+              clearTimeout(timer);
+              reject(e);
+              return;
+            }
+            let buf = '';
+            res.on('data', (c: Buffer) => {
+              buf += c.toString('utf8');
+              if (!posted && buf.includes('event: ready')) {
+                posted = true;
+                void postAdminJson(port, `/admin/memory/review-candidates/${pendingId}/review`, {})
+                  .then(r => {
+                    expect(r.statusCode).toBe(200);
+                  })
+                  .catch(err => {
+                    clearTimeout(timer);
+                    reject(err);
+                  });
+              }
+              if (buf.includes('event: changed')) {
+                clearTimeout(timer);
+                try {
+                  expect(buf).toContain('"reason":"review"');
+                  req.destroy();
+                  resolve();
+                } catch (e) {
+                  reject(e);
+                }
+              }
+            });
+            res.on('error', err => {
+              clearTimeout(timer);
+              reject(err);
+            });
+          }
+        );
+        req.on('error', err => {
+          clearTimeout(timer);
+          reject(err);
+        });
+        req.end();
+      });
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
     }
   });
 });

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -29,6 +29,10 @@ import { registerAdminRelationRoutes } from './admin/admin-relations.routes.js';
 import { registerAdminTelemetryRoutes } from './admin/admin-telemetry.routes.js';
 import { registerAdminGraphRoute } from './admin/admin-graph.routes.js';
 import { registerAdminEmbeddingMapRoute } from './admin/admin-embedding-map.routes.js';
+import {
+  attachReviewCandidatesSse,
+  notifyReviewCandidatesChanged
+} from '../review-candidates-sse-hub.js';
 
 export type { GraphNode, GraphEdge, GraphFilter, GraphResponse } from './admin/admin-graph-response.js';
 
@@ -360,6 +364,23 @@ export function createAdminRouter(
     }
   });
 
+  /** SSE: pending queue updates (same session as GET list; #276). */
+  router.get('/memory/review-candidates/stream', (_req, res) => {
+    try {
+      attachReviewCandidatesSse(res);
+    } catch (error) {
+      logger.error('Review candidates SSE attach failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      if (!res.headersSent) {
+        return res.status(500).json({
+          error: 'Failed to open review candidates stream',
+          message: error instanceof Error ? error.message : 'Unknown error'
+        });
+      }
+    }
+  });
+
   router.post('/memory/review-candidates/:id/review', (req, res) => {
     try {
       if (!db) {
@@ -372,6 +393,7 @@ export function createAdminRouter(
       const nowIso = new Date().toISOString();
       markMemoryReviewCandidateReviewed(db, id, nowIso);
       const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      notifyReviewCandidatesChanged('review');
       return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
     } catch (error) {
       if (error instanceof MemoryReviewCandidateError) {
@@ -399,6 +421,7 @@ export function createAdminRouter(
       const nowIso = new Date().toISOString();
       markMemoryReviewCandidateDismissed(db, id, nowIso);
       const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
+      notifyReviewCandidatesChanged('dismiss');
       return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
     } catch (error) {
       if (error instanceof MemoryReviewCandidateError) {
@@ -449,6 +472,10 @@ export function createAdminRouter(
 
       const batchScheduler = getBatchScheduler();
       const result = await batchScheduler.runJob(jobType);
+
+      if (jobType === 'memory_review_candidates') {
+        notifyReviewCandidatesChanged('batch_memory_review_candidates');
+      }
 
       return res.json({
         message: `배치 작업 ${jobType} 실행 완료`,

--- a/static/js/review-candidates-panel.js
+++ b/static/js/review-candidates-panel.js
@@ -1,10 +1,11 @@
 /**
- * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify, #274 configurable poll)
+ * Review candidates panel (#252 list, #253 row preview + memory body, #255 poll notify, #274 configurable poll, #276 SSE + poll fallback)
  */
 (function (global) {
   'use strict';
 
   const LIST_URL = '/admin/memory/review-candidates?status=pending';
+  const STREAM_URL = '/admin/memory/review-candidates/stream';
   const REASON_TABLE_MAX = 120;
 
   let wired = false;
@@ -16,6 +17,7 @@
   let toastHideTimer = null;
   let actionInFlight = false;
   let pollFailureStreak = 0;
+  let reviewSse = null;
 
   function $(id) {
     return document.getElementById(id);
@@ -439,6 +441,14 @@
     }, safe);
   }
 
+  /** While EventSource is connected, skip poll timers (#276). */
+  function schedulePollAfterMsUnlessSse(delayMs) {
+    if (typeof EventSource !== 'undefined' && reviewSse && reviewSse.readyState === EventSource.OPEN) {
+      return;
+    }
+    schedulePollAfterMs(delayMs);
+  }
+
   function registerVisibilityForPoll() {
     if (visListenerRegistered) {
       return;
@@ -457,6 +467,77 @@
     }
     registerVisibilityForPoll();
     schedulePollAfterMs(getReviewQueueBoot().pollIntervalMs);
+  }
+
+  function stopReviewCandidatesStream() {
+    if (reviewSse) {
+      reviewSse.close();
+      reviewSse = null;
+    }
+  }
+
+  function resumePollingAfterStreamLoss() {
+    stopReviewCandidatesStream();
+    startPollingIfNeeded();
+  }
+
+  async function onReviewQueueSseChanged() {
+    let res;
+    let body;
+    try {
+      const r = await fetchReviewCandidateListJson();
+      res = r.res;
+      body = r.body;
+    } catch {
+      resumePollingAfterStreamLoss();
+      return;
+    }
+    if (!res.ok) {
+      resumePollingAfterStreamLoss();
+      return;
+    }
+    pollFailureStreak = 0;
+    const reviewPanel = $('tab-review-candidates');
+    const onReview = !!(reviewPanel && reviewPanel.classList.contains('active'));
+    if (onReview) {
+      applyListSuccess(body);
+      return;
+    }
+    const candidates = (body && body.candidates) || [];
+    const n = candidates.length;
+    const prev = lastPendingCount;
+    if (prev >= 0 && n > prev) {
+      showNewCandidatesToast(n - prev, false);
+      setReviewTabBadge(n);
+    }
+    lastPendingCount = n;
+  }
+
+  function maybeStartReviewCandidatesEventSource() {
+    if (typeof EventSource === 'undefined') {
+      startPollingIfNeeded();
+      return;
+    }
+    if (reviewSse) {
+      return;
+    }
+    try {
+      reviewSse = new EventSource(STREAM_URL);
+    } catch {
+      reviewSse = null;
+      startPollingIfNeeded();
+      return;
+    }
+    reviewSse.addEventListener('open', function () {
+      clearPollTimer();
+      pollFailureStreak = 0;
+    });
+    reviewSse.addEventListener('changed', function () {
+      void onReviewQueueSseChanged();
+    });
+    reviewSse.onerror = function () {
+      resumePollingAfterStreamLoss();
+    };
   }
 
   async function fetchReviewCandidateListJson() {
@@ -498,11 +579,11 @@
   async function runPollCycle() {
     const boot = getReviewQueueBoot();
     if (document.visibilityState === 'hidden') {
-      schedulePollAfterMs(boot.pollIntervalMs);
+      schedulePollAfterMsUnlessSse(boot.pollIntervalMs);
       return;
     }
     if (lastPendingCount < 0) {
-      schedulePollAfterMs(boot.pollIntervalMs);
+      schedulePollAfterMsUnlessSse(boot.pollIntervalMs);
       return;
     }
     let res;
@@ -533,15 +614,15 @@
       }
       if (onReview) {
         applyListSuccess(body);
-        schedulePollAfterMs(boot.pollIntervalMs);
+        schedulePollAfterMsUnlessSse(boot.pollIntervalMs);
         return;
       }
       lastPendingCount = n;
-      schedulePollAfterMs(boot.pollIntervalMs);
+      schedulePollAfterMsUnlessSse(boot.pollIntervalMs);
       return;
     }
     lastPendingCount = n;
-    schedulePollAfterMs(boot.pollIntervalMs);
+    schedulePollAfterMsUnlessSse(boot.pollIntervalMs);
   }
 
   async function loadList() {
@@ -565,7 +646,7 @@
       }
       applyListSuccess(body);
       pollFailureStreak = 0;
-      startPollingIfNeeded();
+      maybeStartReviewCandidatesEventSource();
     } catch (e) {
       showLoading(false);
       showError(e instanceof Error ? e.message : 'Network error');
@@ -576,6 +657,9 @@
     clearReviewTabBadge();
     if (!wired) {
       wired = true;
+      global.addEventListener('beforeunload', function () {
+        stopReviewCandidatesStream();
+      });
       const btn = $('rc-refresh-btn');
       if (btn) {
         btn.addEventListener('click', function () {


### PR DESCRIPTION
## 변경 사항
- `GET /admin/memory/review-candidates/stream`: 브라우저 세션과 동일한 `/admin` 보호 하에 SSE(`text/event-stream`) 제공
- 프로세스 내 팬아웃(`review-candidates-sse-hub.ts`): `ready`, 주기 `: ping`, `changed` 이벤트
- `changed` 알림: 리뷰/디스미스 성공 후, `memory_review_candidates` 배치 완료 후
- 대시보드 `review-candidates-panel.js`: `EventSource` 연결, 실패 시 기존 #255 폴링으로 복귀; SSE OPEN 동안 폴링 타이머 비활성(`schedulePollAfterMsUnlessSse`)

## 관련 이슈
Closes #276

## 테스트
- `npm run test:ci:server` (352 tests)
- `npm run lint` (errors 0)

## 문서
- `docs/api/en/api-reference.md`, `docs/api/ko/api-reference.md`
- `docs/superpowers/specs/2026-05-05-issue-276-review-queue-sse-design.md`
- `docs/superpowers/plans/2026-05-05-issue-276-review-queue-sse.md`

## 지식 복리
운영 난이도·아키텍처 트레이드오프가 있어 필요 시 `/ce-compound`로 사례 문서화를 제안합니다.