### PR TITLE
fix(monitoring): resolve perf alert false positives (#266)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-perf-alert-false-positive.md
+++ b/docs/superpowers/plans/2026-05-04-perf-alert-false-positive.md
@@ -1,0 +1,433 @@
+# 이슈 #266 성능 알림 false positive 수정 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `performance-monitor.ts` 내 메모리 메트릭 축을 `rss/os.totalmem()`으로 교체하고, 로그 레벨 수정 및 알림 자동 해제 로직을 추가해 이슈 #266의 false positive를 제거한다.
+
+**Architecture:** 단일 파일 `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts` 내 **7곳**을 수정한다. 공개 인터페이스 변경 없음. TDD: 실패 테스트 작성 → 구현 → 통과 순으로 진행한다.
+
+**Tech Stack:** TypeScript, Node.js `os` 모듈, Vitest (`vi.spyOn`)
+
+---
+
+## 파일 구조
+
+| 역할 | 경로 |
+|---|---|
+| 구현 (수정) | `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts` |
+| 테스트 (추가) | `packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts` |
+
+---
+
+## Task 1: 실패 테스트 작성
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts`
+
+- [ ] **Step 1: 파일 상단 import 블록에 `os` 와 `logger` 추가**
+
+파일 최상단 import 블록(`import { describe, it, ...` 줄 근처)에 다음 두 줄이 없으면 추가한다:
+
+```typescript
+import os from 'os';
+import { logger } from '../../../../shared/utils/logger.js';
+```
+
+- [ ] **Step 2: 파일 하단에 새 describe 블록 추가**
+
+파일 끝(현재 215번째 줄 이후)에 다음 블록을 추가한다. `os` 모듈을 spyOn으로 제어해 시스템 메모리를 고정한다.
+
+```typescript
+describe('PerformanceMonitor 메모리 메트릭 (rss/totalmem 축)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeMonitor(thresholds?: { memoryUsagePercent?: number; cpuUsagePercent?: number }) {
+    return new PerformanceMonitor(thresholds);
+  }
+
+  it('V8 힙 충전율이 높아도 rss가 낮으면 알림을 생성하지 않는다', async () => {
+    // heapUsed/heapTotal = 93.75% (기존 로직에선 알림 발생)
+    // rss/totalmem = ~0.37% (새 로직에선 알림 없음)
+    const totalMem = 8 * 1024 * 1024 * 1024; // 8GB
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 30 * 1024 * 1024,
+      heapTotal: 32 * 1024 * 1024,
+      heapUsed: 30 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('heapUsed/heapTotal < 85%이지만 rss/totalmem > 85%이면 알림을 생성한다', async () => {
+    // heapUsed/heapTotal = 75% (기존 로직에선 미발화)
+    // rss/totalmem = 90% (새 로직에선 발화)
+    const totalMem = 1024 * 1024 * 1024; // 1GB
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: Math.round(totalMem * 0.4),
+      heapUsed: Math.round(totalMem * 0.3),  // heapUsed/heapTotal = 75%
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('os.totalmem()이 0이면 알림을 생성하지 않고 오류도 없다', async () => {
+    vi.spyOn(os, 'totalmem').mockReturnValue(0);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 500 * 1024 * 1024,
+      heapTotal: 600 * 1024 * 1024,
+      heapUsed: 500 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await expect(monitor.collectMetrics()).resolves.not.toThrow();
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('memory: 알림 발생 후 조건 해소 시 auto-resolve, 재발생 시 새 알림 생성', async () => {
+    const totalMem = 1024 * 1024 * 1024;
+    const memMock = vi.spyOn(process, 'memoryUsage');
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+
+    // 1단계: 초과 → 알림 생성
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.9),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(1);
+
+    // 2단계: 해소 → auto-resolve
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.5),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.5),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(0);
+
+    // 3단계: 재초과 → 새 알림 생성 (dedup 리셋 확인)
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.9),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(1);
+  });
+
+  it('cpu: 알림 발생 후 조건 해소 시 auto-resolve, 재발생 시 새 알림 생성', async () => {
+    vi.spyOn(os, 'totalmem').mockReturnValue(8 * 1024 * 1024 * 1024);
+    // rss를 낮게 고정해 memory alert가 끼어들지 않게 함
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 100 * 1024 * 1024,
+      heapTotal: 200 * 1024 * 1024,
+      heapUsed: 100 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ cpuUsagePercent: 10 });
+    // collectMetrics 내부의 checkAlerts 부산물을 제거한 뒤 명시적으로 시나리오를 주입한다
+    await monitor.collectMetrics();
+    monitor.clearAlerts();
+
+    // 기준 메트릭을 수집해 cpu.percent만 교체하는 베이스로 사용
+    const baseMetrics = await monitor.collectMetrics();
+    monitor.clearAlerts(); // 위 collectMetrics 부산물도 제거
+
+    const highCpuMetrics = { ...baseMetrics, cpu: { ...baseMetrics.cpu, percent: 80 } };
+    const lowCpuMetrics  = { ...baseMetrics, cpu: { ...baseMetrics.cpu, percent: 5  } };
+
+    // 1단계: 초과 → 알림 생성
+    await (monitor as any).checkAlerts(highCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(1);
+
+    // 2단계: 해소 → auto-resolve
+    await (monitor as any).checkAlerts(lowCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(0);
+
+    // 3단계: 재발화 → 새 알림 생성 (dedup 리셋 확인)
+    await (monitor as any).checkAlerts(highCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(1);
+  });
+
+  it('critical alert는 logger.warn을 사용하고 logger.error를 사용하지 않는다', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    const totalMem = 1024 * 1024 * 1024;
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: Math.round(totalMem * 0.95), // 95% > 90% → critical severity
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.95),
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const criticalWarnCalls = warnSpy.mock.calls.filter(
+      args => args[0] === 'Critical performance alert handling'
+    );
+    const criticalErrorCalls = errorSpy.mock.calls.filter(
+      args => args[0] === 'Critical performance alert handling'
+    );
+
+    expect(criticalWarnCalls.length).toBeGreaterThanOrEqual(1);
+    expect(criticalErrorCalls).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 3: 테스트 실행 — 실패 확인**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts --reporter=verbose 2>&1 | tail -50
+```
+
+기대 결과:
+- `'V8 힙 충전율이 높아도...'` → **FAIL** (현재 heapUsed/heapTotal 기준이므로 알림이 생성됨)
+- `'heapUsed/heapTotal < 85%이지만 rss/totalmem > 85%이면...'` → **FAIL** (현재는 heapUsed/heapTotal=75%로 미발화)
+- `'logger.warn을 사용하고...'` → **FAIL** (현재 logger.error 사용)
+- 나머지(totalmem=0, auto-resolve) → 결과 무관, 구현 후 검증
+
+- [ ] **Step 4: 커밋 (실패 테스트 커밋)**
+
+```bash
+git add packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
+git commit -m "test: add failing tests for rss-based memory metric and auto-resolve (#266)"
+```
+
+---
+
+## Task 2: 메모리 메트릭 교체 구현
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`
+
+참조 라인: `collectMetrics()` ~line 135, `checkAlerts()` ~line 185, 알림 메시지 ~line 199, `handleCriticalAlert()` ~line 956-959
+
+- [ ] **Step 1: `collectMetrics()` 내 `usagePercent` 계산 교체 (line ~135)**
+
+현재 코드:
+```typescript
+const memoryUsagePercent = memUsage.heapTotal > 0 ? (memUsage.heapUsed / memUsage.heapTotal) * 100 : 0;
+```
+
+교체:
+```typescript
+const totalSystemMemory = os.totalmem();
+const memoryUsagePercent = totalSystemMemory > 0 ? (memUsage.rss / totalSystemMemory) * 100 : 0;
+```
+
+- [ ] **Step 2: `checkAlerts()` 내 메모리 계산 교체 (line ~185)**
+
+현재 코드:
+```typescript
+const memoryUsagePercent = (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100;
+```
+
+교체:
+```typescript
+const totalSystemMemory = os.totalmem();
+const memoryUsagePercent = totalSystemMemory > 0
+  ? (metrics.memory.rss / totalSystemMemory) * 100
+  : 0;
+```
+
+- [ ] **Step 3: 알림 메시지 본문 교체 (line ~199)**
+
+현재 코드:
+```typescript
+message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% (${this.formatBytes(metrics.memory.heapUsed)}/${this.formatBytes(metrics.memory.heapTotal)})`,
+```
+
+교체 (`totalSystemMemory`는 Step 2에서 이미 선언된 변수):
+```typescript
+message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% RSS (${this.formatBytes(metrics.memory.rss)} / ${this.formatBytes(totalSystemMemory)})`,
+```
+
+- [ ] **Step 4: `handleCriticalAlert()` 로그 레벨 + payload 교체 (line ~956-959)**
+
+현재 코드:
+```typescript
+logger.error('Critical performance alert handling', {
+  alert,
+  metrics: {
+    memoryUsage: (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100,
+    dbSize: metrics.database.size / (1024 * 1024),
+    queryTime: metrics.database.queryTime
+  }
+});
+```
+
+교체:
+```typescript
+const _totalMem = os.totalmem();
+logger.warn('Critical performance alert handling', {
+  alert,
+  metrics: {
+    memoryUsage: alert.type === 'memory'
+      ? alert.value
+      : (_totalMem > 0 ? (metrics.memory.rss / _totalMem) * 100 : 0),
+    dbSize: metrics.database.size / (1024 * 1024),
+    queryTime: metrics.database.queryTime
+  }
+});
+```
+
+`alert.value`를 우선 사용해 알림 발화 기준값과 로그가 완전히 일치하도록 한다. 비메모리 타입에서 `totalmem === 0`이면 `0`을 사용해 `Infinity` 노출을 방지한다.
+
+- [ ] **Step 5: 테스트 실행 — 진전 확인**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts --reporter=verbose 2>&1 | tail -50
+```
+
+기대 결과:
+- `'V8 힙 충전율이 높아도...'` → **PASS**
+- `'heapUsed/heapTotal < 85%이지만 rss/totalmem > 85%...'` → **PASS**
+- `'logger.warn을 사용하고...'` → **PASS**
+- auto-resolve 테스트 2개 → 아직 FAIL (Task 3에서 구현)
+- 기존 테스트 → **PASS** (변경 없음)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+git commit -m "fix(monitoring): replace heapUsed/heapTotal with rss/os.totalmem() and warn on critical alert (#266)"
+```
+
+---
+
+## Task 3: 알림 자동 해제 (auto-resolve) 구현
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`
+
+`checkAlerts()` 메서드 내에 추가.
+
+- [ ] **Step 1: memory 알림 생성 블록 앞에 auto-resolve 추가**
+
+`checkAlerts()` 내에서 `if (memoryUsagePercent > this.thresholds.memoryUsagePercent)` 블록 **바로 앞**에 삽입:
+
+```typescript
+if (memoryUsagePercent <= this.thresholds.memoryUsagePercent) {
+  const existing = Array.from(this.alerts.values())
+    .find(a => a.type === 'memory' && !a.resolved);
+  if (existing) this.resolveAlert(existing.id);
+}
+```
+
+- [ ] **Step 2: CPU 알림 생성 블록 앞에 auto-resolve 추가**
+
+`checkAlerts()` 내에서 `if (cpuUsagePercent > this.thresholds.cpuUsagePercent)` 블록 **바로 앞**에 삽입:
+
+```typescript
+if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
+  const existing = Array.from(this.alerts.values())
+    .find(a => a.type === 'cpu' && !a.resolved);
+  if (existing) this.resolveAlert(existing.id);
+}
+```
+
+- [ ] **Step 3: 전체 테스트 실행 — 모든 케이스 통과 확인**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts --reporter=verbose 2>&1 | tail -50
+```
+
+기대 결과: 신규 6개 + 기존 테스트 전체 **PASS**
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+git commit -m "fix(monitoring): auto-resolve memory/cpu alerts when condition clears (#266)"
+```
+
+---
+
+## Task 4: 전체 검증
+
+- [ ] **Step 1: 모니터링 도메인 전체 테스트**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/ --reporter=verbose 2>&1 | tail -30
+```
+
+기대 결과: 전체 PASS
+
+- [ ] **Step 2: core 패키지 전체 CI 테스트**
+
+```bash
+npm run test:ci:core 2>&1 | tail -20
+```
+
+기대 결과: 에러 없음
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+cd packages/memento-core && npx tsc --noEmit 2>&1 | head -20
+cd ../..
+```
+
+기대 결과: 에러 없음
+
+---
+
+## 완료 기준
+
+- [ ] `npx vitest run packages/memento-core/src/domains/monitoring/` 전체 PASS
+- [ ] `logger.error` → `logger.warn` 전환 확인:
+  ```bash
+  grep -n "logger\.error.*Critical performance" packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+  ```
+  기대 결과: 출력 없음
+- [ ] 수정 대상 3곳에서 `heapUsed/heapTotal` 잔존 없음:
+  ```bash
+  sed -n '130,145p' packages/memento-core/src/domains/monitoring/services/performance-monitor.ts | grep "heapUsed.*heapTotal"
+  sed -n '180,210p' packages/memento-core/src/domains/monitoring/services/performance-monitor.ts | grep "heapUsed.*heapTotal"
+  sed -n '950,970p' packages/memento-core/src/domains/monitoring/services/performance-monitor.ts | grep "heapUsed.*heapTotal"
+  ```
+  기대 결과: 모두 출력 없음 (line 823의 analytics 코드는 이번 PR 범위 밖이므로 무관)
+- [ ] 타입 에러 없음
+
+---
+
+## 범위 밖 (이번 PR에 포함하지 않음)
+
+- `getMemoryMetrics()` (line ~544)의 `const totalMemory = 1024 * 1024 * 1024` 하드코딩 → 별도 이슈
+- `getMetricsAnalytics()` (line ~823)의 `heapUsed/heapTotal` 사용 → 별도 이슈
+- database/query 타입 알림 auto-resolve → 별도 이슈

--- a/docs/superpowers/specs/2026-05-04-perf-alert-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-04-perf-alert-false-positive-design.md
@@ -56,54 +56,93 @@ logger.error('Critical performance alert handling', { alert, metrics });
 
 ---
 
-### 변경 1: 메모리 메트릭 → `rss / os.totalmem()`
+### 변경 1: 메모리 메트릭 → `rss / os.totalmem()` (2곳 일관 적용)
 
-`checkAlerts()` 내 메모리 계산을 실제 시스템 메모리 기준으로 교체한다.
+`heapUsed/heapTotal` 계산이 같은 파일 내 2곳에 존재한다. 알림 판단 축과 히스토리·표시 축이 서로 다르면 진단 혼선이 생기므로 **두 곳 모두** 교체한다.
+
+**1-a) `collectMetrics()` (line ~135) — 히스토리 저장용 `usagePercent`**
 
 ```typescript
-// 변경 전 (line ~185)
+// 변경 전
+const memoryUsagePercent = memUsage.heapTotal > 0
+  ? (memUsage.heapUsed / memUsage.heapTotal) * 100 : 0;
+
+// 변경 후
+const totalSystemMemory = os.totalmem();
+const memoryUsagePercent = totalSystemMemory > 0
+  ? (memUsage.rss / totalSystemMemory) * 100 : 0;
+```
+
+**1-b) `checkAlerts()` (line ~185) — 알림 판단용 계산**
+
+```typescript
+// 변경 전
 const memoryUsagePercent = (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100;
 
 // 변경 후
-const totalSystemMemory = os.totalmem();  // os는 이미 import됨
+const totalSystemMemory = os.totalmem();
 const memoryUsagePercent = totalSystemMemory > 0
-  ? (metrics.memory.rss / totalSystemMemory) * 100
-  : 0;
+  ? (metrics.memory.rss / totalSystemMemory) * 100 : 0;
 ```
 
 `metrics.memory.rss`는 `collectMetrics()`에서 이미 수집되므로 추가 syscall 없음.
 
----
-
-### 변경 2: `logger.error` → `logger.warn`
-
-`handleCriticalAlert()` 내 로그 레벨을 내려 로그 모니터가 이슈를 생성하지 않도록 한다.
+**알림 메시지 본문 (line ~199)도 일관성을 위해 교체:**
 
 ```typescript
-// 변경 전 (line ~956)
+// 변경 전: heapUsed/heapTotal 바이트 표기로 percent와 분모 불일치
+message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% (${formatBytes(metrics.memory.heapUsed)}/${formatBytes(metrics.memory.heapTotal)})`
+
+// 변경 후: rss/totalmem 기준으로 통일
+message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% RSS (${formatBytes(metrics.memory.rss)} / ${formatBytes(totalSystemMemory)})`
+```
+
+**critical severity 임계값 (`> 90`) 유지 결정:**  
+기존 `heapUsed/heapTotal > 90%` 조건은 새 축 `rss/totalmem > 90%`에서도 유지한다. rss 90%는 훨씬 심각한 상태이므로 critical 분류가 여전히 적절하다. 임계값은 환경변수 `PERF_MEMORY_WARN_PERCENT`로 조정 가능하다.
+
+---
+
+### 변경 2: `logger.error` → `logger.warn` (로그 레벨 + payload 정합성)
+
+**2-a) 로그 레벨 교체 (line ~956):**
+
+```typescript
+// 변경 전
 logger.error('Critical performance alert handling', { alert, metrics: { ... } });
 
 // 변경 후
 logger.warn('Critical performance alert handling', { alert, metrics: { ... } });
 ```
 
-경보 자체의 처리 로직(GC 트리거, DB VACUUM)은 그대로 유지한다.
+**2-b) payload의 `memoryUsage` 계산도 새 축으로 교체 (line ~959):**
+
+```typescript
+// 변경 전: 여전히 heapUsed/heapTotal 사용 → 알림 값과 로그 값 불일치
+memoryUsage: (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100,
+
+// 변경 후: 알림 발화 기준과 동일한 축 사용
+memoryUsage: (metrics.memory.rss / os.totalmem()) * 100,
+```
+
+경보 처리 로직(GC 트리거, DB VACUUM)은 그대로 유지한다.
 
 ---
 
-### 변경 3: 조건 해소 시 알림 자동 해제
+### 변경 3: 조건 해소 시 알림 자동 해제 (memory + cpu 4가지 타입)
 
-`checkAlerts()` 에서 각 타입별로, 임계값 이하일 때 기존 활성 알림을 resolve한다. dedup이 재시작 없이도 자연히 리셋된다.
+`checkAlerts()`에서 각 타입별로, 임계값 이하일 때 기존 활성 알림을 resolve한다. dedup이 재시작 없이도 자연히 리셋된다.
+
+memory와 cpu에 적용한다. database와 query는 조건 해소가 덜 명확하고(DB 크기는 VACUUM 없이는 줄지 않음), 이번 이슈의 직접 원인이 아니므로 **이번 PR 범위에서 제외**하고 별도 이슈로 추적한다.
 
 ```typescript
-// 메모리 체크 앞에 추가
+// 메모리 알림 생성 블록 앞에 추가
 if (memoryUsagePercent <= this.thresholds.memoryUsagePercent) {
   const existing = Array.from(this.alerts.values())
     .find(a => a.type === 'memory' && !a.resolved);
   if (existing) this.resolveAlert(existing.id);
 }
 
-// CPU 체크 앞에 추가 (동일 패턴)
+// CPU 알림 생성 블록 앞에 추가 (동일 패턴)
 if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
   const existing = Array.from(this.alerts.values())
     .find(a => a.type === 'cpu' && !a.resolved);
@@ -118,13 +157,16 @@ if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
 ```
 BatchScheduler (60초 주기)
   → collectMetrics({ tick: true })
+      memoryUsagePercent = rss / os.totalmem()      ← 새 축 (히스토리 저장)
       memory.rss 수집 (기존)
     → checkAlerts(metrics)
-        memoryUsagePercent = rss / os.totalmem()   ← 새 축
-        조건 해소 → resolveAlert(existing)          ← 새 로직
+        memoryUsagePercent = rss / os.totalmem()     ← 새 축 (알림 판단, 일관성 확보)
+        조건 해소 → resolveAlert(existing)           ← 새 로직 (memory, cpu)
         조건 초과 → createAlert (dedup 통과 시)
+          alarmMessage = "rss / totalmem" 기준       ← 메시지 본문 일관성
           severity=critical → handleCriticalAlert()
-            → logger.warn(...)                      ← error → warn
+            → logger.warn(...)                        ← error → warn
+            → payload.memoryUsage = rss/totalmem      ← payload 일관성
             → if memory: global.gc() 시도 (유지)
 ```
 
@@ -132,22 +174,31 @@ BatchScheduler (60초 주기)
 
 ## 테스트 전략
 
-기존 테스트 파일: `packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts`
+기존 테스트 파일: `packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts`  
+추가 위치: `PerformanceMonitor`의 `checkAlerts` 동작을 검증하는 기존 테스트 블록.
 
 추가할 케이스:
 
 | 케이스 | 입력 | 기대 결과 |
 |---|---|---|
 | V8 힙 충전율 높음, rss 낮음 | heapUsed/heapTotal=93%, rss=30MB, totalmem=8GB | 알림 없음 |
-| 실제 RSS 압박 | rss/totalmem > 85% | 알림 생성 |
-| 조건 해소 | 기존 메모리 알림 존재 → 다음 점검에서 rss 정상 | 알림 auto-resolve |
-| critical 처리 로그 레벨 | critical alert 발생 | `logger.warn` 호출, `logger.error` 미호출 |
+| 실제 RSS 압박 | rss/totalmem > 85% | memory 알림 생성 |
+| 조건 해소 → dedup 리셋 | 기존 memory 알림 존재 → rss 정상 → rss 다시 초과 | 1) auto-resolve 2) 새 알림 생성 |
+| critical 처리 로그 레벨 | critical alert 발생 | `logger.warn('Critical performance alert handling')` 호출, `logger.error` 미호출 |
+| `os.totalmem() === 0` 방어 | totalmem=0 환경 | 알림 없음(memoryUsagePercent=0), 오류 없음 |
+
+---
+
+## 범위 밖 (후속 이슈)
+
+- `getMemoryMetrics()` (line ~544)의 `1GB 가정` 하드코딩 — 동일 근본 원인의 다른 발현
+- database/query 타입 알림 auto-resolve — 이번 이슈와 별개 동작
 
 ---
 
 ## 기대 효과
 
 - 이슈 #266 형태의 false positive 에러 로그 제거
-- 실제 RSS 기반 메모리 경보로 더 의미 있는 알림
-- 서버 재시작 없이 조건 해소 시 dedup 자동 리셋
+- 알림 판단·히스토리·메시지·로그 payload 전체가 동일한 rss/totalmem 축으로 일관
+- 서버 재시작 없이 조건 해소 시 dedup 자동 리셋 (memory, cpu)
 - 공개 인터페이스 및 기존 기능 100% 유지

--- a/docs/superpowers/specs/2026-05-04-perf-alert-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-04-perf-alert-false-positive-design.md
@@ -1,0 +1,153 @@
+# 설계: 이슈 #266 — 성능 알림 false positive 수정
+
+**날짜**: 2026-05-04  
+**브랜치**: fix/issue-266-perf-alert-false-positive  
+**변경 파일**: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`
+
+---
+
+## 문제 요약
+
+운영 로그 모니터가 `logger.error('Critical performance alert handling')` 호출을 감지해 이슈 #266을 자동 생성했다. 총 7회 발생(2026-05-03 ~ 05-04), 각 발생은 서버 재시작 직후 첫 번째 성능 점검 사이클에서 triggered.
+
+로그에 기록된 메모리 사용률 93~95%는 **실제 시스템 메모리 압박이 아닌 V8 힙 충전율**이다. 실제 RSS는 30~72MB 수준으로 시스템 전체 메모리 대비 무시할 수 있는 수준이다.
+
+---
+
+## 근본 원인
+
+### 원인 1 (핵심): 잘못된 메모리 메트릭 축
+
+`checkAlerts()` 내부에서 사용하는 메트릭:
+
+```typescript
+// performance-monitor.ts line 185
+const memoryUsagePercent = (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100;
+```
+
+`heapTotal`은 V8이 현재 할당한 힙 크기이지 시스템 전체 메모리가 아니다. V8 GC는 컴팩션 후 `heapTotal`을 줄이므로, 실제 메모리는 충분해도 `heapUsed/heapTotal` 비율이 93%+ 로 급등한다.
+
+실증:
+- 신선한 Node.js 프로세스: `heapUsed/heapTotal = 67.3%`, `heapUsed/totalmem = 0.01%`
+- 이슈 로그: 30MB/32MB = 93.8% — 시스템 관점에서는 정상
+
+### 원인 2: 모니터링 이벤트에 `logger.error` 사용
+
+`handleCriticalAlert()`이 성능 경보를 `logger.error`로 기록한다. 운영 로그 모니터는 `error` 레벨을 애플리케이션 장애로 분류해 이슈를 자동 생성한다.
+
+```typescript
+// performance-monitor.ts line 956
+logger.error('Critical performance alert handling', { alert, metrics });
+```
+
+### 원인 3: 알림 자동 해제 없음 + 재시작 시 dedup 초기화
+
+알림 Map이 인메모리라서 서버 재시작 시 초기화된다. 조건이 해소되어도 알림이 `resolved: false`로 영구 잔존하므로, 재시작마다 dedup이 리셋되어 새 경보가 발화된다.
+
+---
+
+## 설계
+
+### 변경 범위
+
+**단 1개 파일**: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`
+
+새 파일 없음. 공개 인터페이스(`PerformanceMetrics`, `AlertThresholds`, `PerformanceAlert`) 변경 없음.
+
+---
+
+### 변경 1: 메모리 메트릭 → `rss / os.totalmem()`
+
+`checkAlerts()` 내 메모리 계산을 실제 시스템 메모리 기준으로 교체한다.
+
+```typescript
+// 변경 전 (line ~185)
+const memoryUsagePercent = (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100;
+
+// 변경 후
+const totalSystemMemory = os.totalmem();  // os는 이미 import됨
+const memoryUsagePercent = totalSystemMemory > 0
+  ? (metrics.memory.rss / totalSystemMemory) * 100
+  : 0;
+```
+
+`metrics.memory.rss`는 `collectMetrics()`에서 이미 수집되므로 추가 syscall 없음.
+
+---
+
+### 변경 2: `logger.error` → `logger.warn`
+
+`handleCriticalAlert()` 내 로그 레벨을 내려 로그 모니터가 이슈를 생성하지 않도록 한다.
+
+```typescript
+// 변경 전 (line ~956)
+logger.error('Critical performance alert handling', { alert, metrics: { ... } });
+
+// 변경 후
+logger.warn('Critical performance alert handling', { alert, metrics: { ... } });
+```
+
+경보 자체의 처리 로직(GC 트리거, DB VACUUM)은 그대로 유지한다.
+
+---
+
+### 변경 3: 조건 해소 시 알림 자동 해제
+
+`checkAlerts()` 에서 각 타입별로, 임계값 이하일 때 기존 활성 알림을 resolve한다. dedup이 재시작 없이도 자연히 리셋된다.
+
+```typescript
+// 메모리 체크 앞에 추가
+if (memoryUsagePercent <= this.thresholds.memoryUsagePercent) {
+  const existing = Array.from(this.alerts.values())
+    .find(a => a.type === 'memory' && !a.resolved);
+  if (existing) this.resolveAlert(existing.id);
+}
+
+// CPU 체크 앞에 추가 (동일 패턴)
+if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
+  const existing = Array.from(this.alerts.values())
+    .find(a => a.type === 'cpu' && !a.resolved);
+  if (existing) this.resolveAlert(existing.id);
+}
+```
+
+---
+
+## 데이터 플로우 (변경 후)
+
+```
+BatchScheduler (60초 주기)
+  → collectMetrics({ tick: true })
+      memory.rss 수집 (기존)
+    → checkAlerts(metrics)
+        memoryUsagePercent = rss / os.totalmem()   ← 새 축
+        조건 해소 → resolveAlert(existing)          ← 새 로직
+        조건 초과 → createAlert (dedup 통과 시)
+          severity=critical → handleCriticalAlert()
+            → logger.warn(...)                      ← error → warn
+            → if memory: global.gc() 시도 (유지)
+```
+
+---
+
+## 테스트 전략
+
+기존 테스트 파일: `packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts`
+
+추가할 케이스:
+
+| 케이스 | 입력 | 기대 결과 |
+|---|---|---|
+| V8 힙 충전율 높음, rss 낮음 | heapUsed/heapTotal=93%, rss=30MB, totalmem=8GB | 알림 없음 |
+| 실제 RSS 압박 | rss/totalmem > 85% | 알림 생성 |
+| 조건 해소 | 기존 메모리 알림 존재 → 다음 점검에서 rss 정상 | 알림 auto-resolve |
+| critical 처리 로그 레벨 | critical alert 발생 | `logger.warn` 호출, `logger.error` 미호출 |
+
+---
+
+## 기대 효과
+
+- 이슈 #266 형태의 false positive 에러 로그 제거
+- 실제 RSS 기반 메모리 경보로 더 의미 있는 알림
+- 서버 재시작 없이 조건 해소 시 dedup 자동 리셋
+- 공개 인터페이스 및 기존 기능 100% 유지

--- a/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
+++ b/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { PerformanceMonitor } from '../performance-monitor.js';
 import type { PerformanceMetrics } from '../performance-monitor.js';
+import os from 'os';
+import { logger } from '../../../../shared/utils/logger.js';
 
 const toBytes = (mb: number): number => mb * 1024 * 1024;
 
@@ -210,5 +212,162 @@ describe('PerformanceMonitor analytics', () => {
     expect(analytics.database.growthRate).toBeGreaterThan(0);
     expect(analytics.search.totalSearches).toBe(20);
     expect(analytics.search.vectorShare).toBeCloseTo(8 / (8 + 8 + 4));
+  });
+});
+
+describe('PerformanceMonitor 메모리 메트릭 (rss/totalmem 축)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeMonitor(thresholds?: { memoryUsagePercent?: number; cpuUsagePercent?: number }) {
+    return new PerformanceMonitor(thresholds);
+  }
+
+  it('V8 힙 충전율이 높아도 rss가 낮으면 알림을 생성하지 않는다', async () => {
+    const totalMem = 8 * 1024 * 1024 * 1024;
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 30 * 1024 * 1024,
+      heapTotal: 32 * 1024 * 1024,
+      heapUsed: 30 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('heapUsed/heapTotal < 85%이지만 rss/totalmem > 85%이면 알림을 생성한다', async () => {
+    const totalMem = 1024 * 1024 * 1024;
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: Math.round(totalMem * 0.4),
+      heapUsed: Math.round(totalMem * 0.3),
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('os.totalmem()이 0이면 알림을 생성하지 않고 오류도 없다', async () => {
+    vi.spyOn(os, 'totalmem').mockReturnValue(0);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 500 * 1024 * 1024,
+      heapTotal: 600 * 1024 * 1024,
+      heapUsed: 500 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await expect(monitor.collectMetrics()).resolves.not.toThrow();
+    const alerts = monitor.getActiveAlerts().filter(a => a.type === 'memory');
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('memory: 알림 발생 후 조건 해소 시 auto-resolve, 재발생 시 새 알림 생성', async () => {
+    const totalMem = 1024 * 1024 * 1024;
+    const memMock = vi.spyOn(process, 'memoryUsage');
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.9),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(1);
+
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.5),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.5),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(0);
+
+    memMock.mockReturnValue({
+      rss: Math.round(totalMem * 0.9),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.9),
+      external: 0,
+      arrayBuffers: 0
+    });
+    await monitor.collectMetrics();
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'memory')).toHaveLength(1);
+  });
+
+  it('cpu: 알림 발생 후 조건 해소 시 auto-resolve, 재발생 시 새 알림 생성', async () => {
+    vi.spyOn(os, 'totalmem').mockReturnValue(8 * 1024 * 1024 * 1024);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 100 * 1024 * 1024,
+      heapTotal: 200 * 1024 * 1024,
+      heapUsed: 100 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ cpuUsagePercent: 10 });
+    await monitor.collectMetrics();
+    monitor.clearAlerts();
+
+    const baseMetrics = await monitor.collectMetrics();
+    monitor.clearAlerts();
+
+    const highCpuMetrics = { ...baseMetrics, cpu: { ...baseMetrics.cpu, percent: 80 } };
+    const lowCpuMetrics  = { ...baseMetrics, cpu: { ...baseMetrics.cpu, percent: 5  } };
+
+    await (monitor as any).checkAlerts(highCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(1);
+
+    await (monitor as any).checkAlerts(lowCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(0);
+
+    await (monitor as any).checkAlerts(highCpuMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'cpu')).toHaveLength(1);
+  });
+
+  it('critical alert는 logger.warn을 사용하고 logger.error를 사용하지 않는다', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    const totalMem = 1024 * 1024 * 1024;
+    vi.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: Math.round(totalMem * 0.95),
+      heapTotal: totalMem,
+      heapUsed: Math.round(totalMem * 0.95),
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const monitor = makeMonitor({ memoryUsagePercent: 85 });
+    await monitor.collectMetrics();
+
+    const criticalWarnCalls = warnSpy.mock.calls.filter(
+      args => args[0] === 'Critical performance alert handling'
+    );
+    const criticalErrorCalls = errorSpy.mock.calls.filter(
+      args => args[0] === 'Critical performance alert handling'
+    );
+
+    expect(criticalWarnCalls.length).toBeGreaterThanOrEqual(1);
+    expect(criticalErrorCalls).toHaveLength(0);
   });
 });

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -185,6 +185,11 @@ export class PerformanceMonitor {
     // 메모리 사용률 검사
     const totalSystemMemory = os.totalmem();
     const memoryUsagePercent = metrics.memory.usagePercent;
+    if (memoryUsagePercent <= this.thresholds.memoryUsagePercent) {
+      const existing = Array.from(this.alerts.values())
+        .find(a => a.type === 'memory' && !a.resolved);
+      if (existing) this.resolveAlert(existing.id);
+    }
     if (memoryUsagePercent > this.thresholds.memoryUsagePercent) {
       const alertId = `memory-${now.getTime()}`;
       const severity = memoryUsagePercent > 90 ? 'critical' : 'warning';
@@ -254,6 +259,11 @@ export class PerformanceMonitor {
 
     // CPU 사용률 검사
     const cpuUsagePercent = metrics.cpu.percent;
+    if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
+      const existing = Array.from(this.alerts.values())
+        .find(a => a.type === 'cpu' && !a.resolved);
+      if (existing) this.resolveAlert(existing.id);
+    }
     if (cpuUsagePercent > this.thresholds.cpuUsagePercent) {
       const alertId = `cpu-${now.getTime()}`;
       const severity = cpuUsagePercent > 90 ? 'critical' : 'warning';

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -132,7 +132,8 @@ export class PerformanceMonitor {
     // 시스템 지표
     const _systemMetrics = this.getSystemMetrics();
 
-    const memoryUsagePercent = memUsage.heapTotal > 0 ? (memUsage.heapUsed / memUsage.heapTotal) * 100 : 0;
+    const totalSystemMemory = os.totalmem();
+    const memoryUsagePercent = totalSystemMemory > 0 ? (memUsage.rss / totalSystemMemory) * 100 : 0;
     // tick=true: scheduled baseline 갱신 / tick=false: on-demand baseline만 갱신
     const cpuUsagePercent = this.calculateCpuUsage(tick);
 
@@ -182,7 +183,10 @@ export class PerformanceMonitor {
     const now = new Date();
 
     // 메모리 사용률 검사
-    const memoryUsagePercent = (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100;
+    const totalSystemMemory = os.totalmem();
+    const memoryUsagePercent = totalSystemMemory > 0
+      ? (metrics.memory.rss / totalSystemMemory) * 100
+      : 0;
     if (memoryUsagePercent > this.thresholds.memoryUsagePercent) {
       const alertId = `memory-${now.getTime()}`;
       const severity = memoryUsagePercent > 90 ? 'critical' : 'warning';
@@ -196,7 +200,7 @@ export class PerformanceMonitor {
           id: alertId,
           type: 'memory',
           severity,
-          message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% (${this.formatBytes(metrics.memory.heapUsed)}/${this.formatBytes(metrics.memory.heapTotal)})`,
+          message: `High memory usage: ${memoryUsagePercent.toFixed(1)}% RSS (${this.formatBytes(metrics.memory.rss)} / ${this.formatBytes(totalSystemMemory)})`,
           value: memoryUsagePercent,
           threshold: this.thresholds.memoryUsagePercent,
           timestamp: now,
@@ -953,10 +957,13 @@ export class PerformanceMonitor {
    * 심각한 알림 처리
    */
   private async handleCriticalAlert(alert: PerformanceAlert, metrics: PerformanceMetrics): Promise<void> {
-    logger.error('Critical performance alert handling', {
+    const _totalMem = os.totalmem();
+    logger.warn('Critical performance alert handling', {
       alert,
       metrics: {
-        memoryUsage: (metrics.memory.heapUsed / metrics.memory.heapTotal) * 100,
+        memoryUsage: alert.type === 'memory'
+          ? alert.value
+          : (_totalMem > 0 ? (metrics.memory.rss / _totalMem) * 100 : 0),
         dbSize: metrics.database.size / (1024 * 1024),
         queryTime: metrics.database.queryTime
       }

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -186,6 +186,8 @@ export class PerformanceMonitor {
     const totalSystemMemory = os.totalmem();
     const memoryUsagePercent = metrics.memory.usagePercent;
     if (memoryUsagePercent <= this.thresholds.memoryUsagePercent) {
+      // 조건 해소 시 알림을 시스템이 자동 해제한다. resolveAlert()의 acknowledgeAlert() 연쇄 호출은
+      // 알림 서비스에서 해당 알림을 제거하기 위한 의도된 동작이다.
       const existing = Array.from(this.alerts.values())
         .find(a => a.type === 'memory' && !a.resolved);
       if (existing) this.resolveAlert(existing.id);
@@ -212,7 +214,7 @@ export class PerformanceMonitor {
       }
     }
 
-    // 데이터베이스 크기 검사
+    // 데이터베이스 크기 검사 — DB 크기는 VACUUM 없이 자연히 감소하지 않으므로 auto-resolve를 지원하지 않는다.
     const dbSizeMB = metrics.database.size / (1024 * 1024);
     if (dbSizeMB > this.thresholds.databaseSizeMB) {
       const alertId = `database-${now.getTime()}`;
@@ -235,7 +237,7 @@ export class PerformanceMonitor {
       }
     }
 
-    // 쿼리 시간 검사
+    // 쿼리 시간 검사 — 순간 측정값으로 감소를 신뢰할 수 없어 auto-resolve를 지원하지 않는다.
     if (metrics.database.queryTime > this.thresholds.queryTimeMs) {
       const alertId = `query-${now.getTime()}`;
       const severity = metrics.database.queryTime > this.thresholds.queryTimeMs * 2 ? 'critical' : 'warning';
@@ -260,6 +262,7 @@ export class PerformanceMonitor {
     // CPU 사용률 검사
     const cpuUsagePercent = metrics.cpu.percent;
     if (cpuUsagePercent <= this.thresholds.cpuUsagePercent) {
+      // memory와 동일: 조건 해소 시 시스템 auto-resolve. acknowledgeAlert() 연쇄는 의도된 동작.
       const existing = Array.from(this.alerts.values())
         .find(a => a.type === 'cpu' && !a.resolved);
       if (existing) this.resolveAlert(existing.id);

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -184,9 +184,7 @@ export class PerformanceMonitor {
 
     // 메모리 사용률 검사
     const totalSystemMemory = os.totalmem();
-    const memoryUsagePercent = totalSystemMemory > 0
-      ? (metrics.memory.rss / totalSystemMemory) * 100
-      : 0;
+    const memoryUsagePercent = metrics.memory.usagePercent;
     if (memoryUsagePercent > this.thresholds.memoryUsagePercent) {
       const alertId = `memory-${now.getTime()}`;
       const severity = memoryUsagePercent > 90 ? 'critical' : 'warning';
@@ -957,13 +955,13 @@ export class PerformanceMonitor {
    * 심각한 알림 처리
    */
   private async handleCriticalAlert(alert: PerformanceAlert, metrics: PerformanceMetrics): Promise<void> {
-    const _totalMem = os.totalmem();
+    const totalMem = os.totalmem();
     logger.warn('Critical performance alert handling', {
       alert,
       metrics: {
         memoryUsage: alert.type === 'memory'
           ? alert.value
-          : (_totalMem > 0 ? (metrics.memory.rss / _totalMem) * 100 : 0),
+          : (totalMem > 0 ? (metrics.memory.rss / totalMem) * 100 : 0),
         dbSize: metrics.database.size / (1024 * 1024),
         queryTime: metrics.database.queryTime
       }


### PR DESCRIPTION
## Summary

- **메모리 메트릭 축 교체**: `heapUsed/heapTotal`(V8 힙 충전율) → `rss/os.totalmem()`(실제 시스템 메모리 압박). GC 컴팩션 후 V8이 `heapTotal`을 줄이면서 93-95%로 급등하던 false positive 제거.
- **로그 레벨 수정**: `handleCriticalAlert()`의 `logger.error` → `logger.warn`. 운영 로그 모니터가 `error` 레벨을 애플리케이션 장애로 분류해 이슈를 자동 생성하던 문제 차단.
- **조건 해소 시 알림 auto-resolve**: memory/cpu 알림이 임계값 이하로 돌아오면 기존 활성 알림을 자동 해제. 서버 재시작 없이 dedup이 리셋되어 재시작마다 경보가 재발화하던 문제 수정.

## Root Cause

서버 재시작 직후 첫 번째 성능 점검 사이클에서 7회 발생 (2026-05-03 ~ 05-04).

| 지표 | 실제 값 | 잘못된 해석 |
|------|---------|------------|
| `heapUsed/heapTotal` | 93.8% (30MB/32MB) | "메모리 위기" |
| `rss/totalmem` | 0.4% (30MB/8GB) | — 실제 수준 |

## Changes

**1개 파일만 변경**: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`

- `collectMetrics()` line ~135: `usagePercent` 계산 → `rss/totalmem`
- `checkAlerts()` line ~187: 알림 판단 → `metrics.memory.usagePercent` 사용
- 알림 메시지: "% RSS (rss / totalmem)" 형식으로 통일
- `handleCriticalAlert()` line ~956: `logger.error` → `logger.warn`, payload도 동일 축으로 교체
- `checkAlerts()`: memory/cpu 타입에 auto-resolve 로직 추가

공개 인터페이스(`PerformanceMetrics`, `AlertThresholds`, `PerformanceAlert`) 변경 없음.

## Test Plan

- [x] 새 테스트 6개 추가 (`PerformanceMonitor 메모리 메트릭 (rss/totalmem 축)` describe 블록)
  - V8 힙 충전율 높음 + rss 낮음 → 알림 없음 (false positive 재현 및 방지 확인)
  - heapUsed/heapTotal < 85% + rss/totalmem > 85% → 알림 생성 (true positive)
  - `os.totalmem() === 0` 방어 → 알림 없음, 오류 없음
  - memory auto-resolve → 재발화 시퀀스
  - cpu auto-resolve → 재발화 시퀀스
  - critical alert → `logger.warn` 사용, `logger.error` 미호출
- [x] 모니터링 도메인 테스트: 368/368 통과
- [x] 전체 CI: 3757/3758 통과 (1 skipped — 기존)
- [x] TypeScript: 오류 없음

## Out of Scope (후속 이슈)

- `getMemoryMetrics()` line ~544: `const totalMemory = 1024 * 1024 * 1024` 하드코딩
- `getMetricsAnalytics()` line ~838: `heapUsed/heapTotal` fallback
- database/query 알림 auto-resolve

Closes #266

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)