### PR TITLE
fix(server): stdio MCP 서버 1.25.0 미시작 회귀 버그 수정 (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).
 - 잘못 추적되던 `.claude/worktrees/*` gitlink 제거: `actions/checkout` Post 단계의 `git submodule foreach`가 exit 128로 경고 나던 문제 방지
 - CLI(`memento remember` 등)가 HTTP/stdio MCP 서버와 동시에 실행될 때 발생하던 WAL 체크포인트 충돌 및 DB 손상 버그 수정 (#160)
 


### PR DESCRIPTION
## 요약

1.25.0에서 stdio MCP 서버가 즉시 종료되어 클라이언트가 연결할 수 없던 회귀 버그를 추적하고 CHANGELOG에 기록합니다.

Closes #302

## 버그 원인

`packages/memento-server/src/server/index.ts` 리팩토링 시 두 가지 버그가 동시에 도입됨:

| 항목 | 1.25.0 (버그) | fix |
|------|-------------|-----|
| capabilities | `{ tools: {}, resources: {}, prompts: {} }` | `{ ..., logging: {} }` 추가 |
| SetLevelRequestSchema | 수동으로 핸들러 등록 | 제거 (SDK 자동 처리) |

MCP SDK `assertRequestHandlerCapability`가 `logging` capability 없이 `SetLevelRequestSchema` 핸들러 등록 시 예외를 throw → `startServer()` catch 블록에서 `process.exit(1)` 실행 → `server.connect(transport)` 도달 전 프로세스 종료 → 클라이언트 타임아웃.

## 수정 사항

코드 fix는 이미 다음 커밋에서 `main`에 적용됨:
- `e5c08f2` — `logging: {}` capability 추가 + `SetLevelRequestSchema` 핸들러 제거
- `ec17f1d` — 불필요해진 `SetLevelRequestSchema` import 제거

이 PR은 CHANGELOG `[Unreleased] > Fixed` 섹션에 해당 회귀 버그 항목을 추가합니다.

## 영향 범위

`1.25.0`, `1.25.0-a` ~ `1.25.0-d` — 모두 동일 커밋 `b3d4f8a` 기준으로 동일한 버그 포함. `1.26.0-a` 이후 버전에서는 정상 동작.

## 테스트 계획

- [x] `1.26.0-a` 기준 빌드로 stdio initialize 응답 정상 확인 (기존 테스트 통과)
- [x] `stdio.integration.spec.ts` — 실제 child process 기반 roundtrip 테스트 (`e5c08f2`에서 추가됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)