### PR TITLE
fix(monitoring): remove heapUsed/heapTotal dead-code fallback in getMetricsAnalytics

### DIFF
--- a/docs/superpowers/plans/2026-05-09-issue-288-metrics-analytics-fallback.md
+++ b/docs/superpowers/plans/2026-05-09-issue-288-metrics-analytics-fallback.md
@@ -1,0 +1,205 @@
+# Issue #288: getMetricsAnalytics() fallback 제거 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `getMetricsAnalytics()`의 838번 줄에 있는 dead code fallback(`heapUsed/heapTotal` 계산)을 제거하고, `usagePercent ?? 0`으로 단순화한다.
+
+**Architecture:** 단일 파일의 단일 표현식 수정. PR #286 이후 `usagePercent`는 항상 `rss/totalmem` 기준으로 채워지므로 `??` 이후의 fallback은 실행되지 않음. dead code 제거로 코드 명확성 향상.
+
+**Tech Stack:** TypeScript, Vitest, Node.js ≥24
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts:838` | dead code fallback 제거 |
+| Modify | `packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts` | `usagePercent` undefined 레거시 케이스 테스트 추가 |
+
+---
+
+### Task 1: 워크트리 생성
+
+**Files:**
+- (없음 — 저장소 설정만)
+
+- [ ] **Step 1: 워크트리 생성**
+
+```bash
+git worktree add .worktrees/fix/issue-288-metrics-fallback -b fix/issue-288-metrics-fallback
+```
+
+Expected: `.worktrees/fix/issue-288-metrics-fallback/` 디렉토리 생성됨
+
+- [ ] **Step 2: 워크트리로 이동**
+
+```bash
+cd .worktrees/fix/issue-288-metrics-fallback
+```
+
+이후 모든 작업은 이 디렉토리에서 수행한다.
+
+---
+
+### Task 2: 레거시 usagePercent undefined 테스트 케이스 추가 (TDD)
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`describe('PerformanceMonitor analytics', ...)` 블록 내에 다음 케이스를 추가한다 (기존 `'computes averages and shares from metrics history'` 테스트 바로 아래):
+
+```typescript
+it('usagePercent가 없는 레거시 메트릭은 0으로 fallback한다', () => {
+  const monitor = new PerformanceMonitor();
+
+  const legacyMetric = createMetrics({
+    memory: { heapUsed: toBytes(512), usagePercent: undefined as unknown as number }
+  });
+
+  (monitor as any).metricsHistory = [legacyMetric];
+
+  const analytics = monitor.getMetricsAnalytics();
+  expect(analytics.memory.averageUsagePercent).toBe(0);
+  expect(analytics.memory.history).toEqual([0]);
+});
+```
+
+- [ ] **Step 2: 테스트가 실패하는지 확인**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: 새로 추가한 테스트가 FAIL (현재 코드는 `heapUsed/heapTotal` 계산을 하므로 0이 아닌 50이 반환됨)
+
+---
+
+### Task 3: 소스 코드 수정
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/monitoring/services/performance-monitor.ts:838`
+
+- [ ] **Step 1: 838번 줄 수정**
+
+`getMetricsAnalytics()` 함수 내 838번 줄을:
+
+```typescript
+// Before
+const memoryPercentHistory = history.map(m => m.memory.usagePercent ?? (m.memory.heapTotal ? (m.memory.heapUsed / m.memory.heapTotal) * 100 : 0));
+```
+
+아래로 교체한다:
+
+```typescript
+// After
+const memoryPercentHistory = history.map(m => m.memory.usagePercent ?? 0);
+```
+
+- [ ] **Step 2: 테스트 전체 통과 확인**
+
+```bash
+npx vitest run packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: 모든 테스트 PASS (새로 추가한 케이스 포함)
+
+---
+
+### Task 4: 린트 · 타입 체크 · 전체 테스트
+
+**Files:**
+- (없음 — 검증만)
+
+- [ ] **Step 1: 타입 체크**
+
+```bash
+npm run type-check 2>&1 | tail -20
+```
+
+Expected: 에러 없음
+
+- [ ] **Step 2: 린트**
+
+```bash
+npm run lint 2>&1 | tail -20
+```
+
+Expected: 에러 없음 (경고는 허용)
+
+- [ ] **Step 3: 전체 단위 테스트**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: 모든 테스트 통과
+
+---
+
+### Task 5: 커밋 및 PR 생성
+
+**Files:**
+- (없음 — git 작업만)
+
+- [ ] **Step 1: 변경 파일 확인**
+
+```bash
+git diff --stat
+```
+
+Expected: 두 파일 변경됨 (`performance-monitor.ts`, `performance-monitor.spec.ts`)
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/monitoring/services/performance-monitor.ts \
+        packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
+git commit -m "fix(monitoring): remove heapUsed/heapTotal dead-code fallback in getMetricsAnalytics
+
+usagePercent is always populated via rss/totalmem since PR #286.
+The heapUsed/heapTotal fallback path was never executed and used
+the wrong axis — replace with simple usagePercent ?? 0.
+
+Closes #288"
+```
+
+- [ ] **Step 3: PR 생성**
+
+```bash
+gh pr create \
+  --title "fix(monitoring): remove heapUsed/heapTotal dead-code fallback in getMetricsAnalytics" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `getMetricsAnalytics()` 838번 줄의 dead code fallback 제거
+- PR #286 이후 `usagePercent`는 항상 `rss/totalmem` 기준으로 채워지므로 `heapUsed/heapTotal` fallback은 실행되지 않음
+- `usagePercent ?? 0`으로 단순화 (레거시 데이터 대응 포함)
+
+## Test plan
+
+- [ ] 기존 `getMetricsAnalytics()` 테스트 통과 확인
+- [ ] `usagePercent` undefined 레거시 케이스 → 0 fallback 테스트 신규 추가
+- [ ] `npm run type-check`, `npm run lint`, `npm test` 통과
+
+## 지식 복리
+
+해당 없음 (단순 dead code 제거)
+
+Closes #288
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## 완료 기준
+
+- [ ] `performance-monitor.ts` 838번 줄이 `usagePercent ?? 0`으로 단순화됨
+- [ ] 레거시 `usagePercent undefined` 테스트 케이스 추가됨
+- [ ] `npm run type-check`, `npm run lint`, `npm test` 모두 통과
+- [ ] PR 생성 완료

--- a/docs/superpowers/specs/2026-05-09-issue-288-metrics-analytics-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-288-metrics-analytics-fallback-design.md
@@ -1,0 +1,56 @@
+# Issue #288: getMetricsAnalytics() fallback 제거
+
+**날짜:** 2026-05-09  
+**이슈:** [#288](https://github.com/jee1lee/memento/issues/288)  
+**라벨:** bug
+
+## 문제
+
+`performance-monitor.ts`의 `getMetricsAnalytics()` (838번 줄)에 dead code fallback이 존재한다:
+
+```typescript
+const memoryPercentHistory = history.map(m =>
+  m.memory.usagePercent ?? (m.memory.heapTotal ? (m.memory.heapUsed / m.memory.heapTotal) * 100 : 0)
+);
+```
+
+PR #286 이후 `m.memory.usagePercent`는 항상 `rss/totalmem` 기준으로 채워지므로, `??` 이후의 `heapUsed/heapTotal` fallback은 실행되지 않는다. 잘못된 축(heap 기준)의 dead code가 혼선을 유발한다.
+
+## 설계
+
+### 변경 파일
+
+`packages/memento-core/src/domains/monitoring/services/performance-monitor.ts`
+
+### 변경 내용
+
+838번 줄을 단순화한다:
+
+```typescript
+// Before
+const memoryPercentHistory = history.map(m =>
+  m.memory.usagePercent ?? (m.memory.heapTotal ? (m.memory.heapUsed / m.memory.heapTotal) * 100 : 0)
+);
+
+// After
+const memoryPercentHistory = history.map(m => m.memory.usagePercent ?? 0);
+```
+
+`usagePercent`가 undefined인 경우(레거시 데이터) 0으로 fallback한다. 실제 운영에서는 발생하지 않지만 타입 안전성을 위해 유지한다.
+
+### 스코프 외 항목
+
+- 762번 줄의 `heapUsed` trend 계산은 별도 이슈로 처리
+
+## 테스트 전략
+
+기존 `getMetricsAnalytics()` 테스트에서:
+1. `usagePercent`가 채워진 경우 — 기존 동작과 동일한 결과 반환
+2. `usagePercent`가 undefined인 레거시 데이터 — 0으로 fallback
+
+## 구현 계획
+
+1. 워크트리 생성: `fix/issue-288-metrics-fallback`
+2. 838번 줄 단순화
+3. 기존 테스트 통과 확인 + 신규 테스트 케이스 추가(필요 시)
+4. PR 생성

--- a/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
+++ b/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
@@ -213,6 +213,20 @@ describe('PerformanceMonitor analytics', () => {
     expect(analytics.search.totalSearches).toBe(20);
     expect(analytics.search.vectorShare).toBeCloseTo(8 / (8 + 8 + 4));
   });
+
+  it('usagePercent가 없는 레거시 메트릭은 0으로 fallback한다', () => {
+    const monitor = new PerformanceMonitor();
+
+    const legacyMetric = createMetrics({
+      memory: { heapUsed: toBytes(512), usagePercent: undefined as unknown as number }
+    });
+
+    (monitor as any).metricsHistory = [legacyMetric];
+
+    const analytics = monitor.getMetricsAnalytics();
+    expect(analytics.memory.averageUsagePercent).toBe(0);
+    expect(analytics.memory.history).toEqual([0]);
+  });
 });
 
 describe('PerformanceMonitor 메모리 메트릭 (rss/totalmem 축)', () => {

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -835,7 +835,7 @@ export class PerformanceMonitor {
     const average = (values: number[]): number => values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 
     const memoryUsed = history.map(m => m.memory.heapUsed);
-    const memoryPercentHistory = history.map(m => m.memory.usagePercent ?? (m.memory.heapTotal ? (m.memory.heapUsed / m.memory.heapTotal) * 100 : 0));
+    const memoryPercentHistory = history.map(m => m.memory.usagePercent ?? 0);
     const cpuPercentHistory = history.map(m => m.cpu.percent ?? 0);
     const dbSizesMB = history.map(m => toMb(m.database.size));
 


### PR DESCRIPTION
## Summary

- `getMetricsAnalytics()` 838번 줄의 dead code fallback 제거
- PR #286 이후 `usagePercent`는 항상 `rss/totalmem` 기준으로 채워지므로 `heapUsed/heapTotal` fallback은 실행되지 않음
- `usagePercent ?? 0`으로 단순화 (레거시 데이터 대응 포함)

## Test plan

- [x] 기존 `getMetricsAnalytics()` 테스트 17개 통과
- [x] `usagePercent` undefined 레거시 케이스 → 0 fallback 테스트 신규 추가
- [x] `npm run type-check`, `npm run lint`, `npm test` (4,234 tests) 통과

## 지식 복리

해당 없음 (단순 dead code 제거)

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)