### PR TITLE
feat(review-queue): #277 follow-up docs + PoC (#296–#300)

### DIFF
--- a/docs/_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md
+++ b/docs/_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md
@@ -1,0 +1,165 @@
+# 리뷰 큐 경계 인터페이스 · Idempotency 계약 (GitHub #277 후속 / #296)
+
+- **상태:** 설계 확정(구현 전)
+- **기준:** [ADR: 리뷰 후보 산출/전달 확장 전략](../../adr/2026-05-05-issue-277-review-queue-scaling-strategy.md), [후속 구현 계획 §Track B-4](../../superpowers/plans/2026-05-05-issue-277-review-queue-scaling-followup-plan.md)
+- **목표:** in-process 배치·SSE와 향후 외부 큐/워커가 **동일한 계약**으로 교체될 수 있도록 producer/consumer 경계와 중복 전달 안전 규칙을 명문화한다.
+
+## 1. 경계 정의
+
+### 1.1 현재 (옵션 A)
+
+| 구간 | Producer | Consumer | 비고 |
+|------|----------|----------|------|
+| 후보 선정 → DB 반영 | `BatchScheduler.runMemoryReviewCandidatesJob` | `upsertPendingMemoryReviewCandidates` | SQLite 동기 호출 |
+| 변경 알림 → UI | `notifyReviewCandidatesChanged` | Admin SSE `/admin/memory/review-candidates/stream` | in-process, 단일 노드 |
+
+경계는 **함수 호출 + 공유 DB**로 흡수되어 있으며, 별도 메시지 버스는 없다.
+
+### 1.2 목표 (옵션 B/C 대비)
+
+외부 브로커(예: Redis stream, SQS)를 끼우더라도 다음 **논리 경계**는 동일해야 한다.
+
+1. **작업 단위(Work Unit):** “이 `memory_id`에 대해 pending 후보를 특정 이유·우선순위·메타로 맞춘다”는 의미의 멱등 가능한 갱신.
+2. **완료 신호(Completion / Fan-out):** 배치 또는 워커 실행이 끝났을 때 대시보드·다운스트림이 구독할 수 있는 **changed** 알림 (내용은 최소화, 조회는 DB/API로).
+
+## 2. 공통 메시지 봉투 (Envelope)
+
+모든 큐 메시지는 아래 필드를 **필수**로 포함한다. JSON 직렬화를 기본으로 한다 (`application/json` 또는 broker-native JSON body).
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `schema_version` | `number` | 계약 버전. 초기값 `1`. 하위 호환만 additive. |
+| `kind` | `string` | 아래 §3 이벤트 종류 중 하나. |
+| `idempotency_key` | `string` | §4 규칙. 최대 길이 256, `[a-zA-Z0-9_:.-]` 권장. |
+| `correlation_id` | `string` (UUID) | 한 배치 실행·한 발행 세션을 묶는 ID. |
+| `occurred_at` | `string` | RFC3339 UTC. **생산 시각**(큐에 넣은 시각이 아니라 도메인 이벤트 시각이면 `effective_at` 별도). |
+| `producer` | `object` | `{ "name": "memento-batch-scheduler" \| "memento-worker" \| string, "instance_id"?: string }` |
+| `payload` | `object` | `kind`별 페이로드(§3). |
+
+**버전 정책:** `schema_version` 불일치 시 consumer는 **거부(nack)** 하고 DLQ/재처리 정책에 따른다 — [`2026-05-09-review-queue-retry-backoff-dlq-runbook.md`](./2026-05-09-review-queue-retry-backoff-dlq-runbook.md).
+
+## 3. 이벤트 종류(`kind`)
+
+### 3.1 `review_candidate_upsert_requested` (핵심 Work Unit)
+
+배치가 선택한 **단일 후보**에 대한 멱등 upsert 의도를 표현한다. 현재 `runMemoryReviewCandidatesJob`의 `inputs` 원소와 1:1 대응 가능.
+
+**`payload` (schema_version 1):**
+
+```json
+{
+  "memory_id": "mem_…",
+  "priority": 0,
+  "reason": "string",
+  "due_at": "2026-05-09T12:00:00.000Z",
+  "metadata_json": "{\"score_breakdown\":{…}}",
+  "selection_fingerprint": "sha256:…"
+}
+```
+
+- `selection_fingerprint`: producer가 이번 선정에 사용한 입력(예: recall 점수·임계값·규칙 버전)을 해시한 값. **동일 후보라도 선정 근거가 바뀌면 키가 달라져야** 한다(§4).
+
+**Consumer 의미:** `upsertPendingMemoryReviewCandidates`와 동등한 트랜잭션 경로로 처리. 실 실패 시 재시도 가능(at-least-once).
+
+### 3.2 `review_candidates_batch_completed` (관측·스냅샷 트리거)
+
+배치 전체가 끝난 뒤 발행. 운영 메타용.
+
+**`payload`:**
+
+```json
+{
+  "job_type": "memory_review_candidates",
+  "run_started_at": "…",
+  "run_finished_at": "…",
+  "selected_count": 42,
+  "upsert": { "inserted": 3, "updated": 10 },
+  "success": true,
+  "errors": []
+}
+```
+
+- Consumer(s): 로그 집계, `recordMemoryReviewQueueHealthSnapshot` 유사 동작, 외부 모니터링.
+- **Idempotency:** 배치 단위 키(§4.2). 동일 키 재전달 시 스냅샷/메트릭은 중복 집계되지 않도록 consumer 측 **seen-set** 또는 DB unique 권장.
+
+### 3.3 `review_candidates_changed` (얇은 알림)
+
+현재 SSE `notifyReviewCandidatesChanged(reason)` 대체. **상태 전부를 실을 필요 없음.**
+
+**`payload`:**
+
+```json
+{
+  "reason": "batch_memory_review_candidates",
+  "approx_pending_delta_hint": null
+}
+```
+
+UI/SSE는 수신 후 `GET /admin/memory/review-candidates` 또는 metrics를 당겨(refresh)온다.
+
+## 4. Idempotency 계약
+
+### 4.1 도메인 멱등성 (이미 존재)
+
+- `memory_review_candidate`에 대해 **pending 상태에서는 `memory_id`당 최대 1행**(부분 유니크 인덱스).  
+- `upsertPendingMemoryReviewCandidates`는 동일 입력 반복 시 **삽입 대신 갱신**으로 수렴한다.  
+→ **정확히 한 번** 전달이 아니라 **최소 한 번(at-least-once) + 수렴** 모델이 자연스럽다.
+
+### 4.2 메시지 `idempotency_key` 생성 규칙
+
+| kind | 권장 형식 | 안정 조건 |
+|------|-----------|-----------|
+| `review_candidate_upsert_requested` | `mrc:v1:upsert:{memory_id}:{selection_fingerprint}` | 동일 선정 결과 재발행 시 동일 키 |
+| `review_candidates_batch_completed` | `mrc:v1:batch:{correlation_id}` | 한 실행·한 번의 완료 이벤트 |
+| `review_candidates_changed` | `mrc:v1:changed:{correlation_id}:{reason}` 또는 `…:{monotonic_seq}` | UI 새로고침이 과도해도 무방하면 느슨하게 허용 |
+
+**금지:** 랜덤 UUID만으로 upsert 키를 구성하면 동일 도메인 작업이 중복 실행될 수 있다.
+
+### 4.3 Consumer 의무
+
+1. **Upsert 메시지:** 동일 `idempotency_key`를 이미 성공 처리한 경우, 재전달 시 **HTTP 200 / ack**와 동등한 노옵(또는 저장된 결과 반환).  
+2. **Batch completed:** 집계·스냅샷이 **정확히 한 번만** 필요하면 `idempotency_key`를 비즈니스 테이블 또는 Redis SET에 **TTL ≥ 48h**로 기록.  
+3. **Changed:** 멱등 필수 아님; 중복이면 클라이언트가 추가 refresh만 수행.
+
+### 4.4 Producer 의무
+
+- `correlation_id`: 배치 한 번의 실행 내 모든 메시지에 동일 값 사용.
+- 큐 재전파·DLQ 재주입 시 **`idempotency_key` 불변** 유지.
+
+## 5. 어댑터(병행 가능 초안)
+
+Structured Shell 쪽에 두 포트를 두고, 구현체만 교체한다.
+
+```typescript
+/** 발행: 현재는 no-op 뒤 DB 직접 호출, 향후는 broker publish */
+export interface ReviewQueueWorkPublisher {
+  publishUpsert(correlationId: string, msg: Envelope<'review_candidate_upsert_requested'>): Promise<void>;
+  publishBatchCompleted(correlationId: string, msg: Envelope<'review_candidates_batch_completed'>): Promise<void>;
+  publishChanged(correlationId: string, msg: Envelope<'review_candidates_changed'>): Promise<void>;
+}
+
+/** 소비: 현재는 Scheduler가 직접 DB, 향후는 worker가 동일 핸들러 호출 */
+export interface ReviewQueueWorkHandler {
+  handleUpsert(db: Database, envelope: Envelope<'review_candidate_upsert_requested'>): Promise<void>;
+  handleBatchCompleted(db: Database, envelope: Envelope<'review_candidates_batch_completed'>): Promise<void>;
+}
+```
+
+- **InProcessPublisher / InProcessHandler:** 현재 동작과 동일(메시지를 직렬화만 하고 곧바로 handler 호출 가능 — 계약 테스트용).
+- **RedisStreamPublisher / WorkerConsumer:** Gate A→B 시 교체.
+
+## 6. 현재 코드 매핑
+
+| 코드 | 계약 대응 |
+|------|-----------|
+| `runMemoryReviewCandidatesJob` | `correlation_id` = 새 UUID, 루프마다 `review_candidate_upsert_requested` (또는 인프로세스 배치에서는 handler 직호출) |
+| `recordMemoryReviewQueueHealthSnapshot` | `review_candidates_batch_completed` 처리의 일부 |
+| `notifyReviewCandidatesChanged('batch_memory_review_candidates')` | `review_candidates_changed` |
+
+## 7. 검증·후속 이슈
+
+- **단위:** `idempotency_key` 파서·생성기, 동일 키 두 번 처리 시 DB 행 수 불변.
+- **통합:** broker mock으로 at-least-once 중복 전달 시나리오.
+- **다음 작업(계획 §5~6):** fan-out PoC(완료 #297), retry/DLQ 런북([`2026-05-09-review-queue-retry-backoff-dlq-runbook.md`](./2026-05-09-review-queue-retry-backoff-dlq-runbook.md), #298).
+
+이 문서가 Track B 항목 4의 산출물이며, 구현 이슈는 어댑터 인터페이스 도입 + InProcess 구현체 추출부터 분해하면 된다.

--- a/docs/_work/solutions/2026-05-09-review-queue-changed-event-fan-out-poc.md
+++ b/docs/_work/solutions/2026-05-09-review-queue-changed-event-fan-out-poc.md
@@ -1,0 +1,40 @@
+# 리뷰 큐 `review_candidates_changed` 이벤트 fan-out PoC (GitHub #297)
+
+- **상태:** 구현 반영 (실험 경로)
+- **기준 계약:** [`2026-05-09-review-queue-boundary-idempotency-contract.md`](./2026-05-09-review-queue-boundary-idempotency-contract.md) 의 `kind: review_candidates_changed` 봉투
+- **목표:** in-process SSE(#276) 외에 **HTTP POST 릴레이**로 동일 논리 이벤트를 내보내, 브로커/다중 구독자 시나리오에서 지연·실패를 재현·측정할 수 있게 한다.
+
+## 동작
+
+1. `POST /admin/memory/review-candidates/:id/review|dismiss` 성공 또는 `POST /admin/batch/run` 의 `memory_review_candidates` 완료 시, 기존과 같이 SSE `event: changed` 가 발행된다.
+2. `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS` 가 비어 있지 않으면, 같은 시점에 **비동기**로 각 URL에 JSON 봉투를 POST 한다 (응답 경로는 릴레이 완료를 기다리지 않음).
+3. 선택값 `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET` 이 있으면 `Authorization: Bearer …` 헤더를 붙인다.
+
+로그 키워드: `review_candidates_changed fan-out relay finished` / `… relay failed` (`relayHost`, `relayMs`, `relayStatus`).
+
+## 단일 노드 측정
+
+- 릴레이 미설정: SSE만 — 기존 `admin.routes.spec` 의 SSE 시나리오와 동일.
+- 릴레이 1개(로컬 수신기): 수신 측에서 POST 수신 시각과 본문의 `occurred_at` 의 차이를 기록하면 **프로세스 내 SSE + HTTP 홉** 지연을 대략 확인할 수 있다.
+
+## 다중 노드(시뮬레이션)
+
+- **노드 A:** Memento HTTP admin (실제 인스턴스).
+- **노드 B:** 릴레이 URL로 들어오는 POST를 구독하는 경량 서버(예: `node -e` 로 `http.createServer` 수신).
+- A에서 리뷰/배치 트리거 시 B가 수신하면 “한 프로세스 밖으로 이벤트가 나간” 경로가 열린 것이다. SSE는 여전히 A에 붙은 브라우저에만 도달한다(기존 한계).
+
+전면 멀티 노드 SSE 정합성은 Track C / 별도 브로커 도입 후 검증한다. **운영 채택 기준(폴링·sticky·Tier 구조)** 은 [#300](https://github.com/jee1/memento/issues/300) [`2026-05-09-review-queue-sse-multi-instance-strategy.md`](./2026-05-09-review-queue-sse-multi-instance-strategy.md) 를 따른다.
+
+## 손실(loss)
+
+- 릴레이는 best-effort이다. `fetch` 예외나 비-2xx는 경고 로그만 남긴다. 재시도·DLQ·런북: [`2026-05-09-review-queue-retry-backoff-dlq-runbook.md`](./2026-05-09-review-queue-retry-backoff-dlq-runbook.md).
+- **관측:** 수신기가 요청 수를 집계하고, 동일 `idempotency_key` 중복을 카운트하면 at-least-once 전달과 중복 refresh 비용을 평가할 수 있다.
+
+## 환경 변수
+
+| 변수 | 설명 |
+|------|------|
+| `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS` | 쉼표 구분 POST 대상 URL 목록 |
+| `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET` | 선택, Bearer 토큰 |
+
+코드: `packages/memento-server/src/server/review-candidates-changed-fanout.ts`

--- a/docs/_work/solutions/2026-05-09-review-queue-retry-backoff-dlq-runbook.md
+++ b/docs/_work/solutions/2026-05-09-review-queue-retry-backoff-dlq-runbook.md
@@ -1,0 +1,109 @@
+# 리뷰 큐 재시도 · 백오프 · DLQ 정책 및 장애 런북 (GitHub #277 후속 / #298, Track B-6)
+
+- **상태:** 운영 정책 문서 (현재 코드·향후 브로커 도입 모두 대비)
+- **관련:** [경계·멱등 계약](./2026-05-09-review-queue-boundary-idempotency-contract.md), [changed fan-out PoC](./2026-05-09-review-queue-changed-event-fan-out-poc.md), [후속 구현 계획 §Track B](../../superpowers/plans/2026-05-05-issue-277-review-queue-scaling-followup-plan.md)
+- **목표:** 리뷰 큐 경로별 **재시도·백오프·사실상 DLQ** 기준을 한곳에 모으고, 장애 시 **확인 순서·수동 복구**를 재현 가능하게 한다.
+
+## 1. 범위 (레이어망)
+
+| 레이어 | 역할 | at-least-once / 멱등 |
+|--------|------|----------------------|
+| **L1** 배치 `memory_review_candidates` | SQLite 동기 upsert | DB·유니크로 수렴 (계약 §4.1) |
+| **L2** HTTP `review_candidates_changed` 릴레이 | 다운스트림 알림 (PoC) | best-effort; **재시도 없음** (아래 §3) |
+| **L3** Admin SSE `/admin/memory/review-candidates/stream` | 단일 노드 실시간 푸시 | 연결 끊기면 브라우저 재연결 (`retry` 힌트) |
+| **L4** 대시보드 폴링 | 백업 경로 | 폴링 주기 + 오류 시 백오프 시퀀스 |
+
+향후 **외부 브로커·워커**를 끼우면 L1 발행/소비가 큐 기반으로 바뀌고, 본 문서 **§5 권장값**을 제품 기본 정책으로 삼는다.
+
+## 2. 현재 구현 기준 동작
+
+### 2.1 배치 스케줄러 (`BatchScheduler` + `RetryManager`)
+
+- 기본값: `retryAttempts: 3`, `retryDelay: 1000` ms, `maxErrorCount`는 `RetryManager` 생성 시 `retryAttempts * 3`과 연동 (`packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts`).
+- `memory_review_candidates` 잡도 동일 스케줄러를 타므로, **잡 단위 실패 시** 스케줄러·`RetryManager`가 정의하는 재시도·오류 누적 규칙이 적용된다 (세부는 core 구현 및 잡 등록 경로 참고).
+- **의미:** 동기 DB 작업이 반복 실패하면 배치 메타·모니터링(health snapshot 등)에서 드러나야 한다. 큐 **메시지 DLQ**는 아직 없고, **관측 + 수동 재실행**이 1차 복구다.
+
+### 2.2 HTTP 릴레이 fan-out (`review-candidates-changed-fanout.ts`)
+
+- `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS`가 설정된 경우, 각 URL로 `POST` (JSON 봉투 §3.3 계약).
+- **타임아웃:** 3000 ms (`RELAY_TIMEOUT_MS`).
+- **실패 처리:** 네트워크 예외 또는 비-2xx → **`logger.warn` 한 줄**; **재시도·큐 적재 없음** (PoC 성격, fan-out 문서와 동일).
+- **인증(선택):** `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET` → `Authorization: Bearer …`.
+
+### 2.3 SSE 클라이언트 힌트
+
+- 스트림 시작 시 `retry: 3000` 전송 → 표준 SSE 클라이언트는 재연결 간격 힌트로 사용할 수 있음 (`review-candidates-sse-hub.ts`).
+
+### 2.4 대시보드 폴링 백오프
+
+- `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS` — 성공 경로 폴링 주기 (기본 60s, 최소 10s로 클램프).
+- `MEMENTO_REVIEW_QUEUE_POLL_ERROR_BACKOFF_MS` — **쉼표 구간** 밀리초 시퀀스; 연속 API 오류 시 단계별 대기 (`review-queue-dashboard-boot.ts`). 미설정 시 빈 배열(즉시 다음 폴링 시도).
+
+## 3. “DLQ”를 이 코드베이스에서 정의하는 법
+
+외부 브로커가 없을 때 **물리적 DLQ 토픽은 없다**. 대신 아래를 **사실상 DLQ / poison / 정책 위반**으로 취급한다.
+
+| 상황 | 현재 동작 | 운영 해석 |
+|------|-----------|-----------|
+| 릴레이 POST 실패 | 로그만 | 이벤트 **유실 가능** — 다운스트림은 폴링·주기 배치·수동 새로고침으로 정합 |
+| 스키마/계약 불일치 (향후 consumer) | 계약: **nack** | 메시지를 **수동 검토 큐**(스프레드시트/이슈/브로커 DLQ)로 옮기고, 원인 수정 후 **동일 `idempotency_key`로 재주입** (계약 §4.4) |
+| 동일 메시지 무한 재시도 | 브로커 도입 후 방지 | **최대 전달 시도(§5)** 초과 시 DLQ 이동, 알람 |
+
+**수동 재처리 (모든 레이어 공통):**
+
+1. **원인 분류:** 일시 네트워크 / 다운스트림 장애 / 잘못된 페이로드 / 스키마 불일치.
+2. **멱등 키 보존:** 재주입·재전송 시 `idempotency_key` **변경 금지** (계약 §4.4).
+3. **검증:** `GET /admin/memory/review-candidates`·metrics·health snapshot으로 기대 상태 확인.
+4. **필요 시:** `POST /admin/batch/run` (`memory_review_candidates`) 또는 리뷰/-dismiss API로 도메인 상태를 맞춘 뒤, changed 알림이 기대대로 나가는지 로그로 확인.
+
+## 4. 장애 런북 (운영 순서)
+
+### R1 — “대시보드가 안 갱신된다”
+
+1. 브라우저: SSE 연결 여부(개발자 도구 네트워크), 동일 출처·인증 만료.
+2. 서버 로그: `review_candidates_changed fan-out relay failed` 유무, `relayStatus`.
+3. 폴링: `MEMENTO_REVIEW_QUEUE_POLL_INTERVAL_MS`·`…_BACKOFF_MS`가 과도하게 크지 않은지 확인.
+4. 데이터: API·DB에서 후보 행이 실제로 변했는지 확인 (UI만 뒤처진 경우 vs 데이터 미반영).
+
+### R2 — “릴레이 수신기가 이벤트를 못 받는다”
+
+1. URL·방화벽·`RELAY_SECRET` 불일치 확인.
+2. 3s 타임아웃·비-2xx는 **의도적으로 drop** — 수신기 응답 시간·상태 코드를 점검.
+3. **근본 완화:** 브로커 수신측 idempotent ingest + 본 문서 §5 재시도 정책 도입(향후 이슈).
+
+### R3 — “배치는 도는데 pending이 쌓인다”
+
+1. `memory_review_candidates` 실행 결과·에러 카운트 (배치 히스토리·로그).
+2. Gate A 지표(후속 계획 Track A)로 증가율 vs 처리량 비교.
+3. 스케일링 게이트 충족 시 Track B/C 계획 항목으로 에스컬레이션 — **본 문서만으로 큐 용량은 늘지 않는다.**
+
+### R4 — (향후) “consumer가 메시지를 거부(nack)한다”
+
+1. `schema_version`·`kind`·필수 필드 일치 여부.
+2. DLQ에 보관된 원문 JSON에서 `idempotency_key`·`correlation_id` 기록.
+3. 코드·계약 수정 후 **재주입**; duplicate 안전은 consumer 멱등 테이블(계약 §4.3)으로 보장.
+
+## 5. 브로커 도입 시 권장 기본값 (아직 코드 아님)
+
+Gate A→B 이후 워커/브로커를 붙일 때 아래를 **기본 제안**으로 삼는다. 실제 수치는 SLO·트래픽에 맞게 조정.
+
+| 항목 | 권장 |
+|------|------|
+| 최대 소비 시도 | **8회** (초기 + 7 재시도) |
+| 백오프 | **지수 + 전체 상한**(예: 1s × 2^n cap 5m) + **jitter 0~20%** |
+| poison / 파싱 실패 | **즉시 DLQ** (재시도 금지) |
+| `schema_version` 불일치 | 계약대로 nack → DLQ (§경계 문서) |
+| 처리 시간 초과 | DLQ 또는 별도 “slow” 큐 + 알람 |
+| DLQ 재주입 | 온콜 승인 후, **동일 `idempotency_key`**, 소량Canary부터 |
+
+SSE·브라우저 폴링은 **최종 일관성**용이므로, 브로커 정책과 **독립**으로 튜닝한다.
+
+## 6. 검증 체크리스트 (릴리스·장애 훈련)
+
+- [ ] 릴레이 URL을 일부러 500으로 두었을 때 서버가 경고 로그만 남기고 요청 경로는 블로킹하지 않는다.
+- [ ] 릴레이를 끈 상태에서도 대시보드 폴링·수동 새로고침으로 후보 목록이 복구 가능하다.
+- [ ] (브로커 도입 후) 동일 `idempotency_key` 이중 전달 시 도메인 행 수·의미가 깨지지 않는다.
+
+## 7. 변경 이력
+
+- 2026-05-09: 초안 작성 (#298). 릴레이 best-effort·배치 RetryManager·대시보드 백오프·향후 DLQ 권장안 정리.

--- a/docs/_work/solutions/2026-05-09-review-queue-schedule-single-runner-strategy.md
+++ b/docs/_work/solutions/2026-05-09-review-queue-schedule-single-runner-strategy.md
@@ -1,0 +1,40 @@
+# 리뷰 후보 배치 스케줄 단일 실행 전략 (GitHub #299, #277 Track C 선행 결정)
+
+## 문제
+
+- `memory_review_candidates` 는 **프로세스별** `BatchScheduler` 인터벌로 등록된다.
+- **단일 프로세스** 안에서는 동일 잡 이름이 이미 실행 중이면 큐에 넣고 이후에만 재실행한다 (`BatchJobExecutionCoordinator.executeJobWithRetry` + `JobQueue.isRunning`).
+- **여러 HTTP admin 인스턴스**가 같은 DB를 두고 띄우면, 인스턴스마다 인터벌이 돌아 **주기 실행이 N배**가 될 수 있다 (경합·불필요 부하·이벤트 중복의 원인).
+
+## 후보 비교
+
+| 전략 | 장점 | 단점 | 현재 코드베이스 적합성 |
+|------|------|------|------------------------|
+| **A. 외부 트리거 단일 실행자** | 구현 단순, 운영·감사 경로 명확(YAGNI), 장애 시 누가 돌렸는지 추적 쉬움 | 크론/별도 orchestrator·용도별 인스턴스 구분 등 운영 규율 필요 | **채택(기본)** — SQLite 단일 파일 + in-process 스케줄러 철학과 맞음 |
+| **B. 리더 선출(분산 락)** | 자동 페일오버·복제본 동일 설정 가능 | SQLite만으로는 리더십/TTL/펜스 토큰 설계 부담, Redis 등 B 단계와 자연스럽게 묶임 | **예비(B/C)** — Gate B 이후(외부 큐·락 스토어)에서 재평가 |
+| **C. 스케줄러 전부 끄고 worker 전용** | 책임 분리 극대화 | 운영·배포 단위 증가 | ADR #277 Track C, 별도 이슈 |
+
+## 채택안 (2026-05)
+
+1. **기본 운영:** 리뷰 후보 배치의 **주기 실행은 정확히 한 실행자만** 갖도록 한다.
+   - 권장: **한 인스턴스**에만 `BatchScheduler` 기동(다른 인스턴스는 `BATCH_SCHEDULER_ENABLED=false`) **또는**, 모든 인스턴스에서 스케줄러는 켜되 아래 플래그로 **해당 잡 인터벌만 끈다**.
+2. **외부 트리거:** 단일 실행자 인스턴스에 대해 `POST /admin/batch/run` `{ "jobType": "memory_review_candidates" }` 또는 동등한 `runJob`을 크론/GitHub Actions 등에서 호출해 주기를 대체할 수 있다.
+3. **향후:** 멀티 인스턴스가 상시이고 자동 리더 교체가 필요하면 **B 전략**(Redis/DB 리스 임대 등)을 별도 설계로 도입한다.
+
+## 구현 (코드)
+
+- 환경 변수 **`MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED`** (기본 `true`):
+  - `false`이면 `memory_review_candidates` **인터벌 등록 생략**.
+  - **수동** `runJob('memory_review_candidates')` / HTTP 배치 실행은 그대로 동작.
+- `restartJob('memory_review_candidates')` 는 플래그가 꺼져 있으면 `false`를 반환하고 경고 로그만 남긴다.
+
+## 검증 시나리오 (중복 실행 방지 관점)
+
+1. **단일 프로세스:** 동일 잡 연속 트리거 시 한 번에 하나만 실행(기존 JobQueue 동작).
+2. **스케줄 비활성:** `memoryReviewCandidatesSchedulerEnabled=false`로 시작 시 `getStatus().activeJobs`에 `memory_review_candidates` 없음, `runJob`은 성공.
+3. **멀티 인스턴스(운영):** N−1 인스턴스에서 플래그 `false` 또는 스케줄러 비활성 + 1 인스턴스(또는 크론)만 주기 실행 — 설계상 단일 주기원.
+
+## 참고
+
+- 상위 계획: `docs/superpowers/plans/2026-05-05-issue-277-review-queue-scaling-followup-plan.md` Track C 항목 7.
+- ADR: `docs/adr/2026-05-05-issue-277-review-queue-scaling-strategy.md` (후속 작업 5).

--- a/docs/_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md
+++ b/docs/_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md
@@ -1,0 +1,52 @@
+# Review Queue Admin SSE — 멀티 인스턴스 전략 (GitHub #300)
+
+- **상태:** Accepted (문서 확정; 본 이슈 범위에서 코드 변경 없음)
+- **상위 ADR:** [`docs/adr/2026-05-05-issue-277-review-queue-scaling-strategy.md`](../../adr/2026-05-05-issue-277-review-queue-scaling-strategy.md)
+- **관련 구현:** `review-candidates-sse-hub.ts`, `review-candidates-changed-fanout.ts`, `static/js/review-candidates-panel.js`
+
+## 배경
+
+- SSE 허브는 **in-process `Set<Response>`** 로만 fan-out 하며 Redis/공유 버스가 없다 (`review-candidates-sse-hub.ts`).
+- `broadcastReviewCandidatesChanged` 는 로컬 SSE 알림 후, 선택적으로 HTTP POST 릴레이(#297)를 **best-effort** 로 수행한다.
+- 대시보드는 **EventSource + 폴링 폴백**(#276)으로 목록·메트릭을 갱신한다.
+
+## 문제 정의
+
+HTTP admin **인스턴스 A**에서 후보 변경이 일어나면 `changed` 이벤트는 **A에 붙은 SSE 연결**에만 전달된다. **인스턴스 B**에 연결된 브라우저는 A의 메모리 내 클라이언트 집합을 볼 수 없다.
+
+## 사용자 체감 일관성 기준 (완료 조건)
+
+1. **정합성(필수):** 대시보드가 표시하는 pending 목록·메트릭은 **폴링 경로**를 통해 실제 저장 상태와 수렴한다. SSE 유무·교차 인스턴스 여부와 무관하게 “항상 곧 맞는다”가 보장된다.
+2. **저지연(권장):** 단일 인스턴스 또는 **sticky 세션**으로 동일 인스턴스에 머무는 클라이언트는 SSE로 즉시 갱신 트리거를 받을 수 있다.
+3. **교차 인스턴스 저지연(선택):** 공유 버스 또는 **피어 ingest + 로컬 notify** 등은 ADR의 A→B 게이트 및 운영 요구가 있을 때만 도입한다.
+
+## 채택 전략 (계층화)
+
+### Tier 1 — 기본 (YAGNI, 추가 브로커 없음)
+
+| 요소 | 역할 |
+|------|------|
+| **SSE** | **동일 인스턴스**에서 처리된 변경에 대한 저지연 **힌트**. 멀티 인스턴스 전역 브로드캐스트가 아니다. |
+| **폴링** | `pollIntervalMs` / 에러 백오프가 **멀티 인스턴스 정합성의 기본 경로**. |
+| **로드밸런싱** | 가능하면 admin 대시보드에 **세션(또는 쿠키) sticky**를 적용해 API·SSE가 같은 인스턴스를 보도록 한다. |
+
+### Tier 2 — 관측·실험 (#297)
+
+- `MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS` 로 논리 이벤트를 프로세스 밖으로 보내 지연·손실·중복(at-least-once)을 측정한다.
+- **현재 한계:** 릴레이는 **송신 전용**이다. 다른 memento 프로세스의 SSE 클라이언트를 자동 갱신하지 않는다.
+- **선택적 후속:** 피어의 **수신 엔드포인트**가 검증된 봉투만 받아 `notifyReviewCandidatesChanged` 만 호출하고 **재릴레이는 금지**(루프 방지)하면, 릴레이 URL을 피어 admin URL로 두는 패턴으로 교차 인스턴스 SSE에 가까운 효과를 낼 수 있다. 이는 별도 이슈·보안 검토(인증, 소스 검증) 후 구현한다.
+
+### Tier 3 — 공유 버스 (ADR Gate A→B 이후)
+
+- Redis 등 중앙 스트림 + 소비자가 모든 인스턴스에서 동일 이벤트를 구독하는 형태.
+- idempotency·재시도·DLQ는 [`2026-05-09-review-queue-boundary-idempotency-contract.md`](./2026-05-09-review-queue-boundary-idempotency-contract.md), [`2026-05-09-review-queue-retry-backoff-dlq-runbook.md`](./2026-05-09-review-queue-retry-backoff-dlq-runbook.md) 를 따른다.
+
+## 이번 이슈에서 명시적으로 하지 않는 것
+
+- 브로커 또는 전역 SSE 프록시를 **즉시** 도입해 교차 인스턴스 실시간 일치를 완성하는 것.
+
+## 검증
+
+- 단일 노드: 기존 `admin.routes.spec` SSE 시나리오, 패널 스모크.
+- 멀티 노드: sticky 없이 두 인스턴스를 번갈아 호출하면 한쪽 브라우저의 SSE는 다른 인스턴스의 변경을 놓칠 수 있음(설계 허용); **폴링으로 수렴**함을 수동 확인.
+- 릴레이: fan-out PoC 문서의 수신기 집계·`idempotency_key` 중복 카운트.

--- a/docs/adr/2026-05-05-issue-277-review-queue-scaling-strategy.md
+++ b/docs/adr/2026-05-05-issue-277-review-queue-scaling-strategy.md
@@ -77,4 +77,9 @@ B -> C는 아래 조건에서만 검토한다.
 2. 후보 잡 실행 메타 표준 이벤트 정의
 3. 큐 도입 PoC(이벤트 fan-out 경로)
 4. idempotency + retry + DLQ 정책 문서화
-5. 스케줄 단일 실행 전략(leader/external trigger) 설계
+5. 스케줄 단일 실행 전략(leader/external trigger) 설계 — 기본 채택: 외부 트리거·단일 실행자 + `MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED`; 상세 [#299](https://github.com/jee1/memento/issues/299) / `docs/_work/solutions/2026-05-09-review-queue-schedule-single-runner-strategy.md`
+6. **멀티 인스턴스 Admin SSE** — 채택안 확정: Tier 1은 **폴링을 정합성 기본 경로**, SSE는 **동일 인스턴스 저지연 힌트**, 배포는 **sticky 권장**; Tier 2는 기존 HTTP 릴레이 관측; Tier 3는 Gate A→B 후 공유 버스. 상세 [#300](https://github.com/jee1/memento/issues/300) / `docs/_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md`
+
+## Amendment: Multi-instance Admin SSE (2026-05-09, #300)
+
+Admin Review Queue의 SSE는 **프로세스 로컬**이므로 멀티 인스턴스에서는 **교차 인스턴스 실시간 일치**를 보장하지 않는다. 제품 기준은 **폴링으로의 수렴**이며, 저지연 SSE는 sticky 또는 단일 노드에서 최적이다. HTTP 릴레이(#297)는 측정·실험 경로이며, 피어 ingest는 선택 후속이다. 전문은 위 solutions 문서를 따른다.

--- a/docs/superpowers/plans/2026-05-05-issue-277-review-queue-scaling-followup-plan.md
+++ b/docs/superpowers/plans/2026-05-05-issue-277-review-queue-scaling-followup-plan.md
@@ -38,26 +38,27 @@
 ### Track B: 큐 전환 준비 (트리거 충족 시 착수)
 
 4) 큐 경계 인터페이스 설계
-- 산출물: producer/consumer 계약(메시지 스키마, 버전, idempotency key)
+- 산출물: producer/consumer 계약(메시지 스키마, 버전, idempotency key) — 문서: [`docs/_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md`](../../_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md)
 - 완료 조건: 기존 코드와 병행 가능한 adapter 초안
 
 5) 이벤트 fan-out PoC
-- 산출물: review-candidates changed 이벤트를 in-process 외 경로로 전파하는 실험
+- 산출물: review-candidates changed 이벤트를 in-process 외 경로로 전파하는 실험 — **HTTP 릴레이(`MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS`) + 계약 봉투 JSON** ([`docs/_work/solutions/2026-05-09-review-queue-changed-event-fan-out-poc.md`](../../_work/solutions/2026-05-09-review-queue-changed-event-fan-out-poc.md), GitHub #297)
 - 완료 조건: 단일 노드/다중 노드 시나리오에서 이벤트 손실/지연 측정값 확보
 
 6) 재시도/DLQ 정책 문서화
 - 산출물: retry 횟수, backoff, DLQ 전환 기준, 수동 재처리 절차
 - 완료 조건: 장애 대응 런북 포함
+- 구현 상태(2026-05): [`docs/_work/solutions/2026-05-09-review-queue-retry-backoff-dlq-runbook.md`](../../_work/solutions/2026-05-09-review-queue-retry-backoff-dlq-runbook.md) — GitHub [#298](https://github.com/jee1/memento/issues/298)
 
 ### Track C: 멀티 인스턴스 정합성 강화 (필요 시)
 
 7) 스케줄 단일 실행 전략 선택
-- 산출물: leader election 또는 external trigger 비교 및 채택안
+- 산출물: leader election 또는 external trigger 비교 및 채택안 — [`docs/_work/solutions/2026-05-09-review-queue-schedule-single-runner-strategy.md`](../../_work/solutions/2026-05-09-review-queue-schedule-single-runner-strategy.md); 구현: `MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED` (기본 true), GitHub [#299](https://github.com/jee1/memento/issues/299)
 - 완료 조건: 중복 실행 방지 검증 시나리오 통과
 
 8) SSE 전략 재정의
-- 산출물: shared bus fan-out 또는 polling-only 단순화 ADR
-- 완료 조건: 멀티 인스턴스에서도 사용자 체감 일관성 기준 충족
+- 산출물: ~~shared bus fan-out 또는 polling-only 단순화 ADR~~ → **계층 전략 문서 확정** ([#300](https://github.com/jee1/memento/issues/300)): [`docs/_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md`](../../_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md) 및 ADR 후속 항목 6
+- 완료 조건: 멀티 인스턴스에서 **정합성 = 폴링**, SSE = 동일 인스턴스 힌트 + sticky 권장, 릴레이/버스는 게이트에 따른 Tier 2/3로 명시
 
 ## 4. 트리거 기반 게이트
 
@@ -87,7 +88,7 @@
 5. changed 이벤트 fan-out PoC
 6. retry/DLQ/런북 문서화
 7. 스케줄 단일 실행 전략 선택 및 검증
-8. SSE fan-out 또는 polling-only 전략 ADR 확정
+8. 멀티 인스턴스 SSE 전략 문서 확정 ([#300](https://github.com/jee1/memento/issues/300) — `docs/_work/solutions/2026-05-09-review-queue-sse-multi-instance-strategy.md`)
 
 ## 7. 완료 정의
 

--- a/env.example
+++ b/env.example
@@ -125,3 +125,12 @@ MEMENTO_AGENT_GEMINI_API_KEY=
 MEMENTO_AGENT_GEMINI_MODEL=gemini-2.0-flash
 MEMENTO_AGENT_LOG_LEVEL=info
 MEMENTO_AGENT_TIMEOUT_MS=30000
+
+# 리뷰 후보 배치: in-process 주기 등록 on/off (GitHub #299). false면 인터벌만 끄고 POST /admin/batch/run·runJob는 유지.
+# MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED=true
+
+# Admin Review Queue — `review_candidates_changed` HTTP relay PoC (GitHub #297)
+# Comma-separated webhook URLs; in-process SSE still runs. Use for multi-node / broker hop experiments.
+# MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS=http://127.0.0.1:9999/review-candidates-changed
+# Optional Bearer token for receiver auth
+# MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET=

--- a/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts
@@ -361,6 +361,29 @@ describe('BatchScheduler', () => {
       const status = scheduler.getStatus();
       expect(status.activeJobs).toContain('memory_review_candidates');
     });
+
+    it('memoryReviewCandidatesSchedulerEnabled=false이면 주기 등록 없이 runJob는 동작해야 함', async () => {
+      const s = new BatchScheduler({
+        cleanupInterval: 60000,
+        monitoringInterval: 10000,
+        healthCheckInterval: 10000,
+        memoryReviewCandidatesInterval: 60000,
+        memoryReviewCandidatesSchedulerEnabled: false,
+        maxBatchSize: 100,
+        enableLogging: false,
+        enableNotifications: false,
+        enableMetrics: false,
+        maxConcurrentJobs: 2,
+        jobTimeout: 5000,
+        retryAttempts: 2,
+        retryDelay: 100
+      });
+      await s.start(db);
+      expect(s.getStatus().activeJobs).not.toContain('memory_review_candidates');
+      const result = await s.runJob('memory_review_candidates');
+      expect(result.jobType).toBe('memory_review_candidates');
+      await s.stop();
+    });
   });
 
   describe('작업 실행 및 재시도', () => {

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
@@ -24,6 +24,11 @@ export interface BatchJobConfig {
   telemetryCleanupInterval: number;
   /** Issue #243: refresh memory_review_candidate pending rows from selection */
   memoryReviewCandidatesInterval: number;
+  /**
+   * When false, do not register the periodic `memory_review_candidates` interval (GitHub #299).
+   * Manual/HTTP `runJob('memory_review_candidates')` and `/admin/batch/run` still work.
+   */
+  memoryReviewCandidatesSchedulerEnabled: boolean;
 
   maxBatchSize: number;
   enableLogging: boolean;

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
@@ -42,7 +42,7 @@ import type { IntrospectionScanCache } from '../../domains/memory/services/intro
 import { DatabaseUtils } from '../../shared/utils/database.js';
 import { PIIMasker } from '../../shared/utils/pii-masker.js';
 import { logger } from '../../shared/utils/logger.js';
-import { resolveValidatedNumber } from '../../shared/config/environment.js';
+import { resolveBoolean, resolveValidatedNumber } from '../../shared/config/environment.js';
 import type { BatchJobConfig, BatchJobResult, SchedulerStatus } from './batch-scheduler-types.js';
 export type { BatchJobConfig, BatchJobResult, SchedulerStatus } from './batch-scheduler-types.js';
 import { validateBatchJobConfig } from './batch-scheduler-validate-config.js';
@@ -146,6 +146,9 @@ export class BatchScheduler implements IBatchScheduler {
         n => n >= 60_000,
         '최솟값 60000'
       ),
+      memoryReviewCandidatesSchedulerEnabled: resolveBoolean('MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED', {
+        defaultValue: true
+      }),
       maxBatchSize: 1000,
       enableLogging: true,
       enableNotifications: false,
@@ -294,17 +297,23 @@ export class BatchScheduler implements IBatchScheduler {
       6
     );
 
-    this.scheduleJob(
-      'memory_review_candidates',
-      this.config.memoryReviewCandidatesInterval,
-      async () => {
-        const r = await this.runMemoryReviewCandidatesJob();
-        if (!r.success) {
-          throw new Error(r.errors.join('; ') || 'memory_review_candidates batch failed');
-        }
-      },
-      8
-    );
+    if (this.config.memoryReviewCandidatesSchedulerEnabled) {
+      this.scheduleJob(
+        'memory_review_candidates',
+        this.config.memoryReviewCandidatesInterval,
+        async () => {
+          const r = await this.runMemoryReviewCandidatesJob();
+          if (!r.success) {
+            throw new Error(r.errors.join('; ') || 'memory_review_candidates batch failed');
+          }
+        },
+        8
+      );
+    } else {
+      this.log('memory_review_candidates periodic schedule disabled (MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED=false)', {
+        level: 'info'
+      });
+    }
 
     // 작업 큐 처리 시작
     this.startJobProcessor();
@@ -1152,6 +1161,12 @@ export class BatchScheduler implements IBatchScheduler {
     } else if (jobName === 'healthcheck') {
       this.scheduleJob('healthcheck', this.config.healthCheckInterval, async () => { await this.runHealthCheck(); }, 3);
     } else if (jobName === 'memory_review_candidates') {
+      if (!this.config.memoryReviewCandidatesSchedulerEnabled) {
+        this.log('restartJob(memory_review_candidates): periodic schedule is disabled; enable MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED or use runJob', {
+          level: 'warn'
+        });
+        return false;
+      }
       this.scheduleJob(
         'memory_review_candidates',
         this.config.memoryReviewCandidatesInterval,

--- a/packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts
+++ b/packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildReviewCandidatesChangedEnvelope,
+  broadcastReviewCandidatesChanged,
+  parseReviewCandidatesChangedRelayUrls
+} from './review-candidates-changed-fanout.js';
+import { resetReviewCandidatesSseHubForTests } from './review-candidates-sse-hub.js';
+
+describe('review-candidates-changed-fanout', () => {
+  const relayEnv = 'MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS';
+  const secretEnv = 'MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET';
+
+  beforeEach(() => {
+    resetReviewCandidatesSseHubForTests();
+    vi.restoreAllMocks();
+    delete process.env[relayEnv];
+    delete process.env[secretEnv];
+  });
+
+  afterEach(() => {
+    resetReviewCandidatesSseHubForTests();
+    delete process.env[relayEnv];
+    delete process.env[secretEnv];
+  });
+
+  it('parseReviewCandidatesChangedRelayUrls splits and trims', () => {
+    expect(parseReviewCandidatesChangedRelayUrls({ [relayEnv]: ' http://a/x , http://b/y  ' })).toEqual([
+      'http://a/x',
+      'http://b/y'
+    ]);
+    expect(parseReviewCandidatesChangedRelayUrls({})).toEqual([]);
+  });
+
+  it('buildReviewCandidatesChangedEnvelope matches contract shape', () => {
+    const env = buildReviewCandidatesChangedEnvelope('review', 'corr-1');
+    expect(env.schema_version).toBe(1);
+    expect(env.kind).toBe('review_candidates_changed');
+    expect(env.correlation_id).toBe('corr-1');
+    expect(env.idempotency_key).toBe('mrc:v1:changed:corr-1:review');
+    expect(env.producer.name).toBe('memento-http-admin');
+    expect(env.payload).toEqual({ reason: 'review', approx_pending_delta_hint: null });
+  });
+
+  it('broadcastReviewCandidatesChanged POSTs to relay URLs when configured', async () => {
+    process.env[relayEnv] = 'http://127.0.0.1:9/nope';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    broadcastReviewCandidatesChanged({ reason: 'dismiss', correlationId: 'fixed-corr' });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:9/nope',
+      expect.objectContaining({
+        method: 'POST'
+      })
+    );
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    const body = JSON.parse(init.body as string) as { correlation_id?: string };
+    expect(body.correlation_id).toBe('fixed-corr');
+  });
+
+  it('broadcastReviewCandidatesChanged adds Authorization when relay secret set', async () => {
+    process.env[relayEnv] = 'http://127.0.0.1:9/hook';
+    process.env[secretEnv] = 'test-secret';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    broadcastReviewCandidatesChanged({ reason: 'review' });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-secret');
+  });
+});

--- a/packages/memento-server/src/server/review-candidates-changed-fanout.ts
+++ b/packages/memento-server/src/server/review-candidates-changed-fanout.ts
@@ -1,0 +1,126 @@
+/**
+ * Review queue `review_candidates_changed` fan-out PoC (#297).
+ *
+ * Keeps in-process SSE (single-node) and optionally POSTs the same logical event
+ * to comma-separated webhook URLs — simulating a broker hop for loss/latency experiments.
+ *
+ * Envelope aligns with docs/_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md §3.3.
+ */
+import { randomUUID } from 'node:crypto';
+import { notifyReviewCandidatesChanged } from './review-candidates-sse-hub.js';
+import { logger } from '@memento/core';
+
+const RELAY_ENV = 'MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_URLS';
+const RELAY_SECRET_ENV = 'MEMENTO_REVIEW_CANDIDATES_CHANGED_RELAY_SECRET';
+const RELAY_TIMEOUT_MS = 3000;
+
+export type ReviewCandidatesChangedReason =
+  | 'review'
+  | 'dismiss'
+  | 'batch_memory_review_candidates';
+
+/** Wire contract: `kind: review_candidates_changed` (schema v1). */
+export type ReviewCandidatesChangedEnvelope = {
+  schema_version: 1;
+  kind: 'review_candidates_changed';
+  idempotency_key: string;
+  correlation_id: string;
+  occurred_at: string;
+  producer: { name: 'memento-http-admin'; instance_id?: string };
+  payload: {
+    reason: string;
+    approx_pending_delta_hint: null;
+  };
+};
+
+export function parseReviewCandidatesChangedRelayUrls(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env[RELAY_ENV]?.trim();
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export function buildReviewCandidatesChangedEnvelope(
+  reason: ReviewCandidatesChangedReason,
+  correlationId: string
+): ReviewCandidatesChangedEnvelope {
+  const idempotencyKey = `mrc:v1:changed:${correlationId}:${reason}`;
+  const instance_id = typeof process.env.HOSTNAME === 'string' && process.env.HOSTNAME.trim() !== ''
+    ? process.env.HOSTNAME.trim()
+    : undefined;
+
+  return {
+    schema_version: 1,
+    kind: 'review_candidates_changed',
+    idempotency_key: idempotencyKey,
+    correlation_id: correlationId,
+    occurred_at: new Date().toISOString(),
+    producer: { name: 'memento-http-admin', ...(instance_id ? { instance_id } : {}) },
+    payload: {
+      reason,
+      approx_pending_delta_hint: null
+    }
+  };
+}
+
+async function relayPost(url: string, body: ReviewCandidatesChangedEnvelope, secret?: string): Promise<void> {
+  const started = performance.now();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (secret) {
+    headers.Authorization = `Bearer ${secret}`;
+  }
+  let host = url;
+  try {
+    host = new URL(url).host;
+  } catch {
+    /* keep raw for logging if malformed — fetch will fail */
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(RELAY_TIMEOUT_MS)
+    });
+    const relayMs = Math.round(performance.now() - started);
+    logger.info('review_candidates_changed fan-out relay finished', {
+      relayHost: host,
+      relayMs,
+      relayOk: res.ok,
+      relayStatus: res.status
+    });
+  } catch (error) {
+    const relayMs = Math.round(performance.now() - started);
+    logger.warn('review_candidates_changed fan-out relay failed', {
+      relayHost: host,
+      relayMs,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+/** Fire SSE notify, then optionally POST envelope to relay URLs (non-blocking). */
+export function broadcastReviewCandidatesChanged(opts: {
+  reason: ReviewCandidatesChangedReason;
+  correlationId?: string;
+}): void {
+  const { reason, correlationId: correlationIdOpt } = opts;
+  const correlationId = correlationIdOpt ?? randomUUID();
+
+  notifyReviewCandidatesChanged(reason);
+
+  const urls = parseReviewCandidatesChangedRelayUrls();
+  if (urls.length === 0) {
+    return;
+  }
+
+  const envelope = buildReviewCandidatesChangedEnvelope(reason, correlationId);
+  const secret = process.env[RELAY_SECRET_ENV]?.trim() || undefined;
+
+  void Promise.all(urls.map(u => relayPost(u, envelope, secret)));
+}

--- a/packages/memento-server/src/server/review-candidates-sse-hub.ts
+++ b/packages/memento-server/src/server/review-candidates-sse-hub.ts
@@ -1,5 +1,6 @@
 /**
  * In-process SSE fan-out for Admin review queue (#276). Single-node only; no Redis.
+ * Admin routes should call `broadcastReviewCandidatesChanged` (#297) so optional HTTP relay runs too.
  */
 import type { Response } from 'express';
 

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -32,10 +32,8 @@ import { registerAdminRelationRoutes } from './admin/admin-relations.routes.js';
 import { registerAdminTelemetryRoutes } from './admin/admin-telemetry.routes.js';
 import { registerAdminGraphRoute } from './admin/admin-graph.routes.js';
 import { registerAdminEmbeddingMapRoute } from './admin/admin-embedding-map.routes.js';
-import {
-  attachReviewCandidatesSse,
-  notifyReviewCandidatesChanged
-} from '../review-candidates-sse-hub.js';
+import { attachReviewCandidatesSse } from '../review-candidates-sse-hub.js';
+import { broadcastReviewCandidatesChanged } from '../review-candidates-changed-fanout.js';
 import {
   BATCH_RUN_HISTORY_DEFAULT_LIMIT,
   BATCH_RUN_HISTORY_MAX_STORED,
@@ -441,7 +439,7 @@ export function createAdminRouter(
       const nowIso = new Date().toISOString();
       markMemoryReviewCandidateReviewed(db, id, nowIso);
       const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
-      notifyReviewCandidatesChanged('review');
+      broadcastReviewCandidatesChanged({ reason: 'review' });
       return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
     } catch (error) {
       if (error instanceof MemoryReviewCandidateError) {
@@ -469,7 +467,7 @@ export function createAdminRouter(
       const nowIso = new Date().toISOString();
       markMemoryReviewCandidateDismissed(db, id, nowIso);
       const row = listMemoryReviewCandidates(db, {}).find(r => r.id === id);
-      notifyReviewCandidatesChanged('dismiss');
+      broadcastReviewCandidatesChanged({ reason: 'dismiss' });
       return res.json({ ok: true, candidate: row ?? null, timestamp: nowIso });
     } catch (error) {
       if (error instanceof MemoryReviewCandidateError) {
@@ -552,7 +550,7 @@ export function createAdminRouter(
       recordManualBatchRunSuccess(jobType, requestedAt, result);
 
       if (jobType === 'memory_review_candidates') {
-        notifyReviewCandidatesChanged('batch_memory_review_candidates');
+        broadcastReviewCandidatesChanged({ reason: 'batch_memory_review_candidates' });
       }
 
       return res.json({


### PR DESCRIPTION
## What

Delivers the #277 scaling follow-ups tracked as GitHub **#296–#300** (plus cross-links in ADR/plan).

- **#296** — Boundary contract, message envelope, idempotency keys: `docs/_work/solutions/2026-05-09-review-queue-boundary-idempotency-contract.md`
- **#297** — `review_candidates_changed` optional HTTP relay PoC + Vitest: `review-candidates-changed-fanout.ts`, admin route wiring, `env.example`
- **#298** — Retry/backoff/DLQ runbook: `2026-05-09-review-queue-retry-backoff-dlq-runbook.md`
- **#299** — Single-runner strategy + `MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED` (merged with current `memory_review_candidates` failure semantics)
- **#300** — Multi-instance SSE strategy doc

## How to verify

- `npx vitest run packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts`
- `npm run lint` (warnings baseline)

---

Closes #296
Closes #297
Closes #298
Closes #299
Closes #300
