### PR TITLE
docs(slop): policy A — local .slopconfig.local.yaml (#239, #313)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ src/**/*.d.ts.map
 .env.test.local
 .env.production.local
 
+# Local-only slop-detector overrides (see DEVELOPMENT_RULES.md — optional static scan)
+.slopconfig.local.yaml
+
 # Database
 *.db
 *.db-journal

--- a/DEVELOPMENT_RULES.md
+++ b/DEVELOPMENT_RULES.md
@@ -105,4 +105,5 @@ it('should behavior when condition', async () => {
     *   루트 전체(설정 반영): `slop-detector --project . --js --config .slopconfig.yaml`
 *   **`--gate`:** 상단 요약에 Python/LDR가 0으로 보일 수 있다. **`--js` 사용 시 JS/TS Analysis 구간을 게이트 판단의 주된 근거로 본다.**
 *   **CI:** 본 저장소의 필수 CI 게이트에는 포함하지 않는다(후속 이슈에서 선택).
-*   **테스트 경로 무시:** 기본 `.slopconfig`에서는 `*.spec.ts` 등을 대량 제외하지 않는다. 팀 정책에 따라 로컬에서만 ignore를 추가할 수 있다.
+*   **테스트 경로 무시(저장소 기본):** 루트 `.slopconfig.yaml`에는 `*.spec.ts`·`tests/**` 등을 **대량으로 넣지 않는다**([#221](https://github.com/jee1/memento/issues/221) 정책).
+*   **로컬 전용 오버라이드(선택):** Vitest 노이즈를 줄이려면 (1) 루트 `.slopconfig.yaml`을 복사해 `.slopconfig.local.yaml`을 만들고, (2) `ignore`에 개인용 패턴(예: `**/*.spec.ts`, `**/tests/**`)만 추가한다. 이 파일은 `.gitignore`에 포함되어 **커밋되지 않는다**. (3) 스캔 시 `--config .slopconfig.local.yaml`을 지정한다. 예: `slop-detector --project packages --js --config .slopconfig.local.yaml`

--- a/docs/superpowers/plans/2026-05-10-issue-239-slop-policy-local.md
+++ b/docs/superpowers/plans/2026-05-10-issue-239-slop-policy-local.md
@@ -1,0 +1,124 @@
+# Issue #239 — slop 정책 A(로컬 전용 오버라이드) 반영 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 루트 `.slopconfig.yaml`은 변경하지 않고, `.slopconfig.local.yaml`을 gitignore에 추가하며 `DEVELOPMENT_RULES.md`에 로컬 전용 slop 스캔 절차를 문서화하여 이슈 #239·#313의 정책 A를 반영한다.
+
+**Architecture:** 저장소 기본값(#221)은 유지하고, 기여자가 선택적으로 로컬 YAML 한 개로 `slop-detector --config`만 바꿔 동일 CLI 패턴을 재사용한다.
+
+**Tech Stack:** `ai-slop-detector`(PyPI), 기존 `.slopconfig.yaml` v2.0, Git.
+
+**Spec:** [docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md](../specs/2026-05-10-issue-239-slop-followup-design.md)
+
+---
+
+### Task 1: `.gitignore`에 로컬 slop 설정 무시
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: 환경 변수 블록 다음에 항목 추가**
+
+`# Environment variables` 절 직후(`.env.production.local` 다음)에 아래 두 줄을 삽입한다.
+
+```gitignore
+# Local-only slop-detector overrides (see DEVELOPMENT_RULES.md — optional static scan)
+.slopconfig.local.yaml
+```
+
+- [ ] **Step 2: 무시 확인**
+
+```bash
+cd /path/to/repo
+touch .slopconfig.local.yaml
+git check-ignore -v .slopconfig.local.yaml
+```
+
+Expected: `.gitignore:NN:.slopconfig.local.yaml` 형태로 무시됨.
+
+- [ ] **Step 3: 더미 파일 제거**
+
+```bash
+rm -f .slopconfig.local.yaml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(slop): gitignore local .slopconfig.local.yaml (#239)"
+```
+
+---
+
+### Task 2: `DEVELOPMENT_RULES.md` — 로컬 전용 스캔 절차
+
+**Files:**
+- Modify: `DEVELOPMENT_RULES.md` (「선택적 정적 스캔 (slop-detector)」소절)
+
+- [ ] **Step 1: `테스트 경로 무시` 불릿을 확장**
+
+기존 한 줄:
+
+`*   **테스트 경로 무시:** 기본 .slopconfig에서는 *.spec.ts 등을 대량 제외하지 않는다. 팀 정책에 따라 로컬에서만 ignore를 추가할 수 있다.`
+
+을 아래 블록으로 **교체**한다(앞의 `*` 들여쓰기 스타일 유지).
+
+```markdown
+*   **테스트 경로 무시(저장소 기본):** 루트 `.slopconfig.yaml`에는 `*.spec.ts`·`tests/**` 등을 **대량으로 넣지 않는다**([#221](https://github.com/jee1/memento/issues/221) 정책).
+*   **로컬 전용 오버라이드(선택):** Vitest 노이즈를 줄이려면 (1) 루트 `.slopconfig.yaml`을 복사해 `.slopconfig.local.yaml`을 만들고, (2) `ignore`에 개인용 패턴(예: `**/*.spec.ts`, `**/tests/**`)만 추가한다. 이 파일은 `.gitignore`에 포함되어 **커밋되지 않는다**. (3) 스캔 시 `--config .slopconfig.local.yaml`을 지정한다. 예: `slop-detector --project packages --js --config .slopconfig.local.yaml`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add DEVELOPMENT_RULES.md
+git commit -m "docs(slop): document local-only .slopconfig override (#239)"
+```
+
+---
+
+### Task 3: 설계 문서 추적
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md` (이미 본 플랜 작성 시 존재하면 `git add`만)
+
+- [ ] **Step 1: 스펙 파일 추가·커밋**
+
+```bash
+git add docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md
+git commit -m "docs: issue #239 slop follow-up spec (policy A)"
+```
+
+---
+
+### Task 4: 품질 게이트(문서만 변경 시)
+
+**Files:** 없음
+
+- [ ] **Step 1: 린트(저장소 관례에 맞게 선택)**
+
+문서·gitignore만 변경한 경우 필수는 아니나, 팀 관례상 실행하려면:
+
+```bash
+npm run lint
+```
+
+Expected: 기존과 동일하게 통과(문서 변경으로 새 오류 없음).
+
+---
+
+## Self-review (플랜 작성자용)
+
+| Spec § | Task |
+|--------|------|
+| §3 루트 설정 불변 | Task 1–2는 `.slopconfig.yaml` 미수정 |
+| §3 로컬 파일 | Task 1 gitignore + Task 2 절차 |
+| §5 검증 | Task 1 Step 2, Task 4 |
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-10-issue-239-slop-policy-local.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 태스크마다 새 서브에이전트, 태스크 사이 리뷰  
+**2. Inline Execution** — 같은 세션에서 체크포인트로 순차 실행
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md
@@ -1,0 +1,37 @@
+# 설계: 이슈 #239 — slop-detector JS/TS 정리 (정책 A: 커밋 설정에 spec 대량 ignore 없음)
+
+**상위:** [GitHub #239](https://github.com/jee1/memento/issues/239)  
+**관련:** [#221 범위·설정](https://github.com/jee1/memento/issues/221), 서브 [#313](https://github.com/jee1/memento/issues/313)
+
+## 1. 문제
+
+`ai-slop-detector --js`로 스캔하면 Vitest의 긴 `describe`/`it`이 Critical에 많이 잡혀 **프로덕션 신호와 섞인다**. 한편 [#221 설계](./2026-05-02-issue-221-slop-scope-design.md)와 `DEVELOPMENT_RULES.md`에서는 **루트 `.slopconfig.yaml`에 `*.spec.ts` 등을 대량으로 넣지 않는다**고 정했다.
+
+## 2. 목표
+
+- 저장소에 커밋되는 기본 설정은 **#221 정책 유지**(spec/tests 대량 무시 없음).
+- 로컬에서만 노이즈를 줄이고 싶은 기여자에게 **재현 가능한 절차**를 문서로 제공한다.
+- CI·프로덕션 리팩터는 각각 [#314](https://github.com/jee1/memento/issues/314), [#315](https://github.com/jee1/memento/issues/315)에서 다룬다(본 설계의 비범위).
+
+## 3. 결정 사항
+
+| 항목 | 결정 |
+|------|------|
+| 루트 `.slopconfig.yaml` | `**/*.spec.ts` / `tests/**` 등 **추가하지 않음**. |
+| 로컬 오버라이드 | `.slopconfig.local.yaml`을 두고 `gitignore`에 등록. 내용은 **로컬에서만** 유지(루트 YAML 복사 후 필요한 `ignore`만 추가). |
+| 실행 | `slop-detector ... --config .slopconfig.local.yaml` — 루트 설정과 동일한 `ignore` 베이스를 복사한 뒤 로컬 전용 패턴만 덧붙인다(도구가 다중 설정 병합을 지원하지 않으므로 **단일 파일**로 운용). |
+| `--gate` | 기존 문서대로 JS/TS 구간을 주된 근거로 본다. |
+
+## 4. 비목표
+
+- 필수 CI에 slop 하드 게이트 추가.
+- 프로덕션 파일 대규모 리팩터(별도 이슈/플랜).
+
+## 5. 검증
+
+- `.slopconfig.local.yaml`이 저장소에 추적되지 않는다(`git check-ignore -v .slopconfig.local.yaml`).
+- `DEVELOPMENT_RULES.md`에 로컬 절차가 명시되어 있다.
+
+## 6. 참고
+
+- 권장 스캔 명령은 `DEVELOPMENT_RULES.md` 「선택적 정적 스캔」절을 단일 소스로 한다.


### PR DESCRIPTION
## 요약
이슈 #239·#313에서 합의한 **정책 A**: 루트 `.slopconfig.yaml`에는 `*.spec.ts` 등 **대량 ignore를 넣지 않고**(#221 유지), Vitest 노이즈를 줄이려면 **로컬 전용** `.slopconfig.local.yaml`을 사용한다.

## 변경
- `.gitignore`: `.slopconfig.local.yaml`
- `DEVELOPMENT_RULES.md`: 저장소 기본 정책 명시 + 로컬 복사·`--config` 절차
- `docs/superpowers/specs/2026-05-10-issue-239-slop-followup-design.md`
- `docs/superpowers/plans/2026-05-10-issue-239-slop-policy-local.md`

## 비범위
- CI 워크플로(#314), 프로덕션 리팩터 백로그(#315) — 별도 PR

## 지식 복리
- **문제:** Vitest 스펙이 slop Critical에 많이 잡히나, 저장소 기본 설정에 spec 무시를 넣으면 #221과 충돌.
- **해결:** 커밋되지 않는 로컬 YAML + 문서화된 동일 CLI 패턴(`--config`만 교체).

Closes #313

Made with [Cursor](https://cursor.com)