### PR TITLE
ci(slop): advisory JS/TS GitHub Actions workflow (#314)

### DIFF
--- a/.github/workflows/slop-detector-js.yml
+++ b/.github/workflows/slop-detector-js.yml
@@ -1,0 +1,51 @@
+# Advisory JS/TS scan via ai-slop-detector. Not a required merge check (#314).
+# Triggers: manual + weekly schedule. Logs: JS/TS Clean/Suspicious/Critical (ignore --gate HALT for TS-only context).
+
+name: Slop detector (JS/TS)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly Monday 06:15 UTC — low-noise regression signal
+    - cron: '15 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: slop-js-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Advisory: keep default branch green in Actions overview; inspect logs/artifacts on failure.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ai-slop-detector
+        run: pip install --progress-bar off 'ai-slop-detector==3.7.3'
+
+      - name: Scan packages/ (JS/TS)
+        run: |
+          set -o pipefail
+          slop-detector --project packages --js --config .slopconfig.yaml --no-color 2>&1 | tee slop-packages.log
+
+      - name: Scan static/js (JS/TS)
+        run: |
+          set -o pipefail
+          slop-detector --project static/js --js --config .slopconfig.yaml --no-color 2>&1 | tee slop-static-js.log
+
+      - name: Upload scan logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: slop-js-logs-${{ github.run_id }}
+          path: '*.log'
+          retention-days: 14

--- a/DEVELOPMENT_RULES.md
+++ b/DEVELOPMENT_RULES.md
@@ -104,6 +104,6 @@ it('should behavior when condition', async () => {
     *   대시보드 정적 스크립트: `slop-detector --project static/js --js --config .slopconfig.yaml`
     *   루트 전체(설정 반영): `slop-detector --project . --js --config .slopconfig.yaml`
 *   **`--gate`:** 상단 요약에 Python/LDR가 0으로 보일 수 있다. **`--js` 사용 시 JS/TS Analysis 구간을 게이트 판단의 주된 근거로 본다.**
-*   **CI:** 본 저장소의 필수 CI 게이트에는 포함하지 않는다(후속 이슈에서 선택).
+*   **CI:** 본 저장소의 필수 CI 게이트에는 포함하지 않는다. 선택적으로 GitHub Actions **「Slop detector (JS/TS)」** (`.github/workflows/slop-detector-js.yml`)를 사용한다: `workflow_dispatch`와 주간 `schedule`만 트리거하며 **필수 merge check로 등록하지 않는다**([#314](https://github.com/jee1/memento/issues/314)). 실패 시에도 워크플로는 참고용으로 `continue-on-error` 처리되어 Actions 기본 화면이 붉게 덮이지 않도록 했다. 로그·아티팩트의 **JS/TS Analysis** 구간을 본다(`--gate` 상단 HALT는 TS-only 맥락에서 오해 소지가 있음 — 위 `--gate` 항목 참고).
 *   **테스트 경로 무시(저장소 기본):** 루트 `.slopconfig.yaml`에는 `*.spec.ts`·`tests/**` 등을 **대량으로 넣지 않는다**([#221](https://github.com/jee1/memento/issues/221) 정책).
 *   **로컬 전용 오버라이드(선택):** Vitest 노이즈를 줄이려면 (1) 루트 `.slopconfig.yaml`을 복사해 `.slopconfig.local.yaml`을 만들고, (2) `ignore`에 개인용 패턴(예: `**/*.spec.ts`, `**/tests/**`)만 추가한다. 이 파일은 `.gitignore`에 포함되어 **커밋되지 않는다**. (3) 스캔 시 `--config .slopconfig.local.yaml`을 지정한다. 예: `slop-detector --project packages --js --config .slopconfig.local.yaml`


### PR DESCRIPTION
## 요약
[#314](https://github.com/jee1/memento/issues/314) **선택·advisory** CI: `ai-slop-detector` JS/TS 스캔을 GitHub Actions에서 돌릴 수 있게 한다. **브랜치 보호 필수 check로 등록하지 않는다.**

## 동작
- **트리거:** `workflow_dispatch`, 주간 `schedule` (월 06:15 UTC)
- **명령:** `DEVELOPMENT_RULES.md`와 동일 — `packages`, `static/js`, `.slopconfig.yaml`
- **버전:** `ai-slop-detector==3.7.3` (PyPI 고정)
- **로그:** 각 스캔을 `*.log`로 저장 후 아티팩트 업로드 (14일 보관)
- **실패 시:** job `continue-on-error: true` 로 Actions 기본 요약이 항상 빨간색으로 덮이지 않게 함 — 로그·아티팩트에서 **JS/TS Analysis** 확인

## 문서
- `DEVELOPMENT_RULES.md` CI 불릿 확장

## 비목표
- `--ci-mode hard` 필수 게이트, PR마다 자동 실행

Closes #314

Made with [Cursor](https://cursor.com)