### PR TITLE
docs(slop): production Critical backlog (#315)

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
+++ b/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
@@ -1,0 +1,28 @@
+# Issue #315 — Production slop 백로그 (JS/TS Critical 후보)
+
+> **상위:** [#239](https://github.com/jee1/memento/issues/239) · [#315](https://github.com/jee1/memento/issues/315)  
+> **전제:** [#313](https://github.com/jee1/memento/issues/313) 정책 A(저장소 `.slopconfig`에 spec 대량 ignore 없음). 스캔은 `slop-detector --project packages --js --config .slopconfig.yaml` 등으로 재현.
+
+## 우선순위 (제안)
+
+| 순위 | 영역 | 후보 경로(패키지 루트 기준) | 제안 PR 제목 (예시) |
+|------|------|---------------------------|---------------------|
+| 1 | DB 초기화·마이그레이션 | `packages/memento-core/src/infrastructure/database/database/init.ts`, `.../migrate.ts` | refactor(core): slim DB init/migrate for slop readability |
+| 2 | 검색·임베딩 | `packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.ts`, `packages/memento-core/src/domains/memory/services/memory-embedding-service.ts`, `packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts`(대형 헬퍼; `quality-metrics-collector` 등에서 import) | refactor(core): reduce complexity in search/embedding paths |
+| 3 | 트리플 추출 | `packages/memento-core/src/domains/relation/services/triple-extraction/` (우선 `triple-extraction-service.ts`) | refactor(core): split triple extraction pipeline |
+| 4 | HTTP admin | `packages/memento-server/src/**` admin 라우트 | refactor(server): modularize admin routes |
+
+## PR 쪼개기 규칙
+
+- 한 PR에 **한 주제**(한 디렉터리 또는 1~2 파일)만; `any` 제거·함수 분해·중첩 완화 중심.
+- **스키마·동작 변경 없음** 원칙은 [AGENTS.md](../../../AGENTS.md) 품질 게이트 준수.
+- 머지 전: 해당 패키지 `npm run test`·`lint`·`type-check` (또는 루트 스크립트).
+
+## 착수 순서 (첫 1~2건)
+
+1. **PR-A:** `database/init.ts` vs `database/migrate.ts` 중 **Critical가 더 높은 쪽**부터 (로컬 slop 로그로 확인).
+2. **PR-B:** `n-hop-search-service.ts` **또는** `memory-embedding-service.ts` 중 하나만.
+
+## 갱신
+
+재스캔 후 상위 파일이 바뀌면 이 표를 갱신하고 [#315](https://github.com/jee1/memento/issues/315)에 링크한다.


### PR DESCRIPTION
## 요약
[#315](https://github.com/jee1/memento/issues/315) 완료 기준의 **백로그 테이블**을 저장소에 두고 이슈에서 링크할 수 있게 한다.

## 내용
- 우선순위·제안 PR 제목·첫 착수 2건(PR-A/B)
- #239 스캔에서 언급된 경로를 저장소 트리에 맞게 구체화

Refs #315 (이슈는 후속 리팩터 PR 진행 시까지 열어 둠)

Made with [Cursor](https://cursor.com)