### PR TITLE
refactor(core): split triple extraction LLM pipeline helpers

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
+++ b/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
@@ -24,7 +24,8 @@
 2. ~~**PR-B (1/2):** `n-hop-search-service.ts`~~ — 단일 파일 slop 비교로 선정 후 [#327](https://github.com/jee1/memento/pull/327)에서 `searchNHop` 분해·`any` 초기화 제거.
 3. ~~**PR-B (2/2):** `memory-embedding-service.ts`~~ — [#328](https://github.com/jee1/memento/pull/328): 저장/검색 헬퍼 분리, stderr 이모지 → ASCII 진단 태그.
 4. ~~**순위 2 잔여:** `vector-search-quality-metrics.ts`~~ — [#329](https://github.com/jee1/memento/pull/329): Kendall tau-b·vector-only/consolidation 점수 헬퍼 분리(동작·export 동일).
-5. **다음 (순위 3):** `triple-extraction-service.ts` 중심 트리플 추출 파이프라인 분해.
+5. ~~**순위 3:** `triple-extraction-service.ts` + 파이프라인~~ — [#330](https://github.com/jee1/memento/pull/330): `triple-extraction-llm-pipeline.ts`로 LLM 호출·파싱·초기화 로깅 분리, \`enqueueExtractionLog\`로 중복 제거.
+6. **다음 (순위 4):** `packages/memento-server/src/**` admin 라우트 모듈화.
 
 ## 진행 기록
 
@@ -35,6 +36,7 @@
 | 2026-05-10 | `.../anchor/n-hop-search-service.ts` | [#327](https://github.com/jee1/memento/pull/327) | hop 병합·랭킹 헬퍼 추출, `requireVectorContext`로 초기화 통일 |
 | 2026-05-10 | `.../memory/services/memory-embedding-service.ts` | [#328](https://github.com/jee1/memento/pull/328) | 호환성/INSERT·vec SQL·맵 헬퍼, stderr ASCII 태그 |
 | 2026-05-10 | `.../test/helpers/vector-search-quality-metrics.ts` | [#329](https://github.com/jee1/memento/pull/329) | Kendall tau-b·하이브리드 점수 pick 헬퍼 추출 |
+| 2026-05-10 | `.../triple-extraction/triple-extraction-service.ts` (+ pipeline) | [#330](https://github.com/jee1/memento/pull/330) | LLM raw 호출·파싱·init 로깅 모듈 분리, 로깅 enqueue 헬퍼 |
 
 ## 갱신
 

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts
@@ -1,0 +1,120 @@
+/**
+ * Triple 추출 LLM 단계: provider raw 호출, 파싱, 초기화 로깅.
+ * TripleExtractionService에서 분리해 복잡도를 낮춘다.
+ */
+
+import type { GoogleGenerativeAI } from '@google/generative-ai';
+import OpenAI from 'openai';
+import type { LLMClientInitializationResult } from '../../../../shared/services/llm-client-initializer.js';
+import type { Triple, TripleExtractionOptions, TripleExtractionResult } from '../../../../shared/types/triple-extraction.js';
+import { logger } from '../../../../shared/utils/logger.js';
+import {
+  classifyTripleFailureReason,
+} from './triple-extraction-errors.js';
+import {
+  extractRawWithGemini,
+  extractRawWithOllama,
+  extractRawWithOpenAI,
+  type TripleLlmCallDeps,
+} from './triple-extraction-llm-providers.js';
+import { createTripleExtractionFailureResult } from './triple-extraction-result-helpers.js';
+import type { TripleParser } from './triple-parser.js';
+
+/** 테스트·런타임에서 동일 문구로 LLM 미가용 응답을 맞춘다. */
+export const TRIPLE_EXTRACTION_LLM_UNAVAILABLE_MESSAGE =
+  'LLM 서비스를 사용할 수 없습니다. OPENAI_API_KEY 또는 GEMINI_API_KEY를 설정하거나 LLM_PROVIDER를 변경해주세요.';
+
+export function createTripleLlmUnavailableResponse(
+  message: string = TRIPLE_EXTRACTION_LLM_UNAVAILABLE_MESSAGE
+): { result: TripleExtractionResult; rawLLMOutput: string } {
+  return {
+    result: createTripleExtractionFailureResult('llm_unavailable', message),
+    rawLLMOutput: message,
+  };
+}
+
+export type TripleLlmActiveProvider = 'openai' | 'gemini' | 'ollama';
+
+export async function invokeTripleProviderRawOutput(params: {
+  actualProvider: TripleLlmActiveProvider;
+  openaiClient: OpenAI | null;
+  geminiClient: GoogleGenerativeAI | null;
+  deps: TripleLlmCallDeps;
+  prompt: string;
+  options: TripleExtractionOptions;
+}): Promise<string> {
+  const { actualProvider, openaiClient, geminiClient, deps, prompt, options } = params;
+  switch (actualProvider) {
+    case 'openai':
+      if (!openaiClient) {
+        throw new Error('OpenAI 클라이언트가 초기화되지 않았습니다.');
+      }
+      return extractRawWithOpenAI(openaiClient, deps, prompt, options);
+    case 'gemini':
+      if (!geminiClient) {
+        throw new Error('Gemini 클라이언트가 초기화되지 않았습니다.');
+      }
+      return extractRawWithGemini(geminiClient, deps, prompt, options);
+    case 'ollama':
+      return extractRawWithOllama(deps, prompt, options);
+    default: {
+      const _exhaustive: never = actualProvider;
+      throw new Error(`지원하지 않는 LLM Provider: ${_exhaustive}`);
+    }
+  }
+}
+
+export type TripleParsePipelineOutcome =
+  | { ok: true; triples: Triple[]; rawLLMOutput: string }
+  | { ok: false; result: TripleExtractionResult; rawLLMOutput: string };
+
+export function resolveTripleParseOrFailure(
+  parser: TripleParser,
+  rawLLMOutput: string
+): TripleParsePipelineOutcome {
+  const parseResult = parser.parse(rawLLMOutput);
+  if (parseResult.success) {
+    const triples = parseResult.triples;
+    if (triples.length === 0) {
+      return {
+        ok: false,
+        result: createTripleExtractionFailureResult('no_triple', rawLLMOutput),
+        rawLLMOutput,
+      };
+    }
+    if (parseResult.errorType === 'structure') {
+      logger.warn('TripleExtractionService: 일부 triple이 유효하지 않음', {
+        validTriples: triples.length,
+        error: parseResult.error,
+      });
+    }
+    return { ok: true, triples, rawLLMOutput };
+  }
+  const failureReason = classifyTripleFailureReason(
+    parseResult.error,
+    rawLLMOutput,
+    parseResult.errorType
+  );
+  return {
+    ok: false,
+    result: createTripleExtractionFailureResult(failureReason, rawLLMOutput),
+    rawLLMOutput,
+  };
+}
+
+export function logTripleExtractionClientInitResult(result: LLMClientInitializationResult): void {
+  if (result.warnings.length > 0 && result.preferredProvider === null) {
+    result.warnings.forEach((warning) => {
+      logger.warn('LLM 초기화 경고', { warning });
+    });
+  }
+
+  if (result.preferredProvider) {
+    logger.info('TripleExtractionService: LLM 클라이언트 초기화 완료', {
+      preferredProvider: result.preferredProvider,
+      initializedProviders: result.initializedProviders,
+    });
+  } else {
+    logger.error('TripleExtractionService: LLM 클라이언트 초기화 실패 - 모든 provider가 사용 불가능합니다');
+  }
+}

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.ts
@@ -22,7 +22,6 @@ import type { LLMClientInitializationResult } from '../../../../shared/services/
 import { LLMClientInitializer } from '../../../../shared/services/llm-client-initializer.js';
 import type {
   ExtractionInfo,
-  Triple,
   TripleExtractionOptions,
   TripleExtractionResult,
 } from '../../../../shared/types/triple-extraction.js';
@@ -33,15 +32,16 @@ import { EntityLinker } from './entity-linker.js';
 import { PredicateCanonicalizer } from './predicate-canonicalizer.js';
 import {
   classifyTripleExtractionErrorType,
-  classifyTripleFailureReason,
   shouldRetryTripleLlmError,
 } from './triple-extraction-errors.js';
+import type { TripleLlmCallDeps } from './triple-extraction-llm-providers.js';
 import {
-  extractRawWithGemini,
-  extractRawWithOllama,
-  extractRawWithOpenAI,
-  type TripleLlmCallDeps,
-} from './triple-extraction-llm-providers.js';
+  createTripleLlmUnavailableResponse,
+  invokeTripleProviderRawOutput,
+  logTripleExtractionClientInitResult,
+  resolveTripleParseOrFailure,
+  TRIPLE_EXTRACTION_LLM_UNAVAILABLE_MESSAGE,
+} from './triple-extraction-llm-pipeline.js';
 import { TokenBucketRateLimiter } from './triple-extraction-rate-limiter.js';
 import {
   createTripleExtractionFailureResult,
@@ -138,20 +138,7 @@ export class TripleExtractionService {
       this.preferredProvider = result.preferredProvider;
       this.initializedProviders = result.initializedProviders;
 
-      if (result.warnings.length > 0 && result.preferredProvider === null) {
-        result.warnings.forEach((warning) => {
-          logger.warn('LLM 초기화 경고', { warning });
-        });
-      }
-
-      if (result.preferredProvider) {
-        logger.info('TripleExtractionService: LLM 클라이언트 초기화 완료', {
-          preferredProvider: result.preferredProvider,
-          initializedProviders: result.initializedProviders,
-        });
-      } else {
-        logger.error('TripleExtractionService: LLM 클라이언트 초기화 실패 - 모든 provider가 사용 불가능합니다');
-      }
+      logTripleExtractionClientInitResult(result);
     } catch (error) {
       logger.error('TripleExtractionService: LLM 클라이언트 초기화 실패', {
         error: error instanceof Error ? error.message : String(error),
@@ -214,6 +201,17 @@ export class TripleExtractionService {
     return this.preferredProvider !== null;
   }
 
+  private enqueueExtractionLog(
+    result: TripleExtractionResult,
+    memoryId: string | undefined,
+    observation: string,
+    rawLLMOutput: string
+  ): void {
+    this.logExtractionResult(result, memoryId, observation, rawLLMOutput).catch((err) => {
+      logger.error('TripleExtractionService: 로깅 실패', { error: err });
+    });
+  }
+
   async extractTriples(
     observation: string,
     options: TripleExtractionOptions = {},
@@ -226,14 +224,12 @@ export class TripleExtractionService {
     if (!normalizedObservation) {
       const result = createTripleExtractionFailureResult('no_triple', 'Observation이 비어있습니다.');
       const normalizedResult = this.normalizeExtractionResult(result);
-      this.logExtractionResult(
+      this.enqueueExtractionLog(
         normalizedResult,
         memoryId,
         normalizedObservation,
         'Observation이 비어있습니다.'
-      ).catch((err) => {
-        logger.error('TripleExtractionService: 로깅 실패', { error: err });
-      });
+      );
       return normalizedResult;
     }
 
@@ -253,15 +249,10 @@ export class TripleExtractionService {
     }
 
     if (mementoConfig.nodeEnv === 'test' && process.env.MEMENTO_ALLOW_LLM_IN_TESTS !== 'true') {
-      const errorMessage =
-        'LLM 서비스를 사용할 수 없습니다. OPENAI_API_KEY 또는 GEMINI_API_KEY를 설정하거나 LLM_PROVIDER를 변경해주세요.';
+      const errorMessage = TRIPLE_EXTRACTION_LLM_UNAVAILABLE_MESSAGE;
       const result = createTripleExtractionFailureResult('llm_unavailable', errorMessage);
       const normalizedResult = this.normalizeExtractionResult(result);
-      this.logExtractionResult(normalizedResult, memoryId, normalizedObservation, errorMessage).catch(
-        (err) => {
-          logger.error('TripleExtractionService: 로깅 실패', { error: err });
-        }
-      );
+      this.enqueueExtractionLog(normalizedResult, memoryId, normalizedObservation, errorMessage);
       return normalizedResult;
     }
 
@@ -284,11 +275,7 @@ export class TripleExtractionService {
       const cost = costMetrics.totalCost;
       this.statistics.recordExtraction(normalizedResult, extractionTime, false, llmCalls, tokens, cost);
 
-      this.logExtractionResult(normalizedResult, memoryId, normalizedObservation, rawLLMOutput).catch(
-        (err) => {
-          logger.error('TripleExtractionService: 로깅 실패', { error: err });
-        }
-      );
+      this.enqueueExtractionLog(normalizedResult, memoryId, normalizedObservation, rawLLMOutput);
 
       return normalizedResult;
     } catch (error) {
@@ -307,11 +294,7 @@ export class TripleExtractionService {
       const result = createTripleExtractionFailureResult(failureReason, errorMessage);
       const normalizedResult = this.normalizeExtractionResult(result);
 
-      this.logExtractionResult(normalizedResult, memoryId, normalizedObservation, errorMessage).catch(
-        (err) => {
-          logger.error('TripleExtractionService: 로깅 실패', { error: err });
-        }
-      );
+      this.enqueueExtractionLog(normalizedResult, memoryId, normalizedObservation, errorMessage);
 
       return normalizedResult;
     }
@@ -325,9 +308,6 @@ export class TripleExtractionService {
     const actualProvider = this.determineProvider(provider);
 
     if (actualProvider === null) {
-      const errorMessage =
-        'LLM 서비스를 사용할 수 없습니다. OPENAI_API_KEY 또는 GEMINI_API_KEY를 설정하거나 LLM_PROVIDER를 변경해주세요.';
-
       logger.error('TripleExtractionService: LLM 서비스 사용 불가능', {
         requestedProvider: provider,
         preferredProvider: this.preferredProvider,
@@ -335,10 +315,7 @@ export class TripleExtractionService {
         geminiAvailable: this.geminiClient !== null,
       });
 
-      return {
-        result: createTripleExtractionFailureResult('llm_unavailable', errorMessage),
-        rawLLMOutput: errorMessage,
-      };
+      return createTripleLlmUnavailableResponse();
     }
 
     await this.rateLimiter.consume();
@@ -347,60 +324,18 @@ export class TripleExtractionService {
       observation,
     });
 
-    let rawLLMOutput: string;
-    let triples: Triple[] = [];
-
     const deps = this.getLlmCallDeps();
 
+    let rawLLMOutput: string;
     try {
-      switch (actualProvider) {
-        case 'openai':
-          if (!this.openaiClient) {
-            throw new Error('OpenAI 클라이언트가 초기화되지 않았습니다.');
-          }
-          rawLLMOutput = await extractRawWithOpenAI(this.openaiClient, deps, prompt, options);
-          break;
-        case 'gemini':
-          if (!this.geminiClient) {
-            throw new Error('Gemini 클라이언트가 초기화되지 않았습니다.');
-          }
-          rawLLMOutput = await extractRawWithGemini(this.geminiClient, deps, prompt, options);
-          break;
-        case 'ollama':
-          rawLLMOutput = await extractRawWithOllama(deps, prompt, options);
-          break;
-        default:
-          throw new Error(`지원하지 않는 LLM Provider: ${actualProvider}`);
-      }
-
-      const parseResult = this.parser.parse(rawLLMOutput);
-      if (parseResult.success) {
-        triples = parseResult.triples;
-
-        if (triples.length === 0) {
-          return {
-            result: createTripleExtractionFailureResult('no_triple', rawLLMOutput),
-            rawLLMOutput,
-          };
-        }
-
-        if (parseResult.errorType === 'structure') {
-          logger.warn('TripleExtractionService: 일부 triple이 유효하지 않음', {
-            validTriples: triples.length,
-            error: parseResult.error,
-          });
-        }
-      } else {
-        const failureReason = classifyTripleFailureReason(
-          parseResult.error,
-          rawLLMOutput,
-          parseResult.errorType
-        );
-        return {
-          result: createTripleExtractionFailureResult(failureReason, rawLLMOutput),
-          rawLLMOutput,
-        };
-      }
+      rawLLMOutput = await invokeTripleProviderRawOutput({
+        actualProvider,
+        openaiClient: this.openaiClient,
+        geminiClient: this.geminiClient,
+        deps,
+        prompt,
+        options,
+      });
     } catch (error) {
       const errorType = classifyTripleExtractionErrorType(error);
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -415,6 +350,12 @@ export class TripleExtractionService {
 
       throw error;
     }
+
+    const parsed = resolveTripleParseOrFailure(this.parser, rawLLMOutput);
+    if (parsed.ok === false) {
+      return { result: parsed.result, rawLLMOutput: parsed.rawLLMOutput };
+    }
+    const triples = parsed.triples;
 
     const normalizedTriples = this.normalizer.normalize(triples);
 


### PR DESCRIPTION
## Summary
Move LLM call, parse, and init logging out of `triple-extraction-service.ts` into `triple-extraction-llm-pipeline.ts` (no public API change).

- **Pipeline module:** `TRIPLE_EXTRACTION_LLM_UNAVAILABLE_MESSAGE`, `createTripleLlmUnavailableResponse`, `invokeTripleProviderRawOutput`, `resolveTripleParseOrFailure`, `logTripleExtractionClientInitResult`.
- **Service:** `enqueueExtractionLog` dedupes fire-and-forget logging; `extractWithLLM` / `initializeClients` delegate to pipeline helpers.

## Test plan
- [x] `npx vitest run packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts`
- [x] `npm run type-check`
- [x] `npm run lint` (0 errors)

Relates-to: #315

Made with [Cursor](https://cursor.com)