### PR TITLE
refactor(relation): Ollama response helpers in LLM relation extractor

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
+++ b/docs/superpowers/plans/2026-05-10-issue-315-slop-production-backlog.md
@@ -27,20 +27,20 @@
 5. ~~**순위 3:** `triple-extraction-service.ts` + 파이프라인~~ — [#330](https://github.com/jee1/memento/pull/330): `triple-extraction-llm-pipeline.ts`로 LLM 호출·파싱·초기화 로깅 분리, `enqueueExtractionLog`로 중복 제거.
 6. ~~**순위 4:** `memento-server` admin 라우트~~ — [#331](https://github.com/jee1/memento/pull/331): `admin.routes.ts`를 `routes/admin/*` 등록 모듈로 분할(경로·핸들러 동일).
 7. ~~**재스캔:** `slop-detector --project packages --js --config .slopconfig.yaml`~~ — 아래 **재스캔 스냅샷** 반영(2026-05-10).
-8. **다음 (프로덕션 소스 우선):** 아래 표의 **비-spec·비-test** `CRITICAL_DEFICIT`부터 단일 주제 PR(예: `batch-scheduler.ts` → `hybrid-search-engine.ts` → `recall-tool.ts` → `llm-based-relation-extractor.ts`). 테스트 전용 노이즈는 [#221](https://github.com/jee1/memento/issues/221) 정책대로 **커밋된** `.slopconfig`에 대량 ignore 없음; 로컬은 [DEVELOPMENT_RULES.md](../../../DEVELOPMENT_RULES.md)의 `.slopconfig.local.yaml` 권장.
+8. **다음 (프로덕션 소스 우선):** 아래 표의 **비-spec·비-test** `CRITICAL_DEFICIT`부터 단일 주제 PR. `llm-based-relation-extractor.ts` 1차 분해는 [#347](https://github.com/jee1/memento/pull/347)(머지 후 재스캔 권장). 그 외 우선 후보: `batch-scheduler.ts`, `hybrid-search-engine.ts`, `recall-tool.ts`(별도 PR 미열렸다면 여전히 상위), `triple-extraction-llm-providers.ts`(SUSPICIOUS·참고). 테스트 전용 노이즈는 [#221](https://github.com/jee1/memento/issues/221) 정책대로 **커밋된** `.slopconfig`에 대량 ignore 없음; 로컬은 [DEVELOPMENT_RULES.md](../../../DEVELOPMENT_RULES.md)의 `.slopconfig.local.yaml` 권장.
 
-## 재스캔 스냅샷 (2026-05-10)
+## 재스캔 스냅샷 (2026-05-10, PR #347 워킹트리 기준 2차)
 
 - **도구:** `ai-slop-detector==3.7.3`, 명령: `slop-detector --project packages --js --config .slopconfig.yaml --no-color`
 - **관찰:** `CRITICAL_DEFICIT` 다수가 `*.spec.ts`, `src/test/**`, `mcp-client/examples/**` — 백로그 1차 범위(프로덕션)와 분리해 해석할 것.
-- **프로덕션 `CRITICAL_DEFICIT` (재스캔 시점, `packages/` 기준·spec 제외):**
+- **프로덕션 `CRITICAL_DEFICIT` (`packages/` 기준·`*.spec.ts`·`__tests__`·`src/test/**` 제외한 상위):**
 
 | 우선(가칭) | 경로 |
 |-------------|------|
 | A | `memento-core/src/infrastructure/scheduler/batch-scheduler.ts` |
 | B | `memento-core/src/domains/search/algorithms/hybrid-search-engine.ts` |
 | C | `memento-core/src/domains/memory/tools/recall-tool.ts` |
-| D | `memento-core/src/domains/relation/services/llm-based-relation-extractor.ts` |
+| D | `memento-core/src/domains/relation/services/llm-based-relation-extractor.ts` — [#347](https://github.com/jee1/memento/pull/347)에서 Ollama 파싱·JSON trim·에러 로그 공통화 후에도 도구상 CRITICAL 잔존(`determineProvider`, `filterCandidatesByEmbedding`, `extractWithOpenAI`, `extractWithOllama` 등); 머지 후 재스캔으로 점수 변화 확인 |
 | (테스트 헬퍼, 지속) | `memento-core/src/test/helpers/vector-search-quality-metrics.ts` — [#329](https://github.com/jee1/memento/pull/329) 이후에도 도구상 Critical 잔존 가능; `generateOrderPreservationReport` 등 추가 분해 시 재평가 |
 
 - **SUSPICIOUS 예시 (참고):** `triple-extraction-llm-providers.ts` 등 — 필요 시 별도 소과제 PR.
@@ -57,6 +57,7 @@
 | 2026-05-10 | `.../triple-extraction/triple-extraction-service.ts` (+ pipeline) | [#330](https://github.com/jee1/memento/pull/330) | LLM raw 호출·파싱·init 로깅 모듈 분리, 로깅 enqueue 헬퍼 |
 | 2026-05-10 | `memento-server/.../routes/admin.routes.ts` (+ admin/*.routes) | [#331](https://github.com/jee1/memento/pull/331) | 통계·리뷰·배치·성능·도구·프로젝트 메모리 라우트 모듈화 |
 | 2026-05-10 | `slop-detector` packages 재스캔 | (문서) | `ai-slop-detector` 3.7.3; 프로덕션 후보 batch-scheduler / hybrid-search-engine / recall-tool / llm-based-relation-extractor |
+| 2026-05-10 | `.../relation/services/llm-based-relation-extractor.ts` | [#347](https://github.com/jee1/memento/pull/347) | Ollama 응답 파싱·JSON 정리 헬퍼 분리, `buildOllamaErrorLogContext`, `checkOllamaModel` 타입 보강; slop 잔여 이슈는 PR 본문·머지 후 재스캔 참고 |
 
 ## 갱신
 

--- a/docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md
@@ -1,0 +1,170 @@
+# 설계: 이슈 #238 — 실제 LLM provider adapter 연결 분해
+
+**상위:** [GitHub #238](https://github.com/jee1/memento/issues/238)  
+**부모 기능:** [GitHub #82](https://github.com/jee1/memento/issues/82)  
+**관련 구현 이슈:** [#231](https://github.com/jee1/memento/issues/231) ~ [#237](https://github.com/jee1/memento/issues/237)
+
+## 1. 문제
+
+`#238`은 현재 다음 책임을 한 이슈에 함께 담고 있다.
+
+- 실제 provider 활성화 조건과 공통 런타임 계약
+- OpenAI/Gemini/Ollama adapter 구현
+- API 키, timeout, fallback, 비용 가드 설계
+- provider 실패 시 오류 표면
+- 문서화와 smoke 검증
+
+이 조합은 1~2일 PR 단위를 넘기기 쉽고, provider별 SDK 차이와 로컬 런타임 차이 때문에 회귀 범위도 커진다.
+
+## 2. 목표
+
+- `#238`을 umbrella 이슈로 재정의한다.
+- 실행 단위는 `PR 1개로 1~2일 내 검증 가능한 크기`로 유지한다.
+- 공통 런타임 경계와 provider별 구현을 분리해 병렬 작업과 검증을 쉽게 만든다.
+- 기존 mock provider 기반 테스트 경로는 유지한다.
+
+## 3. 결정
+
+`#231`~`#237`은 유지하고, `#238`만 하위 실행 이슈로 분해한다.
+
+이유는 다음과 같다.
+
+- `#231`~`#237`은 이미 계약, context 구성, mock provider, 후보 추출, persistence, CLI, E2E/docs로 책임이 분리돼 있다.
+- `#236`, `#237`은 경계선이지만 아직 단일 PR로 닫을 수 있는 크기다.
+- `#238`만 공통 인프라, provider별 구현, 운영 문서가 함께 묶여 있어 명확히 과대하다.
+
+## 4. 새 구조
+
+### `#238` umbrella
+
+제목은 유지하되 본문을 “실제 provider 연결 작업의 상위 추적 이슈”로 바꾼다.
+
+포함 범위:
+
+- 공통 런타임 경계
+- OpenAI adapter 연결
+- Gemini adapter 연결
+- Ollama adapter 연결 및 로컬 smoke/docs
+
+직접 구현 항목:
+
+- 없음. 실제 코드는 모두 하위 이슈에서 처리한다.
+
+### 하위 이슈 1: provider runtime contract + config gating
+
+공통 런타임 경계를 먼저 고정하는 이슈다.
+
+포함:
+
+- provider enabled/disabled 판단
+- env/config 해석 규칙
+- timeout 기본값과 공통 옵션 shape
+- 사용자 친화적 오류 모델
+- mock provider 경로와 실제 provider 경로의 분기 규칙
+
+제외:
+
+- 특정 provider SDK 호출
+- provider별 요청/응답 매핑
+- 로컬 runtime 설치 가이드
+
+완료 기준:
+
+- 명시적 설정 없이는 실제 provider가 절대 활성화되지 않는다.
+- disabled/provider-misconfigured/provider-runtime-failed 상태가 구분된다.
+- 공통 계약을 검증하는 단위 테스트가 있다.
+
+### 하위 이슈 2: OpenAI adapter 연결
+
+가장 먼저 붙일 실제 hosted provider 구현이다.
+
+포함:
+
+- OpenAI SDK 연동
+- 공통 adapter 계약 매핑
+- provider metadata/result shape 정리
+- misconfiguration/runtime failure 테스트
+
+제외:
+
+- Gemini/Ollama
+- 다중 provider fallback
+- 비용 정책 일반화
+
+완료 기준:
+
+- 명시적 OpenAI 설정이 있을 때만 활성화된다.
+- 실패 시 공통 오류 모델로 반환된다.
+- mock 기반 기존 테스트는 외부 API 없이 유지된다.
+
+### 하위 이슈 3: Gemini adapter 연결
+
+OpenAI와 분리된 두 번째 hosted provider 구현이다.
+
+포함:
+
+- Gemini SDK 연동
+- 공통 adapter 계약 매핑
+- provider별 오류 표면 정리
+
+제외:
+
+- OpenAI/Ollama
+- 자동 provider 선택 정책
+
+완료 기준:
+
+- 명시적 Gemini 설정이 있을 때만 활성화된다.
+- OpenAI 구현과 독립적으로 테스트 가능하다.
+
+### 하위 이슈 4: Ollama adapter + local smoke/docs
+
+로컬 런타임 특성이 커서 별도 이슈로 둔다.
+
+포함:
+
+- Ollama adapter 구현
+- 비활성/미설치/연결 실패 메시지
+- 로컬 smoke 절차 문서
+- provider 설정 가이드 갱신
+
+제외:
+
+- hosted provider 공통 정책 재설계
+- background agent화
+
+완료 기준:
+
+- Ollama 미설치 상태에서 원인을 설명하는 오류가 나온다.
+- 로컬에서 명시적 설정 시 smoke 절차를 따라 수동 검증할 수 있다.
+- mock provider 테스트 경로는 계속 유지된다.
+
+## 5. 권장 순서
+
+1. `provider runtime contract + config gating`
+2. `OpenAI adapter 연결`
+3. `Gemini adapter 연결`
+4. `Ollama adapter + local smoke/docs`
+
+이 순서의 이유는 공통 경계를 먼저 고정해야 provider별 구현이 흔들리지 않기 때문이다. 또한 hosted provider를 먼저 정리하면 로컬 런타임 특수성이 큰 Ollama를 마지막에 별도로 닫을 수 있다.
+
+## 6. 비목표
+
+- `#231`~`#237` 재분해
+- 여러 provider를 한 요청에서 자동 fallback 하는 정책
+- 비용 최적화나 provider auto-tuning
+- LLM 기반 후보 추출 고도화
+- 24/7 background personal agent
+
+## 7. GitHub 정리 방식
+
+- `#238` 본문 상단에 “umbrella” 성격을 명시한다.
+- 하위 이슈 4개를 새로 생성하고 모두 `Parent: #238`를 적는다.
+- `#82`에는 `#231`~`#238`이 MVP 분해 구조임을 유지하되, `#238` 아래에 실제 provider 연결 서브트리가 있음을 링크로 보강한다.
+- 기존 `#238` 본문에 있던 구현 세부사항은 하위 이슈로 이동하고, `#238` 본문에는 추적용 요약만 남긴다.
+
+## 8. 검증
+
+- 각 하위 이슈가 단독 PR로 닫힐 수 있는지 확인한다.
+- 각 하위 이슈의 제외 범위가 겹치지 않는지 확인한다.
+- `#238` 본문이 실행 이슈가 아니라 umbrella로 읽히는지 확인한다.

--- a/packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts
+++ b/packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts
@@ -18,7 +18,7 @@ import type { ICacheService } from '../../../shared/interfaces/cache.interface.j
 import type { IRetryManager } from '../../../shared/interfaces/retry-manager.interface.js';
 import { mementoConfig } from '../../../shared/config/index.js';
 import { getRetryOptions } from '../../../shared/config/retry-options-loader.js';
-import { CACHE,CONFIDENCE,LIMITS,LLM_COST,RATE_LIMITER,TIME } from '../../../shared/constants/relation-constants.js';
+import { CACHE, CONFIDENCE, LIMITS, LLM_COST, RATE_LIMITER, TIME } from '../../../shared/constants/relation-constants.js';
 import { LLMClientInitializer } from '../../../shared/services/llm-client-initializer.js';
 import type { EmbeddingData } from '../../../shared/types/embedding.types.js';
 import type { MemoryItem } from '../../../shared/types/index.js';
@@ -608,9 +608,11 @@ ${memoryList}
         return false;
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as { models?: Array<{ name?: string }> };
       const models = data.models || [];
-      return models.some((m: any) => m.name === model || m.name.startsWith(`${model}:`));
+      return models.some(
+        (m: { name?: string }) => m.name === model || (m.name?.startsWith(`${model}:`) ?? false)
+      );
     } catch (error) {
       logger.warn('Ollama 모델 확인 실패', { 
         error: error instanceof Error ? error.message : String(error),
@@ -619,6 +621,158 @@ ${memoryList}
       });
       return false;
     }
+  }
+
+  /** Ollama 디버그 로그용 요청/프롬프트 요약 (본문 전체는 길이 제한) */
+  private buildOllamaErrorLogContext(
+    requestBody: {
+      model: string;
+      messages: Array<{ role: string; content: string }>;
+      options: { temperature: number; num_predict: number };
+      format: 'json';
+    },
+    prompt: string
+  ): Record<string, unknown> {
+    return {
+      requestBody: {
+        ...requestBody,
+        messages: requestBody.messages.map(msg => ({
+          role: msg.role,
+          contentLength: msg.content.length,
+          contentPreview: msg.content.substring(0, 500),
+          contentFull:
+            msg.content.length < 2000
+              ? msg.content
+              : msg.content.substring(0, 1000) + '...' + msg.content.substring(msg.content.length - 1000)
+        }))
+      },
+      promptLength: prompt.length,
+      promptPreview: prompt.substring(0, 500),
+      promptFull:
+        prompt.length < 2000 ? prompt : prompt.substring(0, 1000) + '...' + prompt.substring(prompt.length - 1000)
+    };
+  }
+
+  /**
+   * Ollama /api/chat 응답 텍스트(NDJSON 또는 JSON)에서 assistant content와 메타 객체 추출
+   */
+  private parseOllamaChatResponsePayload(
+    responseText: string,
+    contentType: string,
+    http: { status: number; statusText: string; headers: Record<string, string> }
+  ): { content: string; data: Record<string, unknown> } {
+    const isNDJSON =
+      contentType.includes('application/x-ndjson') || contentType.includes('ndjson');
+
+    if (isNDJSON) {
+      const lines = responseText.trim().split('\n').filter((line): line is string => line.trim().length > 0);
+      const contentParts: string[] = [];
+      let lastData: Record<string, unknown> | null = null;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line) continue;
+        try {
+          const lineData = JSON.parse(line) as Record<string, unknown>;
+          lastData = lineData;
+          const message = lineData.message;
+          if (message && typeof message === 'object' && message !== null && 'content' in message) {
+            const c = (message as { content?: unknown }).content;
+            if (typeof c === 'string' && c.length > 0) {
+              contentParts.push(c);
+            }
+          }
+          if (lineData.done === true) {
+            break;
+          }
+        } catch (lineParseError) {
+          logger.warn('Ollama NDJSON 라인 파싱 실패', {
+            lineIndex: i,
+            linePreview: line.substring(0, 200),
+            error: lineParseError instanceof Error ? lineParseError.message : String(lineParseError),
+            responseTextLength: responseText.length,
+            responseTextPreview: responseText.substring(0, 500),
+            responseTextFull: responseText
+          });
+        }
+      }
+
+      const content = contentParts.join('');
+      const data: Record<string, unknown> = lastData ?? {};
+      if (data.message && typeof data.message === 'object' && data.message !== null) {
+        (data.message as { content: string }).content = content;
+      } else {
+        data.message = { role: 'assistant', content };
+      }
+      return { content, data };
+    }
+
+    try {
+      const data = JSON.parse(responseText) as Record<string, unknown>;
+      const message = data.message;
+      let content = '';
+      if (message && typeof message === 'object' && message !== null && 'content' in message) {
+        const c = (message as { content?: unknown }).content;
+        content = typeof c === 'string' ? c : '';
+      }
+      return { content, data };
+    } catch (parseError) {
+      logger.error('Ollama API 응답 JSON 파싱 실패', {
+        parseError: parseError instanceof Error ? parseError.message : String(parseError),
+        contentType,
+        isNDJSON,
+        responseTextLength: responseText.length,
+        responseTextPreview: responseText.substring(0, 500),
+        responseTextFull: responseText,
+        status: http.status,
+        statusText: http.statusText,
+        headers: http.headers
+      });
+      throw new Error(
+        `Ollama 응답 JSON 파싱 실패: ${parseError instanceof Error ? parseError.message : String(parseError)}`
+      );
+    }
+  }
+
+  /** JSON.parse가 성공하는 최대 접두사로 `{`…`}` 블록 축소 (후행 노이즈 제거) */
+  private trimToValidJsonObject(content: string): string {
+    let finalJson = content;
+    const firstBraceFinal = finalJson.indexOf('{');
+    const lastBraceFinal = finalJson.lastIndexOf('}');
+    if (firstBraceFinal === -1 || lastBraceFinal === -1 || lastBraceFinal <= firstBraceFinal) {
+      return finalJson;
+    }
+    finalJson = finalJson.substring(firstBraceFinal, lastBraceFinal + 1).trim();
+    let validJson: string | null = null;
+    for (let i = finalJson.length; i > 0; i--) {
+      const testJson = finalJson.substring(0, i).trim();
+      if (testJson.endsWith('}')) {
+        try {
+          JSON.parse(testJson);
+          validJson = testJson;
+          break;
+        } catch {
+          // 계속 시도
+        }
+      }
+    }
+    return validJson ?? finalJson;
+  }
+
+  /** extractJSON + 중괄호 블록 + trimToValidJsonObject 순으로 관계 JSON 문자열 정리 */
+  private prepareOllamaRelationJsonContent(content: string): string {
+    let cleaned = content;
+    const extracted = this.extractJSON(content);
+    if (extracted) {
+      cleaned = extracted;
+    } else {
+      const firstBrace = content.indexOf('{');
+      const lastBrace = content.lastIndexOf('}');
+      if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+        cleaned = content.substring(firstBrace, lastBrace + 1).trim();
+      }
+    }
+    return this.trimToValidJsonObject(cleaned);
   }
 
   /**
@@ -677,24 +831,12 @@ ${memoryList}
           signal: AbortSignal.timeout(60000) // 60초 타임아웃
         });
       } catch (fetchError) {
-        // 에러 발생 시에만 요청 정보 로깅
         logger.error('Ollama API fetch 실패', {
           error: fetchError instanceof Error ? fetchError.message : String(fetchError),
           url: apiUrl,
           baseUrl,
           model,
-          requestBody: {
-            ...requestBody,
-            messages: requestBody.messages.map((msg: { role: string; content: string }) => ({
-              role: msg.role,
-              contentLength: msg.content.length,
-              contentPreview: msg.content.substring(0, 500),
-              contentFull: msg.content.length < 2000 ? msg.content : msg.content.substring(0, 1000) + '...' + msg.content.substring(msg.content.length - 1000)
-            }))
-          },
-          promptLength: prompt.length,
-          promptPreview: prompt.substring(0, 500),
-          promptFull: prompt.length < 2000 ? prompt : prompt.substring(0, 1000) + '...' + prompt.substring(prompt.length - 1000)
+          ...this.buildOllamaErrorLogContext(requestBody, prompt)
         });
         throw fetchError;
       }
@@ -734,96 +876,29 @@ ${memoryList}
         throw new Error(errorMessage);
       }
 
-      // 응답 본문 파싱
-      // Ollama는 NDJSON (Newline Delimited JSON) 형식으로 응답할 수 있습니다
       const contentType = response.headers.get('content-type') || '';
-      const isNDJSON = contentType.includes('application/x-ndjson') || contentType.includes('ndjson');
-      
-      let data: any;
-      let content = '';
-      
+      const isNDJSON =
+        contentType.includes('application/x-ndjson') || contentType.includes('ndjson');
+      const headerRecord = Object.fromEntries(response.headers.entries());
+
       let responseText = '';
+      let data: Record<string, unknown>;
+      let content = '';
       try {
         responseText = await response.text();
-        
-        if (isNDJSON) {
-          // NDJSON 형식 처리: 각 줄을 개별 JSON 객체로 파싱
-          const lines = responseText.trim().split('\n').filter((line): line is string => line.trim().length > 0);
-          
-          let lastData: any = null;
-          const contentParts: string[] = [];
-          
-          for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            if (!line) continue;
-            
-            try {
-              const lineData = JSON.parse(line);
-              lastData = lineData; // 마지막 줄의 메타데이터 사용
-              
-              // message.content가 있으면 합치기
-              if (lineData.message?.content) {
-                contentParts.push(lineData.message.content);
-              }
-              
-              // done이 true이면 완료
-              if (lineData.done === true) {
-                break;
-              }
-            } catch (lineParseError) {
-              // 에러 발생 시에만 로깅
-              logger.warn('Ollama NDJSON 라인 파싱 실패', {
-                lineIndex: i,
-                linePreview: line.substring(0, 200),
-                error: lineParseError instanceof Error ? lineParseError.message : String(lineParseError),
-                responseTextLength: responseText.length,
-                responseTextPreview: responseText.substring(0, 500),
-                responseTextFull: responseText
-              });
-              // 계속 진행
-            }
-          }
-          
-          // content 합치기
-          content = contentParts.join('');
-          
-          // 마지막 데이터를 메인 데이터로 사용 (메타데이터 포함)
-          data = lastData || {};
-          
-          // content를 message에 설정
-          if (data.message) {
-            data.message.content = content;
-          } else {
-            data.message = { role: 'assistant', content };
-          }
-        } else {
-          // 일반 JSON 형식 처리
-          try {
-            data = JSON.parse(responseText);
-            content = data.message?.content || '';
-          } catch (parseError) {
-            // 에러 발생 시에만 상세 로깅
-            logger.error('Ollama API 응답 JSON 파싱 실패', {
-              parseError: parseError instanceof Error ? parseError.message : String(parseError),
-              contentType,
-              isNDJSON,
-              responseTextLength: responseText.length,
-              responseTextPreview: responseText.substring(0, 500),
-              responseTextFull: responseText,
-              status: response.status,
-              statusText: response.statusText,
-              headers: Object.fromEntries(response.headers.entries())
-            });
-            throw new Error(`Ollama 응답 JSON 파싱 실패: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
-          }
-        }
+        const parsed = this.parseOllamaChatResponsePayload(responseText, contentType, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: headerRecord
+        });
+        data = parsed.data;
+        content = parsed.content;
       } catch (textError) {
-        // 에러 발생 시에만 상세 로깅
         logger.error('Ollama API 응답 본문 읽기 실패', {
           textError: textError instanceof Error ? textError.message : String(textError),
           status: response.status,
           statusText: response.statusText,
-          headers: Object.fromEntries(response.headers.entries()),
+          headers: headerRecord,
           contentType,
           isNDJSON,
           responseTextLength: responseText.length,
@@ -832,18 +907,19 @@ ${memoryList}
         });
         throw textError;
       }
-      
-      // content가 없으면 data.message?.content에서 가져오기
-      if (!content && data.message?.content) {
-        content = data.message.content;
+
+      if (!content && data.message && typeof data.message === 'object' && data.message !== null) {
+        const mc = (data.message as { content?: unknown }).content;
+        if (typeof mc === 'string') {
+          content = mc;
+        }
       }
-      
+
       if (!content) {
-        // 에러 발생 시에만 상세 로깅
         logger.error('Ollama 응답이 비어있습니다', {
           status: response.status,
           statusText: response.statusText,
-          headers: Object.fromEntries(response.headers.entries()),
+          headers: headerRecord,
           contentType,
           isNDJSON,
           responseTextLength: responseText.length,
@@ -854,84 +930,28 @@ ${memoryList}
         throw new Error('Ollama 응답이 비어있습니다.');
       }
 
-      // 비용 모니터링 (Ollama는 로컬이므로 비용 0)
-      const promptTokens = data.prompt_eval_count || 0;
-      const completionTokens = data.eval_count || 0;
+      const promptTokens =
+        typeof data.prompt_eval_count === 'number' ? data.prompt_eval_count : 0;
+      const completionTokens = typeof data.eval_count === 'number' ? data.eval_count : 0;
       this.calculateAndLogCost('ollama', promptTokens, completionTokens);
 
-      // Given: Ollama 응답 내용 (JSON 형식이어야 하지만 추가 텍스트가 포함될 수 있음)
-      // When: JSON 파싱 시도
-      // Ollama는 format: 'json' 옵션을 사용하더라도 일부 모델은 JSON 뒤에 추가 텍스트를 포함할 수 있습니다
-      // 따라서 먼저 extractJSON으로 정리한 후 파싱을 시도합니다
-      let cleanedContent = content;
-      const extractedJson = this.extractJSON(content);
-      if (extractedJson) {
-        cleanedContent = extractedJson;
-      } else {
-        // extractJSON이 실패한 경우, 수동으로 첫 번째 '{'부터 마지막 '}'까지 추출
-        const firstBrace = content.indexOf('{');
-        const lastBrace = content.lastIndexOf('}');
-        if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
-          cleanedContent = content.substring(firstBrace, lastBrace + 1).trim();
-        }
-      }
-      
-      // JSON 파싱을 시도하기 전에 한 번 더 정리
-      // "Unexpected non-whitespace character after JSON" 에러를 방지합니다.
-      // 첫 번째 '{'부터 마지막 '}'까지만 추출하고, 그 사이의 모든 텍스트를 제거
-      let finalJson = cleanedContent;
-      const firstBraceFinal = finalJson.indexOf('{');
-      const lastBraceFinal = finalJson.lastIndexOf('}');
-      
-      if (firstBraceFinal !== -1 && lastBraceFinal !== -1 && lastBraceFinal > firstBraceFinal) {
-        finalJson = finalJson.substring(firstBraceFinal, lastBraceFinal + 1).trim();
-        
-        // JSON.parse()가 성공할 때까지 끝 부분을 점진적으로 제거
-        let validJson = null;
-        for (let i = finalJson.length; i > 0; i--) {
-          const testJson = finalJson.substring(0, i).trim();
-          if (testJson.endsWith('}')) {
-            try {
-              JSON.parse(testJson);
-              validJson = testJson;
-              break;
-            } catch {
-              // 계속 시도
-            }
-          }
-        }
-        
-        if (validJson) {
-          finalJson = validJson;
-        }
-      }
-      
+      const finalJson = this.prepareOllamaRelationJsonContent(content);
+
       const parseResult = this.parseLLMResponse(finalJson);
       if (!parseResult.success) {
-        // Then: 파싱 실패 시 상세한 에러 정보와 함께 예외 발생
         logger.error('Ollama 응답 파싱 실패', {
           error: parseResult.error,
           contentLength: content.length,
-          cleanedLength: cleanedContent.length,
           finalLength: finalJson.length,
           contentPreview: content.substring(0, 500),
-          cleanedPreview: cleanedContent.substring(0, 500),
           finalPreview: finalJson.substring(0, 500),
-          contentFull: content.length < 2000 ? content : content.substring(0, 1000) + '...' + content.substring(content.length - 1000),
+          contentFull:
+            content.length < 2000
+              ? content
+              : content.substring(0, 1000) + '...' + content.substring(content.length - 1000),
           model: mementoConfig.ollamaModel,
           baseUrl: mementoConfig.ollamaBaseUrl,
-          requestBody: {
-            ...requestBody,
-            messages: requestBody.messages.map((msg: { role: string; content: string }) => ({
-              role: msg.role,
-              contentLength: msg.content.length,
-              contentPreview: msg.content.substring(0, 500),
-              contentFull: msg.content.length < 2000 ? msg.content : msg.content.substring(0, 1000) + '...' + msg.content.substring(msg.content.length - 1000)
-            }))
-          },
-          promptLength: prompt.length,
-          promptPreview: prompt.substring(0, 500),
-          promptFull: prompt.length < 2000 ? prompt : prompt.substring(0, 1000) + '...' + prompt.substring(prompt.length - 1000),
+          ...this.buildOllamaErrorLogContext(requestBody, prompt),
           responseTextLength: responseText.length,
           responseTextPreview: responseText.substring(0, 500),
           responseTextFull: responseText,
@@ -939,29 +959,17 @@ ${memoryList}
           isNDJSON,
           status: response.status,
           statusText: response.statusText,
-          headers: Object.fromEntries(response.headers.entries())
+          headers: headerRecord
         });
         throw new Error(`LLM 응답 파싱 실패: ${parseResult.error}`);
       }
       return parseResult;
     } catch (error) {
-      // 에러 발생 시에만 상세 로깅
-      logger.error('Ollama 호출 실패', { 
+      logger.error('Ollama 호출 실패', {
         error: error instanceof Error ? error.message : String(error),
         baseUrl: mementoConfig.ollamaBaseUrl,
         model: mementoConfig.ollamaModel,
-        requestBody: {
-          ...requestBody,
-          messages: requestBody.messages.map(msg => ({
-            role: msg.role,
-            contentLength: msg.content.length,
-            contentPreview: msg.content.substring(0, 500),
-            contentFull: msg.content.length < 2000 ? msg.content : msg.content.substring(0, 1000) + '...' + msg.content.substring(msg.content.length - 1000)
-          }))
-        },
-        promptLength: prompt.length,
-        promptPreview: prompt.substring(0, 500),
-        promptFull: prompt.length < 2000 ? prompt : prompt.substring(0, 1000) + '...' + prompt.substring(prompt.length - 1000)
+        ...this.buildOllamaErrorLogContext(requestBody, prompt)
       });
       throw error;
     }


### PR DESCRIPTION
## 요약
- `extractWithOllama`에서 NDJSON/일반 JSON 응답 파싱·JSON 정리 로직을 private 헬퍼로 분리해 가독성과 중복을 줄였습니다.
- `buildOllamaErrorLogContext`로 fetch/파싱/최상위 catch의 요청·프롬프트 로그 필드를 통일했습니다.
- `checkOllamaModel`의 태그 API 응답 타입을 좁혔습니다.

## 검증
- `npm run type-check`
- Vitest: `llm-based-relation-extractor.spec.ts`, `relation-extractor.spec.ts`, `extract-relations-tool.spec.ts`
- `npm run lint` (기존 경고만, 에러 없음)

Refs #315

Made with [Cursor](https://cursor.com)