### PR TITLE
refactor(search): extract per-provider VEC tasks (#349)

### DIFF
--- a/docs/superpowers/plans/2026-05-10-issue-231-personal-agent-contract.md
+++ b/docs/superpowers/plans/2026-05-10-issue-231-personal-agent-contract.md
@@ -1,0 +1,367 @@
+# PersonalKnowledgeAgentService 계약 추가 — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **워크트리:** 구현 시작 전 `superpowers:using-git-worktrees` 스킬로 `issue-231-personal-agent-contract` 브랜치 워크트리를 먼저 생성할 것.
+
+**Goal:** `memento-core`에 `PersonalKnowledgeAgentService` 계약(타입·포트·서비스 골격)을 추가하고, mock DI로 한 턴 실행을 단위 테스트로 검증한다.
+
+**Architecture:** 신규 `domains/personal-agent/` 도메인을 `memento-core` 안에 추가한다. 외부 의존(LLM·context·persistence)은 포트 인터페이스로 추상화해 DI로 주입받으며, 기존 `remember`/`recall`/`memory_injection` 코드는 전혀 변경하지 않는다.
+
+**Tech Stack:** TypeScript, Vitest(`vi.fn()` mock), Node.js ≥ 24
+
+---
+
+## 파일 구조
+
+| 상태 | 경로 | 역할 |
+|------|------|------|
+| 신규 | `packages/memento-core/src/domains/personal-agent/types/agent-types.ts` | 도메인 타입 3종 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/ports/llm-port.ts` | LLM 포트 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/ports/context-port.ts` | Context 포트 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts` | Persistence 포트 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts` | 서비스 골격 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts` | 단위 테스트 |
+| 신규 | `packages/memento-core/src/domains/personal-agent/index.ts` | public export |
+
+---
+
+## Task 1: 디렉터리 생성 & 스펙 파일 작성 (TDD Red)
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts`
+
+- [ ] **Step 1: 디렉터리 생성**
+
+```bash
+mkdir -p packages/memento-core/src/domains/personal-agent/{types,ports,services}
+```
+
+- [ ] **Step 2: 스펙 파일 작성** (아직 import 대상 파일이 없어 type-check 실패 — 의도적)
+
+`packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { PersonalKnowledgeAgentService } from './personal-knowledge-agent-service.js';
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { IContextPort } from '../ports/context-port.js';
+import type { IPersistencePort } from '../ports/persistence-port.js';
+
+describe('PersonalKnowledgeAgentService', () => {
+  function makeDeps() {
+    const completeFn = vi.fn().mockResolvedValue('LLM 응답');
+    const buildContextFn = vi.fn().mockResolvedValue('컨텍스트 텍스트');
+    const proposeCandidatesFn = vi.fn().mockResolvedValue(undefined);
+    const persistFn = vi.fn().mockResolvedValue(undefined);
+
+    const llm = { complete: completeFn } as unknown as ILLMPort;
+    const context = { buildContext: buildContextFn, proposeCandidates: proposeCandidatesFn } as unknown as IContextPort;
+    const persistence = { persist: persistFn } as unknown as IPersistencePort;
+
+    return { llm, context, persistence, completeFn, buildContextFn, proposeCandidatesFn, persistFn };
+  }
+
+  it('mock dependency로 한 턴을 실행하고 llmResponse를 반환한다', async () => {
+    const { llm, context, persistence } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    const result = await svc.runOneTurn({ userMessage: '테스트 입력' });
+
+    expect(result.llmResponse).toBe('LLM 응답');
+    expect(result.persisted).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('buildContext를 userMessage와 projectId로 호출한다', async () => {
+    const { llm, context, persistence, buildContextFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '입력', projectId: 'proj-1' });
+
+    expect(buildContextFn).toHaveBeenCalledWith('입력', 'proj-1');
+  });
+
+  it('projectId 없을 때 buildContext를 undefined로 호출한다', async () => {
+    const { llm, context, persistence, buildContextFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '입력' });
+
+    expect(buildContextFn).toHaveBeenCalledWith('입력', undefined);
+  });
+
+  it('llm.complete를 system+user 메시지로 호출한다', async () => {
+    const { llm, context, persistence, completeFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '질문' });
+
+    expect(completeFn).toHaveBeenCalledWith([
+      { role: 'system', content: '컨텍스트 텍스트' },
+      { role: 'user', content: '질문' },
+    ]);
+  });
+
+  it('LLM 포트가 reject하면 에러를 그대로 전파한다', async () => {
+    const { llm, context, persistence, completeFn } = makeDeps();
+    completeFn.mockRejectedValueOnce(new Error('LLM 오류'));
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await expect(svc.runOneTurn({ userMessage: '입력' })).rejects.toThrow('LLM 오류');
+  });
+});
+```
+
+- [ ] **Step 3: type-check가 실패하는지 확인 (의도된 실패)**
+
+```bash
+npm run type-check -w @memento/core 2>&1 | grep "personal-agent" | head -5
+```
+
+예상 출력: `Cannot find module './personal-knowledge-agent-service.js'` 형태의 오류
+
+---
+
+## Task 2: 타입 & 포트 정의 (TDD Green — 타입 레벨)
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/types/agent-types.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/ports/llm-port.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/ports/context-port.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts`
+
+- [ ] **Step 1: agent-types.ts 작성**
+
+`packages/memento-core/src/domains/personal-agent/types/agent-types.ts`
+
+```typescript
+export interface KnowledgeCandidate {
+  content: string;
+  type: 'episodic' | 'semantic' | 'procedural';
+  importance: number;
+  tags: string[];
+  sourceContext?: string;
+}
+
+export interface PersonalKnowledgeAgentInput {
+  userMessage: string;
+  sessionId?: string;
+  projectId?: string;
+}
+
+export interface PersonalKnowledgeAgentResult {
+  candidates: KnowledgeCandidate[];
+  llmResponse: string;
+  persisted: boolean;
+}
+```
+
+- [ ] **Step 2: llm-port.ts 작성**
+
+`packages/memento-core/src/domains/personal-agent/ports/llm-port.ts`
+
+```typescript
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ILLMPort {
+  complete(messages: LLMMessage[]): Promise<string>;
+}
+```
+
+- [ ] **Step 3: context-port.ts 작성**
+
+`packages/memento-core/src/domains/personal-agent/ports/context-port.ts`
+
+```typescript
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IContextPort {
+  buildContext(userMessage: string, projectId?: string): Promise<string>;
+  proposeCandidates(candidates: KnowledgeCandidate[]): Promise<void>;
+}
+```
+
+- [ ] **Step 4: persistence-port.ts 작성**
+
+`packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts`
+
+```typescript
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IPersistencePort {
+  persist(candidates: KnowledgeCandidate[]): Promise<void>;
+}
+```
+
+- [ ] **Step 5: 포트 파일만 type-check 확인 (서비스 파일 오류는 아직 정상)**
+
+```bash
+npm run type-check -w @memento/core 2>&1 | grep "personal-agent" | head -10
+```
+
+예상: `personal-knowledge-agent-service.ts`를 찾을 수 없다는 오류만 남아 있어야 함 (포트/타입 파일 오류는 사라짐)
+
+---
+
+## Task 3: 서비스 구현 (TDD Green — 런타임)
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts`
+
+- [ ] **Step 1: 서비스 파일 작성**
+
+`packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts`
+
+```typescript
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { IContextPort } from '../ports/context-port.js';
+import type { IPersistencePort } from '../ports/persistence-port.js';
+import type {
+  KnowledgeCandidate,
+  PersonalKnowledgeAgentInput,
+  PersonalKnowledgeAgentResult,
+} from '../types/agent-types.js';
+
+export interface PersonalKnowledgeAgentDeps {
+  llm: ILLMPort;
+  context: IContextPort;
+  persistence: IPersistencePort;
+}
+
+export class PersonalKnowledgeAgentService {
+  constructor(private readonly deps: PersonalKnowledgeAgentDeps) {}
+
+  async runOneTurn(input: PersonalKnowledgeAgentInput): Promise<PersonalKnowledgeAgentResult> {
+    const contextText = await this.deps.context.buildContext(
+      input.userMessage,
+      input.projectId,
+    );
+
+    const llmResponse = await this.deps.llm.complete([
+      { role: 'system', content: contextText },
+      { role: 'user', content: input.userMessage },
+    ]);
+
+    // #234에서 실제 후보 추출 구현
+    const candidates: KnowledgeCandidate[] = [];
+    await this.deps.context.proposeCandidates(candidates);
+
+    // #235에서 승인 흐름 구현
+    await this.deps.persistence.persist(candidates);
+
+    return { candidates, llmResponse, persisted: true };
+  }
+}
+```
+
+- [ ] **Step 2: 스펙 파일만 실행 — 전체 통과 확인**
+
+```bash
+vitest --run packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
+```
+
+예상 출력:
+```
+✓ personal-knowledge-agent-service.spec.ts (5)
+  ✓ PersonalKnowledgeAgentService
+    ✓ mock dependency로 한 턴을 실행하고 llmResponse를 반환한다
+    ✓ buildContext를 userMessage와 projectId로 호출한다
+    ✓ projectId 없을 때 buildContext를 undefined로 호출한다
+    ✓ llm.complete를 system+user 메시지로 호출한다
+    ✓ LLM 포트가 reject하면 에러를 그대로 전파한다
+
+Test Files  1 passed (1)
+Tests       5 passed (5)
+```
+
+- [ ] **Step 3: type-check 통과 확인**
+
+```bash
+npm run type-check -w @memento/core 2>&1 | grep -c "error TS"
+```
+
+예상 출력: `0` (오류 없음)
+
+---
+
+## Task 4: index.ts 작성 & 전체 검증 & 커밋
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/index.ts`
+
+- [ ] **Step 1: index.ts 작성**
+
+`packages/memento-core/src/domains/personal-agent/index.ts`
+
+```typescript
+export type {
+  KnowledgeCandidate,
+  PersonalKnowledgeAgentInput,
+  PersonalKnowledgeAgentResult,
+} from './types/agent-types.js';
+
+export type { LLMMessage, ILLMPort } from './ports/llm-port.js';
+export type { IContextPort } from './ports/context-port.js';
+export type { IPersistencePort } from './ports/persistence-port.js';
+
+export {
+  PersonalKnowledgeAgentService,
+} from './services/personal-knowledge-agent-service.js';
+export type { PersonalKnowledgeAgentDeps } from './services/personal-knowledge-agent-service.js';
+```
+
+- [ ] **Step 2: core 전체 테스트 실행 — 회귀 없음 확인**
+
+```bash
+npm run test:ci:core 2>&1 | tail -10
+```
+
+예상: `Test Files X passed`, `Tests Y passed` — personal-agent 5개 포함, 기존 테스트 모두 통과
+
+- [ ] **Step 3: core type-check 최종 확인**
+
+```bash
+npm run type-check -w @memento/core
+```
+
+예상: 오류 없이 종료 (exit code 0)
+
+- [ ] **Step 4: 변경 파일 스테이징 & 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/
+git commit -m "feat(personal-agent): add PersonalKnowledgeAgentService contract (#231)
+
+- PersonalKnowledgeAgentInput / Result / KnowledgeCandidate 타입 정의
+- ILLMPort / IContextPort / IPersistencePort 포트 인터페이스 정의
+- PersonalKnowledgeAgentService 골격 (DI 기반, mock 가능)
+- mock dependency 한 턴 실행 단위 테스트 5종"
+```
+
+- [ ] **Step 5: 이슈 #231 완료 기준 체크**
+
+```bash
+# 1) type-check 통과
+npm run type-check -w @memento/core && echo "✓ type-check"
+
+# 2) 단위 테스트 통과
+vitest --run packages/memento-core/src/domains/personal-agent/ && echo "✓ tests"
+
+# 3) 기존 core 테스트 회귀 없음
+npm run test:ci:core && echo "✓ no regression"
+```
+
+---
+
+## 완료 기준 요약
+
+| 기준 | 검증 커맨드 |
+|------|------------|
+| TypeScript 타입 오류 없음 | `npm run type-check -w @memento/core` |
+| 신규 단위 테스트 5종 통과 | `vitest --run packages/memento-core/src/domains/personal-agent/` |
+| 기존 core 테스트 회귀 없음 | `npm run test:ci:core` |
+| 기존 `remember`/`recall`/`memory_injection` 변경 없음 | `git diff HEAD -- packages/memento-core/src/domains/memory/` (변경 없어야 함) |

--- a/docs/superpowers/plans/2026-05-10-issue-349-hybrid-search-execution-refactor.md
+++ b/docs/superpowers/plans/2026-05-10-issue-349-hybrid-search-execution-refactor.md
@@ -1,0 +1,41 @@
+# Issue 349 — Hybrid 벡터 실행층 분리 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `hybrid-search-engine.ts`에서 단일 프로바이더 VEC 검색 본문·태스크 생성을 `hybrid-search-provider-parallel.ts`로 옮겨 실행 경로 복잡도를 줄이고, 동작·API는 유지한다.
+
+**Architecture:** `HybridSearchEngine`이 `ProviderVectorSearchDeps`(generateQueryVector, vectorSearch, logSearchStep)를 조립해 병렬 모듈의 `createProviderVectorSearchTask`에 넘긴다. 전체 타임아웃·집계는 기존 `executeProviderSearchesWithOverallTimeout` 유지.
+
+**Tech Stack:** TypeScript, Vitest, 기존 `HYBRID_SEARCH` 상수.
+
+---
+
+### Task 1: 병렬 모듈에 단일 프로바이더 실행 API 추가
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts`
+
+- [ ] **Step 1:** `ProviderVectorSearchDeps`, `ProviderVectorSearchOptions` 타입 및 `runSingleProviderVectorSearch`, `createProviderVectorSearchTask` 구현(기존 엔진 로직 이전).
+- [ ] **Step 2:** 파일 상단 주석에 Issue 349 맥락 한 줄 추가.
+
+### Task 2: HybridSearchEngine 위임으로 교체
+
+**Files:**
+- Modify: `packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts`
+
+- [ ] **Step 1:** `createProviderVectorSearchTask` import.
+- [ ] **Step 2:** private `getProviderVectorSearchDeps()` 추가(또는 `executeVecSearch` 내부 한 번 생성).
+- [ ] **Step 3:** `executeVecSearch`의 `providersToSearch.map`이 모듈 함수를 사용하도록 변경.
+- [ ] **Step 4:** 기존 `runProviderSearchTaskBody`, `createProviderSearchTask` private 메서드 제거.
+
+### Task 3: 검증
+
+**Files:**
+- Test: `packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts`
+
+- [ ] **Step 1:** `cd` 워크트리 루트에서 `npm run type-check`.
+- [ ] **Step 2:** `npx vitest run packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts` (또는 동등한 워크스페이스 명령).
+
+### Task 4: 문서·커밋
+
+- [ ] **Step 1:** 스펙·플랜·코드 변경을 `issue/349-hybrid-search-refactor` 브랜치에 커밋.

--- a/docs/superpowers/specs/2026-05-10-issue-231-personal-agent-contract-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-231-personal-agent-contract-design.md
@@ -1,0 +1,215 @@
+# 설계: 이슈 #231 — PersonalKnowledgeAgentService 계약 추가
+
+**날짜**: 2026-05-10  
+**이슈**: [#231](https://github.com/jee1/memento/issues/231)  
+**부모**: [#82](https://github.com/jee1/memento/issues/82) 개인 지식 축적 Agent MVP  
+**상태**: 설계 완료, 구현 대기
+
+---
+
+## 1. 목표
+
+개인 지식 Agent Loop의 서비스 계약과 타입을 `memento-core` 도메인에 추가한다.  
+실제 LLM·context·persistence 구현은 포트 인터페이스로 추상화하여 #232~#238에서 교체한다.
+
+---
+
+## 2. 범위
+
+### 포함
+- `PersonalKnowledgeAgentInput`, `PersonalKnowledgeAgentResult`, `KnowledgeCandidate` 타입 정의
+- `ILLMPort`, `IContextPort`, `IPersistencePort` 포트 인터페이스 정의
+- `PersonalKnowledgeAgentService` 골격 (DI 기반, mock 가능)
+- mock dependency로 한 턴 실행을 검증하는 단위 테스트
+
+### 제외
+- 실제 LLM provider 연결 (#233, #238)
+- 실제 context 검색 (#232)
+- 실제 `remember` 저장 (#235)
+- CLI 명령 (#236)
+
+---
+
+## 3. 파일 구조
+
+```
+packages/memento-core/src/domains/personal-agent/
+├── types/
+│   └── agent-types.ts
+├── ports/
+│   ├── llm-port.ts
+│   ├── context-port.ts
+│   └── persistence-port.ts
+├── services/
+│   ├── personal-knowledge-agent-service.ts
+│   └── personal-knowledge-agent-service.spec.ts
+└── index.ts
+```
+
+기존 `consolidation` 도메인(`services/` 서브디렉터리 + 코로케이트 스펙 + `index.ts`)과 동일한 패턴.
+
+---
+
+## 4. 타입 정의
+
+**`types/agent-types.ts`**
+
+```typescript
+export interface KnowledgeCandidate {
+  content: string;
+  type: 'episodic' | 'semantic' | 'procedural';
+  importance: number;       // 0.0 ~ 1.0, 기존 메모리 시스템 스케일 준수
+  tags: string[];
+  sourceContext?: string;
+}
+
+export interface PersonalKnowledgeAgentInput {
+  userMessage: string;
+  sessionId?: string;
+  projectId?: string;
+}
+
+export interface PersonalKnowledgeAgentResult {
+  candidates: KnowledgeCandidate[];
+  llmResponse: string;
+  persisted: boolean;
+}
+```
+
+- `KnowledgeCandidate.type`은 기존 `MemoryType` 열거형과 동일 값 사용
+- `sessionId`·`projectId`는 옵셔널 — #231 범위에서 mock이 무시해도 무방
+
+---
+
+## 5. 포트 인터페이스
+
+**`ports/llm-port.ts`**
+```typescript
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ILLMPort {
+  complete(messages: LLMMessage[]): Promise<string>;
+}
+```
+
+**`ports/context-port.ts`**
+```typescript
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IContextPort {
+  buildContext(userMessage: string, projectId?: string): Promise<string>;
+  proposeCandidates(candidates: KnowledgeCandidate[]): Promise<void>;
+}
+```
+
+**`ports/persistence-port.ts`**
+```typescript
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IPersistencePort {
+  persist(candidates: KnowledgeCandidate[]): Promise<void>;
+}
+```
+
+- `ILLMPort`는 아카이브(`memento-agent-issue-100`)의 `LLMProvider` 패턴 단순화
+- `IContextPort`가 context 빌드와 후보 제안을 담당 — #232가 구현할 경계
+- `IPersistencePort` 분리 — #235에서 실제 `remember` 연결 시 교체
+
+---
+
+## 6. 서비스 골격
+
+**`services/personal-knowledge-agent-service.ts`**
+```typescript
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { IContextPort } from '../ports/context-port.js';
+import type { IPersistencePort } from '../ports/persistence-port.js';
+import type {
+  KnowledgeCandidate,
+  PersonalKnowledgeAgentInput,
+  PersonalKnowledgeAgentResult,
+} from '../types/agent-types.js';
+
+export interface PersonalKnowledgeAgentDeps {
+  llm: ILLMPort;
+  context: IContextPort;
+  persistence: IPersistencePort;
+}
+
+export class PersonalKnowledgeAgentService {
+  constructor(private readonly deps: PersonalKnowledgeAgentDeps) {}
+
+  async runOneTurn(input: PersonalKnowledgeAgentInput): Promise<PersonalKnowledgeAgentResult> {
+    const contextText = await this.deps.context.buildContext(
+      input.userMessage,
+      input.projectId,
+    );
+
+    const llmResponse = await this.deps.llm.complete([
+      { role: 'system', content: contextText },
+      { role: 'user', content: input.userMessage },
+    ]);
+
+    // #234에서 실제 후보 추출 구현
+    const candidates: KnowledgeCandidate[] = [];
+    await this.deps.context.proposeCandidates(candidates);
+
+    // #235에서 승인 흐름 구현
+    await this.deps.persistence.persist(candidates);
+
+    return { candidates, llmResponse, persisted: true };
+  }
+}
+```
+
+- `PersonalKnowledgeAgentDeps` 패턴은 `SleepConsolidationServiceDeps`와 동일
+- `candidates = []` stub — #234 전에도 타입 계약 성립
+
+---
+
+## 7. 테스트
+
+**`services/personal-knowledge-agent-service.spec.ts`**
+
+| 케이스 | 검증 내용 |
+|---|---|
+| mock DI로 한 턴 실행 | `llmResponse`, `persisted`, `buildContext` 호출 확인 |
+| `projectId` 없는 입력 | `buildContext(msg, undefined)` 정상 처리 |
+| LLM 실패 | 포트 reject 시 `runOneTurn` propagate |
+
+---
+
+## 8. 의존 방향
+
+```
+personal-agent (domain)
+  └── depends on → shared types 만
+  └── does NOT import → memory / recall / remember 구현체
+```
+
+기존 `remember`·`recall`·`memory_injection` 동작 무변경.
+
+---
+
+## 9. 완료 기준
+
+- `npm run type-check` 통과
+- `personal-knowledge-agent-service.spec.ts` 전체 통과
+- 기존 core 단위 테스트 회귀 없음
+
+---
+
+## 10. 후속 이슈 연결
+
+| 이슈 | 교체/확장 대상 |
+|---|---|
+| #232 | `IContextPort` 실제 구현 (recall 기반) |
+| #233 | `ILLMPort` mock provider 추가 |
+| #234 | `candidates` stub → 실제 추출 |
+| #235 | `IPersistencePort` 실제 구현 |
+| #236 | CLI 명령 추가 |
+| #237 | E2E 시나리오 |
+| #238 | 실제 LLM provider adapter |

--- a/docs/superpowers/specs/2026-05-10-issue-349-hybrid-search-engine-2nd-refactor-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-349-hybrid-search-engine-2nd-refactor-design.md
@@ -1,0 +1,35 @@
+# Issue 349: hybrid-search-engine.ts 2차 복잡도 감소 (실행층)
+
+> 상위: [#348](https://github.com/jee1/memento/issues/348), [#315](https://github.com/jee1/memento/issues/315)  
+> 이슈: [#349](https://github.com/jee1/memento/issues/349)
+
+## 배경
+
+`slop-detector` 재스캔 기준 `hybrid-search-engine.ts`가 여전히 프로덕션 Critical 후보다. [#172](https://github.com/jee1/memento/issues/172) 1차에서 factory·`buildRankingContext` 등 정리가 있었으나, 엔진 파일은 대형 메서드가 남아 있다.
+
+## 목적
+
+`HybridSearchEngine`의 **벡터·멀티 프로바이더 실행 경로** 복잡도를 낮춘다. **검색 동작·랭킹·공개 API는 변경하지 않는다.**
+
+## 1차 범위 (승인된 추천: A)
+
+- 단일 프로바이더 검색 본문(`runProviderSearchTaskBody`에 해당)과 **프로바이더별 타임아웃이 있는 태스크 생성**(`createProviderSearchTask`에 해당)을 `hybrid-search-provider-parallel.ts`로 이동한다.
+- 엔진은 `ProviderVectorSearchDeps`(콜백)로 `generateQueryVector`, `vectorSearchEngine.search`, 로깅을 주입한다. `SearchError` 등 도메인 예외는 기존처럼 `generateQueryVector` 경로에 남긴다(순환 import 방지).
+
+## 비범위 (이슈와 동일)
+
+- 랭킹 공식·가중치 변경
+- `recall` / batch scheduler / relation extractor 정리
+- search subsystem 전면 재설계
+- **2차 이후(별 PR)**: 랭킹·정규화 파이프라인(`normalizeAndDeduplicateResults` 체인) 분리 검토
+
+## 완료 기준
+
+- `hybrid-search-engine.ts` 라인 수·해당 메서드 복잡도 감소
+- `npm run type-check`, 관련 Vitest 통과
+- PR 또는 이슈 코멘트에 `slop-detector` 재스캔 결과 요약(가능 시)
+
+## 검증
+
+- `packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts`
+- `hybrid-search-engine-consolidation.spec.ts` (회귀)

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -22,8 +22,9 @@ import {
 import { RelationGraph } from '../../relation/services/relation-graph.js';
 import { normalizeSearchBySimilarityOutcome } from './hybrid-search-outcome-utils.js';
 import {
+  createProviderVectorSearchTask,
   executeProviderSearchesWithOverallTimeout,
-  type ProviderVectorRaceResult,
+  type ProviderVectorSearchDeps,
 } from './hybrid-search-provider-parallel.js';
 import { ProceduralMemoryMatcher } from './procedural-memory-matcher.js';
 import { computeProcessAttributeFit } from './process-attribute-fit.js';
@@ -627,9 +628,10 @@ export class HybridSearchEngine {
         includeContent: true
       };
       
+      const providerVectorDeps = this.getProviderVectorSearchDeps();
       // 각 provider에 대해 독립적인 검색 작업을 생성하여 병렬 실행을 준비합니다.
-      const searchPromises = providersToSearch.map(provider => 
-        this.createProviderSearchTask(provider, query.query, searchOptions, searchId)
+      const searchPromises = providersToSearch.map(provider =>
+        createProviderVectorSearchTask(providerVectorDeps, provider, query.query, searchOptions, searchId)
       );
       
       // 모든 provider 검색을 실행하고 타임아웃을 관리하여 안정적인 결과 수집을 보장합니다.
@@ -718,112 +720,12 @@ export class HybridSearchEngine {
     return providersToSearch;
   }
 
-  private async runProviderSearchTaskBody(
-    provider: EmbeddingProvider,
-    query: string,
-    searchOptions: { limit: number; threshold: number; types?: MemoryType[]; includeContent: boolean },
-    searchId: string,
-    providerStartTime: bigint,
-    timeoutMeta: { queryEmbeddingProvider?: EmbeddingProvider; tfidfQueryEmbeddingFallback?: boolean }
-  ): Promise<ProviderVectorRaceResult> {
-    try {
-      const { embedding, actualProvider } = await this.generateQueryVector(query, searchId, provider);
-      timeoutMeta.queryEmbeddingProvider = actualProvider;
-      timeoutMeta.tfidfQueryEmbeddingFallback = actualProvider === 'tfidf' && provider !== 'tfidf';
-      if (actualProvider !== provider) {
-        this.logger.logSearchStep(searchId, `VEC 검색 스킵 (provider 불일치: 요청=${provider}, 실제=${actualProvider})`, {
-          provider,
-          actualProvider
-        });
-        const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
-        return {
-          provider,
-          results: [] as Array<VectorSearchResult & { provider: string }>,
-          success: true,
-          timeMs: providerTime,
-          error: null as string | null,
-          queryEmbeddingProvider: actualProvider,
-          tfidfQueryEmbeddingFallback: timeoutMeta.tfidfQueryEmbeddingFallback
-        };
-      }
-      const vecResults = await this.vectorSearchEngine.search(embedding, searchOptions, provider);
-      const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
-      return {
-        provider,
-        results: vecResults.map(result => ({
-          id: result.memory_id,
-          content: result.content,
-          type: result.type,
-          importance: result.importance,
-          created_at: result.created_at,
-          pinned: false,
-          score: result.similarity,
-          similarity: result.similarity,
-          provider
-        })),
-        success: true,
-        timeMs: providerTime,
-        error: null as string | null,
-        queryEmbeddingProvider: actualProvider,
-        tfidfQueryEmbeddingFallback: false
-      };
-    } catch (error) {
-      const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.logSearchStep(searchId, `VEC 벡터 검색 실패 - ${provider}`, {
-        provider,
-        error: errorMessage,
-        timeMs: providerTime
-      });
-      return {
-        provider,
-        results: [] as Array<VectorSearchResult & { provider: string }>,
-        success: false,
-        timeMs: providerTime,
-        error: errorMessage
-      };
-    }
-  }
-
-  /**
-   * 단일 provider 검색 작업 생성 (타임아웃 포함)
-   */
-  private createProviderSearchTask(
-    provider: EmbeddingProvider,
-    query: string,
-    searchOptions: { limit: number; threshold: number; types?: MemoryType[]; includeContent: boolean },
-    searchId: string
-  ): Promise<ProviderVectorRaceResult> {
-    const providerStartTime = process.hrtime.bigint();
-    const timeoutMeta: {
-      queryEmbeddingProvider?: EmbeddingProvider;
-      tfidfQueryEmbeddingFallback?: boolean;
-    } = {};
-
-    const timeoutPromise = new Promise<ProviderVectorRaceResult>(resolve => {
-      setTimeout(() => {
-        const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
-        resolve({
-          provider,
-          results: [] as Array<VectorSearchResult & { provider: string }>,
-          success: false,
-          timeMs: providerTime,
-          error: `Provider 검색 타임아웃 (${HYBRID_SEARCH.PROVIDER_SEARCH_TIMEOUT_MS}ms 초과)`,
-          queryEmbeddingProvider: timeoutMeta.queryEmbeddingProvider,
-          tfidfQueryEmbeddingFallback: timeoutMeta.tfidfQueryEmbeddingFallback
-        });
-      }, HYBRID_SEARCH.PROVIDER_SEARCH_TIMEOUT_MS);
-    });
-
-    const searchTask = this.runProviderSearchTaskBody(
-      provider,
-      query,
-      searchOptions,
-      searchId,
-      providerStartTime,
-      timeoutMeta
-    );
-    return Promise.race([searchTask, timeoutPromise]);
+  private getProviderVectorSearchDeps(): ProviderVectorSearchDeps {
+    return {
+      generateQueryVector: (q, searchId, preferred) => this.generateQueryVector(q, searchId, preferred),
+      vectorSearch: (vector, options, provider) => this.vectorSearchEngine.search(vector, options, provider),
+      logSearchStep: (searchId, step, data) => this.logger.logSearchStep(searchId, step, data)
+    };
   }
 
   /**

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts
@@ -1,10 +1,10 @@
 /**
- * Multi-provider VEC search: overall timeout, Promise.allSettled aggregation, diagnostics.
- * Extracted from HybridSearchEngine to reduce method size (Issue 315).
+ * Multi-provider VEC search: per-provider tasks, overall timeout, Promise.allSettled aggregation, diagnostics.
+ * Extracted from HybridSearchEngine (Issues #315, #349).
  */
 
 import { HYBRID_SEARCH } from '../../../shared/config/constants.js';
-import type { EmbeddingProvider } from '../../../shared/types/index.js';
+import type { EmbeddingProvider, MemoryType } from '../../../shared/types/index.js';
 import type { VectorSearchResult } from '../../memory/services/memory-embedding-service.js';
 
 export type VectorResultWithProvider = VectorSearchResult & { provider: string };
@@ -36,6 +36,145 @@ export type ProviderSearchExecutionSummary = {
 };
 
 export type SearchStepLogger = (searchId: string, step: string, data: unknown) => void;
+
+export type ProviderVectorSearchOptions = {
+  limit: number;
+  threshold: number;
+  types?: MemoryType[];
+  includeContent: boolean;
+};
+
+type VectorSearchRow = {
+  memory_id: string;
+  content: string;
+  type: string;
+  importance: number;
+  created_at: string;
+  similarity: number;
+};
+
+/** Injected from HybridSearchEngine so this module stays free of SearchError / engine imports. */
+export type ProviderVectorSearchDeps = {
+  generateQueryVector: (
+    query: string,
+    searchId: string,
+    preferredProvider: EmbeddingProvider
+  ) => Promise<{ embedding: number[]; actualProvider: EmbeddingProvider }>;
+  vectorSearch: (
+    vector: number[],
+    options: ProviderVectorSearchOptions,
+    provider?: string
+  ) => Promise<VectorSearchRow[]>;
+  logSearchStep: SearchStepLogger;
+};
+
+export async function runSingleProviderVectorSearch(
+  deps: ProviderVectorSearchDeps,
+  provider: EmbeddingProvider,
+  query: string,
+  searchOptions: ProviderVectorSearchOptions,
+  searchId: string,
+  providerStartTime: bigint,
+  timeoutMeta: { queryEmbeddingProvider?: EmbeddingProvider; tfidfQueryEmbeddingFallback?: boolean }
+): Promise<ProviderVectorRaceResult> {
+  try {
+    const { embedding, actualProvider } = await deps.generateQueryVector(query, searchId, provider);
+    timeoutMeta.queryEmbeddingProvider = actualProvider;
+    timeoutMeta.tfidfQueryEmbeddingFallback = actualProvider === 'tfidf' && provider !== 'tfidf';
+    if (actualProvider !== provider) {
+      deps.logSearchStep(searchId, `VEC 검색 스킵 (provider 불일치: 요청=${provider}, 실제=${actualProvider})`, {
+        provider,
+        actualProvider
+      });
+      const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
+      return {
+        provider,
+        results: [] as VectorResultWithProvider[],
+        success: true,
+        timeMs: providerTime,
+        error: null,
+        queryEmbeddingProvider: actualProvider,
+        tfidfQueryEmbeddingFallback: timeoutMeta.tfidfQueryEmbeddingFallback
+      };
+    }
+    const vecResults = await deps.vectorSearch(embedding, searchOptions, provider);
+    const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
+    return {
+      provider,
+      results: vecResults.map(result => ({
+        id: result.memory_id,
+        content: result.content,
+        type: result.type,
+        importance: result.importance,
+        created_at: result.created_at,
+        pinned: false,
+        score: result.similarity,
+        similarity: result.similarity,
+        provider
+      })),
+      success: true,
+      timeMs: providerTime,
+      error: null,
+      queryEmbeddingProvider: actualProvider,
+      tfidfQueryEmbeddingFallback: false
+    };
+  } catch (error) {
+    const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    deps.logSearchStep(searchId, `VEC 벡터 검색 실패 - ${provider}`, {
+      provider,
+      error: errorMessage,
+      timeMs: providerTime
+    });
+    return {
+      provider,
+      results: [] as VectorResultWithProvider[],
+      success: false,
+      timeMs: providerTime,
+      error: errorMessage
+    };
+  }
+}
+
+export function createProviderVectorSearchTask(
+  deps: ProviderVectorSearchDeps,
+  provider: EmbeddingProvider,
+  query: string,
+  searchOptions: ProviderVectorSearchOptions,
+  searchId: string
+): Promise<ProviderVectorRaceResult> {
+  const providerStartTime = process.hrtime.bigint();
+  const timeoutMeta: {
+    queryEmbeddingProvider?: EmbeddingProvider;
+    tfidfQueryEmbeddingFallback?: boolean;
+  } = {};
+
+  const timeoutPromise = new Promise<ProviderVectorRaceResult>(resolve => {
+    setTimeout(() => {
+      const providerTime = Number(process.hrtime.bigint() - providerStartTime) / 1_000_000;
+      resolve({
+        provider,
+        results: [] as VectorResultWithProvider[],
+        success: false,
+        timeMs: providerTime,
+        error: `Provider 검색 타임아웃 (${HYBRID_SEARCH.PROVIDER_SEARCH_TIMEOUT_MS}ms 초과)`,
+        queryEmbeddingProvider: timeoutMeta.queryEmbeddingProvider,
+        tfidfQueryEmbeddingFallback: timeoutMeta.tfidfQueryEmbeddingFallback
+      });
+    }, HYBRID_SEARCH.PROVIDER_SEARCH_TIMEOUT_MS);
+  });
+
+  const searchTask = runSingleProviderVectorSearch(
+    deps,
+    provider,
+    query,
+    searchOptions,
+    searchId,
+    providerStartTime,
+    timeoutMeta
+  );
+  return Promise.race([searchTask, timeoutPromise]);
+}
 
 export async function executeProviderSearchesWithOverallTimeout(
   searchPromises: Promise<ProviderVectorRaceResult>[],


### PR DESCRIPTION
## Summary
Moves single-provider vector search body and per-provider timeout task creation from `HybridSearchEngine` into `hybrid-search-provider-parallel.ts`, using `ProviderVectorSearchDeps` injection. Public search behavior, ranking, and APIs are unchanged.

Relates to https://github.com/jee1/memento/issues/349 (parent: #348, #315).

## Changes
- New exports: `ProviderVectorSearchDeps`, `ProviderVectorSearchOptions`, `runSingleProviderVectorSearch`, `createProviderVectorSearchTask`
- Engine: `getProviderVectorSearchDeps()` + delegation; removed private `runProviderSearchTaskBody` / `createProviderSearchTask`
- `hybrid-search-engine.ts`: ~1691 → ~1593 lines

## Design / plan
- `docs/superpowers/specs/2026-05-10-issue-349-hybrid-search-engine-2nd-refactor-design.md`
- `docs/superpowers/plans/2026-05-10-issue-349-hybrid-search-execution-refactor.md`

## Verification
- `npm run type-check`
- `npx vitest run packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts`
- `npm run lint` (warnings only, no new errors)

## Slop-detector
Re-scan with `slop-detector --project packages --js --config .slopconfig.yaml --no-color`: `hybrid-search-engine.ts` reported as **SUSPICIOUS** (no longer listed under CRITICAL_DEFICIT for that path in the filtered output).

---

### 지식 복리 (Compound)
- N/A for this change set (straight refactor with existing tests).

Made with [Cursor](https://cursor.com)