### PR TITLE
feat(personal-agent): PersonalKnowledgeAgentService 계약 추가 (#231)

### DIFF
--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -1,0 +1,14 @@
+export type {
+  KnowledgeCandidate,
+  PersonalKnowledgeAgentInput,
+  PersonalKnowledgeAgentResult,
+} from './types/agent-types.js';
+
+export type { LLMMessage, ILLMPort } from './ports/llm-port.js';
+export type { IContextPort } from './ports/context-port.js';
+export type { IPersistencePort } from './ports/persistence-port.js';
+
+export {
+  PersonalKnowledgeAgentService,
+} from './services/personal-knowledge-agent-service.js';
+export type { PersonalKnowledgeAgentDeps } from './services/personal-knowledge-agent-service.js';

--- a/packages/memento-core/src/domains/personal-agent/ports/context-port.ts
+++ b/packages/memento-core/src/domains/personal-agent/ports/context-port.ts
@@ -1,0 +1,6 @@
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IContextPort {
+  buildContext(userMessage: string, projectId?: string): Promise<string>;
+  proposeCandidates(candidates: KnowledgeCandidate[]): Promise<void>;
+}

--- a/packages/memento-core/src/domains/personal-agent/ports/llm-port.ts
+++ b/packages/memento-core/src/domains/personal-agent/ports/llm-port.ts
@@ -1,0 +1,8 @@
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ILLMPort {
+  complete(messages: LLMMessage[]): Promise<string>;
+}

--- a/packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts
+++ b/packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts
@@ -1,0 +1,5 @@
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+export interface IPersistencePort {
+  persist(candidates: KnowledgeCandidate[]): Promise<void>;
+}

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PersonalKnowledgeAgentService } from './personal-knowledge-agent-service.js';
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { IContextPort } from '../ports/context-port.js';
+import type { IPersistencePort } from '../ports/persistence-port.js';
+
+describe('PersonalKnowledgeAgentService', () => {
+  function makeDeps() {
+    const completeFn = vi.fn().mockResolvedValue('LLM 응답');
+    const buildContextFn = vi.fn().mockResolvedValue('컨텍스트 텍스트');
+    const proposeCandidatesFn = vi.fn().mockResolvedValue(undefined);
+    const persistFn = vi.fn().mockResolvedValue(undefined);
+
+    const llm = { complete: completeFn } as unknown as ILLMPort;
+    const context = { buildContext: buildContextFn, proposeCandidates: proposeCandidatesFn } as unknown as IContextPort;
+    const persistence = { persist: persistFn } as unknown as IPersistencePort;
+
+    return { llm, context, persistence, completeFn, buildContextFn, proposeCandidatesFn, persistFn };
+  }
+
+  it('mock dependency로 한 턴을 실행하고 llmResponse를 반환한다', async () => {
+    const { llm, context, persistence } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    const result = await svc.runOneTurn({ userMessage: '테스트 입력' });
+
+    expect(result.llmResponse).toBe('LLM 응답');
+    expect(result.persisted).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('buildContext를 userMessage와 projectId로 호출한다', async () => {
+    const { llm, context, persistence, buildContextFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '입력', projectId: 'proj-1' });
+
+    expect(buildContextFn).toHaveBeenCalledWith('입력', 'proj-1');
+  });
+
+  it('projectId 없을 때 buildContext를 undefined로 호출한다', async () => {
+    const { llm, context, persistence, buildContextFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '입력' });
+
+    expect(buildContextFn).toHaveBeenCalledWith('입력', undefined);
+  });
+
+  it('llm.complete를 system+user 메시지로 호출한다', async () => {
+    const { llm, context, persistence, completeFn } = makeDeps();
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await svc.runOneTurn({ userMessage: '질문' });
+
+    expect(completeFn).toHaveBeenCalledWith([
+      { role: 'system', content: '컨텍스트 텍스트' },
+      { role: 'user', content: '질문' },
+    ]);
+  });
+
+  it('LLM 포트가 reject하면 에러를 그대로 전파한다', async () => {
+    const { llm, context, persistence, completeFn } = makeDeps();
+    completeFn.mockRejectedValueOnce(new Error('LLM 오류'));
+    const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+    await expect(svc.runOneTurn({ userMessage: '입력' })).rejects.toThrow('LLM 오류');
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
@@ -25,7 +25,7 @@ describe('PersonalKnowledgeAgentService', () => {
     const result = await svc.runOneTurn({ userMessage: '테스트 입력' });
 
     expect(result.llmResponse).toBe('LLM 응답');
-    expect(result.persisted).toBe(true);
+    expect(result.persisted).toBe(false);
     expect(result.candidates).toEqual([]);
   });
 

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
@@ -1,0 +1,39 @@
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { IContextPort } from '../ports/context-port.js';
+import type { IPersistencePort } from '../ports/persistence-port.js';
+import type {
+  KnowledgeCandidate,
+  PersonalKnowledgeAgentInput,
+  PersonalKnowledgeAgentResult,
+} from '../types/agent-types.js';
+
+export interface PersonalKnowledgeAgentDeps {
+  llm: ILLMPort;
+  context: IContextPort;
+  persistence: IPersistencePort;
+}
+
+export class PersonalKnowledgeAgentService {
+  constructor(private readonly deps: PersonalKnowledgeAgentDeps) {}
+
+  async runOneTurn(input: PersonalKnowledgeAgentInput): Promise<PersonalKnowledgeAgentResult> {
+    const contextText = await this.deps.context.buildContext(
+      input.userMessage,
+      input.projectId,
+    );
+
+    const llmResponse = await this.deps.llm.complete([
+      { role: 'system', content: contextText },
+      { role: 'user', content: input.userMessage },
+    ]);
+
+    // #234에서 실제 후보 추출 구현
+    const candidates: KnowledgeCandidate[] = [];
+    await this.deps.context.proposeCandidates(candidates);
+
+    // #235에서 승인 흐름 구현
+    await this.deps.persistence.persist(candidates);
+
+    return { candidates, llmResponse, persisted: true };
+  }
+}

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
@@ -34,6 +34,6 @@ export class PersonalKnowledgeAgentService {
     // #235에서 승인 흐름 구현
     await this.deps.persistence.persist(candidates);
 
-    return { candidates, llmResponse, persisted: true };
+    return { candidates, llmResponse, persisted: false };
   }
 }

--- a/packages/memento-core/src/domains/personal-agent/types/agent-types.ts
+++ b/packages/memento-core/src/domains/personal-agent/types/agent-types.ts
@@ -1,0 +1,19 @@
+export interface KnowledgeCandidate {
+  content: string;
+  type: 'episodic' | 'semantic' | 'procedural';
+  importance: number;
+  tags: string[];
+  sourceContext?: string;
+}
+
+export interface PersonalKnowledgeAgentInput {
+  userMessage: string;
+  sessionId?: string;
+  projectId?: string;
+}
+
+export interface PersonalKnowledgeAgentResult {
+  candidates: KnowledgeCandidate[];
+  llmResponse: string;
+  persisted: boolean;
+}


### PR DESCRIPTION
## Summary

- `domains/personal-agent/` 신규 도메인 추가 (`memento-core` 내부)
- `PersonalKnowledgeAgentInput` / `PersonalKnowledgeAgentResult` / `KnowledgeCandidate` 타입 정의
- `ILLMPort` / `IContextPort` / `IPersistencePort` 포트 인터페이스 정의 (실제 구현은 #232~#238)
- `PersonalKnowledgeAgentService` 골격 — DI 기반, mock 가능, `runOneTurn()` 메서드
- mock dependency 단위 테스트 5종 추가

## Test Plan

- [x] `vitest --run packages/memento-core/src/domains/personal-agent/` — 5/5 통과
- [x] `npm run type-check -w @memento/core` — 오류 없음
- [x] `npm run test:ci:core` — 3785 passed (회귀 없음)
- [x] `git diff main..HEAD -- packages/memento-core/src/domains/memory/` — 기존 코드 변경 없음

## 지식 복리

해당 사항 없음 (신규 도메인 추가, 재현 어려운 버그나 함정 없음)

Closes #231
Parent: #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)