### PR TITLE
docs: 루트 SSOT 경로를 모노레포에 맞춤 (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Documentation
+- 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
+- [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).
+
 ### Fixed
 - **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).
 - 잘못 추적되던 `.claude/worktrees/*` gitlink 제거: `actions/checkout` Post 단계의 `git submodule foreach`가 exit 128로 경고 나던 문제 방지
@@ -346,6 +350,8 @@
 - **M4**: Kubernetes, Helm Charts
 
 ### 프로젝트 구조
+
+> **역사적 스냅샷**: 아래 트리는 **[1.0.0] (2025-09-22)** 시점 단일 패키지 레이아웃이다. **현재** 저장소는 npm workspaces(`packages/memento-core`, `packages/memento-server`, `packages/memento-client`, `apps/*`) 구조이며, 최신 경로는 [AGENTS.md](AGENTS.md)를 따른다.
 
 ```
 memento/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ docs(readme): 설치 가이드 업데이트
 ### 테스트
 - **테스트 프레임워크**: Vitest
 - **단위 테스트**: `*.spec.ts` 파일로 작성
-- **E2E 테스트**: `src/test/` 디렉토리에 작성
+- **통합·시나리오 테스트**: 루트 `tests/` 및 필요 시 `packages/memento-core/src/test/`, `packages/memento-server/src/test/` 등에 두고, 단위 스펙은 각 패키지 `src/` 아래 `*.spec.ts`로 작성
 - **테스트 실행**: `npm run test`
 
 ### 브랜치 전략
@@ -106,7 +106,7 @@ docs(readme): 설치 가이드 업데이트
 
 ## 📁 프로젝트 구조
 
-npm workspaces 모노레포입니다. 도메인·DB·MCP 도구 구현은 **`packages/memento-core`**에, MCP/HTTP 서버는 **`packages/memento-server`**에 있습니다. 루트 `src/`·`tests/`에는 공유 스크립트·시나리오 테스트 등이 있습니다.
+npm workspaces 모노레포입니다. 도메인·DB·MCP 도구 구현은 **`packages/memento-core`**에, MCP/HTTP 서버는 **`packages/memento-server`**에 있습니다. 루트 **`tests/`**에는 워크스페이스·통합 수준 Vitest 스위트가 있고, 빌드·검증·운영 보조 스크립트는 주로 **`scripts/`**에 있습니다.
 
 ```
 packages/
@@ -115,8 +115,8 @@ packages/
 └── memento-client/   # @memento/client — 서버 연결 클라이언트
 apps/
 └── experimental-example/   # in-process 사용 예시
-src/                  # 루트 스크립트·일부 테스트·에셋 복사 등
-tests/                # 통합 픽스처·통합 테스트
+scripts/              # 빌드·검증·운영 보조 스크립트
+tests/                # 루트 워크스페이스 통합·품질 게이트 스펙 등
 ```
 
 자세한 디렉터리 역할은 [AGENTS.md](AGENTS.md)를 참고하세요.

--- a/README.en.md
+++ b/README.en.md
@@ -298,10 +298,10 @@ npm run test -- --coverage
 ## 📚 Developer Guidelines
 
 ### Repository Guidelines (`AGENTS.md`)
-- **Project Structure**: Module organization under `src/`
+- **Project Structure**: npm workspaces — code lives under `packages/memento-core`, `packages/memento-server`, `packages/memento-client`, plus `apps/` and root-level `tests/`. See [AGENTS.md](AGENTS.md).
 - **Build/Test Commands**: `npm run dev`, `npm run build`, `npm run test`, etc.
 - **Coding Style**: Node.js ≥ 24, TypeScript ES modules, 2-space indentation
-- **Testing Guidelines**: Vitest based, `src/test/` or `*.spec.ts` files
+- **Testing Guidelines**: Vitest; colocate `*.spec.ts` under each package `src/`, workspace-level specs under root `tests/`, and scenario drivers under `packages/*/src/test/` where applicable.
 - **Commit/PR Guidelines**: Conventional Commits, Korean context included
 - **Environment/Database**: `.env` configuration, `data/` folder management
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ npm run test -- --coverage
 - **프로젝트 구조**: npm workspaces 모노레포 — `packages/memento-core`, `packages/memento-server`, `packages/memento-client`, `apps/*`. 서버 코드는 `packages/memento-server`, 도메인·인프라는 `packages/memento-core`.
 - **빌드/테스트 명령어**: `npm run build`(core→server→client), `npm run dev`·`npm start`(서버), `npm run db:init`·`npm run db:migrate`(DB), `npm test` 등. 상세는 [AGENTS.md](AGENTS.md) 참조.
 - **코딩 스타일**: Node.js ≥ 24, TypeScript ES 모듈, 2칸 들여쓰기
-- **테스트 가이드라인**: Vitest 기반, 각 패키지 `src/` 내 `*.spec.ts` 또는 루트 `src/test/`
+- **테스트 가이드라인**: Vitest 기반. 단위·스펙은 주로 `packages/memento-core/src/**`, `packages/memento-server/src/**` 등 패키지 트리의 `*.spec.ts`에 두고, 루트 `tests/`에는 워크스페이스 수준 통합 스펙이 있다.
 - **커밋/PR 가이드라인**: Conventional Commits, 한국어 컨텍스트 포함
 - **환경/데이터베이스**: `.env` 설정, `data/` 폴더 관리
 


### PR DESCRIPTION
## 요약
- `README.md` / `README.en.md`: 프로젝트 구조·테스트 가이드 문구를 `packages/*` 및 루트 `tests/` 기준으로 정리했습니다.
- `CONTRIBUTING.md`: 존재하지 않는 루트 `src/` 트리 설명을 제거하고, `scripts/`·`tests/`·패키지별 `src/test/` 안내로 맞췄습니다.
- `CHANGELOG.md`: `[Unreleased]`에 문서 변경을 기록하고, `[1.0.0]`의 디렉터리 트리가 역사적 스냅샷임을 명시했습니다.

## 검증
- `npm run docs:audit-links`
- `npm run lint` (경고만, 오류 0)
- `npm test` (337 files, 4260 passed, 1 skipped)

Closes #359

Made with [Cursor](https://cursor.com)