### PR TITLE
docs(ko): user-manual Compose·HTTP 포트 정리 (#362 PR2/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
 - [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).
 - 패키지·앱 README 9경로: 루트 스크립트·실제 디렉터리 트리·내부 링크 정합성 정리 (#361).
+- `docs/guides/ko/user-manual.md`: Docker Compose 파일명·기본 HTTP 포트(9001) 안내를 현재 스택에 맞게 조정 (#362).
 
 ### Fixed
 - **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).

--- a/docs/guides/ko/user-manual.md
+++ b/docs/guides/ko/user-manual.md
@@ -41,10 +41,10 @@ npm run dev
 
 ```bash
 # Docker Compose로 실행
-docker-compose -f docker-compose.team.yml up -d
+docker-compose up -d
 
 # 서버 상태 확인
-curl http://localhost:8080/health
+curl http://localhost:9001/health
 ```
 
 ### MCP 클라이언트 설정
@@ -90,13 +90,13 @@ AI Agent와의 대화에서 중요한 정보를 기억으로 저장할 수 있�
 
 #### `@memento/client` HTTP 클라이언트 예시
 
-HTTP 서버가 실행 중일 때(예: `npm run dev:http`, 기본 `http://localhost:8080`) npm 패키지 **`@memento/client`** 로 호출할 수 있습니다.
+HTTP 서버가 실행 중일 때(예: `npm run dev:http`, 기본 `http://localhost:9001`(`PORT`/`MCP_SERVER_PORT` 환경 변수로 변경 가능)) npm 패키지 **`@memento/client`** 로 호출할 수 있습니다.
 
 ```typescript
 import { MementoClient } from '@memento/client';
 
 const client = new MementoClient({
-  serverUrl: 'http://localhost:8080',
+  serverUrl: 'http://localhost:9001',
 });
 
 await client.connect();
@@ -450,7 +450,7 @@ ws.on('message', (data) => {
 
 **해결 방법**:
 1. 서버가 실행 중인지 확인
-2. 포트가 올바른지 확인 (기본: 8080)
+2. 포트가 올바른지 확인 (로컬 HTTP 기본: 9001; `docker-compose.dev.yml` 예시는 8080)
 3. 방화벽 설정 확인
 
 #### 2. 검색 결과가 없음


### PR DESCRIPTION
## Summary
- `docs/guides/ko/user-manual.md`: 존재하지 않는 `docker-compose.team.yml` 대신 기본 `docker-compose up -d` 흐름으로 정리합니다.
- HTTP 예시·문제 해결 섹션의 기본 포트를 코드/compose 기본값인 **9001**에 맞추고, `PORT`/`MCP_SERVER_PORT` 및 `docker-compose.dev.yml`(8080 예시)를 주석으로 안내합니다.
- `CHANGELOG.md` `[Unreleased]` Documentation 항목에 기록합니다.

## Split
이슈 #362 **2/5** — `user-manual.md`만 변경합니다.

## Verification
- `npm run docs:verify-npm-scripts`
- `npm run docs:audit-links`
- `npm run lint`
- `npm test`

Refs: #362

Made with [Cursor](https://cursor.com)