### PR TITLE
docs(ko): embedding 가이드 import 경로 정리 (#362 PR3/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
 - [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).
 - 패키지·앱 README 9경로: 루트 스크립트·실제 디렉터리 트리·내부 링크 정합성 정리 (#361).
+- `docs/guides/ko/embedding-service-guide.md`: 예제 import 경로를 `packages/memento-core/src/domains/embedding/services/`로 정리하고, 상대 경로 가정(cwd)을 명시 (#362).
 
 ### Fixed
 - **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).

--- a/docs/guides/ko/embedding-service-guide.md
+++ b/docs/guides/ko/embedding-service-guide.md
@@ -16,11 +16,13 @@ Memento 프로젝트의 임베딩 서비스는 4가지 제공자를 지원하는
 4. **폴백 메커니즘**: 상위 제공자 실패 시 자동으로 다음 우선순위 제공자로 전환
 
 ## 빠른 시작
+**경로 안내**: 아래 TypeScript `import` 예시는 작업 디렉터리를 `packages/memento-core`로 두었다고 가정한 상대 경로입니다.
+
 
 ### 1. 기본 사용법
 
 ```typescript
-import { UnifiedEmbeddingService } from './src/services/unified-embedding-service.js';
+import { UnifiedEmbeddingService } from './src/domains/embedding/services/unified-embedding-service.js';
 
 const embeddingService = new UnifiedEmbeddingService();
 
@@ -75,7 +77,7 @@ EMBEDDING_DIMENSIONS=384  # MiniLM 기본값
 - 리소스 제약 환경
 
 ```typescript
-import { LightweightEmbeddingService } from './src/services/lightweight-embedding-service.js';
+import { LightweightEmbeddingService } from './src/domains/embedding/services/lightweight-embedding-service.js';
 
 const tfidfService = new LightweightEmbeddingService();
 const result = await tfidfService.generateEmbedding('빠른 처리가 필요한 텍스트');
@@ -95,7 +97,7 @@ const result = await tfidfService.generateEmbedding('빠른 처리가 필요한 
 - 성능과 정확성의 균형
 
 ```typescript
-import { MiniLMEmbeddingService } from './src/services/minilm-embedding-service.js';
+import { MiniLMEmbeddingService } from './src/domains/embedding/services/minilm-embedding-service.js';
 
 const minilmService = new MiniLMEmbeddingService();
 const result = await minilmService.generateEmbedding('의미를 이해해야 하는 텍스트');
@@ -251,7 +253,7 @@ try {
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { UnifiedEmbeddingService } from '../src/services/unified-embedding-service.js';
+import { UnifiedEmbeddingService } from './src/domains/embedding/services/unified-embedding-service.js';
 
 describe('임베딩 서비스 테스트', () => {
   it('텍스트 임베딩 생성', async () => {
@@ -269,9 +271,6 @@ describe('임베딩 서비스 테스트', () => {
 
 ```bash
 # 벤치마크 실행
-npm run test:embedding-benchmark
-
-# 특정 서비스 테스트
 npm run test:embedding-benchmark
 ```
 
@@ -302,11 +301,11 @@ A: MiniLM 모델이 메모리를 많이 사용합니다. TF-IDF를 사용하거�
 
 ```typescript
 // 기존 코드
-import { EmbeddingService } from './src/services/embedding-service.js';
+import { EmbeddingService } from './src/domains/embedding/services/embedding-service.js';
 const oldService = new EmbeddingService();
 
 // 새로운 코드
-import { UnifiedEmbeddingService } from './src/services/unified-embedding-service.js';
+import { UnifiedEmbeddingService } from './src/domains/embedding/services/unified-embedding-service.js';
 const newService = new UnifiedEmbeddingService();
 
 // API는 동일하므로 코드 변경 최소화


### PR DESCRIPTION
## Summary
- `docs/guides/ko/embedding-service-guide.md`: 레거시 `./src/services/*` 예시를 `packages/memento-core/src/domains/embedding/services/*` 기준으로 바꾸고, 상대 import를 쓸 때의 **cwd 가정**을 명시합니다.
- 벤치마크 섹션의 중복 `npm run test:embedding-benchmark` 블록을 정리합니다.
- `cursor-mcp-setup.md`, `migration-system-guide.md`는 #362 관점에서 재확인했으며(포트·모듈 경로), 추가 수정은 필요 없었습니다.
- `CHANGELOG.md` `[Unreleased]` Documentation 항목에 기록합니다.

## Split
이슈 #362 **3/5** — 본 PR의 실질 변경은 `embedding-service-guide.md`(+CHANGELOG)입니다.

## Verification
- `npm run docs:verify-npm-scripts`
- `npm run docs:audit-links`
- `npm run lint`

Refs: #362

Made with [Cursor](https://cursor.com)