### PR TITLE
docs(ko): LLM 가이드 import cwd 명시 (#362 PR4/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
 - [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).
 - 패키지·앱 README 9경로: 루트 스크립트·실제 디렉터리 트리·내부 링크 정합성 정리 (#361).
+- `docs/guides/ko/llm-provider-configuration.md`: `./src/...` 예시가 루트 `src/`로 오해되지 않도록 `packages/memento-core` cwd 가정을 명시 (#362).
 
 ### Fixed
 - **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).

--- a/docs/guides/ko/llm-provider-configuration.md
+++ b/docs/guides/ko/llm-provider-configuration.md
@@ -45,6 +45,8 @@ LLM Provider 선택은 다음 우선순위에 따라 결정됩니다:
 
 ## LLMClientInitializer 사용법
 
+**경로 안내**: 아래 TypeScript 예시의 `./src/...` import는 **`packages/memento-core` 디렉터리를 작업 cwd로 둔 경우**를 가정합니다. 저장소 루트에 존재하지 않는 `src/`와 혼동하지 마세요.
+
 ### 기본 사용법
 
 ```typescript


### PR DESCRIPTION
## Summary
- `docs/guides/ko/llm-provider-configuration.md`: `./src/...` 예시가 **저장소 루트의 `src/`**로 오해되지 않도록, `packages/memento-core`를 cwd로 둔 경우임을 명시합니다.
- `cache-synchronization-strategy.md`, `relation-labeling-guide.md`, `how-to-check-anchor-connections.md`는 이미 `packages/memento-core/...` 링크 중심이라 추가 수정이 필요 없었습니다(점검만 수행).
- `CHANGELOG.md` `[Unreleased]` Documentation 항목에 기록합니다.

## Split
이슈 #362 **4/5** — 실질 변경은 `llm-provider-configuration.md`(+CHANGELOG)입니다.

## Verification
- `npm run docs:verify-npm-scripts`
- `npm run docs:audit-links`
- `npm run lint`

Refs: #362

Made with [Cursor](https://cursor.com)