### PR TITLE
docs(ko): 레거시 마이그레이션 가이드 정리 (#362 PR5/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
 - [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).
 - 패키지·앱 README 9경로: 루트 스크립트·실제 디렉터리 트리·내부 링크 정합성 정리 (#361).
+- `docs/guides/ko/legacy-scripts-migration-guide.md`: 루트 `src/` 가정이 들어갈 수 있는 TS import 예시를 제거하고 CLI 실행 예시로 정리 (#362).
+- `docs/guides/ko` 소형 가이드 8개(`type-param-rollout`, `recall-performance-tuning`, `multi-agent-usage`, `environment-variable-governance`, `obsidian-cli-setup`, `mcp-server-instructions`, `memento-cli-for-ai`, `sdd-workflow`): #362 기준 경로·명령 점검 — 추가 수정 없음.
 
 ### Fixed
 - **[회귀] stdio MCP 서버가 1.25.0에서 시작되지 않는 버그 수정** (#302): `capabilities`에 `logging: {}` 누락 + `SetLevelRequestSchema` 핸들러 수동 등록이 결합되어 MCP SDK가 예외를 throw, `process.exit(1)`으로 프로세스가 종료되던 문제. `logging: {}` capability 추가 및 중복 핸들러 제거로 수정 (SDK가 자동 처리).

--- a/docs/guides/ko/legacy-scripts-migration-guide.md
+++ b/docs/guides/ko/legacy-scripts-migration-guide.md
@@ -54,12 +54,12 @@ npx tsx scripts/simple-update.js
 - 로깅 및 추적
 
 **사용 예제**:
-```typescript
-import { runUpdateMigration } from './scripts/simple-update-wrapper.js';
-
-// 실행 대기 중인 모든 마이그레이션 실행
-await runUpdateMigration();
+```bash
+# 저장소 루트에서 실행 (정식 마이그레이션 래퍼)
+npx tsx scripts/simple-update-wrapper.ts
 ```
+
+> **참고**: 래퍼 구현은 `packages/memento-core` 쪽 마이그레이션 러너를 호출합니다. 루트 `src/` 경로를 가정하는 예시는 사용하지 마세요.
 
 ## 마이그레이션 체크리스트
 


### PR DESCRIPTION
## Summary
- `docs/guides/ko/legacy-scripts-migration-guide.md`: 루트 `src/` 가정으로 읽힐 수 있는 TS import 예시를 제거하고, 저장소 루트에서 실행하는 `npx tsx scripts/simple-update-wrapper.ts` 흐름으로 정리합니다.
- `docs/guides/ko` 소형 가이드 8개는 #362 기준(경로·명령)으로 재점검했으며 추가 수정은 필요 없었습니다.
- `CHANGELOG.md` `[Unreleased]` Documentation 항목에 기록합니다.

## Split
이슈 #362 **5/5** — 본 PR은 `legacy-scripts-migration-guide.md`(+CHANGELOG) 중심이며, 나머지 소형 KO 가이드는 점검 로그를 CHANGELOG에 남깁니다.

## Verification
- `npm run docs:verify-npm-scripts`
- `npm run docs:audit-links`
- `npm run lint`

Refs: #362

Made with [Cursor](https://cursor.com)