### PR TITLE
docs(api): align client import with @memento/client (#364)

### DIFF
--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -216,8 +216,8 @@ interface RememberResult {
 #### Usage Example
 
 ```typescript
-// Using the actually implemented client
-import { createMementoClient } from './src/client/index.js';
+// Use the workspace package `@memento/client` (see `packages/memento-client`).
+import { createMementoClient } from '@memento/client';
 
 const client = createMementoClient();
 await client.connect();

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -221,8 +221,8 @@ interface RememberResult {
 #### 사용 예시
 
 ```typescript
-// 실제 구현된 클라이언트 사용법
-import { createMementoClient } from './src/client/index.js';
+// Use the workspace package `@memento/client` (see `packages/memento-client`).
+import { createMementoClient } from '@memento/client';
 
 const client = createMementoClient();
 await client.connect();


### PR DESCRIPTION
## Summary
- Updates KO/EN `docs/api/*/api-reference.md` usage examples to import `createMementoClient` from `@memento/client` instead of the removed `./src/client` path.

## Issue
Closes #364 (parent #357).

## Verification
- `npm run docs:audit-links`


Made with [Cursor](https://cursor.com)