### PR TITLE
docs(architecture): monorepo paths in async augmentation doc (#365)

### DIFF
--- a/docs/architecture/ko/async-augmentation-pipeline.md
+++ b/docs/architecture/ko/async-augmentation-pipeline.md
@@ -9,7 +9,7 @@
 - **remember / remember_procedure** 호출 시:
   - 메모리 항목을 DB에 **append-only**로 저장한다.
   - 응답은 **저장 직후** 반환한다. Augmentation(Triple 추출, 콘솔리데이션 등) 완료를 기다리지 않는다.
-- 구현: `src/domains/memory/tools/remember-tool.ts`, `remember-procedure-tool.ts`에서 DB write 성공 후 즉시 반환. Triple 추출 등은 `BatchScheduler.addJob()`으로 JobQueue에만 등록.
+- 구현: `packages/memento-core/src/domains/memory/tools/remember-tool.ts`, `remember-procedure-tool.ts`에서 DB write 성공 후 즉시 반환. Triple 추출 등은 `BatchScheduler.addJob()`으로 JobQueue에만 등록.
 
 ## 워커 정제
 
@@ -25,9 +25,9 @@
 | 메모리 정리(TTL 등) | `ForgettingPolicyService` | cleanup 배치 |
 
 참고 파일:
-- `src/infrastructure/scheduler/batch-scheduler.ts`
-- `src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts`
-- `src/workers/consolidation-score-worker.ts`
+- `packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts`
+- `packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts`
+- `packages/memento-core/src/workers/consolidation-score-worker.ts`
 
 ## 실패 재시도·모니터링
 


### PR DESCRIPTION
## Summary
- Updates `docs/architecture/ko/async-augmentation-pipeline.md` to use `packages/memento-core/...` paths instead of legacy root-relative `src/...` references.

## Issue
Closes #365 (parent #357).

## Verification
- `npm run docs:audit-links`


Made with [Cursor](https://cursor.com)