### PR TITLE
docs(operations): correct migration status script location (#366)

### DIFF
--- a/docs/operations/en/check-migration-status.md
+++ b/docs/operations/en/check-migration-status.md
@@ -32,8 +32,8 @@ DB_PATH=/path/to/memory.db npm run db:check-migration
 # Recommended: use the root script
 npm run db:check-migration [database-path]
 
-# Or run with tsx (root src/scripts)
-npx tsx src/scripts/check-migration-status.ts [database-path]
+# Or run with tsx from the repo root (`packages/memento-server/src/scripts`)
+npx tsx packages/memento-server/src/scripts/check-migration-status.ts [database-path]
 ```
 
 ## What is checked

--- a/docs/operations/ko/check-migration-status.md
+++ b/docs/operations/ko/check-migration-status.md
@@ -34,8 +34,8 @@ DB_PATH=/home/jee1lee/git/data/memento.db npm run db:check-migration
 # 권장: 루트에서 DB 마이그레이션 상태 점검 스크립트 실행
 npm run db:check-migration [database-path]
 
-# 또는 tsx로 직접 실행 (루트 src/scripts)
-tsx src/scripts/check-migration-status.ts [database-path]
+# 또는 tsx로 직접 실행 (저장소 루트에서 `packages/memento-server/src/scripts`)
+tsx packages/memento-server/src/scripts/check-migration-status.ts [database-path]
 ```
 
 **표시되는 정보:**

--- a/docs/operations/ko/scripts-index.md
+++ b/docs/operations/ko/scripts-index.md
@@ -9,7 +9,7 @@
 | auto-setup.js | 개발 환경 자동 설정 | `npm run setup` 또는 `npm run postinstall` |
 | verify-bin.js | 빌드 산출물·바이너리 검증 | `npm run verify-bin` |
 | check-and-fix-trigger.ts | DB 트리거 상태 확인/수정 | `npm run db:check-trigger`, `npm run db:fix-trigger` |
-| check-migration-status | 마이그레이션 상태 확인 | `npm run db:check-migration` (실제: src/scripts) |
+| check-migration-status | 마이그레이션 상태 확인 | `npm run db:check-migration` (구현: `packages/memento-server/src/scripts`) |
 | generate-relation-report.ts | 관계 엔진 리포트 생성 | `npm run generate-relation-report` |
 | weekly-relation-validation.ts | 관계 검증 (주간) | `npm run weekly-relation-validation` |
 | quality-thresholds.ts | 품질 임계값 | `npm run quality:thresholds` |


### PR DESCRIPTION
## Summary
- Updates KO/EN migration status guides and `scripts-index.md` so direct `tsx` invocations and the script inventory point at `packages/memento-server/src/scripts/check-migration-status.ts` instead of the removed `src/scripts` path.

## Issue
Closes #366 (parent #357).

## Verification
- `npm run docs:audit-links`
- `npm run docs:verify-npm-scripts`


Made with [Cursor](https://cursor.com)