### PR TITLE
docs(reference/ko): align paths and reader SSOT links (#367)

### DIFF
--- a/docs/reference/ko/Multi-Provider-Search-Performance-Testing.md
+++ b/docs/reference/ko/Multi-Provider-Search-Performance-Testing.md
@@ -17,7 +17,7 @@ npm run test:multi-provider-performance
 
 또는 직접 실행:
 ```bash
-npx tsx src/test/multi-provider-search-performance-benchmark.ts
+npx tsx packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts
 ```
 
 **측정 항목:**
@@ -66,7 +66,7 @@ npm run test:single-provider-regression
 
 또는 직접 실행:
 ```bash
-npx tsx src/test/test-single-provider-regression.ts
+npx tsx packages/memento-core/src/test/test-single-provider-regression.ts
 ```
 
 **검증 항목:**

--- a/docs/reference/ko/ci-test-timeout-guide.md
+++ b/docs/reference/ko/ci-test-timeout-guide.md
@@ -25,7 +25,7 @@ GitHub Actions에서 테스트가 오래 걸리거나 타임아웃으로 통과�
 ### 2. 사용 스크립트
 
 - `test:ci` — 로컬에서 전체 한 번에 실행할 때 (기존과 동일).
-- `test:ci:root` — `src/`, `tests/` (루트 전용).
+- `test:ci:root` — 루트 `tests/` 전용 (Vitest).
 - `test:ci:core` — `packages/memento-core/src/`.
 - `test:ci:server` — `packages/memento-server/src/`.
 - 클라이언트 — CI에서는 `npm run build` 후 `npm run test:ci -w @memento/client` 한 번만 실행.
@@ -43,7 +43,7 @@ GitHub Actions에서 테스트가 오래 걸리거나 타임아웃으로 통과�
 
 ## 현황 참고
 
-- **테스트 규모**: 루트 src/tests 약 225, memento-core 약 197, memento-server 13, memento-client 1 (총 약 436).
+- **테스트 규모**: 루트 `tests/` 약 225, memento-core 약 197, memento-server 13, memento-client 1 (총 약 436).
 - **이미 적용된 완화**: `SKIP_DB_TESTS`, `SKIP_INTEGRATION_TESTS`, `vitest.config.ts`의 CI 전용 exclude(일부 db/integration/performance 등).
 
 ---

--- a/docs/reference/ko/external-api-calls.md
+++ b/docs/reference/ko/external-api-calls.md
@@ -20,11 +20,11 @@
 
 ## 핵심 모듈 외부 API 호출 목록
 
-다음은 `src/domains/embedding/` 및 `src/domains/relation/` 디렉토리의 외부 API 호출 목록입니다.
+다음은 `packages/memento-core/src/domains/embedding/` 및 `packages/memento-core/src/domains/relation/` 디렉토리의 외부 API 호출 목록입니다.
 
 ### 우선순위 높음 (즉시 전환 권장)
 
-1. **src/domains/relation/services/llm-based-relation-extractor.ts** (우선순위: 135)
+1. **packages/memento-core/src/domains/relation/services/llm-based-relation-extractor.ts** (우선순위: 135)
    - 호출 수: 10개
    - 타입: fetch, sdk
    - 주요 호출:
@@ -34,21 +34,21 @@
      - `.completions.create()` - OpenAI API 호출
      - `.getGenerativeModel()`, `.generateContent()` - Gemini API 호출
 
-2. **src/domains/embedding/services/embedding-service.ts** (우선순위: 35)
+2. **packages/memento-core/src/domains/embedding/services/embedding-service.ts** (우선순위: 35)
    - 호출 수: 3개
    - 타입: sdk
    - 주요 호출:
      - `new OpenAI()` - OpenAI 클라이언트 초기화
      - OpenAI SDK import
 
-3. **src/domains/embedding/services/openai-embedding-service.ts** (우선순위: 35)
+3. **packages/memento-core/src/domains/embedding/services/openai-embedding-service.ts** (우선순위: 35)
    - 호출 수: 3개
    - 타입: sdk
    - 주요 호출:
      - `new OpenAI()` - OpenAI 클라이언트 초기화
      - OpenAI SDK import
 
-4. **src/domains/embedding/services/gemini-embedding-service.ts** (우선순위: 35)
+4. **packages/memento-core/src/domains/embedding/services/gemini-embedding-service.ts** (우선순위: 35)
    - 호출 수: 3개
    - 타입: sdk
    - 주요 호출:

--- a/docs/reference/ko/memento-repository-current-state-report.md
+++ b/docs/reference/ko/memento-repository-current-state-report.md
@@ -4,7 +4,8 @@
 **일자**: 2026-03-04  
 **범위**: 진입점, 패키지, 서버 vs 라이브러리 표면, 도메인 구조, 배포·MCP·HTTP 관련 문서/관례, 외부 소비자 사용 경로. **모노레포 구조 제안은 포함하지 않음.**
 
-> **적용 상태 (2026-03)**: 이 문서는 모노레포 전환 **이전** 상태를 기록한 조사 보고서입니다. 현재 저장소는 **npm workspaces 모노레포**로 전환되어 있으며, 실제 구조·진입점은 [AGENTS.md](../../../AGENTS.md) 및 [README.md](../../../README.md)를 참조하세요. (packages/memento-core, packages/memento-server, packages/memento-client, apps/*)
+> **적용 상태 (2026-03)**: 이 문서는 모노레포 전환 **이전** 상태를 기록한 조사 보고서입니다. 현재 저장소는 **npm workspaces 모노레포**로 전환되어 있으며, 실제 구조·진입점은 [AGENTS.md](../../../AGENTS.md) 및 [README.md](../../../README.md)를 참조하세요. (packages/memento-core, packages/memento-server, packages/memento-client, apps/*)  
+> **최신 가이드**: 일상 개발·경로 기준은 [개발자 가이드](../../guides/ko/developer-guide.md), [아키텍처 개요](../../architecture/ko/)를 함께 보세요.
 
 ---
 

--- a/docs/reference/ko/monorepo-migration-current-state-report.md
+++ b/docs/reference/ko/monorepo-migration-current-state-report.md
@@ -4,7 +4,8 @@
 **컨텍스트**: [docs/_work/brainstorms/2026-03-04-monorepo-memento-core-brainstorm.md](../../_work/brainstorms/2026-03-04-monorepo-memento-core-brainstorm.md) (Approach A: 3패키지 분리 선택).  
 **범위**: 구현 계획 없음. 현재 상태와 관찰된 패턴만 기술.
 
-> **적용 상태 (2026-03)**: 모노레포 전환이 **완료**되었습니다. 루트에 workspaces 정의, `packages/memento-core`, `packages/memento-server`, `packages/memento-client`, `apps/*` 구성. 실제 구조·빌드·실행은 [AGENTS.md](../../../AGENTS.md) 및 [README.md](../../../README.md) 참조.
+> **적용 상태 (2026-03)**: 모노레포 전환이 **완료**되었습니다. 루트에 workspaces 정의, `packages/memento-core`, `packages/memento-server`, `packages/memento-client`, `apps/*` 구성. 실제 구조·빌드·실행은 [AGENTS.md](../../../AGENTS.md) 및 [README.md](../../../README.md) 참조.  
+> **최신 가이드**: [개발자 가이드](../../guides/ko/developer-guide.md), [아키텍처](../../architecture/ko/) — 전환 후 경로·DDL의 SSOT.
 
 ---
 

--- a/docs/reference/ko/prd-vector-search-stability-2025-10.md
+++ b/docs/reference/ko/prd-vector-search-stability-2025-10.md
@@ -94,15 +94,18 @@
 - 잔여 과제: 문서 마무리(5.3) 및 전체 테스트 실행/증적 정리(5.4).
 
 ## 13. 테스트 커버리지 업데이트
-- `src/algorithms/vector-search-engine.spec.ts`  
+
+> **경로 (2026-05)**: 아래 스펙 파일은 모노레포 기준 `packages/memento-core/src/domains/search/algorithms/__tests__/`에 있습니다. 최신 실행은 저장소 루트에서 `npm test` 또는 개별 `vitest` 경로를 사용하세요.
+
+- `packages/memento-core/src/domains/search/algorithms/__tests__/vector-search-engine.spec.ts`  
   - 다중 타입 필터를 IN 절+바인딩으로 전달하는지 검증.  
   - 제공자별 차원 검증 실패 시 vec 쿼리가 호출되지 않는지 확인.  
   - sqlite-vec 미설치 환경에서 안전 폴백을 검증.  
   - 고차원(OpenAI/Gemini) 제공자에 대한 includeMetadata 흐름 확인.  
-- `src/algorithms/hybrid-search-engine.spec.ts`  
+- `packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts`  
   - vec 경로 활성화 시 타입 배열 전달과 임베딩 생성 플로를 검증.  
   - vec 인덱스가 비활성화된 경우 `searchBySimilarity` 폴백에 타입 배열이 동일하게 전달되는지 확인.  
-- 시나리오 스크립트: `npx vitest run src/algorithms/vector-search-engine.spec.ts src/algorithms/hybrid-search-engine.spec.ts`
+- 시나리오 예시: `npx vitest run packages/memento-core/src/domains/search/algorithms/__tests__/vector-search-engine.spec.ts packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts`
 
 ## 14. 릴리스 노트 초안
 ### 14.1 개선 사항


### PR DESCRIPTION
## Summary
- Updates operational reference docs under `docs/reference/ko/` so runnable commands and module paths match the npm workspaces layout (`packages/memento-core`, etc.).
- Adds explicit links to current developer and architecture guides on historical snapshot reports.
- Corrects `test:ci:root` documentation to match root `package.json` (Vitest over `tests/` only).

## Issue
Closes #367 (parent #357).

## Verification
- `npm run docs:audit-links`


Made with [Cursor](https://cursor.com)