### PR TITLE
docs(reference/en): monorepo logger paths (#368)

### DIFF
--- a/docs/reference/en/logging-schema.md
+++ b/docs/reference/en/logging-schema.md
@@ -1,6 +1,6 @@
 # Logging field schema
 
-This document describes the logging field schema of the standard logger module (`src/shared/utils/logger.ts`) in the Memento project.
+This document describes the logging field schema of the standard logger module in the Memento monorepo. The standard logger lives at `packages/memento-core/src/shared/utils/logger.ts`; the MCP logger lives at `packages/memento-server/src/server/mcp-logger.ts`.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Updates `docs/reference/en/logging-schema.md` to reference `packages/memento-core` / `packages/memento-server` paths instead of the removed root `src/shared` layout.

## Issue
Closes #368 (parent #357).

## Verification
- `npm run docs:audit-links`


Made with [Cursor](https://cursor.com)