### PR TITLE
feat(personal-agent): 개인 지식 context builder (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **하이브리드·텍스트·벡터 검색**: `MemorySearchFilters`의 `project_id` / `owner_id`가 FTS·VEC SQL 및 임베딩 유사도(`searchBySimilarity`) fallback까지 전달되어, DB 단계에서 스코프가 적용됩니다. `memory_injection` / `buildKnowledgeContextBundle` 경로에서 좁은 스코프일 때 후보 부족을 줄이기 위해 검색 `limit` 배수를 키웁니다 (#232, PR #386 후속).
+
 ### Documentation
 - 루트 SSOT 문서(README, README.en, CONTRIBUTING)의 디렉터리·테스트 경로 설명을 현재 npm workspaces 트리에 맞게 정리 (#359).
 - [1.0.0] 절의 디렉터리 트리는 당시 레이아웃의 역사적 스냅샷임을 명시 (#359).

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-12)
 
 ## Corpus Check
-- 964 files · ~1,399,779 words
+- 967 files · ~1,387,828 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4866 nodes · 6028 edges · 961 communities detected
+- 4876 nodes · 6037 edges · 964 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -971,6 +971,9 @@
 - [[_COMMUNITY_Community 958|Community 958]]
 - [[_COMMUNITY_Community 959|Community 959]]
 - [[_COMMUNITY_Community 960|Community 960]]
+- [[_COMMUNITY_Community 961|Community 961]]
+- [[_COMMUNITY_Community 962|Community 962]]
+- [[_COMMUNITY_Community 963|Community 963]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -1534,132 +1537,132 @@ Cohesion: 0.29
 Nodes (1): RememberTool
 
 ### Community 136 - "Community 136"
-Cohesion: 0.33
-Nodes (1): MemoryInjectionPrompt
-
-### Community 137 - "Community 137"
 Cohesion: 0.22
 Nodes (1): ConsolidationRepository
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (1): PredicateCanonicalizer
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (2): escapeHtml(), QualityReporter
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.31
 Nodes (6): countMagicNumbers(), findMagicNumbers(), getAllTsFiles(), isCoreModule(), isExcluded(), main()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.36
 Nodes (9): checkSqlInjection(), findFiles(), findSqlInjectionPatterns(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (9): countAnyTypes(), findAnyTypes(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.22
 Nodes (1): MementoAssistant
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.28
 Nodes (4): registerHandlers(), runHeavyInit(), Semaphore, startServer()
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.36
 Nodes (1): TripleExtractionLogger
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.31
 Nodes (1): MigrationRunner
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (1): BackupManager
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (1): AnchorTableMigration
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.36
 Nodes (1): FactMetadataFieldsMigration
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.39
 Nodes (1): MemoryItemIsConsolidatedMigration
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.39
 Nodes (1): TripleExtractionFieldsMigration
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.42
 Nodes (1): FeedbackEventAttributionMigration
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.33
 Nodes (1): ProceduralVersionIndexesMigration
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.36
 Nodes (1): MemoryItemAttributionMigration
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.36
 Nodes (1): KgTripleTableMigration
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.39
 Nodes (1): SoftDeleteFieldsMigration
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.36
 Nodes (1): MemoryItemOwnerIdMigration
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (1): RetryManager
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.36
 Nodes (1): FileLogger
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.28
 Nodes (3): convertMemoryRowToItem(), isMemoryType(), isPrivacyScope()
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.31
 Nodes (1): LoggingRateLimiter
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.31
 Nodes (4): buildLogMessage(), formatTime(), logToStderr(), safeStringify()
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.36
 Nodes (7): canonicalizeHttpBindHostForListen(), formatHttpBindHostForUrl(), getMementoHttpSecurityStartupViolationMessage(), isHttpBindHostRemotelyReachable(), isIpv4Loopback127Block(), isIpv4MappedLoopback(), MementoHttpSecurityStartupError
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.22
 Nodes (2): DefaultSearchLogger, HybridSearchFactory
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.22
-Nodes (0):
+Nodes (0): 
 
-### Community 166 - "Community 166"
+### Community 165 - "Community 165"
 Cohesion: 0.36
 Nodes (1): LlmProceduralExtractor
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.44
 Nodes (8): buildWindowCounts(), computeMemoryReviewQueueHealthLive(), countCandidates(), listMemoryReviewQueueHealthSnapshots(), maybeRecordMemoryReviewQueueHealthSnapshot(), memoryReviewQueueHealthSnapshotTableReady(), recordMemoryReviewQueueHealthSnapshot(), snapshotTableReady()
+
+### Community 167 - "Community 167"
+Cohesion: 0.42
+Nodes (7): buildKnowledgeContextBundle(), estimateTokens(), filterByOwner(), formatMemoryPrompt(), summarizeMemories(), summarizeMemoryContent(), updateConsolidationScoreMetadata()
 
 ### Community 168 - "Community 168"
 Cohesion: 0.22
@@ -1723,7 +1726,7 @@ Nodes (4): deleteServerInfo(), readServerInfo(), serverInfoPath(), writeServerIn
 
 ### Community 183 - "Community 183"
 Cohesion: 0.25
-Nodes (0):
+Nodes (0): 
 
 ### Community 184 - "Community 184"
 Cohesion: 0.46
@@ -1775,7 +1778,7 @@ Nodes (1): BatchJobExecutionCoordinator
 
 ### Community 196 - "Community 196"
 Cohesion: 0.25
-Nodes (0):
+Nodes (0): 
 
 ### Community 197 - "Community 197"
 Cohesion: 0.29
@@ -1791,7 +1794,7 @@ Nodes (2): isPIIMaskingEnabled(), PIIMasker
 
 ### Community 200 - "Community 200"
 Cohesion: 0.25
-Nodes (0):
+Nodes (0): 
 
 ### Community 201 - "Community 201"
 Cohesion: 0.25
@@ -1859,7 +1862,7 @@ Nodes (1): RetryQueue
 
 ### Community 217 - "Community 217"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 218 - "Community 218"
 Cohesion: 0.52
@@ -1983,7 +1986,7 @@ Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapD
 
 ### Community 248 - "Community 248"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
@@ -2011,7 +2014,7 @@ Nodes (1): TestMigration
 
 ### Community 255 - "Community 255"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 256 - "Community 256"
 Cohesion: 0.33
@@ -2027,7 +2030,7 @@ Nodes (1): TelemetryEventsMigration
 
 ### Community 259 - "Community 259"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 260 - "Community 260"
 Cohesion: 0.33
@@ -2074,508 +2077,508 @@ Cohesion: 0.47
 Nodes (1): VectorPerformanceRepositoryImpl
 
 ### Community 271 - "Community 271"
+Cohesion: 0.4
+Nodes (2): normalizeMemoryTypesForSearch(), ToolContextKnowledgeContextAdapter
+
+### Community 272 - "Community 272"
 Cohesion: 0.47
 Nodes (2): FeedbackTool, normalizeFeedbackCreatedAtToIso()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (1): SummarizationService
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.47
 Nodes (3): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.47
 Nodes (3): chunkSucceeded(), failureMessageFromResult(), TriplePipelineOrchestrator
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.6
 Nodes (5): executePerformanceAlerts(), handleList(), handleResolve(), handleSearch(), handleStats()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.47
 Nodes (1): RuntimeDiagnosticsLogger
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.47
 Nodes (1): MigrateEmbeddingsTool
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.47
 Nodes (3): cleanupTestDatabase(), createTestDatabaseWithoutServices(), setupTestDatabase()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.6
 Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.6
 Nodes (5): readDockerLogs(), readJsonlFiles(), resolveDockerLogsRef(), runDocker(), splitJsonlLines()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.4
 Nodes (2): emptyState(), loadState()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (5): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), truncateTitle()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.8
 Nodes (5): buildRequestOptions(), getDashboardAuth(), mementoAdminFetch(), performFetch(), waitForSession()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.6
 Nodes (3): broadcastReviewCandidatesChanged(), buildReviewCandidatesChangedEnvelope(), parseReviewCandidatesChangedRelayUrls()
 
-### Community 285 - "Community 285"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 286 - "Community 286"
-Cohesion: 0.6
-Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 287 - "Community 287"
 Cohesion: 0.6
-Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
 
 ### Community 288 - "Community 288"
+Cohesion: 0.6
+Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+
+### Community 289 - "Community 289"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (1): SseServer
 
-### Community 290 - "Community 290"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 291 - "Community 291"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 292 - "Community 292"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 294 - "Community 294"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 295 - "Community 295"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 296 - "Community 296"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 297 - "Community 297"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 298 - "Community 298"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 299 - "Community 299"
 Cohesion: 0.5
 Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
-### Community 299 - "Community 299"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 300 - "Community 300"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 301 - "Community 301"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 302 - "Community 302"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 303 - "Community 303"
 Cohesion: 0.5
 Nodes (2): getStopWords(), isStopWord()
 
-### Community 303 - "Community 303"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 304 - "Community 304"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 307 - "Community 307"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 308 - "Community 308"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 309 - "Community 309"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 313 - "Community 313"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 314 - "Community 314"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 315 - "Community 315"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 316 - "Community 316"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 317 - "Community 317"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 318 - "Community 318"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): TokenBucketRateLimiter
 
 ### Community 319 - "Community 319"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 320 - "Community 320"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.7
 Nodes (4): recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 327 - "Community 327"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 328 - "Community 328"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 329 - "Community 329"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
 
-### Community 330 - "Community 330"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 331 - "Community 331"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 332 - "Community 332"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 333 - "Community 333"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): BraveSearchProvider
 
 ### Community 335 - "Community 335"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 336 - "Community 336"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (1): DatabaseOptimizeTool
 
-### Community 337 - "Community 337"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 338 - "Community 338"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 339 - "Community 339"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 340 - "Community 340"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 341 - "Community 341"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 342 - "Community 342"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
-Nodes (1): RelationValidatorExecutor
+Nodes (0): 
 
 ### Community 344 - "Community 344"
+Cohesion: 0.5
+Nodes (1): RelationValidatorExecutor
+
+### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (1): QualityMeasurementBatchJob
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.5
 Nodes (1): SleepConsolidationBatchJob
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (1): TelemetryCleanupBatchJob
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 351 - "Community 351"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 352 - "Community 352"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 353 - "Community 353"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 354 - "Community 354"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 355 - "Community 355"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 356 - "Community 356"
 Cohesion: 0.5
-Nodes (1): SearchResultCombiner
+Nodes (1): RestoreAnchorsTool
 
 ### Community 357 - "Community 357"
-Cohesion: 0.67
-Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
+Cohesion: 0.5
+Nodes (1): SearchResultCombiner
 
 ### Community 358 - "Community 358"
 Cohesion: 0.67
-Nodes (2): computeProcessAttributeFit(), toSet()
+Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeProcessAttributeFit(), toSet()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
-Nodes (1): ForgettingStatsTool
+Nodes (0): 
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
-Nodes (1): GetTelemetrySummaryTool
+Nodes (1): ForgettingStatsTool
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
-Nodes (1): PersonalKnowledgeAgentService
+Nodes (1): GetTelemetrySummaryTool
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): PersonalKnowledgeAgentService
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 366 - "Community 366"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 368 - "Community 368"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 370 - "Community 370"
+Cohesion: 0.5
+Nodes (1): RememberProcedureTool
+
+### Community 371 - "Community 371"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 372 - "Community 372"
 Cohesion: 0.83
 Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
-### Community 371 - "Community 371"
+### Community 373 - "Community 373"
 Cohesion: 0.83
 Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
-### Community 372 - "Community 372"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 373 - "Community 373"
-Cohesion: 0.5
-Nodes (1): GetRelationsTool
-
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (0): 
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): GetRelationsTool
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): RemoveRelationTool
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): ExtractRelationsTool
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): AddRelationTool
 
 ### Community 380 - "Community 380"
-Cohesion: 0.67
-Nodes (2): createBulkMemories(), createTestMemory()
+Cohesion: 0.5
+Nodes (1): RelationRetryManager
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 382 - "Community 382"
-Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Cohesion: 0.67
+Nodes (2): createBulkMemories(), createTestMemory()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): TripleNormalizer
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (0): 
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): PerformanceStatsTool
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 392 - "Community 392"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 393 - "Community 393"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (2): buildBenchmarkCorpus(), normalizeTags()
 
-### Community 393 - "Community 393"
+### Community 395 - "Community 395"
 Cohesion: 0.83
 Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
 
-### Community 394 - "Community 394"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 395 - "Community 395"
-Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
-
 ### Community 396 - "Community 396"
-Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 397 - "Community 397"
 Cohesion: 0.83
@@ -2583,3242 +2586,3256 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 399 - "Community 399"
+Cohesion: 0.83
+Nodes (3): main(), parseArgs(), printHelp()
+
+### Community 400 - "Community 400"
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+
+### Community 401 - "Community 401"
 Cohesion: 1.0
 Nodes (3): checkDatabaseIntegrity(), log(), main()
 
-### Community 400 - "Community 400"
+### Community 402 - "Community 402"
 Cohesion: 1.0
 Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
-### Community 401 - "Community 401"
+### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (2): inferLevel(), parseAppLogLine()
 
-### Community 402 - "Community 402"
+### Community 404 - "Community 404"
 Cohesion: 0.67
 Nodes (2): createMonitorRuntime(), runForever()
 
-### Community 403 - "Community 403"
+### Community 405 - "Community 405"
 Cohesion: 0.67
 Nodes (2): main(), runExample()
 
-### Community 404 - "Community 404"
+### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (1): SlowTransport
 
-### Community 405 - "Community 405"
+### Community 407 - "Community 407"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 407 - "Community 407"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), sendOptions()
-
 ### Community 408 - "Community 408"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 409 - "Community 409"
 Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
+Nodes (2): createMockResponse(), sendOptions()
 
 ### Community 410 - "Community 410"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 411 - "Community 411"
+Cohesion: 1.0
+Nodes (2): createMockResponse(), runAdminAuthProbe()
+
+### Community 412 - "Community 412"
 Cohesion: 1.0
 Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
-### Community 411 - "Community 411"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 412 - "Community 412"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 414 - "Community 414"
-Cohesion: 1.0
-Nodes (2): loadEnv(), resolveEnvPath()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 416 - "Community 416"
 Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
+Nodes (2): loadEnv(), resolveEnvPath()
 
 ### Community 417 - "Community 417"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 418 - "Community 418"
+Cohesion: 1.0
+Nodes (2): compareServices(), testServerSynchronization()
+
+### Community 419 - "Community 419"
 Cohesion: 1.0
 Nodes (2): assert(), testMementoClient()
 
-### Community 418 - "Community 418"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 420 - "Community 420"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NoopSearchProvider
 
 ### Community 423 - "Community 423"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 424 - "Community 424"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 425 - "Community 425"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 426 - "Community 426"
 Cohesion: 1.0
 Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
-### Community 425 - "Community 425"
+### Community 427 - "Community 427"
 Cohesion: 1.0
 Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
-### Community 426 - "Community 426"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 428 - "Community 428"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 434 - "Community 434"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 435 - "Community 435"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 436 - "Community 436"
 Cohesion: 1.0
 Nodes (2): getVectorTableName(), validateTableName()
 
-### Community 435 - "Community 435"
+### Community 437 - "Community 437"
 Cohesion: 1.0
 Nodes (2): issue(), validateConfiguration()
 
-### Community 436 - "Community 436"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 438 - "Community 438"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Nodes (0): 
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FeedbackRepository
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 446 - "Community 446"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 447 - "Community 447"
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
+
+### Community 448 - "Community 448"
 Cohesion: 1.0
 Nodes (2): generateMemoryId(), rollbackToVersion()
 
-### Community 447 - "Community 447"
+### Community 449 - "Community 449"
 Cohesion: 1.0
 Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
-### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 449 - "Community 449"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 453 - "Community 453"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 455 - "Community 455"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 456 - "Community 456"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 457 - "Community 457"
 Cohesion: 1.0
 Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
-### Community 456 - "Community 456"
+### Community 458 - "Community 458"
 Cohesion: 1.0
 Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
-### Community 457 - "Community 457"
+### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
-### Community 458 - "Community 458"
+### Community 460 - "Community 460"
 Cohesion: 1.0
 Nodes (2): compareToolResults(), testToolConsistency()
 
-### Community 459 - "Community 459"
+### Community 461 - "Community 461"
 Cohesion: 1.0
 Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
-### Community 460 - "Community 460"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 461 - "Community 461"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 463 - "Community 463"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 464 - "Community 464"
-Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 465 - "Community 465"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 466 - "Community 466"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 467 - "Community 467"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 468 - "Community 468"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 469 - "Community 469"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 470 - "Community 470"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 471 - "Community 471"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 472 - "Community 472"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 473 - "Community 473"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 474 - "Community 474"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 475 - "Community 475"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 476 - "Community 476"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 483 - "Community 483"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 484 - "Community 484"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 485 - "Community 485"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 486 - "Community 486"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 487 - "Community 487"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 488 - "Community 488"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 489 - "Community 489"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 490 - "Community 490"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 491 - "Community 491"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 492 - "Community 492"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 493 - "Community 493"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 494 - "Community 494"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 495 - "Community 495"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 496 - "Community 496"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 497 - "Community 497"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 498 - "Community 498"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 499 - "Community 499"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 500 - "Community 500"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 501 - "Community 501"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 502 - "Community 502"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 503 - "Community 503"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 504 - "Community 504"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 505 - "Community 505"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 506 - "Community 506"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 507 - "Community 507"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 508 - "Community 508"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 509 - "Community 509"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 510 - "Community 510"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 511 - "Community 511"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 512 - "Community 512"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 513 - "Community 513"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 514 - "Community 514"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 515 - "Community 515"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 516 - "Community 516"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 517 - "Community 517"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 518 - "Community 518"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 519 - "Community 519"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 520 - "Community 520"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 521 - "Community 521"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 522 - "Community 522"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 523 - "Community 523"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 524 - "Community 524"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 525 - "Community 525"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 526 - "Community 526"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 527 - "Community 527"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 528 - "Community 528"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 529 - "Community 529"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 530 - "Community 530"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 531 - "Community 531"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 532 - "Community 532"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 533 - "Community 533"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 534 - "Community 534"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 535 - "Community 535"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 536 - "Community 536"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 537 - "Community 537"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 538 - "Community 538"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 539 - "Community 539"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 540 - "Community 540"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 541 - "Community 541"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 542 - "Community 542"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 543 - "Community 543"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 544 - "Community 544"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 545 - "Community 545"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 546 - "Community 546"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 547 - "Community 547"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 548 - "Community 548"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 549 - "Community 549"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 550 - "Community 550"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 551 - "Community 551"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 552 - "Community 552"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 553 - "Community 553"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 554 - "Community 554"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 555 - "Community 555"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 556 - "Community 556"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 557 - "Community 557"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 558 - "Community 558"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 559 - "Community 559"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 560 - "Community 560"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 561 - "Community 561"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 562 - "Community 562"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 563 - "Community 563"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 564 - "Community 564"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 565 - "Community 565"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 566 - "Community 566"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 570 - "Community 570"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 571 - "Community 571"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 572 - "Community 572"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 573 - "Community 573"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 576 - "Community 576"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 577 - "Community 577"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 578 - "Community 578"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 580 - "Community 580"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 582 - "Community 582"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 583 - "Community 583"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 584 - "Community 584"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 585 - "Community 585"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 586 - "Community 586"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 587 - "Community 587"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 589 - "Community 589"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 590 - "Community 590"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 591 - "Community 591"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 592 - "Community 592"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 593 - "Community 593"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 594 - "Community 594"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 595 - "Community 595"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 596 - "Community 596"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 598 - "Community 598"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 601 - "Community 601"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 602 - "Community 602"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 604 - "Community 604"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 605 - "Community 605"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 606 - "Community 606"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 607 - "Community 607"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 608 - "Community 608"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 609 - "Community 609"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 610 - "Community 610"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 611 - "Community 611"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 613 - "Community 613"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 614 - "Community 614"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 615 - "Community 615"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 616 - "Community 616"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 617 - "Community 617"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 618 - "Community 618"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 619 - "Community 619"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 620 - "Community 620"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 621 - "Community 621"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 622 - "Community 622"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 623 - "Community 623"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 626 - "Community 626"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 628 - "Community 628"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 630 - "Community 630"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 631 - "Community 631"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 632 - "Community 632"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 633 - "Community 633"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 634 - "Community 634"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 635 - "Community 635"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 636 - "Community 636"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 637 - "Community 637"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 638 - "Community 638"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 639 - "Community 639"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 640 - "Community 640"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 641 - "Community 641"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 642 - "Community 642"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 643 - "Community 643"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 644 - "Community 644"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 645 - "Community 645"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 646 - "Community 646"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 647 - "Community 647"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 648 - "Community 648"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 649 - "Community 649"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 650 - "Community 650"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 651 - "Community 651"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 652 - "Community 652"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 653 - "Community 653"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 654 - "Community 654"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 655 - "Community 655"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 656 - "Community 656"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 657 - "Community 657"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 658 - "Community 658"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 659 - "Community 659"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 660 - "Community 660"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 661 - "Community 661"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 662 - "Community 662"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 663 - "Community 663"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 664 - "Community 664"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 665 - "Community 665"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 666 - "Community 666"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 667 - "Community 667"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 668 - "Community 668"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 669 - "Community 669"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 670 - "Community 670"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 671 - "Community 671"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 672 - "Community 672"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 673 - "Community 673"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 674 - "Community 674"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 675 - "Community 675"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 676 - "Community 676"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 677 - "Community 677"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 678 - "Community 678"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 679 - "Community 679"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 680 - "Community 680"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 681 - "Community 681"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 682 - "Community 682"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 683 - "Community 683"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 684 - "Community 684"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 685 - "Community 685"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 686 - "Community 686"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 687 - "Community 687"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 688 - "Community 688"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 689 - "Community 689"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 690 - "Community 690"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 691 - "Community 691"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 692 - "Community 692"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 693 - "Community 693"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 694 - "Community 694"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 695 - "Community 695"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 696 - "Community 696"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 697 - "Community 697"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 698 - "Community 698"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 699 - "Community 699"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 700 - "Community 700"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 701 - "Community 701"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 702 - "Community 702"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 703 - "Community 703"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 704 - "Community 704"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 705 - "Community 705"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 706 - "Community 706"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 707 - "Community 707"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 708 - "Community 708"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 709 - "Community 709"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 710 - "Community 710"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 711 - "Community 711"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 712 - "Community 712"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 713 - "Community 713"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 714 - "Community 714"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 715 - "Community 715"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 716 - "Community 716"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 717 - "Community 717"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 718 - "Community 718"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 719 - "Community 719"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 720 - "Community 720"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 723 - "Community 723"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 725 - "Community 725"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 728 - "Community 728"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 729 - "Community 729"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 730 - "Community 730"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 731 - "Community 731"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 732 - "Community 732"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 733 - "Community 733"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 734 - "Community 734"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 735 - "Community 735"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 736 - "Community 736"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 737 - "Community 737"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 738 - "Community 738"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 739 - "Community 739"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 740 - "Community 740"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 741 - "Community 741"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 743 - "Community 743"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 744 - "Community 744"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 745 - "Community 745"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 746 - "Community 746"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 747 - "Community 747"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 748 - "Community 748"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 749 - "Community 749"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 750 - "Community 750"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 754 - "Community 754"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 756 - "Community 756"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 757 - "Community 757"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 758 - "Community 758"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 759 - "Community 759"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 760 - "Community 760"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 761 - "Community 761"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 762 - "Community 762"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 763 - "Community 763"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 764 - "Community 764"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 765 - "Community 765"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 766 - "Community 766"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 767 - "Community 767"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 768 - "Community 768"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 769 - "Community 769"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 770 - "Community 770"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 771 - "Community 771"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 772 - "Community 772"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 773 - "Community 773"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 774 - "Community 774"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 775 - "Community 775"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 776 - "Community 776"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 777 - "Community 777"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 778 - "Community 778"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 779 - "Community 779"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 781 - "Community 781"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 782 - "Community 782"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 783 - "Community 783"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 784 - "Community 784"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 785 - "Community 785"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 786 - "Community 786"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 787 - "Community 787"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 788 - "Community 788"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 789 - "Community 789"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 790 - "Community 790"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 791 - "Community 791"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 792 - "Community 792"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 793 - "Community 793"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 794 - "Community 794"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 795 - "Community 795"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 796 - "Community 796"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 797 - "Community 797"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 798 - "Community 798"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 799 - "Community 799"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 800 - "Community 800"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 801 - "Community 801"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 802 - "Community 802"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 803 - "Community 803"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 804 - "Community 804"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 805 - "Community 805"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 806 - "Community 806"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 807 - "Community 807"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 808 - "Community 808"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 809 - "Community 809"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 810 - "Community 810"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 811 - "Community 811"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 812 - "Community 812"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 813 - "Community 813"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 814 - "Community 814"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 815 - "Community 815"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 816 - "Community 816"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 817 - "Community 817"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 818 - "Community 818"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 819 - "Community 819"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 820 - "Community 820"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 821 - "Community 821"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 822 - "Community 822"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 823 - "Community 823"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 824 - "Community 824"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 825 - "Community 825"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 826 - "Community 826"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 827 - "Community 827"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 828 - "Community 828"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 829 - "Community 829"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 830 - "Community 830"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 831 - "Community 831"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 832 - "Community 832"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 833 - "Community 833"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 834 - "Community 834"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 835 - "Community 835"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 836 - "Community 836"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 837 - "Community 837"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 838 - "Community 838"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 839 - "Community 839"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 840 - "Community 840"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 841 - "Community 841"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 842 - "Community 842"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 843 - "Community 843"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 844 - "Community 844"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 845 - "Community 845"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 846 - "Community 846"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 847 - "Community 847"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 848 - "Community 848"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 849 - "Community 849"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 850 - "Community 850"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 851 - "Community 851"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 852 - "Community 852"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 853 - "Community 853"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 854 - "Community 854"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 855 - "Community 855"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 856 - "Community 856"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 857 - "Community 857"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 858 - "Community 858"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 859 - "Community 859"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 860 - "Community 860"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 861 - "Community 861"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 862 - "Community 862"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 863 - "Community 863"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 864 - "Community 864"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 865 - "Community 865"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 866 - "Community 866"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 867 - "Community 867"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 868 - "Community 868"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 869 - "Community 869"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 870 - "Community 870"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 871 - "Community 871"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 872 - "Community 872"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 873 - "Community 873"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 874 - "Community 874"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 875 - "Community 875"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 876 - "Community 876"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 877 - "Community 877"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 878 - "Community 878"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 879 - "Community 879"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 880 - "Community 880"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 881 - "Community 881"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 882 - "Community 882"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 883 - "Community 883"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 884 - "Community 884"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 885 - "Community 885"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 886 - "Community 886"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 887 - "Community 887"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 888 - "Community 888"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 889 - "Community 889"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 890 - "Community 890"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 891 - "Community 891"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 892 - "Community 892"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 893 - "Community 893"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 894 - "Community 894"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 895 - "Community 895"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 896 - "Community 896"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 897 - "Community 897"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 898 - "Community 898"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 899 - "Community 899"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 900 - "Community 900"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 901 - "Community 901"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 902 - "Community 902"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 903 - "Community 903"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 904 - "Community 904"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 905 - "Community 905"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 906 - "Community 906"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 907 - "Community 907"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 908 - "Community 908"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 909 - "Community 909"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 910 - "Community 910"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 911 - "Community 911"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 912 - "Community 912"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 913 - "Community 913"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 914 - "Community 914"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 915 - "Community 915"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 916 - "Community 916"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 917 - "Community 917"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 918 - "Community 918"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 919 - "Community 919"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 920 - "Community 920"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 921 - "Community 921"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 922 - "Community 922"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 923 - "Community 923"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 924 - "Community 924"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 925 - "Community 925"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 926 - "Community 926"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 928 - "Community 928"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 929 - "Community 929"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 930 - "Community 930"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 931 - "Community 931"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 932 - "Community 932"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 933 - "Community 933"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 934 - "Community 934"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 935 - "Community 935"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 936 - "Community 936"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 937 - "Community 937"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 938 - "Community 938"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 939 - "Community 939"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 940 - "Community 940"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 941 - "Community 941"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 942 - "Community 942"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 943 - "Community 943"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 944 - "Community 944"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 945 - "Community 945"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 946 - "Community 946"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 947 - "Community 947"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 948 - "Community 948"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 949 - "Community 949"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 950 - "Community 950"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 951 - "Community 951"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 952 - "Community 952"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 953 - "Community 953"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 954 - "Community 954"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 955 - "Community 955"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 956 - "Community 956"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 957 - "Community 957"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 958 - "Community 958"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 959 - "Community 959"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 960 - "Community 960"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
+
+### Community 961 - "Community 961"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 962 - "Community 962"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 963 - "Community 963"
+Cohesion: 1.0
+Nodes (0): 
 
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 469`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 471`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 472`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 473`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 474`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 475`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 476`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 477`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 478`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 479`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 480`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 481`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 482`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 483`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 484`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 485`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 486`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 487`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 488`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 489`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 490`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 491`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 492`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 493`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 494`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 495`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 496`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 497`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 498`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 499`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 500`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 501`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 502`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 503`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 504`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 505`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 506`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 507`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 508`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 509`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 510`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 511`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 512`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 513`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 514`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 515`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 516`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 517`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 518`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 519`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 520`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 521`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 522`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 523`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 524`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 525`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 526`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 527`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 528`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 529`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 530`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 531`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 532`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 533`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 534`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 535`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 536`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 537`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 538`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 539`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 544`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 545`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 546`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 547`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 550`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 551`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 552`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 554`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 555`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 556`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 557`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 558`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 559`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 560`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `isMemoryItemType()`, `index.ts`
+- **Thin community `Community 561`** (2 nodes): `isMemoryItemType()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 562`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 563`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 564`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 565`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 566`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 567`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 568`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 569`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 570`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 571`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 572`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 573`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 574`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 575`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 576`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 577`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 578`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 579`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 580`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 581`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 582`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 583`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 584`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 585`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 586`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 587`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 589`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 591`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 592`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 594`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 595`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 596`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 598`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 599`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 600`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 601`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 602`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 603`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 604`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 605`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 606`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 607`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 608`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 609`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 610`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 611`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 612`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 613`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 614`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 615`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 616`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 617`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 618`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 619`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 620`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 621`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 622`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 623`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 624`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 625`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 626`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 627`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 628`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 629`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 630`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 631`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 632`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 633`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 634`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 635`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 636`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 637`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 638`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 639`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 640`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 641`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 642`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 643`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 644`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 645`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 646`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 647`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 648`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 649`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 650`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 651`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 652`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 653`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 654`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 655`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 656`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 657`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 658`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 659`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 660`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 661`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 662`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 663`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `types.ts`
+- **Thin community `Community 664`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 665`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `index.ts`
+- **Thin community `Community 666`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 667`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 668`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 669`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 670`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 671`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 672`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `transport.ts`
+- **Thin community `Community 673`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `index.ts`
+- **Thin community `Community 674`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 675`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 676`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 677`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 678`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 687`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 701`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `context.ts`
+- **Thin community `Community 703`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `index.ts`
+- **Thin community `Community 708`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `types.ts`
+- **Thin community `Community 711`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 712`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 714`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 715`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 716`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 718`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 719`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 721`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 722`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `index.ts`
+- **Thin community `Community 723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 724`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 725`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 726`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 727`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 728`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 729`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 730`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 731`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 732`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `types.ts`
+- **Thin community `Community 733`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 734`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 735`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 736`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 740`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 741`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 751`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 768`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 769`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 770`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 771`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 772`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 773`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 774`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 775`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 776`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 777`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 778`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `error-types.ts`
+- **Thin community `Community 779`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 780`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 781`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `search.types.ts`
+- **Thin community `Community 782`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 784`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `constants.ts`
+- **Thin community `Community 785`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 786`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 787`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 790`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 792`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 793`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 794`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 796`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 797`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 798`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 799`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 800`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 801`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 802`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 803`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 804`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 805`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 809`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 810`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 811`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 812`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 813`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 814`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 816`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 821`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 822`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `index.ts`
+- **Thin community `Community 824`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `database-types.ts`
+- **Thin community `Community 826`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `index.ts`
+- **Thin community `Community 846`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 847`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `index.ts`
+- **Thin community `Community 849`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 850`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 851`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `context-port.ts`
+- **Thin community `Community 852`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 853`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 855`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 856`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 857`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 858`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 859`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 860`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 861`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 862`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 863`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 864`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 866`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 876`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 877`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `index.ts`
+- **Thin community `Community 886`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 888`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 898`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `types.ts`
+- **Thin community `Community 908`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `types.ts`
+- **Thin community `Community 923`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 925`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 927`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 928`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 929`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 936`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 937`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 939`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 940`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 943`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 949`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `types.ts`
+- **Thin community `Community 950`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 963`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 659
+      "community": 661
     },
     {
       "label": "vitest.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 660
+      "community": 662
     },
     {
       "label": "assistant.spec.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "types.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 662
+      "community": 664
     },
     {
       "label": "types.spec.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "assistant.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_ts",
-      "community": 143
+      "community": 142
     },
     {
       "label": "MementoAssistant",
@@ -57,7 +57,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L21",
       "id": "assistant_mementoassistant",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".constructor()",
@@ -65,7 +65,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L34",
       "id": "assistant_mementoassistant_constructor",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".fromEnv()",
@@ -73,7 +73,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L46",
       "id": "assistant_mementoassistant_fromenv",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".beforeUserTurn()",
@@ -81,7 +81,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L61",
       "id": "assistant_mementoassistant_beforeuserturn",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".afterAssistantTurn()",
@@ -89,7 +89,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L67",
       "id": "assistant_mementoassistant_afterassistantturn",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".recall()",
@@ -97,7 +97,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L75",
       "id": "assistant_mementoassistant_recall",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".remember()",
@@ -105,7 +105,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L78",
       "id": "assistant_mementoassistant_remember",
-      "community": 143
+      "community": 142
     },
     {
       "label": ".close()",
@@ -113,7 +113,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L81",
       "id": "assistant_mementoassistant_close",
-      "community": 143
+      "community": 142
     },
     {
       "label": "index.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 404
+      "community": 406
     },
     {
       "label": "SlowTransport",
@@ -137,7 +137,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 404
+      "community": 406
     },
     {
       "label": ".recall()",
@@ -145,7 +145,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 404
+      "community": 406
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "after-assistant-turn.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 469
+      "community": 471
     },
     {
       "label": "afterAssistantTurn()",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 469
+      "community": 471
     },
     {
       "label": "before-user-turn.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 405
+      "community": 407
     },
     {
       "label": "beforeUserTurn()",
@@ -185,7 +185,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 405
+      "community": 407
     },
     {
       "label": "withTimeout()",
@@ -193,7 +193,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 405
+      "community": 407
     },
     {
       "label": "auto-recall-policy.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 470
+      "community": 472
     },
     {
       "label": "shouldAutoRecall()",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 470
+      "community": 472
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "auto-remember-policy.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 471
+      "community": 473
     },
     {
       "label": "rememberDispatch()",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 471
+      "community": 473
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "channel-scope.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 406
+      "community": 408
     },
     {
       "label": "scopeRecallFilters()",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 406
+      "community": 408
     },
     {
       "label": "scopeRememberTags()",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 406
+      "community": 408
     },
     {
       "label": "channel-scope.spec.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "http-transport.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "mock-transport.spec.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "transport.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "http-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "factory.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 472
+      "community": 474
     },
     {
       "label": "createTransportFromEnv()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 472
+      "community": 474
     },
     {
       "label": "stdio-transport.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "mock-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "createRateLimitedLogger()",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 327
+      "community": 328
     },
     {
       "label": "levelFromEnv()",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 327
+      "community": 328
     },
     {
       "label": "consoleSink()",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 327
+      "community": 328
     },
     {
       "label": "logger.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "retry-queue.spec.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "retry-queue.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "http.integration.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "start-http-server.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "startTestHttpServer()",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 328
+      "community": 329
     },
     {
       "label": "findFreePort()",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 328
+      "community": 329
     },
     {
       "label": "waitForHealth()",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 328
+      "community": 329
     },
     {
       "label": "http-server-runner.js",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 685
+      "community": 687
     },
     {
       "label": "test-integration.js",
@@ -905,7 +905,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 473
+      "community": 475
     },
     {
       "label": "testBasicFunctionality()",
@@ -913,7 +913,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 473
+      "community": 475
     },
     {
       "label": "performance-optimizer.js",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 474
+      "community": 476
     },
     {
       "label": "basicUsageExample()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 474
+      "community": 476
     },
     {
       "label": "performance-examples.ts",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 475
+      "community": 477
     },
     {
       "label": "advancedUsageExample()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 475
+      "community": 477
     },
     {
       "label": "migration-guide.ts",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 476
+      "community": 478
     },
     {
       "label": "makeNullRunner()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 476
+      "community": 478
     },
     {
       "label": "telemetry-cli.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "getRepoRoot()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 329
+      "community": 330
     },
     {
       "label": "collectEnvKeys()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 329
+      "community": 330
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 329
+      "community": 330
     },
     {
       "label": "server-info.ts",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 407
+      "community": 409
     },
     {
       "label": "createMockResponse()",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 407
+      "community": 409
     },
     {
       "label": "sendOptions()",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 407
+      "community": 409
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "index-factory.spec.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "context.spec.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "server-factory.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 477
+      "community": 479
     },
     {
       "label": "createServerFactory()",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 477
+      "community": 479
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 408
+      "community": 410
     },
     {
       "label": "readRepoFile()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 408
+      "community": 410
     },
     {
       "label": "sectionBetween()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 408
+      "community": 410
     },
     {
       "label": "http-server.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_ts",
-      "community": 284
+      "community": 285
     },
     {
       "label": "parseReviewCandidatesChangedRelayUrls()",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L36",
       "id": "review_candidates_changed_fanout_parsereviewcandidateschangedrelayurls",
-      "community": 284
+      "community": 285
     },
     {
       "label": "buildReviewCandidatesChangedEnvelope()",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L47",
       "id": "review_candidates_changed_fanout_buildreviewcandidateschangedenvelope",
-      "community": 284
+      "community": 285
     },
     {
       "label": "relayPost()",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L70",
       "id": "review_candidates_changed_fanout_relaypost",
-      "community": 284
+      "community": 285
     },
     {
       "label": "broadcastReviewCandidatesChanged()",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L108",
       "id": "review_candidates_changed_fanout_broadcastreviewcandidateschanged",
-      "community": 284
+      "community": 285
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2265,7 +2265,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 478
+      "community": 480
     },
     {
       "label": "startStdioServer()",
@@ -2273,7 +2273,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 478
+      "community": 480
     },
     {
       "label": "server-factory.spec.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "server-state.spec.ts",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_integration_spec_ts",
-      "community": 285
+      "community": 286
     },
     {
       "label": "postJson()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L11",
       "id": "auth_session_integration_spec_postjson",
-      "community": 285
+      "community": 286
     },
     {
       "label": "getJson()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L52",
       "id": "auth_session_integration_spec_getjson",
-      "community": 285
+      "community": 286
     },
     {
       "label": "deleteRequest()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L87",
       "id": "auth_session_integration_spec_deleterequest",
-      "community": 285
+      "community": 286
     },
     {
       "label": "startRealHttpServer()",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L126",
       "id": "auth_session_integration_spec_startrealhttpserver",
-      "community": 285
+      "community": 286
     },
     {
       "label": "mcp.routes.streamable-http.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 330
+      "community": 331
     },
     {
       "label": "postJsonRpc()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 330
+      "community": 331
     },
     {
       "label": "openSse()",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 330
+      "community": 331
     },
     {
       "label": "index.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_ts",
-      "community": 144
+      "community": 143
     },
     {
       "label": "Semaphore",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L52",
       "id": "index_semaphore",
-      "community": 144
+      "community": 143
     },
     {
       "label": ".constructor()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L55",
       "id": "index_semaphore_constructor",
-      "community": 144
+      "community": 143
     },
     {
       "label": ".acquire()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L56",
       "id": "index_semaphore_acquire",
-      "community": 144
+      "community": 143
     },
     {
       "label": ".release()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L60",
       "id": "index_semaphore_release",
-      "community": 144
+      "community": 143
     },
     {
       "label": "runHeavyInit()",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L87",
       "id": "index_runheavyinit",
-      "community": 144
+      "community": 143
     },
     {
       "label": "registerHandlers()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L106",
       "id": "index_registerhandlers",
-      "community": 144
+      "community": 143
     },
     {
       "label": "startServer()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L135",
       "id": "index_startserver",
-      "community": 144
+      "community": 143
     },
     {
       "label": "cleanup()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L173",
       "id": "index_cleanup",
-      "community": 144
+      "community": 143
     },
     {
       "label": "server-info.spec.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 479
+      "community": 481
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 479
+      "community": 481
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 409
+      "community": 411
     },
     {
       "label": "createMockResponse()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 409
+      "community": 411
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 409
+      "community": 411
     },
     {
       "label": "server-state.ts",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "bootstrap.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_sse_hub_ts",
-      "community": 286
+      "community": 287
     },
     {
       "label": "resetReviewCandidatesSseHubForTests()",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L12",
       "id": "review_candidates_sse_hub_resetreviewcandidatesssehubfortests",
-      "community": 286
+      "community": 287
     },
     {
       "label": "writeSafe()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L23",
       "id": "review_candidates_sse_hub_writesafe",
-      "community": 286
+      "community": 287
     },
     {
       "label": "attachReviewCandidatesSse()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L39",
       "id": "review_candidates_sse_hub_attachreviewcandidatessse",
-      "community": 286
+      "community": 287
     },
     {
       "label": "notifyReviewCandidatesChanged()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L69",
       "id": "review_candidates_sse_hub_notifyreviewcandidateschanged",
-      "community": 286
+      "community": 287
     },
     {
       "label": "index.spec.ts",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "sse-server-impl.ts",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "startSseServer()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 331
+      "community": 332
     },
     {
       "label": "stopSseServer()",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 331
+      "community": 332
     },
     {
       "label": "cleanupSseServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 331
+      "community": 332
     },
     {
       "label": "http-server.ts",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "batch-run-history.ts",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_instance_lock_ts",
-      "community": 287
+      "community": 288
     },
     {
       "label": "isProcessAlive()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L21",
       "id": "instance_lock_isprocessalive",
-      "community": 287
+      "community": 288
     },
     {
       "label": "getLockFilePath()",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L33",
       "id": "instance_lock_getlockfilepath",
-      "community": 287
+      "community": 288
     },
     {
       "label": "tryAcquireLock()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L45",
       "id": "instance_lock_tryacquirelock",
-      "community": 287
+      "community": 288
     },
     {
       "label": "releaseLock()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L70",
       "id": "instance_lock_releaselock",
-      "community": 287
+      "community": 288
     },
     {
       "label": "cors-policy.ts",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 410
+      "community": 412
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 410
+      "community": 412
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 410
+      "community": 412
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 480
+      "community": 482
     },
     {
       "label": "makeMocks()",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 480
+      "community": 482
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 481
+      "community": 483
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 481
+      "community": 483
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 482
+      "community": 484
     },
     {
       "label": "createMockResponse()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 482
+      "community": 484
     },
     {
       "label": "index.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "readCookie()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 332
+      "community": 333
     },
     {
       "label": "writeUnauthorized()",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 332
+      "community": 333
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 332
+      "community": 333
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 483
+      "community": 485
     },
     {
       "label": "createServiceInjector()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 483
+      "community": 485
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 484
+      "community": 486
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 484
+      "community": 486
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 485
+      "community": 487
     },
     {
       "label": "createMockResponse()",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 485
+      "community": 487
     },
     {
       "label": "session-store.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "session-store.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 486
+      "community": 488
     },
     {
       "label": "createSessionStore()",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 486
+      "community": 488
     },
     {
       "label": "stdio-server.ts",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 288
+      "community": 289
     },
     {
       "label": "StdioServer",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 288
+      "community": 289
     },
     {
       "label": ".start()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 288
+      "community": 289
     },
     {
       "label": ".stop()",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 288
+      "community": 289
     },
     {
       "label": ".cleanup()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 288
+      "community": 289
     },
     {
       "label": "sse-server.ts",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 289
+      "community": 290
     },
     {
       "label": "SseServer",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".start()",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".stop()",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".cleanup()",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 289
+      "community": 290
     },
     {
       "label": "test-database.ts",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_test_helpers_test_database_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "setupTestDatabase()",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L14",
       "id": "test_database_setuptestdatabase",
-      "community": 278
+      "community": 279
     },
     {
       "label": "cleanupTestDatabase()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L263",
       "id": "test_database_cleanuptestdatabase",
-      "community": 278
+      "community": 279
     },
     {
       "label": "quality.routes.spec.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "admin.routes.ts",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 487
+      "community": 489
     },
     {
       "label": "createAdminRouter()",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 487
+      "community": 489
     },
     {
       "label": "auth.routes.ts",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 290
+      "community": 291
     },
     {
       "label": "readBearerToken()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 290
+      "community": 291
     },
     {
       "label": "readApiKeyHeader()",
@@ -3489,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 290
+      "community": 291
     },
     {
       "label": "readCookie()",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 290
+      "community": 291
     },
     {
       "label": "createAuthRouter()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 290
+      "community": 291
     },
     {
       "label": "mcp.routes.ts",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 488
+      "community": 490
     },
     {
       "label": "createToolsRouter()",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 488
+      "community": 490
     },
     {
       "label": "api.routes.ts",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 489
+      "community": 491
     },
     {
       "label": "createApiRouter()",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 489
+      "community": 491
     },
     {
       "label": "quality.routes.ts",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 490
+      "community": 492
     },
     {
       "label": "createQualityRouter()",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 490
+      "community": 492
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 411
+      "community": 413
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 411
+      "community": 413
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 411
+      "community": 413
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 412
+      "community": 414
     },
     {
       "label": "parseParams()",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 412
+      "community": 414
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 412
+      "community": 414
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 491
+      "community": 493
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 491
+      "community": 493
     },
     {
       "label": "admin-graph-response.ts",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 492
+      "community": 494
     },
     {
       "label": "buildGraphResponse()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 492
+      "community": 494
     },
     {
       "label": "admin-tools.routes.ts",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 493
+      "community": 495
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 493
+      "community": 495
     },
     {
       "label": "admin-batch.routes.ts",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 494
+      "community": 496
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 494
+      "community": 496
     },
     {
       "label": "admin-graph.routes.ts",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 495
+      "community": 497
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 495
+      "community": 497
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 413
+      "community": 415
     },
     {
       "label": "parseCleanupParams()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 413
+      "community": 415
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 413
+      "community": 415
     },
     {
       "label": "admin-relations.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 496
+      "community": 498
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 496
+      "community": 498
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 497
+      "community": 499
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 497
+      "community": 499
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 498
+      "community": 500
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 498
+      "community": 500
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 499
+      "community": 501
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 499
+      "community": 501
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 414
+      "community": 416
     },
     {
       "label": "resolveEnvPath()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 414
+      "community": 416
     },
     {
       "label": "loadEnv()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 414
+      "community": 416
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 500
+      "community": 502
     },
     {
       "label": "runCli()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 500
+      "community": 502
     },
     {
       "label": "option-map.ts",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 415
+      "community": 417
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 415
+      "community": 417
     },
     {
       "label": "runQualityMeasurement()",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 415
+      "community": 417
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 501
+      "community": 503
     },
     {
       "label": "testSimpleAlerts()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 501
+      "community": 503
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 502
+      "community": 504
     },
     {
       "label": "testBasicFunctionality()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 502
+      "community": 504
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 503
+      "community": 505
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 503
+      "community": 505
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 416
+      "community": 418
     },
     {
       "label": "compareServices()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 416
+      "community": 418
     },
     {
       "label": "testServerSynchronization()",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 416
+      "community": 418
     },
     {
       "label": "test-error-logging.ts",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 504
+      "community": 506
     },
     {
       "label": "testErrorLogging()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 504
+      "community": 506
     },
     {
       "label": "debug-http-v2.ts",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 505
+      "community": 507
     },
     {
       "label": "testFetch()",
@@ -4241,7 +4241,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 505
+      "community": 507
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 506
+      "community": 508
     },
     {
       "label": "initializeTestDatabase()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 506
+      "community": 508
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 507
+      "community": 509
     },
     {
       "label": "testReflexionE2E()",
@@ -4289,7 +4289,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 507
+      "community": 509
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 508
+      "community": 510
     },
     {
       "label": "testAlertsDirect()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 508
+      "community": 510
     },
     {
       "label": "test-client.ts",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 417
+      "community": 419
     },
     {
       "label": "assert()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 417
+      "community": 419
     },
     {
       "label": "testMementoClient()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 417
+      "community": 419
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 509
+      "community": 511
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 509
+      "community": 511
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 510
+      "community": 512
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 510
+      "community": 512
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 511
+      "community": 513
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 511
+      "community": 513
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4457,7 +4457,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4465,7 +4465,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 418
+      "community": 420
     },
     {
       "label": "createBaseSchema()",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 418
+      "community": 420
     },
     {
       "label": "createTestMemory()",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 418
+      "community": 420
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 419
+      "community": 421
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 419
+      "community": 421
     },
     {
       "label": "findNodeForAnchor()",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 419
+      "community": 421
     },
     {
       "label": "vitest.config.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "brave-search-provider.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "BraveSearchProvider",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 333
+      "community": 334
     },
     {
       "label": ".constructor()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 333
+      "community": 334
     },
     {
       "label": ".search()",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 333
+      "community": 334
     },
     {
       "label": "noop-search-provider.ts",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 420
+      "community": 422
     },
     {
       "label": "NoopSearchProvider",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 420
+      "community": 422
     },
     {
       "label": ".search()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 420
+      "community": 422
     },
     {
       "label": "search-factory.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 512
+      "community": 514
     },
     {
       "label": "createSearchProvider()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 512
+      "community": 514
     },
     {
       "label": "search-provider.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "llm-provider.ts",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "claude-provider.spec.ts",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "types.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 513
+      "community": 515
     },
     {
       "label": "loadAgentConfig()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 513
+      "community": 515
     },
     {
       "label": "system-prompt.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "vitest.config.ts",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "utils.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 514
+      "community": 516
     },
     {
       "label": "buildMemory()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 514
+      "community": 516
     },
     {
       "label": "context-injector.ts",
@@ -5489,7 +5489,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "logger.ts",
@@ -5497,7 +5497,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 421
+      "community": 423
     },
     {
       "label": "shouldLog()",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 421
+      "community": 423
     },
     {
       "label": "log()",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 421
+      "community": 423
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 334
+      "community": 335
     },
     {
       "label": "constructor()",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L231",
       "id": "bootstrap_spec_constructor",
-      "community": 334
+      "community": 335
     },
     {
       "label": "loadBootstrap()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L254",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 334
+      "community": 335
     },
     {
       "label": "installTimeoutSpy()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L258",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 334
+      "community": 335
     },
     {
       "label": "index.ts",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 422
+      "community": 424
     },
     {
       "label": "createMementoCore()",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 422
+      "community": 424
     },
     {
       "label": "closeDatabase()",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 422
+      "community": 424
     },
     {
       "label": "bootstrap.ts",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 515
+      "community": 517
     },
     {
       "label": "initializeServices()",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 515
+      "community": 517
     },
     {
       "label": "context.ts",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createServerContext()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L15",
       "id": "context_createservercontext",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createToolContext()",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L24",
       "id": "context_createtoolcontext",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L37",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 335
+      "community": 336
     },
     {
       "label": "write-and-meta.ts",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 516
+      "community": 518
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 516
+      "community": 518
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 517
+      "community": 519
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 517
+      "community": 519
     },
     {
       "label": "anchor-stack.ts",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 518
+      "community": 520
     },
     {
       "label": "createAnchorStack()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 518
+      "community": 520
     },
     {
       "label": "failure-reflexion.ts",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 519
+      "community": 521
     },
     {
       "label": "startFailureAndReflexion()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 519
+      "community": 521
     },
     {
       "label": "search-and-embedding.ts",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 520
+      "community": 522
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 520
+      "community": 522
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 521
+      "community": 523
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 521
+      "community": 523
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 522
+      "community": 524
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 522
+      "community": 524
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 523
+      "community": 525
     },
     {
       "label": "createInput()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 523
+      "community": 525
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 291
+      "community": 292
     },
     {
       "label": "extract()",
@@ -6561,7 +6561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 291
+      "community": 292
     },
     {
       "label": "waitForEventProcessing()",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 291
+      "community": 292
     },
     {
       "label": "createProceduralMemory()",
@@ -6577,7 +6577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 291
+      "community": 292
     },
     {
       "label": "createFailureEvent()",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 291
+      "community": 292
     },
     {
       "label": "relation-graph-factory.ts",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 524
+      "community": 526
     },
     {
       "label": "createRelationGraph()",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 524
+      "community": 526
     },
     {
       "label": "consolidation-score-service.ts",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_ts",
-      "community": 145
+      "community": 144
     },
     {
       "label": "TripleExtractionLogger",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L61",
       "id": "triple_extraction_logger_tripleextractionlogger",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".constructor()",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L65",
       "id": "triple_extraction_logger_tripleextractionlogger_constructor",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".logExtraction()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L91",
       "id": "triple_extraction_logger_tripleextractionlogger_logextraction",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".createLogEntry()",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L128",
       "id": "triple_extraction_logger_tripleextractionlogger_createlogentry",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".ensureLogDirectory()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L191",
       "id": "triple_extraction_logger_tripleextractionlogger_ensurelogdirectory",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".getLogFilePath()",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L207",
       "id": "triple_extraction_logger_tripleextractionlogger_getlogfilepath",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".listLogFiles()",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L233",
       "id": "triple_extraction_logger_tripleextractionlogger_listlogfiles",
-      "community": 145
+      "community": 144
     },
     {
       "label": ".deleteOldLogs()",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L266",
       "id": "triple_extraction_logger_tripleextractionlogger_deleteoldlogs",
-      "community": 145
+      "community": 144
     },
     {
       "label": "database-optimize-tool.ts",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 336
+      "community": 337
     },
     {
       "label": ".constructor()",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 336
+      "community": 337
     },
     {
       "label": ".handle()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 336
+      "community": 337
     },
     {
       "label": "migration-history-service.ts",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 423
+      "community": 425
     },
     {
       "label": "createBaseSchema()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 423
+      "community": 425
     },
     {
       "label": "measureTime()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 423
+      "community": 425
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 525
+      "community": 527
     },
     {
       "label": "createBaseSchema()",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 525
+      "community": 527
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 526
+      "community": 528
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 526
+      "community": 528
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 527
+      "community": 529
     },
     {
       "label": "openLockTestDatabase()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 527
+      "community": 529
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 337
+      "community": 338
     },
     {
       "label": "createPlan()",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 337
+      "community": 338
     },
     {
       "label": "createResult()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 337
+      "community": 338
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 528
+      "community": 530
     },
     {
       "label": "createProgress()",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 528
+      "community": 530
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 723
+      "community": 725
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 529
+      "community": 531
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 529
+      "community": 531
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 530
+      "community": 532
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 530
+      "community": 532
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 424
+      "community": 426
     },
     {
       "label": "addMissingColumn()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 424
+      "community": 426
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 424
+      "community": 426
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "init.ts",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 531
+      "community": 533
     },
     {
       "label": "createDbPath()",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 531
+      "community": 533
     },
     {
       "label": "migrate.spec.ts",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "migrate.ts",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 425
+      "community": 427
     },
     {
       "label": "isDuplicateColumnError()",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 425
+      "community": 427
     },
     {
       "label": "migrateDatabase()",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 425
+      "community": 427
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "migration-runner.ts",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_ts",
-      "community": 146
+      "community": 145
     },
     {
       "label": "MigrationRunner",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L19",
       "id": "migration_runner_migrationrunner",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".constructor()",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L24",
       "id": "migration_runner_migrationrunner_constructor",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".runMigration()",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L33",
       "id": "migration_runner_migrationrunner_runmigration",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".rollbackMigration()",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L174",
       "id": "migration_runner_migrationrunner_rollbackmigration",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".runMigrations()",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L199",
       "id": "migration_runner_migrationrunner_runmigrations",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".calculateChecksum()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L222",
       "id": "migration_runner_migrationrunner_calculatechecksum",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".getBackupManager()",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L231",
       "id": "migration_runner_migrationrunner_getbackupmanager",
-      "community": 146
+      "community": 145
     },
     {
       "label": ".getVersionManager()",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L238",
       "id": "migration_runner_migrationrunner_getversionmanager",
-      "community": 146
+      "community": 145
     },
     {
       "label": "migration-runner.integration.spec.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 532
+      "community": 534
     },
     {
       "label": "createBaseSchema()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 532
+      "community": 534
     },
     {
       "label": "migration-logger.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "migration-detector.ts",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 732
+      "community": 734
     },
     {
       "label": "backup-manager.ts",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_ts",
-      "community": 147
+      "community": 146
     },
     {
       "label": "BackupManager",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L37",
       "id": "backup_manager_backupmanager",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".constructor()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L40",
       "id": "backup_manager_backupmanager_constructor",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".ensureBackupsDirectory()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L50",
       "id": "backup_manager_backupmanager_ensurebackupsdirectory",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".createBackup()",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L68",
       "id": "backup_manager_backupmanager_createbackup",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".restoreBackup()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L132",
       "id": "backup_manager_backupmanager_restorebackup",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".cleanupOldBackups()",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L165",
       "id": "backup_manager_backupmanager_cleanupoldbackups",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".findLatestBackup()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L210",
       "id": "backup_manager_backupmanager_findlatestbackup",
-      "community": 147
+      "community": 146
     },
     {
       "label": ".getBackupsDirectory()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L244",
       "id": "backup_manager_backupmanager_getbackupsdirectory",
-      "community": 147
+      "community": 146
     },
     {
       "label": "backup-manager.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "dependency-validator.ts",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "schema-version-manager.ts",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "createMemoryItemTable()",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 338
+      "community": 339
     },
     {
       "label": "columnExists()",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 338
+      "community": 339
     },
     {
       "label": "indexExists()",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 338
+      "community": 339
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_ts",
-      "community": 148
+      "community": 147
     },
     {
       "label": "AnchorTableMigration",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L20",
       "id": "004_anchor_table_anchortablemigration",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".executeSQL()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L29",
       "id": "004_anchor_table_anchortablemigration_executesql",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".tableExists()",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L54",
       "id": "004_anchor_table_anchortablemigration_tableexists",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".indexExists()",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L65",
       "id": "004_anchor_table_anchortablemigration_indexexists",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".validateBefore()",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L76",
       "id": "004_anchor_table_anchortablemigration_validatebefore",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".up()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L102",
       "id": "004_anchor_table_anchortablemigration_up",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".down()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L136",
       "id": "004_anchor_table_anchortablemigration_down",
-      "community": 148
+      "community": 147
     },
     {
       "label": ".validateAfter()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L158",
       "id": "004_anchor_table_anchortablemigration_validateafter",
-      "community": 148
+      "community": 147
     },
     {
       "label": "020-process-attribute-table.ts",
@@ -8593,7 +8593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_ts",
-      "community": 149
+      "community": 148
     },
     {
       "label": "FactMetadataFieldsMigration",
@@ -8601,7 +8601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L18",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".tableExists()",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L23",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_tableexists",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".columnExists()",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L30",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_columnexists",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".indexExists()",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L35",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_indexexists",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".validateBefore()",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L42",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validatebefore",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".up()",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L59",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_up",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".down()",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L68",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_down",
-      "community": 149
+      "community": 148
     },
     {
       "label": ".validateAfter()",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L96",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validateafter",
-      "community": 149
+      "community": 148
     },
     {
       "label": "032-add-project-id.ts",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createMemoryItemTable()",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createSchemaVersionTable()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 292
+      "community": 293
     },
     {
       "label": "columnExists()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 292
+      "community": 293
     },
     {
       "label": "indexExists()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 292
+      "community": 293
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_025_memory_item_is_consolidated_ts",
-      "community": 150
+      "community": 149
     },
     {
       "label": "MemoryItemIsConsolidatedMigration",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L9",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".tableExists()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L14",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_tableexists",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".columnExists()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L21",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_columnexists",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".indexExists()",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L26",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_indexexists",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".validateBefore()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L33",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validatebefore",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".up()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L35",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_up",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".down()",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L49",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_down",
-      "community": 150
+      "community": 149
     },
     {
       "label": ".validateAfter()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L58",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validateafter",
-      "community": 150
+      "community": 149
     },
     {
       "label": "030-triple-extraction-fields.spec.ts",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createMemoryItemTable()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createSchemaVersionTable()",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 293
+      "community": 294
     },
     {
       "label": "columnExists()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 293
+      "community": 294
     },
     {
       "label": "indexExists()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 293
+      "community": 294
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -9105,7 +9105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 533
+      "community": 535
     },
     {
       "label": "createBaseSchema()",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 533
+      "community": 535
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9297,7 +9297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 534
+      "community": 536
     },
     {
       "label": "createBaseSchema()",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 534
+      "community": 536
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 535
+      "community": 537
     },
     {
       "label": "createBaseSchema()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 535
+      "community": 537
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createMemoryItemTable()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 294
+      "community": 295
     },
     {
       "label": "columnExists()",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 294
+      "community": 295
     },
     {
       "label": "indexExists()",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 294
+      "community": 295
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_ts",
-      "community": 151
+      "community": 150
     },
     {
       "label": "TripleExtractionFieldsMigration",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".tableExists()",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L15",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_tableexists",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".columnExists()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L22",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_columnexists",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".indexExists()",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L27",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_indexexists",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".validateBefore()",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L34",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validatebefore",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".up()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L36",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_up",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".down()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L61",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_down",
-      "community": 151
+      "community": 150
     },
     {
       "label": ".validateAfter()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L69",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validateafter",
-      "community": 151
+      "community": 150
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_021_feedback_event_attribution_ts",
-      "community": 152
+      "community": 151
     },
     {
       "label": "FeedbackEventAttributionMigration",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L9",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".tableExists()",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L14",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_tableexists",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".columnExists()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L21",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_columnexists",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".indexExists()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L26",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_indexexists",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".validateBefore()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L33",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validatebefore",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".up()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L57",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_up",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".down()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L89",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_down",
-      "community": 152
+      "community": 151
     },
     {
       "label": ".validateAfter()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L107",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validateafter",
-      "community": 152
+      "community": 151
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 426
+      "community": 428
     },
     {
       "label": "createMemoryItemTable()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 426
+      "community": 428
     },
     {
       "label": "tableExists()",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 426
+      "community": 428
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 427
+      "community": 429
     },
     {
       "label": "createMemoryItemTable()",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 427
+      "community": 429
     },
     {
       "label": "tableExists()",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 427
+      "community": 429
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_ts",
-      "community": 153
+      "community": 152
     },
     {
       "label": "ProceduralVersionIndexesMigration",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L18",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".columnExists()",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L23",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_columnexists",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".tableExists()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L28",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_tableexists",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".indexExists()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L35",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_indexexists",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".validateBefore()",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L42",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validatebefore",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".up()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L62",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_up",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".down()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L73",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_down",
-      "community": 153
+      "community": 152
     },
     {
       "label": ".validateAfter()",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L81",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validateafter",
-      "community": 153
+      "community": 152
     },
     {
       "label": "002-mirix-schema-expansion.spec.ts",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 536
+      "community": 538
     },
     {
       "label": "createBaseSchema()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 536
+      "community": 538
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 537
+      "community": 539
     },
     {
       "label": "createSchemaWith018()",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 537
+      "community": 539
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 538
+      "community": 540
     },
     {
       "label": "createBaseSchema()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 538
+      "community": 540
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createMemoryLinkTable()",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 339
+      "community": 340
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_ts",
-      "community": 154
+      "community": 153
     },
     {
       "label": "MemoryItemAttributionMigration",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L18",
       "id": "016_memory_item_attribution_memoryitemattributionmigration",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".tableExists()",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L23",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_tableexists",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".columnExists()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L30",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_columnexists",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".indexExists()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L35",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_indexexists",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".validateBefore()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L42",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validatebefore",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".up()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L62",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_up",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".down()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L69",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_down",
-      "community": 154
+      "community": 153
     },
     {
       "label": ".validateAfter()",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L87",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validateafter",
-      "community": 154
+      "community": 153
     },
     {
       "label": "027-telemetry-events.ts",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createMemoryItemTable()",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 295
+      "community": 296
     },
     {
       "label": "columnExists()",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 295
+      "community": 296
     },
     {
       "label": "indexExists()",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 295
+      "community": 296
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_ts",
-      "community": 155
+      "community": 154
     },
     {
       "label": "KgTripleTableMigration",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L17",
       "id": "018_kg_triple_table_kgtripletablemigration",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".tableExists()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L22",
       "id": "018_kg_triple_table_kgtripletablemigration_tableexists",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".columnExists()",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L29",
       "id": "018_kg_triple_table_kgtripletablemigration_columnexists",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".indexExists()",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L34",
       "id": "018_kg_triple_table_kgtripletablemigration_indexexists",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".validateBefore()",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L41",
       "id": "018_kg_triple_table_kgtripletablemigration_validatebefore",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".up()",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L58",
       "id": "018_kg_triple_table_kgtripletablemigration_up",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".down()",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L80",
       "id": "018_kg_triple_table_kgtripletablemigration_down",
-      "community": 155
+      "community": 154
     },
     {
       "label": ".validateAfter()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L91",
       "id": "018_kg_triple_table_kgtripletablemigration_validateafter",
-      "community": 155
+      "community": 154
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createMemoryItemTable()",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "columnExists()",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "indexExists()",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 539
+      "community": 541
     },
     {
       "label": "createBaseSchema()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 539
+      "community": 541
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_ts",
-      "community": 156
+      "community": 155
     },
     {
       "label": "SoftDeleteFieldsMigration",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_softdeletefieldsmigration",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".tableExists()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L14",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_tableexists",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".columnExists()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L21",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_columnexists",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".indexExists()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L26",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_indexexists",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".validateBefore()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L33",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validatebefore",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".up()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_up",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".down()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L52",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_down",
-      "community": 156
+      "community": 155
     },
     {
       "label": ".validateAfter()",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L59",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validateafter",
-      "community": 156
+      "community": 155
     },
     {
       "label": "006-fts5-reflection-notes.spec.ts",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 540
+      "community": 542
     },
     {
       "label": "createBaseSchema()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 540
+      "community": 542
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 428
+      "community": 430
     },
     {
       "label": "createBaseSchema()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 428
+      "community": 430
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 428
+      "community": 430
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_ts",
-      "community": 157
+      "community": 156
     },
     {
       "label": "MemoryItemOwnerIdMigration",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L17",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".tableExists()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L22",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_tableexists",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".columnExists()",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L29",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_columnexists",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".indexExists()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L34",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_indexexists",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".validateBefore()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L41",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validatebefore",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".up()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L58",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_up",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".down()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L63",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_down",
-      "community": 157
+      "community": 156
     },
     {
       "label": ".validateAfter()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L75",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validateafter",
-      "community": 157
+      "community": 156
     },
     {
       "label": "003-consolidation-score-fields.spec.ts",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 541
+      "community": 543
     },
     {
       "label": "createBaseSchema()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 541
+      "community": 543
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 340
+      "community": 341
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 340
+      "community": 341
     },
     {
       "label": "getIndexNames()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 340
+      "community": 341
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "createSchemaWith019()",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 341
+      "community": 342
     },
     {
       "label": "tableExists()",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 341
+      "community": 342
     },
     {
       "label": "columnExists()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 341
+      "community": 342
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "cache-service.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "batch-scheduler.ts",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 342
+      "community": 343
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -12721,7 +12721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 342
+      "community": 343
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 342
+      "community": 343
     },
     {
       "label": "health-checker.ts",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 542
+      "community": 544
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 542
+      "community": 544
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 543
+      "community": 545
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 543
+      "community": 545
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 429
+      "community": 431
     },
     {
       "label": "readInsertedUpdated()",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 429
+      "community": 431
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 429
+      "community": 431
     },
     {
       "label": "relation-validator-executor.ts",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_relation_validator_executor_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "RelationValidatorExecutor",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L31",
       "id": "relation_validator_executor_relationvalidatorexecutor",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".constructor()",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L34",
       "id": "relation_validator_executor_relationvalidatorexecutor_constructor",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".execute()",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L49",
       "id": "relation_validator_executor_relationvalidatorexecutor_execute",
-      "community": 343
+      "community": 344
     },
     {
       "label": "batch-scheduler-types.ts",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 544
+      "community": 546
     },
     {
       "label": "validateBatchJobConfig()",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 544
+      "community": 546
     },
     {
       "label": "retry-manager.ts",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_retry_manager_ts",
-      "community": 158
+      "community": 157
     },
     {
       "label": "RetryManager",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L103",
       "id": "retry_manager_retrymanager",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".constructor()",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L107",
       "id": "retry_manager_retrymanager_constructor",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".shouldRetry()",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L119",
       "id": "retry_manager_retrymanager_shouldretry",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".resetErrorCount()",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L158",
       "id": "retry_manager_retrymanager_reseterrorcount",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".incrementErrorCount()",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L168",
       "id": "retry_manager_retrymanager_incrementerrorcount",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".getErrorCount()",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L181",
       "id": "retry_manager_retrymanager_geterrorcount",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".clearAllErrorCounts()",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L188",
       "id": "retry_manager_retrymanager_clearallerrorcounts",
-      "community": 158
+      "community": 157
     },
     {
       "label": ".retry()",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L218",
       "id": "retry_manager_retrymanager_retry",
-      "community": 158
+      "community": 157
     },
     {
       "label": "batch-job-execution-coordinator.ts",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_file_logger_ts",
-      "community": 159
+      "community": 158
     },
     {
       "label": "FileLogger",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L38",
       "id": "file_logger_filelogger",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".constructor()",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L42",
       "id": "file_logger_filelogger_constructor",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".log()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L81",
       "id": "file_logger_filelogger_log",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".logWarn()",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L128",
       "id": "file_logger_filelogger_logwarn",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".logError()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L160",
       "id": "file_logger_filelogger_logerror",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".sanitizeData()",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L194",
       "id": "file_logger_filelogger_sanitizedata",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".getLogFilePath()",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L211",
       "id": "file_logger_filelogger_getlogfilepath",
-      "community": 159
+      "community": 158
     },
     {
       "label": ".setEnabled()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L220",
       "id": "file_logger_filelogger_setenabled",
-      "community": 159
+      "community": 158
     },
     {
       "label": "job-queue.ts",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 297
+      "community": 298
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 297
+      "community": 298
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L113",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 297
+      "community": 298
     },
     {
       "label": "runLogRotation()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L168",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 297
+      "community": 298
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 739
+      "community": 741
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 430
+      "community": 432
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 430
+      "community": 432
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 430
+      "community": 432
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 431
+      "community": 433
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13425,7 +13425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 431
+      "community": 433
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 431
+      "community": 433
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L16",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 344
+      "community": 345
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L46",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 344
+      "community": 345
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L83",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 344
+      "community": 345
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 298
+      "community": 299
     },
     {
       "label": "runMemoryCleanup()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 298
+      "community": 299
     },
     {
       "label": "runMonitoring()",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 298
+      "community": 299
     },
     {
       "label": "runHealthCheck()",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 298
+      "community": 299
     },
     {
       "label": "file-logger.spec.ts",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "retry-manager.spec.ts",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 545
+      "community": 547
     },
     {
       "label": "shouldRetry()",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 545
+      "community": 547
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 546
+      "community": 548
     },
     {
       "label": "baseResult()",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 546
+      "community": 548
     },
     {
       "label": "job-queue.spec.ts",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "job()",
@@ -13633,7 +13633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 299
+      "community": 300
     },
     {
       "label": "job1()",
@@ -13641,7 +13641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 299
+      "community": 300
     },
     {
       "label": "job2()",
@@ -13649,7 +13649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 299
+      "community": 300
     },
     {
       "label": "job3()",
@@ -13657,7 +13657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 299
+      "community": 300
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 547
+      "community": 549
     },
     {
       "label": "initializeTestDatabase()",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 547
+      "community": 549
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 345
+      "community": 346
     },
     {
       "label": ".constructor()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 345
+      "community": 346
     },
     {
       "label": ".execute()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 345
+      "community": 346
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".constructor()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".execute()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 346
+      "community": 347
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".constructor()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".execute()",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 347
+      "community": 348
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 432
+      "community": 434
     },
     {
       "label": "generateId()",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 432
+      "community": 434
     },
     {
       "label": "initializeTestDatabase()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 432
+      "community": 434
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 548
+      "community": 550
     },
     {
       "label": "createQualityTables()",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 548
+      "community": 550
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 433
+      "community": 435
     },
     {
       "label": "generateId()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 433
+      "community": 435
     },
     {
       "label": "initializeTestDatabase()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 433
+      "community": 435
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "stopwords.spec.ts",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "type-guards.ts",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_guards_ts",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isMemoryRow()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L32",
       "id": "type_guards_ismemoryrow",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isMemoryType()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L53",
       "id": "type_guards_ismemorytype",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isPrivacyScope()",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L63",
       "id": "type_guards_isprivacyscope",
-      "community": 160
+      "community": 159
     },
     {
       "label": "convertMemoryRowToItem()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L74",
       "id": "type_guards_convertmemoryrowtoitem",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isRelationRow()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L144",
       "id": "type_guards_isrelationrow",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isExistingRelationRow()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L176",
       "id": "type_guards_isexistingrelationrow",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isMetadataRow()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L201",
       "id": "type_guards_ismetadatarow",
-      "community": 160
+      "community": 159
     },
     {
       "label": "isSqlParam()",
@@ -14033,7 +14033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L216",
       "id": "type_guards_issqlparam",
-      "community": 160
+      "community": 159
     },
     {
       "label": "procedural-memory-extractor.ts",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 434
+      "community": 436
     },
     {
       "label": "validateTableName()",
@@ -14153,7 +14153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 434
+      "community": 436
     },
     {
       "label": "getVectorTableName()",
@@ -14161,7 +14161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 434
+      "community": 436
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14169,7 +14169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 549
+      "community": 551
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 549
+      "community": 551
     },
     {
       "label": "environment-check.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "isTestEnvironment()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 348
+      "community": 349
     },
     {
       "label": "isValidationDisabled()",
@@ -14201,7 +14201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 348
+      "community": 349
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -14209,7 +14209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 348
+      "community": 349
     },
     {
       "label": "db-path.spec.ts",
@@ -14217,7 +14217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 300
+      "community": 301
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 300
+      "community": 301
     },
     {
       "label": "extractKeyTokens()",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 300
+      "community": 301
     },
     {
       "label": "getSearchQueryExamples()",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 300
+      "community": 301
     },
     {
       "label": "relation-type-converter.ts",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "toDbRelationType()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 301
+      "community": 302
     },
     {
       "label": "fromDbRelationType()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 301
+      "community": 302
     },
     {
       "label": "isValidDbRelationType()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 301
+      "community": 302
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 301
+      "community": 302
     },
     {
       "label": "db-path.ts",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 550
+      "community": 552
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 550
+      "community": 552
     },
     {
       "label": "error-handling.spec.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 551
+      "community": 553
     },
     {
       "label": "operation()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 551
+      "community": 553
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_rate_limiter_ts",
-      "community": 161
+      "community": 160
     },
     {
       "label": "LoggingRateLimiter",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L31",
       "id": "logging_rate_limiter_loggingratelimiter",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".constructor()",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L38",
       "id": "logging_rate_limiter_loggingratelimiter_constructor",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".canSend()",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L52",
       "id": "logging_rate_limiter_loggingratelimiter_cansend",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".consume()",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L61",
       "id": "logging_rate_limiter_loggingratelimiter_consume",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".refill()",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L76",
       "id": "logging_rate_limiter_loggingratelimiter_refill",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".getDroppedCount()",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L88",
       "id": "logging_rate_limiter_loggingratelimiter_getdroppedcount",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".resetDroppedCount()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L95",
       "id": "logging_rate_limiter_loggingratelimiter_resetdroppedcount",
-      "community": 161
+      "community": 160
     },
     {
       "label": ".getAvailableTokens()",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L102",
       "id": "logging_rate_limiter_loggingratelimiter_getavailabletokens",
-      "community": 161
+      "community": 160
     },
     {
       "label": "type-param-validator.ts",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "relation-visualizer.ts",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 435
+      "community": 437
     },
     {
       "label": "issue()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 435
+      "community": 437
     },
     {
       "label": "validateConfiguration()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 435
+      "community": 437
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "cache-key-generator.ts",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 436
+      "community": 438
     },
     {
       "label": "transactionFn()",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 436
+      "community": 438
     },
     {
       "label": "outerTransaction()",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 436
+      "community": 438
     },
     {
       "label": "write-coalescing.ts",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "validateReflectionNote()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 349
+      "community": 350
     },
     {
       "label": "validateReflectionNotes()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 349
+      "community": 350
     },
     {
       "label": "formatValidationErrors()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 349
+      "community": 350
     },
     {
       "label": "environment-check.spec.ts",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "path-validator.ts",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 552
+      "community": 554
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 552
+      "community": 554
     },
     {
       "label": "error-handling.ts",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 553
+      "community": 555
     },
     {
       "label": "withErrorHandling()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 553
+      "community": 555
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_ts",
-      "community": 162
+      "community": 161
     },
     {
       "label": "validateLogMetadata()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L54",
       "id": "logger_validatelogmetadata",
-      "community": 162
+      "community": 161
     },
     {
       "label": "isMCPMode()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L160",
       "id": "logger_ismcpmode",
-      "community": 162
+      "community": 161
     },
     {
       "label": "safeStringify()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L173",
       "id": "logger_safestringify",
-      "community": 162
+      "community": 161
     },
     {
       "label": "formatTime()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L181",
       "id": "logger_formattime",
-      "community": 162
+      "community": 161
     },
     {
       "label": "buildLogMessage()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L191",
       "id": "logger_buildlogmessage",
-      "community": 162
+      "community": 161
     },
     {
       "label": "logToStderr()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L209",
       "id": "logger_logtostderr",
-      "community": 162
+      "community": 161
     },
     {
       "label": "logWithMCPLogger()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L240",
       "id": "logger_logwithmcplogger",
-      "community": 162
+      "community": 161
     },
     {
       "label": "isCliQuiet()",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L294",
       "id": "logger_iscliquiet",
-      "community": 162
+      "community": 161
     },
     {
       "label": "ensure-meta-memory-stats-schema.ts",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 554
+      "community": 556
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 554
+      "community": 556
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 437
+      "community": 439
     },
     {
       "label": "createValidReflectionNote()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 437
+      "community": 439
     },
     {
       "label": "createLargeNote()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 437
+      "community": 439
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 555
+      "community": 557
     },
     {
       "label": "initializeTestDatabase()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 555
+      "community": 557
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 556
+      "community": 558
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 556
+      "community": 558
     },
     {
       "label": "logging-helpers.ts",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "pii-masker.ts",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "getStopWords()",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 302
+      "community": 303
     },
     {
       "label": "getEnglishStopWords()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 302
+      "community": 303
     },
     {
       "label": "getKoreanStopWords()",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 302
+      "community": 303
     },
     {
       "label": "isStopWord()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 302
+      "community": 303
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "path-validator.spec.ts",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "triple-cache.spec.ts",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "logger-schema.spec.ts",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 557
+      "community": 559
     },
     {
       "label": "initializeTestDatabase()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 557
+      "community": 559
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "benchmark.types.ts",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 558
+      "community": 560
     },
     {
       "label": "assertMacroCategory()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 558
+      "community": 560
     },
     {
       "label": "migration.types.ts",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "consolidation-score.types.ts",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "consolidation.types.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "vector-search.types.ts",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "procedural-versioning.ts",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "triple-extraction.ts",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "feedback.types.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "embedding.types.ts",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "relation-graph.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "failure-event.ts",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "index.ts",
@@ -15921,7 +15921,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 559
+      "community": 561
     },
     {
       "label": "isMemoryItemType()",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 559
+      "community": 561
     },
     {
       "label": "error-types.ts",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "ranking.types.ts",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "alerts.types.ts",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "relation.ts",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "isApplicableRelationType()",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L151",
       "id": "relation_isapplicablerelationtype",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getRelationCategory()",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L161",
       "id": "relation_getrelationcategory",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getRelationBoost()",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L168",
       "id": "relation_getrelationboost",
-      "community": 350
+      "community": 351
     },
     {
       "label": "search.types.ts",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "index.spec.ts",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "constants.ts",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "environment.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "retry-options-loader.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 560
+      "community": 562
     },
     {
       "label": "validateConfig()",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 560
+      "community": 562
     },
     {
       "label": "config-loader-utils.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "constants.spec.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "config-validation.spec.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "relation-constants.ts",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "introspection-constants.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "http-bind-policy.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_ts",
-      "community": 163
+      "community": 162
     },
     {
       "label": "MementoHttpSecurityStartupError",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L5",
       "id": "http_bind_policy_mementohttpsecuritystartuperror",
-      "community": 163
+      "community": 162
     },
     {
       "label": ".constructor()",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L8",
       "id": "http_bind_policy_mementohttpsecuritystartuperror_constructor",
-      "community": 163
+      "community": 162
     },
     {
       "label": "isIpv4Loopback127Block()",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L17",
       "id": "http_bind_policy_isipv4loopback127block",
-      "community": 163
+      "community": 162
     },
     {
       "label": "isIpv4MappedLoopback()",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L32",
       "id": "http_bind_policy_isipv4mappedloopback",
-      "community": 163
+      "community": 162
     },
     {
       "label": "canonicalizeHttpBindHostForListen()",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L53",
       "id": "http_bind_policy_canonicalizehttpbindhostforlisten",
-      "community": 163
+      "community": 162
     },
     {
       "label": "formatHttpBindHostForUrl()",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L64",
       "id": "http_bind_policy_formathttpbindhostforurl",
-      "community": 163
+      "community": 162
     },
     {
       "label": "isHttpBindHostRemotelyReachable()",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L72",
       "id": "http_bind_policy_ishttpbindhostremotelyreachable",
-      "community": 163
+      "community": 162
     },
     {
       "label": "getMementoHttpSecurityStartupViolationMessage()",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L87",
       "id": "http_bind_policy_getmementohttpsecuritystartupviolationmessage",
-      "community": 163
+      "community": 162
     },
     {
       "label": "reflexion-worker.interface.ts",
@@ -16441,7 +16441,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16449,7 +16449,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "cache.interface.ts",
@@ -16457,7 +16457,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16465,7 +16465,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "error-logging.interface.ts",
@@ -16473,7 +16473,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16481,7 +16481,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16489,7 +16489,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "database.interface.ts",
@@ -16497,7 +16497,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16505,7 +16505,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16513,7 +16513,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "llm-client-initializer.ts",
@@ -16697,7 +16697,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 438
+      "community": 440
     },
     {
       "label": "getMockMementoConfig()",
@@ -16705,7 +16705,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 438
+      "community": 440
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 438
+      "community": 440
     },
     {
       "label": "initialize.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "openai-client.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "environment-priority.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -16785,7 +16785,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "gemini-client.spec.ts",
@@ -16793,7 +16793,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "search-local-tool.ts",
@@ -16801,7 +16801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "SearchLocalTool",
@@ -16809,7 +16809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 351
+      "community": 352
     },
     {
       "label": ".constructor()",
@@ -16817,7 +16817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 351
+      "community": 352
     },
     {
       "label": ".handle()",
@@ -16825,7 +16825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 351
+      "community": 352
     },
     {
       "label": "get-anchor-tool.ts",
@@ -16833,7 +16833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "GetAnchorTool",
@@ -16841,7 +16841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 352
+      "community": 353
     },
     {
       "label": ".constructor()",
@@ -16849,7 +16849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 352
+      "community": 353
     },
     {
       "label": ".handle()",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 352
+      "community": 353
     },
     {
       "label": "set-anchor-tool.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "SetAnchorTool",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".constructor()",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".handle()",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 353
+      "community": 354
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "ClearAnchorTool",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".constructor()",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".handle()",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 354
+      "community": 355
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "RestoreAnchorsTool",
@@ -16937,7 +16937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".constructor()",
@@ -16945,7 +16945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".handle()",
@@ -16953,7 +16953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 355
+      "community": 356
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -16961,7 +16961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "initializeTestDatabase()",
@@ -16969,7 +16969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 303
+      "community": 304
     },
     {
       "label": "createMockEmbeddingService()",
@@ -16977,7 +16977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 303
+      "community": 304
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -16985,7 +16985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 303
+      "community": 304
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -16993,7 +16993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 303
+      "community": 304
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -17001,7 +17001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "initializeTestDatabase()",
@@ -17009,7 +17009,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 304
+      "community": 305
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17017,7 +17017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 304
+      "community": 305
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17025,7 +17025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 304
+      "community": 305
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17033,7 +17033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 304
+      "community": 305
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -17041,7 +17041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "initializeTestDatabase()",
@@ -17049,7 +17049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 305
+      "community": 306
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17057,7 +17057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 305
+      "community": 306
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17065,7 +17065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 305
+      "community": 306
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17073,7 +17073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 305
+      "community": 306
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -17081,7 +17081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 561
+      "community": 563
     },
     {
       "label": "initializeTestDatabase()",
@@ -17089,7 +17089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 561
+      "community": 563
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17097,7 +17097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 562
+      "community": 564
     },
     {
       "label": "initializeTestDatabase()",
@@ -17105,7 +17105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 562
+      "community": 564
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "QueryFilterStrategy",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".constructor()",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".filter()",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".execute()",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 306
+      "community": 307
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "local-search-service.ts",
@@ -17241,7 +17241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17249,7 +17249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17377,7 +17377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17385,7 +17385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 563
+      "community": 565
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17393,7 +17393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 563
+      "community": 565
     },
     {
       "label": "embedding-types.ts",
@@ -17401,7 +17401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17409,7 +17409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -17417,7 +17417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "NHopSearchStrategy",
@@ -17425,7 +17425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".constructor()",
@@ -17433,7 +17433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".search()",
@@ -17441,7 +17441,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".execute()",
@@ -17449,7 +17449,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 307
+      "community": 308
     },
     {
       "label": "query-filter-service.ts",
@@ -17617,7 +17617,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "FallbackSearchService",
@@ -17625,7 +17625,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 308
+      "community": 309
     },
     {
       "label": ".setDatabase()",
@@ -17633,7 +17633,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 308
+      "community": 309
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -17641,7 +17641,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 308
+      "community": 309
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -17649,7 +17649,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 308
+      "community": 309
     },
     {
       "label": "index.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "fallback-strategy.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "FallbackStrategy",
@@ -17673,7 +17673,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".constructor()",
@@ -17681,7 +17681,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".fallback()",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".execute()",
@@ -17697,7 +17697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 309
+      "community": 310
     },
     {
       "label": "anchor-search-service.ts",
@@ -17841,7 +17841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18089,7 +18089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18097,7 +18097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18105,7 +18105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "vector-search.factory.ts",
@@ -18161,7 +18161,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_hybrid_search_factory_ts",
-      "community": 164
+      "community": 163
     },
     {
       "label": "DefaultSearchLogger",
@@ -18169,7 +18169,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L27",
       "id": "hybrid_search_factory_defaultsearchlogger",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".logSearchStart()",
@@ -18177,7 +18177,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L28",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstart",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".logSearchStep()",
@@ -18185,7 +18185,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L32",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstep",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".logSearchComplete()",
@@ -18193,7 +18193,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L36",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchcomplete",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".logSearchError()",
@@ -18201,7 +18201,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L48",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearcherror",
-      "community": 164
+      "community": 163
     },
     {
       "label": "HybridSearchFactory",
@@ -18209,7 +18209,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L58",
       "id": "hybrid_search_factory_hybridsearchfactory",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".createDefaultEngine()",
@@ -18217,7 +18217,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L62",
       "id": "hybrid_search_factory_hybridsearchfactory_createdefaultengine",
-      "community": 164
+      "community": 163
     },
     {
       "label": ".createEngine()",
@@ -18225,7 +18225,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L91",
       "id": "hybrid_search_factory_hybridsearchfactory_createengine",
-      "community": 164
+      "community": 163
     },
     {
       "label": "hybrid-search.factory.spec.ts",
@@ -18233,7 +18233,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 564
+      "community": 566
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18241,7 +18241,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 564
+      "community": 566
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18249,7 +18249,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "search-result-combiner.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "SearchResultCombiner",
@@ -18265,7 +18265,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L19",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".combine()",
@@ -18273,7 +18273,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L31",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".generateHybridReason()",
@@ -18281,7 +18281,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L100",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 356
+      "community": 357
     },
     {
       "label": "search-engine.ts",
@@ -18433,7 +18433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -18441,7 +18441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L71",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 357
+      "community": 358
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -18449,7 +18449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L139",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 357
+      "community": 358
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -18457,7 +18457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L179",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 357
+      "community": 358
     },
     {
       "label": "search-ranking.ts",
@@ -19321,7 +19321,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 565
+      "community": 567
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19329,7 +19329,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 565
+      "community": 567
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19449,7 +19449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "normalize()",
@@ -19457,7 +19457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 358
+      "community": 359
     },
     {
       "label": "toSet()",
@@ -19465,7 +19465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 358
+      "community": 359
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -19473,7 +19473,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 358
+      "community": 359
     },
     {
       "label": "procedural-memory-matcher.spec.ts",
@@ -19481,7 +19481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19489,7 +19489,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19497,7 +19497,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 439
+      "community": 441
     },
     {
       "label": "initializeTestDatabase()",
@@ -19505,7 +19505,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 439
+      "community": 441
     },
     {
       "label": "createValidReflectionNote()",
@@ -19513,7 +19513,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 439
+      "community": 441
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -19521,7 +19521,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_spec_ts",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockTextSearchEngine()",
@@ -19529,7 +19529,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L44",
       "id": "hybrid_search_engine_spec_createmocktextsearchengine",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockEmbeddingService()",
@@ -19537,7 +19537,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L48",
       "id": "hybrid_search_engine_spec_createmockembeddingservice",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -19545,7 +19545,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L54",
       "id": "hybrid_search_engine_spec_createmockvectorsearchengine",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockResultCombiner()",
@@ -19553,7 +19553,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L60",
       "id": "hybrid_search_engine_spec_createmockresultcombiner",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockWeightCalculator()",
@@ -19561,7 +19561,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L64",
       "id": "hybrid_search_engine_spec_createmockweightcalculator",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createMockLogger()",
@@ -19569,7 +19569,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L68",
       "id": "hybrid_search_engine_spec_createmocklogger",
-      "community": 165
+      "community": 164
     },
     {
       "label": "createTestMemory()",
@@ -19577,7 +19577,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L536",
       "id": "hybrid_search_engine_spec_createtestmemory",
-      "community": 165
+      "community": 164
     },
     {
       "label": "p95()",
@@ -19585,7 +19585,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L2621",
       "id": "hybrid_search_engine_spec_p95",
-      "community": 165
+      "community": 164
     },
     {
       "label": "hybrid-search-engine-consolidation.spec.ts",
@@ -19593,7 +19593,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -19601,7 +19601,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "search-engine.spec.ts",
@@ -19609,7 +19609,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "createCountingSearchDb()",
@@ -19617,7 +19617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 359
+      "community": 360
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -19625,7 +19625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 359
+      "community": 360
     },
     {
       "label": "createSearchRows()",
@@ -19633,7 +19633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 359
+      "community": 360
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -19641,7 +19641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "vector-search.repository.ts",
@@ -19833,7 +19833,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -19841,7 +19841,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "vector-search.service.ts",
@@ -19937,7 +19937,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 566
+      "community": 568
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -19945,7 +19945,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 566
+      "community": 568
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 567
+      "community": 569
     },
     {
       "label": "createMockRepository()",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 567
+      "community": 569
     },
     {
       "label": "vector-index-manager.ts",
@@ -20281,7 +20281,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "selectScore()",
@@ -20289,7 +20289,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 310
+      "community": 311
     },
     {
       "label": "computeNormalizationRange()",
@@ -20297,7 +20297,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 310
+      "community": 311
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -20305,7 +20305,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".normalize()",
@@ -20313,7 +20313,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 310
+      "community": 311
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -20321,7 +20321,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 568
+      "community": 570
     },
     {
       "label": "createMockRepositories()",
@@ -20329,7 +20329,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 568
+      "community": 570
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20337,7 +20337,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20345,7 +20345,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 569
+      "community": 571
     },
     {
       "label": "createMockIndexRepository()",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 569
+      "community": 571
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20529,7 +20529,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20537,7 +20537,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20545,7 +20545,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "spaced-repetition.ts",
@@ -20873,7 +20873,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -20881,7 +20881,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "ForgettingStatsTool",
@@ -20889,7 +20889,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".constructor()",
@@ -20897,7 +20897,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".handle()",
@@ -20905,7 +20905,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 360
+      "community": 361
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -20913,7 +20913,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21049,7 +21049,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21057,7 +21057,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "priority-calculation.service.ts",
@@ -21937,7 +21937,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "recall-probability.service.ts",
@@ -22041,7 +22041,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "telemetry.types.ts",
@@ -22049,7 +22049,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22057,7 +22057,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 570
+      "community": 572
     },
     {
       "label": "openTelemetryDb()",
@@ -22065,7 +22065,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 570
+      "community": 572
     },
     {
       "label": "telemetry-repository.ts",
@@ -22225,7 +22225,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 311
+      "community": 312
     },
     {
       "label": "makeSearchQuality()",
@@ -22233,7 +22233,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 311
+      "community": 312
     },
     {
       "label": "makeMemoryQuality()",
@@ -22241,7 +22241,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 311
+      "community": 312
     },
     {
       "label": "makeConsolidationQuality()",
@@ -22249,7 +22249,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 311
+      "community": 312
     },
     {
       "label": "makeContext()",
@@ -22257,7 +22257,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 311
+      "community": 312
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -22265,7 +22265,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -22273,7 +22273,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".constructor()",
@@ -22281,7 +22281,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".handle()",
@@ -22289,7 +22289,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 361
+      "community": 362
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -22297,7 +22297,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "telemetry-service.ts",
@@ -22425,7 +22425,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "llm-port.ts",
@@ -22433,7 +22433,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "persistence-port.ts",
@@ -22441,7 +22441,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "context-port.ts",
@@ -22449,7 +22449,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "agent-types.ts",
@@ -22457,7 +22457,55 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 851
+      "community": 853
+    },
+    {
+      "label": "tool-context-knowledge-context-adapter.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
+      "community": 271
+    },
+    {
+      "label": "normalizeMemoryTypesForSearch()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L11",
+      "id": "tool_context_knowledge_context_adapter_normalizememorytypesforsearch",
+      "community": 271
+    },
+    {
+      "label": "ToolContextKnowledgeContextAdapter",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L25",
+      "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "community": 271
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L26",
+      "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
+      "community": 271
+    },
+    {
+      "label": ".buildContext()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L28",
+      "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
+      "community": 271
+    },
+    {
+      "label": ".proposeCandidates()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L54",
+      "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
+      "community": 271
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -22465,7 +22513,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -22473,7 +22521,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".constructor()",
@@ -22481,7 +22529,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".complete()",
@@ -22489,7 +22537,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".createRequestId()",
@@ -22497,7 +22545,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 312
+      "community": 313
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -22505,7 +22553,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -22513,15 +22561,15 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 571
+      "community": 573
     },
     {
       "label": "makeDeps()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
-      "source_location": "L9",
+      "source_location": "L17",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 571
+      "community": 573
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -22529,7 +22577,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -22537,7 +22585,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L16",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".constructor()",
@@ -22545,7 +22593,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L17",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".runOneTurn()",
@@ -22553,7 +22601,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L19",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 362
+      "community": 363
     },
     {
       "label": "core-memory-repository.ts",
@@ -22561,7 +22609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "kg-triple-repository.ts",
@@ -22569,7 +22617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "process-attribute-repository.ts",
@@ -22577,7 +22625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -22585,7 +22633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -22593,7 +22641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "feedback-repository.ts",
@@ -22601,7 +22649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 440
+      "community": 442
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -22609,7 +22657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 440
+      "community": 442
     },
     {
       "label": "FeedbackRepository",
@@ -22617,7 +22665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 440
+      "community": 442
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -22625,7 +22673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -22633,7 +22681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -22641,7 +22689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -22649,7 +22697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -22657,7 +22705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -22665,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 572
+      "community": 574
     },
     {
       "label": "createKgTripleTable()",
@@ -22673,7 +22721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 572
+      "community": 574
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -22681,7 +22729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 573
+      "community": 575
     },
     {
       "label": "createProcessAttributeTable()",
@@ -22689,7 +22737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 573
+      "community": 575
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -22697,7 +22745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 574
+      "community": 576
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -22705,7 +22753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 574
+      "community": 576
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -22713,7 +22761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -22721,7 +22769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 575
+      "community": 577
     },
     {
       "label": "createCoreMemoryTable()",
@@ -22729,7 +22777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 575
+      "community": 577
     },
     {
       "label": "remember-tool.ts",
@@ -22817,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 441
+      "community": 443
     },
     {
       "label": "validateRecallQuery()",
@@ -22825,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 441
+      "community": 443
     },
     {
       "label": "validateRecallFilters()",
@@ -22833,7 +22881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 441
+      "community": 443
     },
     {
       "label": "recall-tool-schema.ts",
@@ -22841,7 +22889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 576
+      "community": 578
     },
     {
       "label": "normalizeProviderFilter()",
@@ -22849,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 576
+      "community": 578
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -22857,79 +22905,31 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 136
+      "community": 364
     },
     {
       "label": "MemoryInjectionPrompt",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L30",
+      "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 136
+      "community": 364
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L31",
+      "source_location": "L29",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 136
+      "community": 364
     },
     {
       "label": ".handle()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L77",
+      "source_location": "L82",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 136
-    },
-    {
-      "label": ".summarizeMemories()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L208",
-      "id": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "community": 136
-    },
-    {
-      "label": ".summarizeMemoryContent()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L247",
-      "id": "memory_injection_prompt_memoryinjectionprompt_summarizememorycontent",
-      "community": 136
-    },
-    {
-      "label": ".formatMemoryPrompt()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L291",
-      "id": "memory_injection_prompt_memoryinjectionprompt_formatmemoryprompt",
-      "community": 136
-    },
-    {
-      "label": ".getMemoryTypeEmoji()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L320",
-      "id": "memory_injection_prompt_memoryinjectionprompt_getmemorytypeemoji",
-      "community": 136
-    },
-    {
-      "label": ".estimateTokens()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L333",
-      "id": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "community": 136
-    },
-    {
-      "label": ".updateConsolidationScoreMetadata()",
-      "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L349",
-      "id": "memory_injection_prompt_memoryinjectionprompt_updateconsolidationscoremetadata",
-      "community": 136
+      "community": 364
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -22937,7 +22937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 363
+      "community": 365
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 363
+      "community": 365
     },
     {
       "label": ".constructor()",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 363
+      "community": 365
     },
     {
       "label": ".handle()",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 363
+      "community": 365
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 364
+      "community": 366
     },
     {
       "label": "ProceduralRollbackTool",
@@ -22977,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 364
+      "community": 366
     },
     {
       "label": ".constructor()",
@@ -22985,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 364
+      "community": 366
     },
     {
       "label": ".handle()",
@@ -22993,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 364
+      "community": 366
     },
     {
       "label": "feedback-tool.ts",
@@ -23001,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_feedback_tool_ts",
-      "community": 271
+      "community": 272
     },
     {
       "label": "normalizeFeedbackCreatedAtToIso()",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L14",
       "id": "feedback_tool_normalizefeedbackcreatedattoiso",
-      "community": 271
+      "community": 272
     },
     {
       "label": "FeedbackTool",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L63",
       "id": "feedback_tool_feedbacktool",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".constructor()",
@@ -23025,7 +23025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L64",
       "id": "feedback_tool_feedbacktool_constructor",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".feedbackContractError()",
@@ -23033,7 +23033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L106",
       "id": "feedback_tool_feedbacktool_feedbackcontracterror",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".handle()",
@@ -23041,7 +23041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L119",
       "id": "feedback_tool_feedbacktool_handle",
-      "community": 271
+      "community": 272
     },
     {
       "label": "cleanup-memory-tool.ts",
@@ -23049,7 +23049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 365
+      "community": 367
     },
     {
       "label": "CleanupMemoryTool",
@@ -23057,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 365
+      "community": 367
     },
     {
       "label": ".constructor()",
@@ -23065,7 +23065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 365
+      "community": 367
     },
     {
       "label": ".handle()",
@@ -23073,7 +23073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 365
+      "community": 367
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23081,7 +23081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 442
+      "community": 444
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23089,7 +23089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 442
+      "community": 444
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23097,7 +23097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 442
+      "community": 444
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -23297,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 366
+      "community": 368
     },
     {
       "label": "ProceduralDiffTool",
@@ -23305,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 366
+      "community": 368
     },
     {
       "label": ".constructor()",
@@ -23313,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 366
+      "community": 368
     },
     {
       "label": ".handle()",
@@ -23321,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 366
+      "community": 368
     },
     {
       "label": "unpin-tool.ts",
@@ -23441,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 367
+      "community": 369
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -23449,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 367
+      "community": 369
     },
     {
       "label": ".constructor()",
@@ -23457,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 367
+      "community": 369
     },
     {
       "label": ".handle()",
@@ -23465,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 367
+      "community": 369
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -23473,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 368
+      "community": 370
     },
     {
       "label": "RememberProcedureTool",
@@ -23481,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 368
+      "community": 370
     },
     {
       "label": ".constructor()",
@@ -23489,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 368
+      "community": 370
     },
     {
       "label": ".handle()",
@@ -23497,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 368
+      "community": 370
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -23505,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -23513,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 313
+      "community": 314
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -23521,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 313
+      "community": 314
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -23529,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 313
+      "community": 314
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -23537,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 313
+      "community": 314
     },
     {
       "label": "recall-tool-results.ts",
@@ -23545,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 577
+      "community": 579
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -23553,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 577
+      "community": 579
     },
     {
       "label": "recall-tool.ts",
@@ -23689,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "forget-tool.ts",
@@ -23833,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 578
+      "community": 580
     },
     {
       "label": "createSchema()",
@@ -23841,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 578
+      "community": 580
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -23849,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "remember-tool.spec.ts",
@@ -23857,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 443
+      "community": 445
     },
     {
       "label": "initializeTestDatabase()",
@@ -23865,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 443
+      "community": 445
     },
     {
       "label": "createValidReflectionNote()",
@@ -23873,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 443
+      "community": 445
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -23881,7 +23881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -23889,7 +23889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 579
+      "community": 581
     },
     {
       "label": "createSchema()",
@@ -23897,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 579
+      "community": 581
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -23905,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 369
+      "community": 371
     },
     {
       "label": "generateId()",
@@ -23913,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 369
+      "community": 371
     },
     {
       "label": "initializeTestDatabase()",
@@ -23921,7 +23921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 369
+      "community": 371
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -23929,7 +23929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 369
+      "community": 371
     },
     {
       "label": "forget-tool.spec.ts",
@@ -23937,7 +23937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -23945,7 +23945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -23953,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 580
+      "community": 582
     },
     {
       "label": "initializeTestDatabase()",
@@ -23961,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 580
+      "community": 582
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -23969,7 +23969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 581
+      "community": 583
     },
     {
       "label": "parseData()",
@@ -23977,7 +23977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 581
+      "community": 583
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -23985,7 +23985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "recall-tool.spec.ts",
@@ -23993,7 +23993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 444
+      "community": 446
     },
     {
       "label": "initializeTestDatabase()",
@@ -24001,7 +24001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 444
+      "community": 446
     },
     {
       "label": "createValidReflectionNote()",
@@ -24009,7 +24009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 444
+      "community": 446
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24017,7 +24017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24025,7 +24025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24033,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "meta-memory-service.ts",
@@ -24161,7 +24161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 370
+      "community": 372
     },
     {
       "label": "fieldDiff()",
@@ -24169,7 +24169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 370
+      "community": 372
     },
     {
       "label": "parseStepsJson()",
@@ -24177,7 +24177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 370
+      "community": 372
     },
     {
       "label": "computeProceduralDiff()",
@@ -24185,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 370
+      "community": 372
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24193,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -24201,7 +24201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".constructor()",
@@ -24209,7 +24209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".notFound()",
@@ -24217,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".notActionable()",
@@ -24225,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 314
+      "community": 315
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -24233,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 371
+      "community": 373
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24241,7 +24241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 371
+      "community": 373
     },
     {
       "label": "parsePositiveInt()",
@@ -24249,7 +24249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 371
+      "community": 373
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24257,7 +24257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 371
+      "community": 373
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -24265,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 582
+      "community": 584
     },
     {
       "label": "createBaseSchema()",
@@ -24273,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 582
+      "community": 584
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -24281,7 +24281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_llm_extractor_ts",
-      "community": 166
+      "community": 165
     },
     {
       "label": "LlmProceduralExtractor",
@@ -24289,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L31",
       "id": "procedural_llm_extractor_llmproceduralextractor",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".constructor()",
@@ -24297,7 +24297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L37",
       "id": "procedural_llm_extractor_llmproceduralextractor_constructor",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".extract()",
@@ -24305,7 +24305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L47",
       "id": "procedural_llm_extractor_llmproceduralextractor_extract",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".buildMessages()",
@@ -24313,7 +24313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L68",
       "id": "procedural_llm_extractor_llmproceduralextractor_buildmessages",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".callLLM()",
@@ -24321,7 +24321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L83",
       "id": "procedural_llm_extractor_llmproceduralextractor_callllm",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".callOpenAI()",
@@ -24329,7 +24329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L102",
       "id": "procedural_llm_extractor_llmproceduralextractor_callopenai",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".callGemini()",
@@ -24337,7 +24337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L132",
       "id": "procedural_llm_extractor_llmproceduralextractor_callgemini",
-      "community": 166
+      "community": 165
     },
     {
       "label": ".parseResponse()",
@@ -24345,7 +24345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L171",
       "id": "procedural_llm_extractor_llmproceduralextractor_parseresponse",
-      "community": 166
+      "community": 165
     },
     {
       "label": "memory-review-candidate-selection-scoring.spec.ts",
@@ -24353,7 +24353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 583
+      "community": 585
     },
     {
       "label": "baseRow()",
@@ -24361,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 583
+      "community": 585
     },
     {
       "label": "procedural-versioning.ts",
@@ -24369,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 372
+      "community": 374
     },
     {
       "label": "getVersionChain()",
@@ -24377,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 372
+      "community": 374
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -24385,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 372
+      "community": 374
     },
     {
       "label": "getNextVersionNumber()",
@@ -24393,7 +24393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 372
+      "community": 374
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -24401,7 +24401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 445
+      "community": 447
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -24409,7 +24409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 445
+      "community": 447
     },
     {
       "label": ".runScan()",
@@ -24417,7 +24417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 445
+      "community": 447
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -24425,7 +24425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 446
+      "community": 448
     },
     {
       "label": "generateMemoryId()",
@@ -24433,7 +24433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 446
+      "community": 448
     },
     {
       "label": "rollbackToVersion()",
@@ -24441,7 +24441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 446
+      "community": 448
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -24513,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 447
+      "community": 449
     },
     {
       "label": "selectionWindowLimit()",
@@ -24521,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 447
+      "community": 449
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -24529,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 447
+      "community": 449
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -24537,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "IntrospectionScanCache",
@@ -24545,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".set()",
@@ -24553,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".get()",
@@ -24561,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".clear()",
@@ -24569,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 315
+      "community": 316
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -24577,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -24585,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 584
+      "community": 586
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -24593,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 584
+      "community": 586
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -24601,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "openDb()",
@@ -24609,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 585
+      "community": 587
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -24961,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_ts",
-      "community": 167
+      "community": 166
     },
     {
       "label": "snapshotTableReady()",
@@ -24969,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L45",
       "id": "memory_review_queue_health_service_snapshottableready",
-      "community": 167
+      "community": 166
     },
     {
       "label": "countCandidates()",
@@ -24977,7 +24977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L54",
       "id": "memory_review_queue_health_service_countcandidates",
-      "community": 167
+      "community": 166
     },
     {
       "label": "buildWindowCounts()",
@@ -24985,7 +24985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L61",
       "id": "memory_review_queue_health_service_buildwindowcounts",
-      "community": 167
+      "community": 166
     },
     {
       "label": "computeMemoryReviewQueueHealthLive()",
@@ -24993,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L84",
       "id": "memory_review_queue_health_service_computememoryreviewqueuehealthlive",
-      "community": 167
+      "community": 166
     },
     {
       "label": "memoryReviewQueueHealthSnapshotTableReady()",
@@ -25001,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L105",
       "id": "memory_review_queue_health_service_memoryreviewqueuehealthsnapshottableready",
-      "community": 167
+      "community": 166
     },
     {
       "label": "recordMemoryReviewQueueHealthSnapshot()",
@@ -25009,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L112",
       "id": "memory_review_queue_health_service_recordmemoryreviewqueuehealthsnapshot",
-      "community": 167
+      "community": 166
     },
     {
       "label": "listMemoryReviewQueueHealthSnapshots()",
@@ -25017,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L162",
       "id": "memory_review_queue_health_service_listmemoryreviewqueuehealthsnapshots",
-      "community": 167
+      "community": 166
     },
     {
       "label": "maybeRecordMemoryReviewQueueHealthSnapshot()",
@@ -25025,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L176",
       "id": "memory_review_queue_health_service_mayberecordmemoryreviewqueuehealthsnapshot",
-      "community": 167
+      "community": 166
     },
     {
       "label": "memory-embedding-service.ts",
@@ -25201,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 586
+      "community": 588
     },
     {
       "label": "createBaseSchema()",
@@ -25209,7 +25209,79 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 586
+      "community": 588
+    },
+    {
+      "label": "knowledge-context-bundle-builder.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "community": 167
+    },
+    {
+      "label": "estimateTokens()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L44",
+      "id": "knowledge_context_bundle_builder_estimatetokens",
+      "community": 167
+    },
+    {
+      "label": "getMemoryTypeEmoji()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L48",
+      "id": "knowledge_context_bundle_builder_getmemorytypeemoji",
+      "community": 167
+    },
+    {
+      "label": "summarizeMemoryContent()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L58",
+      "id": "knowledge_context_bundle_builder_summarizememorycontent",
+      "community": 167
+    },
+    {
+      "label": "summarizeMemories()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L97",
+      "id": "knowledge_context_bundle_builder_summarizememories",
+      "community": 167
+    },
+    {
+      "label": "formatMemoryPrompt()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L131",
+      "id": "knowledge_context_bundle_builder_formatmemoryprompt",
+      "community": 167
+    },
+    {
+      "label": "updateConsolidationScoreMetadata()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L157",
+      "id": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
+      "community": 167
+    },
+    {
+      "label": "filterByOwner()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L266",
+      "id": "knowledge_context_bundle_builder_filterbyowner",
+      "community": 167
+    },
+    {
+      "label": "buildKnowledgeContextBundle()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L277",
+      "id": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "community": 167
     },
     {
       "label": "core-memory-cache-service.ts",
@@ -25401,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -25409,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 448
+      "community": 450
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -25417,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 448
+      "community": 450
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -25425,7 +25497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 448
+      "community": 450
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -25433,7 +25505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -25441,7 +25513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "core-memory-service.ts",
@@ -25601,7 +25673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 587
+      "community": 589
     },
     {
       "label": "createBaseSchema()",
@@ -25609,7 +25681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 587
+      "community": 589
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -25617,7 +25689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 588
+      "community": 590
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -25625,7 +25697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 588
+      "community": 590
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -25705,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -25713,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -25721,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 589
+      "community": 591
     },
     {
       "label": "createSchema()",
@@ -25729,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 589
+      "community": 591
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -25737,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -25745,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 590
+      "community": 592
     },
     {
       "label": "createSchema()",
@@ -25753,7 +25825,15 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 590
+      "community": 592
+    },
+    {
+      "label": "knowledge-context-bundle-builder.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
+      "community": 882
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -25761,7 +25841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 591
+      "community": 593
     },
     {
       "label": "createBaseSchema()",
@@ -25769,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 591
+      "community": 593
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -25777,7 +25857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 880
+      "community": 883
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -25785,7 +25865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 592
+      "community": 594
     },
     {
       "label": "createSchema()",
@@ -25793,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 592
+      "community": 594
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -25801,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 881
+      "community": 884
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -25809,7 +25889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 882
+      "community": 885
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -25929,7 +26009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 883
+      "community": 886
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26193,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 884
+      "community": 887
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26201,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 593
+      "community": 595
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26209,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 593
+      "community": 595
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26217,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 885
+      "community": 888
     },
     {
       "label": "consolidation-repository.ts",
@@ -26225,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_ts",
-      "community": 137
+      "community": 136
     },
     {
       "label": "ConsolidationRepository",
@@ -26233,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L25",
       "id": "consolidation_repository_consolidationrepository",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".constructor()",
@@ -26241,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L26",
       "id": "consolidation_repository_consolidationrepository_constructor",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".getLookbackDays()",
@@ -26249,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L28",
       "id": "consolidation_repository_consolidationrepository_getlookbackdays",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".findEpisodicCandidates()",
@@ -26257,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L37",
       "id": "consolidation_repository_consolidationrepository_findepisodiccandidates",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".findSemanticsByOwner()",
@@ -26265,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L87",
       "id": "consolidation_repository_consolidationrepository_findsemanticsbyowner",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".updateSemanticMemory()",
@@ -26273,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L103",
       "id": "consolidation_repository_consolidationrepository_updatesemanticmemory",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".loadEmbeddingsMap()",
@@ -26281,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L118",
       "id": "consolidation_repository_consolidationrepository_loadembeddingsmap",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".insertSemanticMemory()",
@@ -26289,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L151",
       "id": "consolidation_repository_consolidationrepository_insertsemanticmemory",
-      "community": 137
+      "community": 136
     },
     {
       "label": ".markEpisodicsConsolidated()",
@@ -26297,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L177",
       "id": "consolidation_repository_consolidationrepository_markepisodicsconsolidated",
-      "community": 137
+      "community": 136
     },
     {
       "label": "sleep-consolidation-service.ts",
@@ -26449,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 594
+      "community": 596
     },
     {
       "label": "row()",
@@ -26457,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 594
+      "community": 596
     },
     {
       "label": "summarization-service.ts",
@@ -26465,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_ts",
-      "community": 272
+      "community": 273
     },
     {
       "label": "SummarizationService",
@@ -26473,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L16",
       "id": "summarization_service_summarizationservice",
-      "community": 272
+      "community": 273
     },
     {
       "label": ".hasLlmConfigured()",
@@ -26481,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L17",
       "id": "summarization_service_summarizationservice_hasllmconfigured",
-      "community": 272
+      "community": 273
     },
     {
       "label": ".extractiveFallback()",
@@ -26489,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L23",
       "id": "summarization_service_summarizationservice_extractivefallback",
-      "community": 272
+      "community": 273
     },
     {
       "label": ".summarizeCluster()",
@@ -26497,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L36",
       "id": "summarization_service_summarizationservice_summarizecluster",
-      "community": 272
+      "community": 273
     },
     {
       "label": ".summarizeMergeForConsolidation()",
@@ -26505,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L118",
       "id": "summarization_service_summarizationservice_summarizemergeforconsolidation",
-      "community": 272
+      "community": 273
     },
     {
       "label": "sleep-consolidation-service.spec.ts",
@@ -26513,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "insertEpisodic()",
@@ -26521,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 316
+      "community": 317
     },
     {
       "label": "insertEmbedding()",
@@ -26529,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 316
+      "community": 317
     },
     {
       "label": "FailingRepo",
@@ -26537,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".insertSemanticMemory()",
@@ -26545,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 316
+      "community": 317
     },
     {
       "label": "clustering-service.spec.ts",
@@ -26553,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 595
+      "community": 597
     },
     {
       "label": "ep()",
@@ -26561,7 +26641,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 595
+      "community": 597
     },
     {
       "label": "relation-graph.port.ts",
@@ -26569,7 +26649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 886
+      "community": 889
     },
     {
       "label": "get-relations-tool.ts",
@@ -26577,7 +26657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 373
+      "community": 375
     },
     {
       "label": "GetRelationsTool",
@@ -26585,7 +26665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 373
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -26593,7 +26673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 373
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -26601,7 +26681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 373
+      "community": 375
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -26609,7 +26689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 596
+      "community": 598
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -26617,7 +26697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 596
+      "community": 598
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -26625,7 +26705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 374
+      "community": 376
     },
     {
       "label": "VisualizeRelationsTool",
@@ -26633,7 +26713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 374
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -26641,7 +26721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 374
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -26649,7 +26729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 374
+      "community": 376
     },
     {
       "label": "remove-relation-tool.ts",
@@ -26657,7 +26737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 375
+      "community": 377
     },
     {
       "label": "RemoveRelationTool",
@@ -26665,7 +26745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 375
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -26673,7 +26753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 375
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -26681,7 +26761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 375
+      "community": 377
     },
     {
       "label": "extract-relations-tool.ts",
@@ -26689,7 +26769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 376
+      "community": 378
     },
     {
       "label": "ExtractRelationsTool",
@@ -26697,7 +26777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 376
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -26705,7 +26785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 376
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -26713,7 +26793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 376
+      "community": 378
     },
     {
       "label": "add-relation-tool.ts",
@@ -26721,7 +26801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 377
+      "community": 379
     },
     {
       "label": "AddRelationTool",
@@ -26729,7 +26809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 377
+      "community": 379
     },
     {
       "label": ".constructor()",
@@ -26737,7 +26817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 377
+      "community": 379
     },
     {
       "label": ".handle()",
@@ -26745,7 +26825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 377
+      "community": 379
     },
     {
       "label": "extract-triples-tool.ts",
@@ -26753,7 +26833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_ts",
-      "community": 273
+      "community": 274
     },
     {
       "label": "resolveExtractTriplesOwner()",
@@ -26761,7 +26841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L37",
       "id": "extract_triples_tool_resolveextracttriplesowner",
-      "community": 273
+      "community": 274
     },
     {
       "label": "normalizeChunkOverlapForPipeline()",
@@ -26769,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L42",
       "id": "extract_triples_tool_normalizechunkoverlapforpipeline",
-      "community": 273
+      "community": 274
     },
     {
       "label": "ExtractTriplesTool",
@@ -26777,7 +26857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L52",
       "id": "extract_triples_tool_extracttriplestool",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".constructor()",
@@ -26785,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L53",
       "id": "extract_triples_tool_extracttriplestool_constructor",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".handle()",
@@ -26793,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L84",
       "id": "extract_triples_tool_extracttriplestool_handle",
-      "community": 273
+      "community": 274
     },
     {
       "label": "get-relations-tool.spec.ts",
@@ -26801,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 449
+      "community": 451
     },
     {
       "label": "createBaseSchema()",
@@ -26809,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 449
+      "community": 451
     },
     {
       "label": "createTestMemory()",
@@ -26817,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 449
+      "community": 451
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -26825,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 450
+      "community": 452
     },
     {
       "label": "createBaseSchema()",
@@ -26833,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 450
+      "community": 452
     },
     {
       "label": "createTestMemory()",
@@ -26841,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 450
+      "community": 452
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -26849,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 451
+      "community": 453
     },
     {
       "label": "createBaseSchema()",
@@ -26857,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 451
+      "community": 453
     },
     {
       "label": "createTestMemory()",
@@ -26865,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 451
+      "community": 453
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -26873,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 887
+      "community": 890
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -26881,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 452
+      "community": 454
     },
     {
       "label": "createBaseSchema()",
@@ -26889,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 452
+      "community": 454
     },
     {
       "label": "createTestMemory()",
@@ -26897,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 452
+      "community": 454
     },
     {
       "label": "relation-retry-manager.ts",
@@ -26905,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 378
+      "community": 380
     },
     {
       "label": "RelationRetryManager",
@@ -26913,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 378
+      "community": 380
     },
     {
       "label": ".constructor()",
@@ -26921,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 378
+      "community": 380
     },
     {
       "label": ".retry()",
@@ -26929,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 378
+      "community": 380
     },
     {
       "label": "relation-errors.ts",
@@ -27681,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 379
+      "community": 381
     },
     {
       "label": "loadTestDataset()",
@@ -27689,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 379
+      "community": 381
     },
     {
       "label": "createBaseSchema()",
@@ -27697,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 379
+      "community": 381
     },
     {
       "label": "createTestMemory()",
@@ -27705,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 379
+      "community": 381
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -27713,7 +27793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 888
+      "community": 891
     },
     {
       "label": "relation-graph.spec.ts",
@@ -27721,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 453
+      "community": 455
     },
     {
       "label": "createBaseSchema()",
@@ -27729,7 +27809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 453
+      "community": 455
     },
     {
       "label": "createTestMemory()",
@@ -27737,7 +27817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 453
+      "community": 455
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -27745,7 +27825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 597
+      "community": 599
     },
     {
       "label": "createTestMemory()",
@@ -27753,7 +27833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 597
+      "community": 599
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -27761,7 +27841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 380
+      "community": 382
     },
     {
       "label": "createBaseSchema()",
@@ -27769,7 +27849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 380
+      "community": 382
     },
     {
       "label": "createTestMemory()",
@@ -27777,7 +27857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 380
+      "community": 382
     },
     {
       "label": "createBulkMemories()",
@@ -27785,7 +27865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 380
+      "community": 382
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -27793,7 +27873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 598
+      "community": 600
     },
     {
       "label": "createTestMemory()",
@@ -27801,7 +27881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 598
+      "community": 600
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -27865,7 +27945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 889
+      "community": 892
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -27873,7 +27953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 890
+      "community": 893
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -27881,7 +27961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 454
+      "community": 456
     },
     {
       "label": "getMockMementoConfig()",
@@ -27889,7 +27969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 454
+      "community": 456
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -27897,7 +27977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 454
+      "community": 456
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -27905,7 +27985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 891
+      "community": 894
     },
     {
       "label": "provider-openai.spec.ts",
@@ -27913,7 +27993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 892
+      "community": 895
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -27921,7 +28001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 893
+      "community": 896
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -27929,7 +28009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 894
+      "community": 897
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -27937,7 +28017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 317
+      "community": 318
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -27945,7 +28025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".constructor()",
@@ -27953,7 +28033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".consume()",
@@ -27961,7 +28041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".refill()",
@@ -27969,7 +28049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 317
+      "community": 318
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -27977,7 +28057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 381
+      "community": 383
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -27985,7 +28065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 381
+      "community": 383
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -27993,7 +28073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 381
+      "community": 383
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28001,7 +28081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 381
+      "community": 383
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -28009,7 +28089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_ts",
-      "community": 274
+      "community": 275
     },
     {
       "label": "chunkSucceeded()",
@@ -28017,7 +28097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L20",
       "id": "triple_pipeline_orchestrator_chunksucceeded",
-      "community": 274
+      "community": 275
     },
     {
       "label": "failureMessageFromResult()",
@@ -28025,7 +28105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L27",
       "id": "triple_pipeline_orchestrator_failuremessagefromresult",
-      "community": 274
+      "community": 275
     },
     {
       "label": "TriplePipelineOrchestrator",
@@ -28033,7 +28113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L35",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator",
-      "community": 274
+      "community": 275
     },
     {
       "label": ".constructor()",
@@ -28041,7 +28121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L36",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_constructor",
-      "community": 274
+      "community": 275
     },
     {
       "label": ".run()",
@@ -28049,7 +28129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L40",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_run",
-      "community": 274
+      "community": 275
     },
     {
       "label": "triple-extraction-statistics.ts",
@@ -28249,7 +28329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 599
+      "community": 601
     },
     {
       "label": "extract()",
@@ -28257,7 +28337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 599
+      "community": 601
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -28265,7 +28345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 455
+      "community": 457
     },
     {
       "label": "tripleDedupeKey()",
@@ -28273,7 +28353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 455
+      "community": 457
     },
     {
       "label": "mergeTripleLists()",
@@ -28281,7 +28361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 455
+      "community": 457
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -28289,7 +28369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 895
+      "community": 898
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -28297,7 +28377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 318
+      "community": 319
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -28305,7 +28385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 318
+      "community": 319
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -28313,7 +28393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L38",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 318
+      "community": 319
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -28321,7 +28401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L71",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 318
+      "community": 319
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -28329,7 +28409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L105",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 318
+      "community": 319
     },
     {
       "label": "triple-extraction-service.ts",
@@ -28473,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 896
+      "community": 899
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -28481,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 897
+      "community": 900
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -28489,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 898
+      "community": 901
     },
     {
       "label": "triple-extractor.ts",
@@ -28633,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 382
+      "community": 384
     },
     {
       "label": "TripleNormalizer",
@@ -28641,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 382
+      "community": 384
     },
     {
       "label": ".constructor()",
@@ -28649,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 382
+      "community": 384
     },
     {
       "label": ".normalize()",
@@ -28657,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 382
+      "community": 384
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -28665,7 +28745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 899
+      "community": 902
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -28673,7 +28753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 383
+      "community": 385
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -28681,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 383
+      "community": 385
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -28689,7 +28769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 383
+      "community": 385
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -28697,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 383
+      "community": 385
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -28705,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 900
+      "community": 903
     },
     {
       "label": "triple-parser.ts",
@@ -28713,7 +28793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 319
+      "community": 320
     },
     {
       "label": "TripleParser",
@@ -28721,7 +28801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".parse()",
@@ -28729,7 +28809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".extractJSON()",
@@ -28737,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".isValidTriple()",
@@ -28745,7 +28825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 319
+      "community": 320
     },
     {
       "label": "triple-text-chunker.ts",
@@ -28753,7 +28833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 600
+      "community": 602
     },
     {
       "label": "splitTextIntoChunks()",
@@ -28761,7 +28841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 600
+      "community": 602
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -28769,7 +28849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 601
+      "community": 603
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -28777,7 +28857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 601
+      "community": 603
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -28785,7 +28865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_ts",
-      "community": 138
+      "community": 137
     },
     {
       "label": "PredicateCanonicalizer",
@@ -28793,7 +28873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L95",
       "id": "predicate_canonicalizer_predicatecanonicalizer",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".constructor()",
@@ -28801,7 +28881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L99",
       "id": "predicate_canonicalizer_predicatecanonicalizer_constructor",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".buildReverseIndex()",
@@ -28809,7 +28889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L107",
       "id": "predicate_canonicalizer_predicatecanonicalizer_buildreverseindex",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".normalizeKey()",
@@ -28817,7 +28897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L125",
       "id": "predicate_canonicalizer_predicatecanonicalizer_normalizekey",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".canonicalize()",
@@ -28825,7 +28905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L135",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalize",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".canonicalizeBatch()",
@@ -28833,7 +28913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L177",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalizebatch",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".addPredicate()",
@@ -28841,7 +28921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L187",
       "id": "predicate_canonicalizer_predicatecanonicalizer_addpredicate",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".getDictionary()",
@@ -28849,7 +28929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L206",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getdictionary",
-      "community": 138
+      "community": 137
     },
     {
       "label": ".getCanonicalPredicates()",
@@ -28857,7 +28937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L213",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getcanonicalpredicates",
-      "community": 138
+      "community": 137
     },
     {
       "label": "entity-linker.spec.ts",
@@ -28865,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 901
+      "community": 904
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -28873,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 902
+      "community": 905
     },
     {
       "label": "interfaces.spec.ts",
@@ -28881,7 +28961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 903
+      "community": 906
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -28889,7 +28969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 904
+      "community": 907
     },
     {
       "label": "triple-parser.spec.ts",
@@ -28897,7 +28977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 905
+      "community": 908
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -28905,7 +28985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 602
+      "community": 604
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -28913,7 +28993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 602
+      "community": 604
     },
     {
       "label": "extract-relations-openai.ts",
@@ -28921,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 603
+      "community": 605
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -28929,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 603
+      "community": 605
     },
     {
       "label": "types.ts",
@@ -28937,7 +29017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 906
+      "community": 909
     },
     {
       "label": "ollama-chat-support.ts",
@@ -28945,7 +29025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 384
+      "community": 386
     },
     {
       "label": "checkOllamaModel()",
@@ -28953,7 +29033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 384
+      "community": 386
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -28961,7 +29041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 384
+      "community": 386
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -28969,7 +29049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 384
+      "community": 386
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -28977,7 +29057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 604
+      "community": 606
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -28985,7 +29065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 604
+      "community": 606
     },
     {
       "label": "provider-selection.ts",
@@ -28993,7 +29073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 456
+      "community": 458
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29001,7 +29081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 456
+      "community": 458
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29009,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 456
+      "community": 458
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29017,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 605
+      "community": 607
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29025,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 605
+      "community": 607
     },
     {
       "label": "llm-response-parse.ts",
@@ -29033,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 320
+      "community": 321
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -29041,7 +29121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 320
+      "community": 321
     },
     {
       "label": "trimToValidJsonObject()",
@@ -29049,7 +29129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 320
+      "community": 321
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -29057,7 +29137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 320
+      "community": 321
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -29065,7 +29145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 320
+      "community": 321
     },
     {
       "label": "embedding-provider-factory.ts",
@@ -29305,7 +29385,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 385
+      "community": 387
     },
     {
       "label": "createMockService()",
@@ -29313,7 +29393,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 385
+      "community": 387
     },
     {
       "label": "resolver()",
@@ -29321,7 +29401,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 385
+      "community": 387
     },
     {
       "label": "priority()",
@@ -29329,7 +29409,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 385
+      "community": 387
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -29337,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 907
+      "community": 910
     },
     {
       "label": "embedding-service.ts",
@@ -30449,7 +30529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 908
+      "community": 911
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -30457,7 +30537,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 909
+      "community": 912
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -30465,7 +30545,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 457
+      "community": 459
     },
     {
       "label": "createSchema()",
@@ -30473,7 +30553,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 457
+      "community": 459
     },
     {
       "label": "seedMemoryItem()",
@@ -30481,7 +30561,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 457
+      "community": 459
     },
     {
       "label": "embedding-service.spec.ts",
@@ -30489,7 +30569,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 910
+      "community": 913
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -30497,7 +30577,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 911
+      "community": 914
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -30505,7 +30585,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 912
+      "community": 915
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -30513,7 +30593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 386
+      "community": 388
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -30521,7 +30601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 386
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -30529,7 +30609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 386
+      "community": 388
     },
     {
       "label": ".handle()",
@@ -30537,7 +30617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 386
+      "community": 388
     },
     {
       "label": "performance-alerts.ts",
@@ -30545,7 +30625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_alerts_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "executePerformanceAlerts()",
@@ -30553,7 +30633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L66",
       "id": "performance_alerts_executeperformancealerts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "handleStats()",
@@ -30561,7 +30641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L113",
       "id": "performance_alerts_handlestats",
-      "community": 275
+      "community": 276
     },
     {
       "label": "handleList()",
@@ -30569,7 +30649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L145",
       "id": "performance_alerts_handlelist",
-      "community": 275
+      "community": 276
     },
     {
       "label": "handleSearch()",
@@ -30577,7 +30657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L183",
       "id": "performance_alerts_handlesearch",
-      "community": 275
+      "community": 276
     },
     {
       "label": "handleResolve()",
@@ -30585,7 +30665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L208",
       "id": "performance_alerts_handleresolve",
-      "community": 275
+      "community": 276
     },
     {
       "label": "performance-stats-tool.ts",
@@ -30593,7 +30673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 387
+      "community": 389
     },
     {
       "label": "PerformanceStatsTool",
@@ -30601,7 +30681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 387
+      "community": 389
     },
     {
       "label": ".constructor()",
@@ -30609,7 +30689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 387
+      "community": 389
     },
     {
       "label": ".handle()",
@@ -30617,7 +30697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 387
+      "community": 389
     },
     {
       "label": "resolve-error.ts",
@@ -30625,7 +30705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 606
+      "community": 608
     },
     {
       "label": "executeResolveError()",
@@ -30633,7 +30713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 606
+      "community": 608
     },
     {
       "label": "error-stats.ts",
@@ -30641,7 +30721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 607
+      "community": 609
     },
     {
       "label": "executeErrorStats()",
@@ -30649,7 +30729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 607
+      "community": 609
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -30657,7 +30737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 913
+      "community": 916
     },
     {
       "label": "resolve-error.spec.ts",
@@ -30665,7 +30745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 914
+      "community": 917
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -30673,7 +30753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 608
+      "community": 610
     },
     {
       "label": "createBaseSchema()",
@@ -30681,7 +30761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 608
+      "community": 610
     },
     {
       "label": "error-stats.spec.ts",
@@ -30689,7 +30769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 915
+      "community": 918
     },
     {
       "label": "performance-monitor.ts",
@@ -31433,7 +31513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_runtime_diagnostics_logger_ts",
-      "community": 276
+      "community": 277
     },
     {
       "label": "RuntimeDiagnosticsLogger",
@@ -31441,7 +31521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L4",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".constructor()",
@@ -31449,7 +31529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L5",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_constructor",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".writeSample()",
@@ -31457,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L10",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writesample",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".writeEvent()",
@@ -31465,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writeevent",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".appendJsonl()",
@@ -31473,7 +31553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L26",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_appendjsonl",
-      "community": 276
+      "community": 277
     },
     {
       "label": "error-logging-service.ts",
@@ -31601,7 +31681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 916
+      "community": 919
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -31609,7 +31689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 917
+      "community": 920
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -31617,7 +31697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 918
+      "community": 921
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -31625,7 +31705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 919
+      "community": 922
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -31633,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "toBytes()",
@@ -31641,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 321
+      "community": 322
     },
     {
       "label": "createMetrics()",
@@ -31649,7 +31729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 321
+      "community": 322
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -31657,7 +31737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 321
+      "community": 322
     },
     {
       "label": "makeMonitor()",
@@ -31665,7 +31745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 321
+      "community": 322
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -31673,7 +31753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 609
+      "community": 611
     },
     {
       "label": "restoreEnvValue()",
@@ -31681,7 +31761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 609
+      "community": 611
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -31689,7 +31769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 388
+      "community": 390
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -31697,7 +31777,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 388
+      "community": 390
     },
     {
       "label": "createQualityMetricsTable()",
@@ -31705,7 +31785,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 388
+      "community": 390
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -31713,7 +31793,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 388
+      "community": 390
     },
     {
       "label": "quality-recorder.ts",
@@ -31785,7 +31865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 610
+      "community": 612
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -31793,7 +31873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 610
+      "community": 612
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -31873,7 +31953,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 611
+      "community": 613
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -31881,7 +31961,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 611
+      "community": 613
     },
     {
       "label": "quality-reporter.ts",
@@ -31889,7 +31969,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_ts",
-      "community": 139
+      "community": 138
     },
     {
       "label": "escapeHtml()",
@@ -31897,7 +31977,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L24",
       "id": "quality_reporter_escapehtml",
-      "community": 139
+      "community": 138
     },
     {
       "label": "QualityReporter",
@@ -31905,7 +31985,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L175",
       "id": "quality_reporter_qualityreporter",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".constructor()",
@@ -31913,7 +31993,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L179",
       "id": "quality_reporter_qualityreporter_constructor",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".collectReportData()",
@@ -31921,7 +32001,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L193",
       "id": "quality_reporter_qualityreporter_collectreportdata",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".generateMarkdownReport()",
@@ -31929,7 +32009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L354",
       "id": "quality_reporter_qualityreporter_generatemarkdownreport",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".generateJsonReport()",
@@ -31937,7 +32017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L435",
       "id": "quality_reporter_qualityreporter_generatejsonreport",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".generateHtmlReport()",
@@ -31945,7 +32025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L445",
       "id": "quality_reporter_qualityreporter_generatehtmlreport",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".generateReport()",
@@ -31953,7 +32033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L731",
       "id": "quality_reporter_qualityreporter_generatereport",
-      "community": 139
+      "community": 138
     },
     {
       "label": ".saveReportToFile()",
@@ -31961,7 +32041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L765",
       "id": "quality_reporter_qualityreporter_savereporttofile",
-      "community": 139
+      "community": 138
     },
     {
       "label": "quality-reporter.spec.ts",
@@ -31969,7 +32049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 389
+      "community": 391
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -31977,7 +32057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 389
+      "community": 391
     },
     {
       "label": "createQualityMetricsTable()",
@@ -31985,7 +32065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 389
+      "community": 391
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -31993,7 +32073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 389
+      "community": 391
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32001,7 +32081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 920
+      "community": 923
     },
     {
       "label": "quality-assurance-service.ts",
@@ -32281,7 +32361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 390
+      "community": 392
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32289,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 390
+      "community": 392
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32297,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 390
+      "community": 392
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32305,7 +32385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 390
+      "community": 392
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -32313,7 +32393,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_migrate_embeddings_tool_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "MigrateEmbeddingsTool",
@@ -32321,7 +32401,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L38",
       "id": "migrate_embeddings_tool_migrateembeddingstool",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".constructor()",
@@ -32329,7 +32409,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L42",
       "id": "migrate_embeddings_tool_migrateembeddingstool_constructor",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".loadVecExtension()",
@@ -32337,7 +32417,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L82",
       "id": "migrate_embeddings_tool_migrateembeddingstool_loadvecextension",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".createAndStoreEmbeddingForProvider()",
@@ -32345,7 +32425,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L95",
       "id": "migrate_embeddings_tool_migrateembeddingstool_createandstoreembeddingforprovider",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".handle()",
@@ -32353,7 +32433,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L183",
       "id": "migrate_embeddings_tool_migrateembeddingstool_handle",
-      "community": 277
+      "community": 278
     },
     {
       "label": "tool-registry.ts",
@@ -32497,7 +32577,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 921
+      "community": 924
     },
     {
       "label": "base-tool.ts",
@@ -32793,7 +32873,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 612
+      "community": 614
     },
     {
       "label": "testBootstrapIntegration()",
@@ -32801,7 +32881,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 612
+      "community": 614
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -32809,7 +32889,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 613
+      "community": 615
     },
     {
       "label": "measureRecall()",
@@ -32817,7 +32897,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 613
+      "community": 615
     },
     {
       "label": "test-embedding.ts",
@@ -32825,7 +32905,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 614
+      "community": 616
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -32833,7 +32913,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 614
+      "community": 616
     },
     {
       "label": "test-tool-consistency.ts",
@@ -32841,7 +32921,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 458
+      "community": 460
     },
     {
       "label": "compareToolResults()",
@@ -32849,7 +32929,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 458
+      "community": 460
     },
     {
       "label": "testToolConsistency()",
@@ -32857,7 +32937,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 458
+      "community": 460
     },
     {
       "label": "test-quality-assurance.ts",
@@ -32865,7 +32945,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 459
+      "community": 461
     },
     {
       "label": "createQualityTables()",
@@ -32873,7 +32953,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 459
+      "community": 461
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -32881,7 +32961,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 459
+      "community": 461
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -32889,7 +32969,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "PerformanceBenchmark",
@@ -32897,7 +32977,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".measureOperation()",
@@ -32905,7 +32985,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".getResults()",
@@ -32913,7 +32993,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".getSummary()",
@@ -32921,7 +33001,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 322
+      "community": 323
     },
     {
       "label": "test-search.ts",
@@ -32929,7 +33009,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 615
+      "community": 617
     },
     {
       "label": "testSearchFunctionality()",
@@ -32937,7 +33017,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 615
+      "community": 617
     },
     {
       "label": "test-forgetting.ts",
@@ -32945,7 +33025,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 616
+      "community": 618
     },
     {
       "label": "testForgettingFunctionality()",
@@ -32953,7 +33033,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 616
+      "community": 618
     },
     {
       "label": "mock-database.spec.ts",
@@ -32961,7 +33041,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 922
+      "community": 925
     },
     {
       "label": "test-m1-completion.ts",
@@ -32969,7 +33049,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 617
+      "community": 619
     },
     {
       "label": "testM1Completion()",
@@ -32977,7 +33057,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 617
+      "community": 619
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -32985,7 +33065,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 618
+      "community": 620
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -32993,7 +33073,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 618
+      "community": 620
     },
     {
       "label": "vitest.setup.ts",
@@ -33001,7 +33081,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 923
+      "community": 926
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33009,7 +33089,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 619
+      "community": 621
     },
     {
       "label": "parseItems()",
@@ -33017,7 +33097,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 619
+      "community": 621
     },
     {
       "label": "test-memory-resource.ts",
@@ -33025,7 +33105,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 460
+      "community": 462
     },
     {
       "label": "setupResourceHandlers()",
@@ -33033,7 +33113,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 460
+      "community": 462
     },
     {
       "label": "createTestMemories()",
@@ -33041,7 +33121,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 460
+      "community": 462
     },
     {
       "label": "test-regression.ts",
@@ -33049,7 +33129,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 620
+      "community": 622
     },
     {
       "label": "testRegression()",
@@ -33057,7 +33137,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 620
+      "community": 622
     },
     {
       "label": "test-anchor-system.ts",
@@ -33121,7 +33201,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 924
+      "community": 927
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33193,7 +33273,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 621
+      "community": 623
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33201,7 +33281,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 621
+      "community": 623
     },
     {
       "label": "visualize-recency.ts",
@@ -33265,7 +33345,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 925
+      "community": 928
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -33329,7 +33409,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 622
+      "community": 624
     },
     {
       "label": "constructor()",
@@ -33337,7 +33417,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 622
+      "community": 624
     },
     {
       "label": "mock-database.ts",
@@ -33569,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 926
+      "community": 929
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -33577,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 391
+      "community": 393
     },
     {
       "label": "telemetryDb()",
@@ -33585,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 391
+      "community": 393
     },
     {
       "label": "percentile95()",
@@ -33593,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 391
+      "community": 393
     },
     {
       "label": "run()",
@@ -33601,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 391
+      "community": 393
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -33609,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 623
+      "community": 625
     },
     {
       "label": "createTestMemories()",
@@ -33617,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 623
+      "community": 625
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -33625,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 624
+      "community": 626
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -33633,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 624
+      "community": 626
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -33641,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 927
+      "community": 930
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -33649,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 625
+      "community": 627
     },
     {
       "label": "seedCluster()",
@@ -33657,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 625
+      "community": 627
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -33665,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 461
+      "community": 463
     },
     {
       "label": "readSource()",
@@ -33673,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 461
+      "community": 463
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -33681,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 461
+      "community": 463
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -33689,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 392
+      "community": 394
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -33697,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 392
+      "community": 394
     },
     {
       "label": "normalizeTags()",
@@ -33705,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 392
+      "community": 394
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -33713,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 392
+      "community": 394
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -33721,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 626
+      "community": 628
     },
     {
       "label": "writeFixtureDir()",
@@ -33729,7 +33809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 626
+      "community": 628
     },
     {
       "label": "search-quality-metrics.ts",
@@ -33825,7 +33905,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 928
+      "community": 931
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -33889,7 +33969,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 393
+      "community": 395
     },
     {
       "label": "normalizeMemoryType()",
@@ -33897,7 +33977,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 393
+      "community": 395
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -33905,7 +33985,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 393
+      "community": 395
     },
     {
       "label": "seedOneCorpusRow()",
@@ -33913,7 +33993,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 393
+      "community": 395
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -33921,7 +34001,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 929
+      "community": 932
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -33929,7 +34009,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 930
+      "community": 933
     },
     {
       "label": "test-database.ts",
@@ -33937,7 +34017,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_test_database_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "createTestDatabaseWithoutServices()",
@@ -33945,7 +34025,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L198",
       "id": "test_database_createtestdatabasewithoutservices",
-      "community": 278
+      "community": 279
     },
     {
       "label": "createTestMemory()",
@@ -33953,7 +34033,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L209",
       "id": "test_database_createtestmemory",
-      "community": 278
+      "community": 279
     },
     {
       "label": "search-quality-candidate-builder.ts",
@@ -33961,7 +34041,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 627
+      "community": 629
     },
     {
       "label": "mergeCandidateIds()",
@@ -33969,7 +34049,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 627
+      "community": 629
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -33977,7 +34057,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 462
+      "community": 464
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -33985,7 +34065,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 462
+      "community": 464
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -33993,7 +34073,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 462
+      "community": 464
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34001,7 +34081,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 931
+      "community": 934
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34009,7 +34089,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 932
+      "community": 935
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34209,7 +34289,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 933
+      "community": 936
     },
     {
       "label": "query-counter.ts",
@@ -34217,7 +34297,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 394
+      "community": 396
     },
     {
       "label": "extractQueryType()",
@@ -34225,7 +34305,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 394
+      "community": 396
     },
     {
       "label": "isExcluded()",
@@ -34233,7 +34313,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 394
+      "community": 396
     },
     {
       "label": "createQueryCounter()",
@@ -34241,7 +34321,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 394
+      "community": 396
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -34609,7 +34689,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 628
+      "community": 630
     },
     {
       "label": "copyDir()",
@@ -34617,7 +34697,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 628
+      "community": 630
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -34625,7 +34705,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 629
+      "community": 631
     },
     {
       "label": "readRootPackageJson()",
@@ -34633,7 +34713,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 629
+      "community": 631
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -34641,7 +34721,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 630
+      "community": 632
     },
     {
       "label": "readJson()",
@@ -34649,7 +34729,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 630
+      "community": 632
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -34657,7 +34737,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 631
+      "community": 633
     },
     {
       "label": "readWorkflow()",
@@ -34665,7 +34745,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 631
+      "community": 633
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -34729,7 +34809,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 632
+      "community": 634
     },
     {
       "label": "readStaticFile()",
@@ -34737,7 +34817,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 632
+      "community": 634
     },
     {
       "label": "smoke.spec.ts",
@@ -34745,7 +34825,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 633
+      "community": 635
     },
     {
       "label": "extractFencedBlocks()",
@@ -34753,7 +34833,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 633
+      "community": 635
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -34825,7 +34905,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 395
+      "community": 397
     },
     {
       "label": "parseArgs()",
@@ -34833,7 +34913,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 395
+      "community": 397
     },
     {
       "label": "printHelp()",
@@ -34841,7 +34921,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 395
+      "community": 397
     },
     {
       "label": "main()",
@@ -34849,7 +34929,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 395
+      "community": 397
     },
     {
       "label": "check-magic-numbers.ts",
@@ -34857,7 +34937,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L1",
       "id": "scripts_check_magic_numbers_ts",
-      "community": 140
+      "community": 139
     },
     {
       "label": "isCoreModule()",
@@ -34865,7 +34945,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L73",
       "id": "check_magic_numbers_iscoremodule",
-      "community": 140
+      "community": 139
     },
     {
       "label": "isExcluded()",
@@ -34873,7 +34953,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L77",
       "id": "check_magic_numbers_isexcluded",
-      "community": 140
+      "community": 139
     },
     {
       "label": "findMagicNumbers()",
@@ -34881,7 +34961,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L82",
       "id": "check_magic_numbers_findmagicnumbers",
-      "community": 140
+      "community": 139
     },
     {
       "label": "getAllTsFiles()",
@@ -34889,7 +34969,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L130",
       "id": "check_magic_numbers_getalltsfiles",
-      "community": 140
+      "community": 139
     },
     {
       "label": "countMagicNumbers()",
@@ -34897,7 +34977,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L161",
       "id": "check_magic_numbers_countmagicnumbers",
-      "community": 140
+      "community": 139
     },
     {
       "label": "printResultsJSON()",
@@ -34905,7 +34985,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L195",
       "id": "check_magic_numbers_printresultsjson",
-      "community": 140
+      "community": 139
     },
     {
       "label": "printResultsCSV()",
@@ -34913,7 +34993,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L214",
       "id": "check_magic_numbers_printresultscsv",
-      "community": 140
+      "community": 139
     },
     {
       "label": "printResultsText()",
@@ -34921,7 +35001,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L222",
       "id": "check_magic_numbers_printresultstext",
-      "community": 140
+      "community": 139
     },
     {
       "label": "main()",
@@ -34929,7 +35009,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L233",
       "id": "check_magic_numbers_main",
-      "community": 140
+      "community": 139
     },
     {
       "label": "prepack-bundle-core.js",
@@ -34937,7 +35017,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 634
+      "community": 636
     },
     {
       "label": "shouldInclude()",
@@ -34945,7 +35025,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 634
+      "community": 636
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -34953,7 +35033,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 463
+      "community": 465
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -34961,7 +35041,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 463
+      "community": 465
     },
     {
       "label": "readTarString()",
@@ -34969,7 +35049,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 463
+      "community": 465
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35033,7 +35113,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 635
+      "community": 637
     },
     {
       "label": "fixMigration()",
@@ -35041,7 +35121,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 635
+      "community": 637
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35049,7 +35129,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 934
+      "community": 937
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35113,7 +35193,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 396
+      "community": 398
     },
     {
       "label": "parseArgs()",
@@ -35121,7 +35201,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 396
+      "community": 398
     },
     {
       "label": "printHelp()",
@@ -35129,7 +35209,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 396
+      "community": 398
     },
     {
       "label": "main()",
@@ -35137,7 +35217,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 396
+      "community": 398
     },
     {
       "label": "check-path-traversal.ts",
@@ -35337,7 +35417,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 323
+      "community": 324
     },
     {
       "label": "parseArgs()",
@@ -35345,7 +35425,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 323
+      "community": 324
     },
     {
       "label": "printHelp()",
@@ -35353,7 +35433,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 323
+      "community": 324
     },
     {
       "label": "printThresholds()",
@@ -35361,7 +35441,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 323
+      "community": 324
     },
     {
       "label": "main()",
@@ -35369,7 +35449,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 323
+      "community": 324
     },
     {
       "label": "simple-update.js",
@@ -35377,7 +35457,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 636
+      "community": 638
     },
     {
       "label": "updateEmbeddings()",
@@ -35385,7 +35465,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 636
+      "community": 638
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -35553,7 +35633,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 637
+      "community": 639
     },
     {
       "label": "analyzeEmbeddings()",
@@ -35561,7 +35641,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 637
+      "community": 639
     },
     {
       "label": "test-docker.js",
@@ -35569,7 +35649,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 638
+      "community": 640
     },
     {
       "label": "testDockerServer()",
@@ -35577,7 +35657,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 638
+      "community": 640
     },
     {
       "label": "pack-with-restore.js",
@@ -35585,7 +35665,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 935
+      "community": 938
     },
     {
       "label": "run-migration.js",
@@ -35593,7 +35673,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 639
+      "community": 641
     },
     {
       "label": "runMigration()",
@@ -35601,7 +35681,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 639
+      "community": 641
     },
     {
       "label": "safe-migration.js",
@@ -35609,7 +35689,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 640
+      "community": 642
     },
     {
       "label": "safeMigration()",
@@ -35617,7 +35697,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 640
+      "community": 642
     },
     {
       "label": "generate-ground-truth.ts",
@@ -35681,7 +35761,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 641
+      "community": 643
     },
     {
       "label": "saveWorkMemory()",
@@ -35689,7 +35769,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 641
+      "community": 643
     },
     {
       "label": "check-file-sizes.ts",
@@ -35857,7 +35937,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 936
+      "community": 939
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -35865,7 +35945,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 642
+      "community": 644
     },
     {
       "label": "main()",
@@ -35873,7 +35953,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 642
+      "community": 644
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -35881,7 +35961,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 397
+      "community": 399
     },
     {
       "label": "parseArgs()",
@@ -35889,7 +35969,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 397
+      "community": 399
     },
     {
       "label": "printHelp()",
@@ -35897,7 +35977,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 397
+      "community": 399
     },
     {
       "label": "main()",
@@ -35905,7 +35985,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 397
+      "community": 399
     },
     {
       "label": "verify-bin.js",
@@ -35913,7 +35993,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 937
+      "community": 940
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -35921,7 +36001,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 324
+      "community": 325
     },
     {
       "label": "getTriggerInfo()",
@@ -35929,7 +36009,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 324
+      "community": 325
     },
     {
       "label": "fixTriggers()",
@@ -35937,7 +36017,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 324
+      "community": 325
     },
     {
       "label": "checkMigrationVersion()",
@@ -35945,7 +36025,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 324
+      "community": 325
     },
     {
       "label": "main()",
@@ -35953,7 +36033,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 324
+      "community": 325
     },
     {
       "label": "simple-migrate.js",
@@ -35961,7 +36041,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 643
+      "community": 645
     },
     {
       "label": "analyzeEmbeddings()",
@@ -35969,7 +36049,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 643
+      "community": 645
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -35977,7 +36057,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 644
+      "community": 646
     },
     {
       "label": "fixVectorDimensions()",
@@ -35985,7 +36065,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 644
+      "community": 646
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -35993,7 +36073,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 398
+      "community": 400
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36001,7 +36081,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 398
+      "community": 400
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36009,7 +36089,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 398
+      "community": 400
     },
     {
       "label": "main()",
@@ -36017,7 +36097,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 398
+      "community": 400
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36025,7 +36105,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 464
+      "community": 466
     },
     {
       "label": "loadVecExtension()",
@@ -36033,7 +36113,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 464
+      "community": 466
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36041,7 +36121,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 464
+      "community": 466
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36049,7 +36129,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 645
+      "community": 647
     },
     {
       "label": "runUpdateMigration()",
@@ -36057,7 +36137,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 645
+      "community": 647
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36065,7 +36145,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 465
+      "community": 467
     },
     {
       "label": "reappearanceRate()",
@@ -36073,7 +36153,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 465
+      "community": 467
     },
     {
       "label": "main()",
@@ -36081,7 +36161,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 465
+      "community": 467
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36089,7 +36169,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 646
+      "community": 648
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36097,7 +36177,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 646
+      "community": 648
     },
     {
       "label": "generate-relation-report.ts",
@@ -36169,7 +36249,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L1",
       "id": "scripts_check_sql_injection_ts",
-      "community": 141
+      "community": 140
     },
     {
       "label": "parseArgs()",
@@ -36177,7 +36257,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L56",
       "id": "check_sql_injection_parseargs",
-      "community": 141
+      "community": 140
     },
     {
       "label": "printHelp()",
@@ -36185,7 +36265,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L87",
       "id": "check_sql_injection_printhelp",
-      "community": 141
+      "community": 140
     },
     {
       "label": "matchesPattern()",
@@ -36193,7 +36273,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L110",
       "id": "check_sql_injection_matchespattern",
-      "community": 141
+      "community": 140
     },
     {
       "label": "shouldExclude()",
@@ -36201,7 +36281,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L129",
       "id": "check_sql_injection_shouldexclude",
-      "community": 141
+      "community": 140
     },
     {
       "label": "findFiles()",
@@ -36209,7 +36289,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L141",
       "id": "check_sql_injection_findfiles",
-      "community": 141
+      "community": 140
     },
     {
       "label": "findSqlInjectionPatterns()",
@@ -36217,7 +36297,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L179",
       "id": "check_sql_injection_findsqlinjectionpatterns",
-      "community": 141
+      "community": 140
     },
     {
       "label": "checkSqlInjection()",
@@ -36225,7 +36305,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L453",
       "id": "check_sql_injection_checksqlinjection",
-      "community": 141
+      "community": 140
     },
     {
       "label": "printResults()",
@@ -36233,7 +36313,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L483",
       "id": "check_sql_injection_printresults",
-      "community": 141
+      "community": 140
     },
     {
       "label": "main()",
@@ -36241,7 +36321,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L542",
       "id": "check_sql_injection_main",
-      "community": 141
+      "community": 140
     },
     {
       "label": "quality-benchmark-category-report.spec.ts",
@@ -36249,7 +36329,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 647
+      "community": 649
     },
     {
       "label": "sampleReport()",
@@ -36257,7 +36337,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 647
+      "community": 649
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -36265,7 +36345,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 938
+      "community": 941
     },
     {
       "label": "debug-embeddings.js",
@@ -36273,7 +36353,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 648
+      "community": 650
     },
     {
       "label": "debugEmbeddings()",
@@ -36281,7 +36361,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 648
+      "community": 650
     },
     {
       "label": "check-db-integrity.js",
@@ -36289,7 +36369,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 399
+      "community": 401
     },
     {
       "label": "log()",
@@ -36297,7 +36377,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 399
+      "community": 401
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -36305,7 +36385,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 399
+      "community": 401
     },
     {
       "label": "main()",
@@ -36313,7 +36393,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 399
+      "community": 401
     },
     {
       "label": "mcp-http-client.js",
@@ -36553,7 +36633,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 649
+      "community": 651
     },
     {
       "label": "backupEmbeddings()",
@@ -36561,7 +36641,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 649
+      "community": 651
     },
     {
       "label": "count-any-types.ts",
@@ -36569,7 +36649,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L1",
       "id": "scripts_count_any_types_ts",
-      "community": 142
+      "community": 141
     },
     {
       "label": "parseArgs()",
@@ -36577,7 +36657,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L56",
       "id": "count_any_types_parseargs",
-      "community": 142
+      "community": 141
     },
     {
       "label": "printHelp()",
@@ -36585,7 +36665,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L92",
       "id": "count_any_types_printhelp",
-      "community": 142
+      "community": 141
     },
     {
       "label": "matchesPattern()",
@@ -36593,7 +36673,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L118",
       "id": "count_any_types_matchespattern",
-      "community": 142
+      "community": 141
     },
     {
       "label": "shouldExclude()",
@@ -36601,7 +36681,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L137",
       "id": "count_any_types_shouldexclude",
-      "community": 142
+      "community": 141
     },
     {
       "label": "findFiles()",
@@ -36609,7 +36689,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L149",
       "id": "count_any_types_findfiles",
-      "community": 142
+      "community": 141
     },
     {
       "label": "findAnyTypes()",
@@ -36617,7 +36697,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L186",
       "id": "count_any_types_findanytypes",
-      "community": 142
+      "community": 141
     },
     {
       "label": "countAnyTypes()",
@@ -36625,7 +36705,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L251",
       "id": "count_any_types_countanytypes",
-      "community": 142
+      "community": 141
     },
     {
       "label": "printResults()",
@@ -36633,7 +36713,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L278",
       "id": "count_any_types_printresults",
-      "community": 142
+      "community": 141
     },
     {
       "label": "main()",
@@ -36641,7 +36721,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L318",
       "id": "count_any_types_main",
-      "community": 142
+      "community": 141
     },
     {
       "label": "count-console-logs.ts",
@@ -36777,7 +36857,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 939
+      "community": 942
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -36785,7 +36865,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 940
+      "community": 943
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -36793,7 +36873,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 941
+      "community": 944
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -36801,7 +36881,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 942
+      "community": 945
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -36809,7 +36889,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 650
+      "community": 652
     },
     {
       "label": "jsonEmbedding()",
@@ -36817,7 +36897,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 650
+      "community": 652
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -36825,7 +36905,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 943
+      "community": 946
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -36833,7 +36913,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 944
+      "community": 947
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -36841,7 +36921,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 945
+      "community": 948
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -36849,7 +36929,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 651
+      "community": 653
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -36857,7 +36937,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 651
+      "community": 653
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -36865,7 +36945,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 946
+      "community": 949
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -36873,7 +36953,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 652
+      "community": 654
     },
     {
       "label": "jsonEmbedding()",
@@ -36881,7 +36961,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 652
+      "community": 654
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -36889,7 +36969,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 653
+      "community": 655
     },
     {
       "label": "main()",
@@ -36897,7 +36977,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 653
+      "community": 655
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -36905,7 +36985,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 654
+      "community": 656
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -36913,7 +36993,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 654
+      "community": 656
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -36921,7 +37001,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 466
+      "community": 468
     },
     {
       "label": "createBackup()",
@@ -36929,7 +37009,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 466
+      "community": 468
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -36937,7 +37017,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 466
+      "community": 468
     },
     {
       "label": "restore-legacy.ps1",
@@ -36945,7 +37025,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 947
+      "community": 950
     },
     {
       "label": "check-retry-usage.ts",
@@ -37017,7 +37097,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_simple_throws_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "isTestFile()",
@@ -37025,7 +37105,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L29",
       "id": "analyze_simple_throws_istestfile",
-      "community": 279
+      "community": 280
     },
     {
       "label": "shouldExcludeDir()",
@@ -37033,7 +37113,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L38",
       "id": "analyze_simple_throws_shouldexcludedir",
-      "community": 279
+      "community": 280
     },
     {
       "label": "findThrows()",
@@ -37041,7 +37121,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L45",
       "id": "analyze_simple_throws_findthrows",
-      "community": 279
+      "community": 280
     },
     {
       "label": "scanDirectory()",
@@ -37049,7 +37129,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L102",
       "id": "analyze_simple_throws_scandirectory",
-      "community": 279
+      "community": 280
     },
     {
       "label": "main()",
@@ -37057,7 +37137,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L126",
       "id": "analyze_simple_throws_main",
-      "community": 279
+      "community": 280
     },
     {
       "label": "analyze-benchmark-test-data.ts",
@@ -37065,7 +37145,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 655
+      "community": 657
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37073,7 +37153,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 655
+      "community": 657
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37169,7 +37249,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 656
+      "community": 658
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37177,7 +37257,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 656
+      "community": 658
     },
     {
       "label": "sources.ts",
@@ -37185,7 +37265,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "splitJsonlLines()",
@@ -37193,7 +37273,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L13",
       "id": "sources_splitjsonllines",
-      "community": 280
+      "community": 281
     },
     {
       "label": "runDocker()",
@@ -37201,7 +37281,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L22",
       "id": "sources_rundocker",
-      "community": 280
+      "community": 281
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -37209,7 +37289,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L42",
       "id": "sources_resolvedockerlogsref",
-      "community": 280
+      "community": 281
     },
     {
       "label": "readDockerLogs()",
@@ -37217,7 +37297,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L89",
       "id": "sources_readdockerlogs",
-      "community": 280
+      "community": 281
     },
     {
       "label": "readJsonlFiles()",
@@ -37225,7 +37305,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L118",
       "id": "sources_readjsonlfiles",
-      "community": 280
+      "community": 281
     },
     {
       "label": "types.ts",
@@ -37233,7 +37313,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 948
+      "community": 951
     },
     {
       "label": "issue-body.ts",
@@ -37241,7 +37321,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 400
+      "community": 402
     },
     {
       "label": "startMarker()",
@@ -37249,7 +37329,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 400
+      "community": 402
     },
     {
       "label": "renderManagedIssueBody()",
@@ -37257,7 +37337,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 400
+      "community": 402
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -37265,7 +37345,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 400
+      "community": 402
     },
     {
       "label": "fingerprint.ts",
@@ -37273,7 +37353,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 467
+      "community": 469
     },
     {
       "label": "normalizeMessage()",
@@ -37281,7 +37361,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 467
+      "community": 469
     },
     {
       "label": "createFingerprint()",
@@ -37289,7 +37369,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 467
+      "community": 469
     },
     {
       "label": "sanitizer.ts",
@@ -37297,7 +37377,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 468
+      "community": 470
     },
     {
       "label": "limitUtf8Bytes()",
@@ -37305,7 +37385,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 468
+      "community": 470
     },
     {
       "label": "sanitizeExcerpt()",
@@ -37313,7 +37393,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 468
+      "community": 470
     },
     {
       "label": "parsers.ts",
@@ -37321,7 +37401,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 401
+      "community": 403
     },
     {
       "label": "inferLevel()",
@@ -37329,7 +37409,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 401
+      "community": 403
     },
     {
       "label": "parseAppLogLine()",
@@ -37337,7 +37417,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 401
+      "community": 403
     },
     {
       "label": "parseJsonlRecord()",
@@ -37345,7 +37425,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 401
+      "community": 403
     },
     {
       "label": "index.ts",
@@ -37353,7 +37433,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 402
+      "community": 404
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -37361,7 +37441,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 402
+      "community": 404
     },
     {
       "label": "createMonitorRuntime()",
@@ -37369,7 +37449,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 402
+      "community": 404
     },
     {
       "label": "runForever()",
@@ -37377,7 +37457,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 402
+      "community": 404
     },
     {
       "label": "promotion.ts",
@@ -37385,7 +37465,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 657
+      "community": 659
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -37393,7 +37473,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 657
+      "community": 659
     },
     {
       "label": "state-store.ts",
@@ -37401,7 +37481,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_state_store_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "emptyState()",
@@ -37409,7 +37489,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L5",
       "id": "state_store_emptystate",
-      "community": 281
+      "community": 282
     },
     {
       "label": "loadState()",
@@ -37417,7 +37497,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L9",
       "id": "state_store_loadstate",
-      "community": 281
+      "community": 282
     },
     {
       "label": "saveState()",
@@ -37425,7 +37505,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L20",
       "id": "state_store_savestate",
-      "community": 281
+      "community": 282
     },
     {
       "label": "upsertOccurrence()",
@@ -37433,7 +37513,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L27",
       "id": "state_store_upsertoccurrence",
-      "community": 281
+      "community": 282
     },
     {
       "label": "appendOccurrence()",
@@ -37441,7 +37521,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L55",
       "id": "state_store_appendoccurrence",
-      "community": 281
+      "community": 282
     },
     {
       "label": "monitor.ts",
@@ -37449,7 +37529,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 325
+      "community": 326
     },
     {
       "label": "recordMonitorError()",
@@ -37457,7 +37537,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L20",
       "id": "monitor_recordmonitorerror",
-      "community": 325
+      "community": 326
     },
     {
       "label": "withFingerprint()",
@@ -37465,7 +37545,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L29",
       "id": "monitor_withfingerprint",
-      "community": 325
+      "community": 326
     },
     {
       "label": "syncFingerprint()",
@@ -37473,7 +37553,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_syncfingerprint",
-      "community": 325
+      "community": 326
     },
     {
       "label": "runMonitorCycle()",
@@ -37481,7 +37561,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L103",
       "id": "monitor_runmonitorcycle",
-      "community": 325
+      "community": 326
     },
     {
       "label": "github-client.ts",
@@ -37553,7 +37633,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_detectors_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "nowIso()",
@@ -37561,7 +37641,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L6",
       "id": "detectors_nowiso",
-      "community": 282
+      "community": 283
     },
     {
       "label": "truncateTitle()",
@@ -37569,7 +37649,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L10",
       "id": "detectors_truncatetitle",
-      "community": 282
+      "community": 283
     },
     {
       "label": "detectAppLogEvent()",
@@ -37577,7 +37657,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L14",
       "id": "detectors_detectapplogevent",
-      "community": 282
+      "community": 283
     },
     {
       "label": "detectRuntimeAnomaly()",
@@ -37585,7 +37665,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L62",
       "id": "detectors_detectruntimeanomaly",
-      "community": 282
+      "community": 283
     },
     {
       "label": "detectDockerAnomaly()",
@@ -37593,7 +37673,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L85",
       "id": "detectors_detectdockeranomaly",
-      "community": 282
+      "community": 283
     },
     {
       "label": "config.ts",
@@ -37657,7 +37737,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 949
+      "community": 952
     },
     {
       "label": "issue-body.spec.ts",
@@ -37665,7 +37745,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 950
+      "community": 953
     },
     {
       "label": "github-client.spec.ts",
@@ -37673,7 +37753,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 951
+      "community": 954
     },
     {
       "label": "config.spec.ts",
@@ -37681,7 +37761,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 952
+      "community": 955
     },
     {
       "label": "detectors.spec.ts",
@@ -37689,7 +37769,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 953
+      "community": 956
     },
     {
       "label": "sources.spec.ts",
@@ -37697,7 +37777,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 954
+      "community": 957
     },
     {
       "label": "parsers.spec.ts",
@@ -37705,7 +37785,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 955
+      "community": 958
     },
     {
       "label": "monitor.spec.ts",
@@ -37713,7 +37793,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "config()",
@@ -37721,7 +37801,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 658
+      "community": 660
     },
     {
       "label": "fingerprint.spec.ts",
@@ -37729,7 +37809,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 956
+      "community": 959
     },
     {
       "label": "state-store.spec.ts",
@@ -37737,7 +37817,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 957
+      "community": 960
     },
     {
       "label": "sanitizer.spec.ts",
@@ -37745,7 +37825,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 958
+      "community": 961
     },
     {
       "label": "entrypoint.spec.ts",
@@ -37753,7 +37833,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 959
+      "community": 962
     },
     {
       "label": "index.ts",
@@ -37761,7 +37841,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 403
+      "community": 405
     },
     {
       "label": "main()",
@@ -37769,7 +37849,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 403
+      "community": 405
     },
     {
       "label": "index.ts",
@@ -37777,7 +37857,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 403
+      "community": 405
     },
     {
       "label": "runExample()",
@@ -37785,7 +37865,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 403
+      "community": 405
     },
     {
       "label": "index.spec.ts",
@@ -37793,7 +37873,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 960
+      "community": 963
     },
     {
       "label": "memento-admin-fetch.js",
@@ -37801,7 +37881,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L1",
       "id": "static_js_memento_admin_fetch_js",
-      "community": 283
+      "community": 284
     },
     {
       "label": "getDashboardAuth()",
@@ -37809,7 +37889,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L8",
       "id": "memento_admin_fetch_getdashboardauth",
-      "community": 283
+      "community": 284
     },
     {
       "label": "waitForSession()",
@@ -37817,7 +37897,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L12",
       "id": "memento_admin_fetch_waitforsession",
-      "community": 283
+      "community": 284
     },
     {
       "label": "buildRequestOptions()",
@@ -37825,7 +37905,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L20",
       "id": "memento_admin_fetch_buildrequestoptions",
-      "community": 283
+      "community": 284
     },
     {
       "label": "performFetch()",
@@ -37833,7 +37913,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L28",
       "id": "memento_admin_fetch_performfetch",
-      "community": 283
+      "community": 284
     },
     {
       "label": "mementoAdminFetch()",
@@ -37841,7 +37921,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L51",
       "id": "memento_admin_fetch_mementoadminfetch",
-      "community": 283
+      "community": 284
     },
     {
       "label": "dashboard-auth.js",
@@ -38897,7 +38977,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 326
+      "community": 327
     },
     {
       "label": "getTabButtons()",
@@ -38905,7 +38985,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 326
+      "community": 327
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -38913,7 +38993,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 326
+      "community": 327
     },
     {
       "label": "setRovingTabindex()",
@@ -38921,7 +39001,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 326
+      "community": 327
     },
     {
       "label": "activateTab()",
@@ -38929,7 +39009,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 326
+      "community": 327
     }
   ],
   "links": [
@@ -78644,6 +78724,78 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
+      "_tgt": "tool_context_knowledge_context_adapter_normalizememorytypesforsearch",
+      "source": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
+      "target": "tool_context_knowledge_context_adapter_normalizememorytypesforsearch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
+      "_tgt": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "source": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
+      "target": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L47",
+      "weight": 1.0,
+      "_src": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
+      "_tgt": "tool_context_knowledge_context_adapter_normalizememorytypesforsearch",
+      "source": "tool_context_knowledge_context_adapter_normalizememorytypesforsearch",
+      "target": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L26",
+      "weight": 1.0,
+      "_src": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "_tgt": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
+      "source": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "target": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L28",
+      "weight": 1.0,
+      "_src": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "_tgt": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
+      "source": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "target": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
+      "source_location": "L54",
+      "weight": 1.0,
+      "_src": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "_tgt": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
+      "source": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
+      "target": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "weight": 1.0,
@@ -78705,7 +78857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
-      "source_location": "L9",
+      "source_location": "L17",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
       "_tgt": "personal_knowledge_agent_service_spec_makedeps",
@@ -79017,7 +79169,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L30",
+      "source_location": "L28",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
       "_tgt": "memory_injection_prompt_memoryinjectionprompt",
@@ -79029,7 +79181,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L31",
+      "source_location": "L29",
       "weight": 1.0,
       "_src": "memory_injection_prompt_memoryinjectionprompt",
       "_tgt": "memory_injection_prompt_memoryinjectionprompt_constructor",
@@ -79041,156 +79193,12 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L77",
+      "source_location": "L82",
       "weight": 1.0,
       "_src": "memory_injection_prompt_memoryinjectionprompt",
       "_tgt": "memory_injection_prompt_memoryinjectionprompt_handle",
       "source": "memory_injection_prompt_memoryinjectionprompt",
       "target": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L208",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L247",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_summarizememorycontent",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_summarizememorycontent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L291",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_formatmemoryprompt",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_formatmemoryprompt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L320",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_getmemorytypeemoji",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_getmemorytypeemoji",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L333",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L349",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_updateconsolidationscoremetadata",
-      "source": "memory_injection_prompt_memoryinjectionprompt",
-      "target": "memory_injection_prompt_memoryinjectionprompt_updateconsolidationscoremetadata",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L161",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_updateconsolidationscoremetadata",
-      "source": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "target": "memory_injection_prompt_memoryinjectionprompt_updateconsolidationscoremetadata",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L179",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "source": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "target": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L182",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_formatmemoryprompt",
-      "source": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "target": "memory_injection_prompt_memoryinjectionprompt_formatmemoryprompt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L186",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "source": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "target": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L226",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_summarizememorycontent",
-      "source": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "target": "memory_injection_prompt_memoryinjectionprompt_summarizememorycontent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
-      "source_location": "L227",
-      "weight": 1.0,
-      "_src": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "_tgt": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
-      "source": "memory_injection_prompt_memoryinjectionprompt_summarizememories",
-      "target": "memory_injection_prompt_memoryinjectionprompt_estimatetokens",
       "confidence_score": 1.0
     },
     {
@@ -83391,6 +83399,186 @@
       "_tgt": "memory_review_candidate_selection_service_spec_createbaseschema",
       "source": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
       "target": "memory_review_candidate_selection_service_spec_createbaseschema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_estimatetokens",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_estimatetokens",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L48",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_getmemorytypeemoji",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_getmemorytypeemoji",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L58",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_summarizememorycontent",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_summarizememorycontent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L97",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_summarizememories",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_summarizememories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L131",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_formatmemoryprompt",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_formatmemoryprompt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L157",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L266",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_filterbyowner",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_filterbyowner",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L277",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "_tgt": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "source": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L114",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_summarizememories",
+      "_tgt": "knowledge_context_bundle_builder_estimatetokens",
+      "source": "knowledge_context_bundle_builder_estimatetokens",
+      "target": "knowledge_context_bundle_builder_summarizememories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L344",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "_tgt": "knowledge_context_bundle_builder_estimatetokens",
+      "source": "knowledge_context_bundle_builder_estimatetokens",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L113",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_summarizememories",
+      "_tgt": "knowledge_context_bundle_builder_summarizememorycontent",
+      "source": "knowledge_context_bundle_builder_summarizememorycontent",
+      "target": "knowledge_context_bundle_builder_summarizememories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L342",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "_tgt": "knowledge_context_bundle_builder_summarizememories",
+      "source": "knowledge_context_bundle_builder_summarizememories",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L343",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "_tgt": "knowledge_context_bundle_builder_formatmemoryprompt",
+      "source": "knowledge_context_bundle_builder_formatmemoryprompt",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L323",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "_tgt": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
+      "source": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
+      "source_location": "L318",
+      "weight": 1.0,
+      "_src": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
+      "_tgt": "knowledge_context_bundle_builder_filterbyowner",
+      "source": "knowledge_context_bundle_builder_filterbyowner",
+      "target": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * buildKnowledgeContextBundle 단위·통합 검증 (#232)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { setupTestDatabase, cleanupTestDatabase } from '../../../../test/helpers/test-database.js';
+import { createHybridSearchEngine } from '../../../search/algorithms/hybrid-search-engine.js';
+import { ErrorLoggingService } from '../../../monitoring/services/error-logging-service.js';
+import type { ToolContext } from '../../../tools/types.js';
+import { MemoryEmbeddingService } from '../../services/memory-embedding-service.js';
+import { buildKnowledgeContextBundle } from '../knowledge-context-bundle-builder.js';
+import { ToolContextKnowledgeContextAdapter } from '../../../personal-agent/adapters/tool-context-knowledge-context-adapter.js';
+
+describe('buildKnowledgeContextBundle', () => {
+  let db: Database.Database;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    db = await setupTestDatabase();
+    const errorLoggingService = new ErrorLoggingService(db);
+    const embeddingService = new MemoryEmbeddingService();
+    const hybridSearchEngine = createHybridSearchEngine(undefined, embeddingService);
+    context = {
+      db,
+      services: {
+        hybridSearchEngine,
+        embeddingService,
+        errorLoggingService,
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await cleanupTestDatabase(db);
+  });
+
+  it('projectId가 지정되면 해당 프로젝트 기억만 번들에 포함한다', async () => {
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, project_id, created_at)
+      VALUES
+        ('ctx_mine', 'semantic', 'ctx-proj-a 전용 내용', 0.9, 'proj-a', datetime('now')),
+        ('ctx_other', 'semantic', 'ctx-proj-b 다른 내용', 0.9, 'proj-b', datetime('now'))
+    `);
+
+    const bundle = await buildKnowledgeContextBundle(
+      {
+        db,
+        hybridSearchEngine: context.services!.hybridSearchEngine!,
+      },
+      { query: 'ctx-proj', projectId: 'proj-a', maxMemories: 5, tokenBudget: 2000 },
+    );
+
+    expect(bundle.promptText).toContain('ctx-proj-a 전용');
+    expect(bundle.promptText).not.toContain('ctx-proj-b');
+    expect(bundle.itemCount).toBeGreaterThanOrEqual(1);
+    expect(bundle.contextSummary).toContain('관련 기억');
+  });
+
+  it('ownerId가 지정되면 해당 소유자 기억만 포함한다', async () => {
+    db.exec(`
+      INSERT INTO memory_item (id, type, content, importance, owner_id, created_at)
+      VALUES
+        ('ctx_own_a', 'episodic', 'owner-scope 알파 내용', 0.9, 'agent-a', datetime('now')),
+        ('ctx_own_b', 'episodic', 'owner-scope 베타 내용', 0.9, 'agent-b', datetime('now'))
+    `);
+
+    const bundle = await buildKnowledgeContextBundle(
+      {
+        db,
+        hybridSearchEngine: context.services!.hybridSearchEngine!,
+      },
+      { query: 'owner-scope', ownerId: 'agent-a', maxMemories: 5, tokenBudget: 2000 },
+    );
+
+    expect(bundle.promptText).toContain('알파');
+    expect(bundle.promptText).not.toContain('베타');
+  });
+});
+
+describe('ToolContextKnowledgeContextAdapter', () => {
+  let db: Database.Database;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    db = await setupTestDatabase();
+    const errorLoggingService = new ErrorLoggingService(db);
+    const embeddingService = new MemoryEmbeddingService();
+    const hybridSearchEngine = createHybridSearchEngine(undefined, embeddingService);
+    context = {
+      db,
+      services: {
+        hybridSearchEngine,
+        embeddingService,
+        errorLoggingService,
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await cleanupTestDatabase(db);
+  });
+
+  it('buildContext가 번들을 반환한다', async () => {
+    const adapter = new ToolContextKnowledgeContextAdapter(context);
+    const bundle = await adapter.buildContext({ userMessage: '아무 검색어' });
+    expect(bundle.promptText).toBeDefined();
+    expect(typeof bundle.itemCount).toBe('number');
+    expect(typeof bundle.tokenEstimate).toBe('number');
+    expect(bundle.contextSummary).toBeDefined();
+  });
+});

--- a/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
+++ b/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
@@ -6,12 +6,12 @@
 import type Database from 'better-sqlite3';
 import { mementoConfig } from '../../../shared/config/index.js';
 import type { IConsolidationScoreService } from '../../../shared/interfaces/consolidation-score.interface.js';
-import type { MemoryType } from '../../../shared/types/index.js';
+import { isFullMemoryItemTypeSet, type MemoryType } from '../../../shared/types/index.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
 import { emitTfidfFallbackWarningIfNeeded } from '../../../shared/utils/embedding-provider-diagnostics.js';
 import { logger } from '../../../shared/utils/logger.js';
 import type { WriteCoalescingManager } from '../../../shared/utils/write-coalescing.js';
-import type { HybridSearchEngine } from '../../search/algorithms/hybrid-search-engine.js';
+import type { HybridSearchEngine, HybridSearchResult } from '../../search/algorithms/hybrid-search-engine.js';
 
 export interface KnowledgeContextBundleBuilderDeps {
   db: Database.Database;
@@ -95,7 +95,7 @@ function summarizeMemoryContent(content: string, maxTokens: number): string {
 }
 
 function summarizeMemories(
-  memories: any[],
+  memories: HybridSearchResult[],
   tokenBudget: number,
   maxMemories: number,
 ): Array<{ id: string; content: string; type: string; importance: number; summary: string }> {
@@ -103,9 +103,7 @@ function summarizeMemories(
   let usedTokens = 0;
   const maxTokensPerMemory = Math.floor(tokenBudget / maxMemories);
 
-  const sortedMemories = memories
-    .sort((a, b) => b.finalScore + b.importance - (a.finalScore + a.importance))
-    .slice(0, maxMemories);
+  const sortedMemories = [...memories].sort((a, b) => b.finalScore + b.importance - (a.finalScore + a.importance)).slice(0, maxMemories);
 
   for (const memory of sortedMemories) {
     if (usedTokens >= tokenBudget) break;
@@ -158,7 +156,7 @@ async function updateConsolidationScoreMetadata(
   db: Database.Database,
   consolidationScoreService: IConsolidationScoreService,
   writeCoalescingManager: WriteCoalescingManager | undefined,
-  searchItems: any[],
+  searchItems: HybridSearchResult[],
 ): Promise<void> {
   if (!searchItems || searchItems.length === 0) {
     return;
@@ -169,7 +167,7 @@ async function updateConsolidationScoreMetadata(
     const nowISO = now.toISOString();
 
     for (const item of searchItems) {
-      const memoryId = item.id || item.memory_id;
+      const memoryId = item.id;
       if (!memoryId) {
         continue;
       }
@@ -263,12 +261,12 @@ async function updateConsolidationScoreMetadata(
   }
 }
 
-function filterByOwner(memories: any[], ownerId?: string | string[]): any[] {
+function filterByOwner(memories: HybridSearchResult[], ownerId?: string | string[]): HybridSearchResult[] {
   if (ownerId === undefined || ownerId === null) {
     return memories;
   }
   const ownerIds = Array.isArray(ownerId) ? ownerId : [ownerId];
-  return memories.filter((m: any) => m.owner_id != null && ownerIds.includes(String(m.owner_id)));
+  return memories.filter((m) => m.owner_id != null && ownerIds.includes(String(m.owner_id)));
 }
 
 /**
@@ -289,7 +287,7 @@ export async function buildKnowledgeContextBundle(
 
   const finalMemoryTypes: MemoryType[] | undefined =
     filteredMemoryTypes && filteredMemoryTypes.length > 0
-      ? filteredMemoryTypes.length === 4
+      ? isFullMemoryItemTypeSet(filteredMemoryTypes)
         ? undefined
         : filteredMemoryTypes
       : undefined;
@@ -311,9 +309,12 @@ export async function buildKnowledgeContextBundle(
     searchResult.tfidf_query_embedding_fallback_providers,
   );
 
-  let memories = searchResult.items;
+  // TODO(#232 follow-up): project_id / owner_id를 검색 단계(SQL/하이브리드 filters)에서 적용하지 않고
+  // 여기서 후처리만 하므로, 좁은 필터일 때 limit 이전에 걸러져 후보가 maxMemories보다 훨씬 적을 수 있음.
+
+  let memories: HybridSearchResult[] = searchResult.items;
   if (projectId) {
-    memories = memories.filter((m: any) => m.project_id != null && m.project_id === projectId);
+    memories = memories.filter((m) => m.project_id != null && m.project_id === projectId);
   }
   memories = filterByOwner(memories, ownerId);
 

--- a/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
+++ b/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
@@ -292,12 +292,24 @@ export async function buildKnowledgeContextBundle(
         : filteredMemoryTypes
       : undefined;
 
+  const hasScope = Boolean(
+    (projectId && projectId.length > 0) ||
+      (ownerId !== undefined &&
+        ownerId !== null &&
+        (Array.isArray(ownerId) ? ownerId.length > 0 : String(ownerId).length > 0)),
+  );
+  const searchLimitMultiplier = hasScope ? 6 : 2;
+
   const searchResult = await deps.hybridSearchEngine.search(deps.db, {
     query,
     filters: {
       type: finalMemoryTypes,
+      ...(projectId && projectId.length > 0 ? { project_id: projectId } : {}),
+      ...(ownerId !== undefined && ownerId !== null
+        ? { owner_id: ownerId }
+        : {}),
     },
-    limit: maxMemories * 2,
+    limit: maxMemories * searchLimitMultiplier,
     vectorWeight: 0.7,
     textWeight: 0.3,
   });
@@ -309,9 +321,7 @@ export async function buildKnowledgeContextBundle(
     searchResult.tfidf_query_embedding_fallback_providers,
   );
 
-  // TODO(#232 follow-up): project_id / owner_id를 검색 단계(SQL/하이브리드 filters)에서 적용하지 않고
-  // 여기서 후처리만 하므로, 좁은 필터일 때 limit 이전에 걸러져 후보가 maxMemories보다 훨씬 적을 수 있음.
-
+  // project_id / owner_id는 하이브리드 검색 filters 및 SQL(텍스트·VEC·임베딩 fallback)에서 적용됨.
   let memories: HybridSearchResult[] = searchResult.items;
   if (projectId) {
     memories = memories.filter((m) => m.project_id != null && m.project_id === projectId);

--- a/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
+++ b/packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts
@@ -1,0 +1,367 @@
+/**
+ * memory_injection / 개인 지식 Agent가 공유하는 컨텍스트 번들 구성 로직.
+ * 하이브리드 검색 → project/owner 필터 → (선택) consolidation 메타 갱신 → 토큰 예산 내 요약 → 프롬프트 문자열
+ */
+
+import type Database from 'better-sqlite3';
+import { mementoConfig } from '../../../shared/config/index.js';
+import type { IConsolidationScoreService } from '../../../shared/interfaces/consolidation-score.interface.js';
+import type { MemoryType } from '../../../shared/types/index.js';
+import { DatabaseUtils } from '../../../shared/utils/database.js';
+import { emitTfidfFallbackWarningIfNeeded } from '../../../shared/utils/embedding-provider-diagnostics.js';
+import { logger } from '../../../shared/utils/logger.js';
+import type { WriteCoalescingManager } from '../../../shared/utils/write-coalescing.js';
+import type { HybridSearchEngine } from '../../search/algorithms/hybrid-search-engine.js';
+
+export interface KnowledgeContextBundleBuilderDeps {
+  db: Database.Database;
+  hybridSearchEngine: HybridSearchEngine;
+  consolidationScoreService?: IConsolidationScoreService;
+  writeCoalescingManager?: WriteCoalescingManager;
+}
+
+export interface KnowledgeContextBundleParams {
+  query: string;
+  tokenBudget?: number;
+  maxMemories?: number;
+  /** core/vault 제거·검증된 타입만 전달 */
+  memoryTypes?: MemoryType[];
+  projectId?: string;
+  ownerId?: string | string[];
+}
+
+export interface KnowledgeContextBundle {
+  /** LLM system 프롬프트에 넣을 본문 */
+  promptText: string;
+  /** 요약에 포함된 기억 개수 */
+  itemCount: number;
+  tokenEstimate: number;
+  /** Agent Loop 메타용 한 줄 요약 */
+  contextSummary: string;
+  query: string;
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function getMemoryTypeEmoji(type: string): string {
+  const emojiMap: Record<string, string> = {
+    working: '🧠',
+    episodic: '📝',
+    semantic: '📚',
+    procedural: '⚙️',
+  };
+  return emojiMap[type] || '💭';
+}
+
+function summarizeMemoryContent(content: string, maxTokens: number): string {
+  const words = content.split(' ');
+  const maxWords = Math.floor(maxTokens / 1.5);
+
+  if (words.length <= maxWords) {
+    return content;
+  }
+
+  const sentences = content.split(/[.!?]+/).filter((s) => s.trim().length > 0);
+
+  if (sentences.length <= 2) {
+    return words.slice(0, maxWords).join(' ') + '...';
+  }
+
+  const firstSentence = sentences[0]?.trim() || '';
+  const lastSentence = sentences[sentences.length - 1]?.trim() || '';
+  const middleSentences = sentences.slice(1, -1);
+
+  let summary = firstSentence;
+  let remainingWords = maxWords - firstSentence.split(' ').length;
+
+  if (remainingWords > 0 && middleSentences.length > 0) {
+    const middleText = middleSentences.join('. ');
+    const middleWords = middleText.split(' ');
+    const middleWordsToInclude = Math.min(remainingWords - lastSentence.split(' ').length, middleWords.length);
+
+    if (middleWordsToInclude > 0) {
+      summary += ' ' + middleWords.slice(0, middleWordsToInclude).join(' ');
+      remainingWords -= middleWordsToInclude;
+    }
+  }
+
+  if (remainingWords > 0) {
+    summary += ' ' + lastSentence;
+  }
+
+  return summary + (summary.length < content.length ? '...' : '');
+}
+
+function summarizeMemories(
+  memories: any[],
+  tokenBudget: number,
+  maxMemories: number,
+): Array<{ id: string; content: string; type: string; importance: number; summary: string }> {
+  const summaries: Array<{ id: string; content: string; type: string; importance: number; summary: string }> = [];
+  let usedTokens = 0;
+  const maxTokensPerMemory = Math.floor(tokenBudget / maxMemories);
+
+  const sortedMemories = memories
+    .sort((a, b) => b.finalScore + b.importance - (a.finalScore + a.importance))
+    .slice(0, maxMemories);
+
+  for (const memory of sortedMemories) {
+    if (usedTokens >= tokenBudget) break;
+
+    const summary = summarizeMemoryContent(memory.content, maxTokensPerMemory);
+    const summaryTokens = estimateTokens(summary);
+
+    if (usedTokens + summaryTokens <= tokenBudget) {
+      summaries.push({
+        id: memory.id,
+        content: memory.content,
+        type: memory.type,
+        importance: memory.importance,
+        summary,
+      });
+      usedTokens += summaryTokens;
+    }
+  }
+
+  return summaries;
+}
+
+function formatMemoryPrompt(
+  summaries: Array<{ id: string; content: string; type: string; importance: number; summary: string }>,
+  query: string,
+): string {
+  if (summaries.length === 0) {
+    return '관련 기억을 찾을 수 없습니다.';
+  }
+
+  let prompt = `# 관련 기억 (${summaries.length}개)\n\n`;
+  prompt += `**검색 쿼리**: "${query}"\n\n`;
+
+  summaries.forEach((memory, index) => {
+    const typeEmoji = getMemoryTypeEmoji(memory.type);
+    const importanceStars = '★'.repeat(Math.ceil(memory.importance * 5));
+
+    prompt += `## ${index + 1}. ${typeEmoji} ${memory.type.toUpperCase()} 기억\n`;
+    prompt += `**중요도**: ${importanceStars} (${memory.importance.toFixed(2)})\n`;
+    prompt += `**내용**: ${memory.summary}\n\n`;
+  });
+
+  prompt += '---\n';
+  prompt += '*이 기억들은 현재 대화와 관련된 맥락 정보입니다. 참고하여 더 정확하고 관련성 높은 답변을 제공하세요.*';
+
+  return prompt;
+}
+
+async function updateConsolidationScoreMetadata(
+  db: Database.Database,
+  consolidationScoreService: IConsolidationScoreService,
+  writeCoalescingManager: WriteCoalescingManager | undefined,
+  searchItems: any[],
+): Promise<void> {
+  if (!searchItems || searchItems.length === 0) {
+    return;
+  }
+
+  try {
+    const now = new Date();
+    const nowISO = now.toISOString();
+
+    for (const item of searchItems) {
+      const memoryId = item.id || item.memory_id;
+      if (!memoryId) {
+        continue;
+      }
+
+      try {
+        const memory = DatabaseUtils.get(
+          db,
+          `SELECT 
+              recall_count, 
+              last_accessed_at, 
+              g_value, 
+              created_at, 
+              type, 
+              pinned 
+            FROM memory_item 
+            WHERE id = ?`,
+          [memoryId],
+        ) as
+          | {
+              recall_count: number;
+              last_accessed_at: string | null;
+              g_value: number | null;
+              created_at: string;
+              type: MemoryType;
+              pinned: boolean | number;
+            }
+          | undefined;
+
+        if (!memory) {
+          logger.warn(`[knowledge-context-bundle] 메모리를 찾을 수 없습니다: ${memoryId}`);
+          continue;
+        }
+
+        const newRecallCount = (memory.recall_count || 0) + 1;
+
+        const lastAccessedAt = memory.last_accessed_at ? new Date(memory.last_accessed_at) : new Date(memory.created_at);
+        const timeElapsed = consolidationScoreService.calculateTimeElapsed(
+          lastAccessedAt,
+          new Date(memory.created_at),
+          now,
+        );
+
+        const newGValue = consolidationScoreService.updateGValueForRecall({
+          previousGValue: memory.g_value,
+          timeElapsed,
+        });
+
+        const scoreResult = consolidationScoreService.calculateScore({
+          recallCount: newRecallCount,
+          lastAccessedAt: now,
+          createdAt: new Date(memory.created_at),
+          gValue: newGValue,
+          type: memory.type,
+          pinned: memory.pinned === 1 || memory.pinned === true,
+        });
+
+        if (writeCoalescingManager) {
+          writeCoalescingManager.addWrite({
+            memoryId,
+            fields: {
+              recall_count: newRecallCount,
+              last_accessed_at: nowISO,
+              g_value: newGValue,
+              consolidation_score: scoreResult.score,
+            },
+          });
+        } else {
+          DatabaseUtils.run(
+            db,
+            `UPDATE memory_item 
+               SET 
+                 recall_count = ?,
+                 last_accessed_at = ?,
+                 g_value = ?,
+                 consolidation_score = ?
+               WHERE id = ?`,
+            [newRecallCount, nowISO, newGValue, scoreResult.score, memoryId],
+          );
+        }
+      } catch (error) {
+        logger.warn(`[knowledge-context-bundle] 메모리 업데이트 실패 (${memoryId})`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  } catch (error) {
+    logger.error('[knowledge-context-bundle] Consolidation Score 메타데이터 업데이트 실패', {
+      itemCount: searchItems.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function filterByOwner(memories: any[], ownerId?: string | string[]): any[] {
+  if (ownerId === undefined || ownerId === null) {
+    return memories;
+  }
+  const ownerIds = Array.isArray(ownerId) ? ownerId : [ownerId];
+  return memories.filter((m: any) => m.owner_id != null && ownerIds.includes(String(m.owner_id)));
+}
+
+/**
+ * memory_injection과 동일한 검색·요약·포맷 경로로 컨텍스트 번들을 생성합니다.
+ */
+export async function buildKnowledgeContextBundle(
+  deps: KnowledgeContextBundleBuilderDeps,
+  params: KnowledgeContextBundleParams,
+): Promise<KnowledgeContextBundle> {
+  const {
+    query,
+    tokenBudget = 1000,
+    maxMemories = 5,
+    memoryTypes: filteredMemoryTypes,
+    projectId,
+    ownerId,
+  } = params;
+
+  const finalMemoryTypes: MemoryType[] | undefined =
+    filteredMemoryTypes && filteredMemoryTypes.length > 0
+      ? filteredMemoryTypes.length === 4
+        ? undefined
+        : filteredMemoryTypes
+      : undefined;
+
+  const searchResult = await deps.hybridSearchEngine.search(deps.db, {
+    query,
+    filters: {
+      type: finalMemoryTypes,
+    },
+    limit: maxMemories * 2,
+    vectorWeight: 0.7,
+    textWeight: 0.3,
+  });
+
+  emitTfidfFallbackWarningIfNeeded(
+    searchResult.fallback_used,
+    searchResult.query_embedding_providers,
+    searchResult.tfidf_query_embedding_fallback,
+    searchResult.tfidf_query_embedding_fallback_providers,
+  );
+
+  let memories = searchResult.items;
+  if (projectId) {
+    memories = memories.filter((m: any) => m.project_id != null && m.project_id === projectId);
+  }
+  memories = filterByOwner(memories, ownerId);
+
+  logger.debug('[knowledge-context-bundle] 검색된 기억', { count: memories.length });
+
+  if (mementoConfig.consolidationScoreEnabled && deps.consolidationScoreService && memories.length > 0) {
+    await updateConsolidationScoreMetadata(
+      deps.db,
+      deps.consolidationScoreService,
+      deps.writeCoalescingManager,
+      memories,
+    );
+  }
+
+  if (memories.length === 0) {
+    const emptyText = '관련 기억을 찾을 수 없습니다.';
+    return {
+      promptText: emptyText,
+      itemCount: 0,
+      tokenEstimate: 0,
+      contextSummary: '관련 기억 0건',
+      query,
+    };
+  }
+
+  const summary = summarizeMemories(memories, tokenBudget, maxMemories);
+  const formattedPrompt = formatMemoryPrompt(summary, query);
+  const tokenEstimate = estimateTokens(formattedPrompt);
+
+  const typeCounts = summary.reduce<Record<string, number>>((acc, row) => {
+    acc[row.type] = (acc[row.type] ?? 0) + 1;
+    return acc;
+  }, {});
+  const breakdown = Object.entries(typeCounts)
+    .map(([t, n]) => `${t} ${n}`)
+    .join(', ');
+  const contextSummary = `관련 기억 ${summary.length}건 (${breakdown}), 추정 토큰 ${tokenEstimate}`;
+
+  logger.info('[knowledge-context-bundle] 완료', {
+    memoryCount: summary.length,
+    tokenCount: tokenEstimate,
+  });
+
+  return {
+    promptText: formattedPrompt,
+    itemCount: summary.length,
+    tokenEstimate,
+    contextSummary,
+    query,
+  };
+}

--- a/packages/memento-core/src/domains/memory/services/memory-embedding-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-embedding-service.ts
@@ -37,6 +37,8 @@ export interface VectorSearchResult {
   tags?: string[];
   similarity: number;
   score: number;
+  project_id?: string | null;
+  owner_id?: string | null;
 }
 
 /** searchBySimilarity 결과: 쿼리 임베딩에 실제 사용된 provider 진단용 */
@@ -52,6 +54,8 @@ interface SimilaritySearchRow {
   tags: string | null;
   similarity: number;
   score: number;
+  project_id?: string | null;
+  owner_id?: string | null;
 }
 
 /** Row shape from provider stats GROUP BY query */
@@ -179,11 +183,31 @@ export class MemoryEmbeddingService {
   private buildVecSimilarityQuery(
     provider: EmbeddingProvider,
     tableName: string,
-    filters?: { type?: MemoryType[]; limit?: number; threshold?: number }
+    filters?: {
+      type?: MemoryType[];
+      limit?: number;
+      threshold?: number;
+      project_id?: string;
+      owner_id?: string | string[];
+    }
   ): { sql: string; params: unknown[] } {
     const typeFilter = filters?.type
       ? 'AND m.type IN (' + filters.type.map(() => '?').join(',') + ')'
       : '';
+    const projectClause =
+      typeof filters?.project_id === 'string' && filters.project_id.length > 0
+        ? 'AND m.project_id = ?'
+        : '';
+    let ownerClause = '';
+    const ownerParams: unknown[] = [];
+    const o = filters?.owner_id;
+    if (typeof o === 'string' && o.length > 0) {
+      ownerClause = 'AND m.owner_id = ?';
+      ownerParams.push(o);
+    } else if (Array.isArray(o) && o.length > 0) {
+      ownerClause = 'AND m.owner_id IN (' + o.map(() => '?').join(',') + ')';
+      ownerParams.push(...o);
+    }
     const sql =
       'SELECT ' +
       '  m.id, ' +
@@ -194,6 +218,8 @@ export class MemoryEmbeddingService {
       '  m.last_accessed, ' +
       '  m.pinned, ' +
       '  m.tags, ' +
+      '  m.project_id, ' +
+      '  m.owner_id, ' +
       '  v.distance as similarity, ' +
       '  (1 - v.distance) as score ' +
       'FROM memory_item m ' +
@@ -202,12 +228,25 @@ export class MemoryEmbeddingService {
       tableName +
       ' v ON me.id = v.rowid ' +
       'WHERE me.embedding_provider = ? ' +
+      'AND (COALESCE(m.is_deleted, 0) = 0) ' +
       typeFilter +
+      projectClause +
+      ' ' +
+      ownerClause +
       ' ' +
       'ORDER BY v.distance ASC ' +
       'LIMIT ?';
 
-    const params: unknown[] = [provider, ...(filters?.type || []), filters?.limit || 10];
+    const projectParams: unknown[] =
+      typeof filters?.project_id === 'string' && filters.project_id.length > 0 ? [filters.project_id] : [];
+
+    const params: unknown[] = [
+      provider,
+      ...(filters?.type || []),
+      ...projectParams,
+      ...ownerParams,
+      filters?.limit || 10,
+    ];
     return { sql, params };
   }
 
@@ -222,7 +261,9 @@ export class MemoryEmbeddingService {
       pinned: Boolean(row.pinned),
       tags: this.safeParseTags(row.tags),
       similarity: row.similarity,
-      score: row.score
+      score: row.score,
+      ...(row.project_id !== undefined ? { project_id: row.project_id } : {}),
+      ...(row.owner_id !== undefined ? { owner_id: row.owner_id } : {}),
     }));
   }
 
@@ -329,6 +370,8 @@ export class MemoryEmbeddingService {
       type?: MemoryType[];
       limit?: number;
       threshold?: number;
+      project_id?: string;
+      owner_id?: string | string[];
     }
   ): Promise<SearchBySimilarityOutcome> {
     if (!this.embeddingService.isAvailable()) {

--- a/packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts
@@ -457,6 +457,30 @@ describe('MemoryInjectionPrompt', () => {
     });
   });
 
+  describe('owner_id 필터', () => {
+    it('owner_id가 지정되면 해당 소유자 기억만 주입한다', async () => {
+      db.exec(`
+        INSERT INTO memory_item (id, type, content, importance, owner_id, created_at)
+        VALUES
+          ('inj_owner_a', 'episodic', 'owner-a 전용 노트', 0.9, 'agent-a', datetime('now')),
+          ('inj_owner_b', 'episodic', 'owner-b 전용 노트', 0.9, 'agent-b', datetime('now'))
+      `);
+
+      const result = await tool.handle(
+        {
+          query: '전용 노트',
+          owner_id: 'agent-a',
+        },
+        context,
+      );
+
+      expect(result.isError).toBeFalsy();
+      const text = result.content?.[0]?.text ?? JSON.stringify(result);
+      expect(text).toContain('owner-a');
+      expect(text).not.toContain('owner-b');
+    });
+  });
+
   describe('도구 메타데이터', () => {
     it('도구 이름을 올바르게 반환해야 함', () => {
       // When: 도구 정의 조회
@@ -491,6 +515,8 @@ describe('MemoryInjectionPrompt', () => {
       expect(definition.inputSchema.properties.max_memories).toBeDefined();
       expect(definition.inputSchema.properties.memory_types).toBeDefined();
       expect(definition.inputSchema.properties.importance_threshold).toBeDefined();
+      expect(definition.inputSchema.properties.project_id).toBeDefined();
+      expect(definition.inputSchema.properties.owner_id).toBeDefined();
     });
   });
 });

--- a/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
+++ b/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
@@ -4,17 +4,13 @@
  */
 
 import { z } from 'zod';
-import { mementoConfig } from '../../../shared/config/index.js';
-import type { IConsolidationScoreService } from '../../../shared/interfaces/consolidation-score.interface.js';
 import { isMemoryItemType,type MemoryType } from '../../../shared/types/index.js';
-import { DatabaseUtils } from '../../../shared/utils/database.js';
-import { emitTfidfFallbackWarningIfNeeded } from '../../../shared/utils/embedding-provider-diagnostics.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { PIIMasker } from '../../../shared/utils/pii-masker.js';
-import type { WriteCoalescingManager } from '../../../shared/utils/write-coalescing.js';
 import { BaseTool } from '../../../tools/base-tool.js';
 import type { ToolContext } from '../../../tools/types.js';
 import { CommonSchemas } from '../../../tools/types.js';
+import { buildKnowledgeContextBundle } from '../services/knowledge-context-bundle-builder.js';
 
 const MemoryInjectionSchema = z.object({
   query: z.string().describe('검색할 내용을 자연어 문장으로 입력하세요. 키워드 나열보다 문장 형태가 의미 기반 검색 품질을 높입니다.'),
@@ -24,7 +20,9 @@ const MemoryInjectionSchema = z.object({
   importance_threshold: z.number().optional().describe('중요도 임계값 (기본값: 0.5)'),
   // Project-scoped memory (Issue #81)
   project_id: z.string().max(200).optional()
-    .describe('지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색')
+    .describe('지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색'),
+  owner_id: z.union([z.string(), z.array(z.string())]).optional()
+    .describe('소유자(owner) 범위로 결과를 제한합니다. 미지정 시 owner 필터를 적용하지 않습니다.')
 });
 
 export class MemoryInjectionPrompt extends BaseTool {
@@ -67,6 +65,13 @@ export class MemoryInjectionPrompt extends BaseTool {
             type: 'string',
             description: '지정 시 해당 프로젝트 기억만 주입. 미지정 시 전체 기억에서 검색',
             maxLength: 200
+          },
+          owner_id: {
+            oneOf: [
+              { type: 'string' },
+              { type: 'array', items: { type: 'string' } }
+            ],
+            description: '소유자(owner) 범위로 결과를 제한합니다.'
           }
         },
         required: ['query']
@@ -81,7 +86,8 @@ export class MemoryInjectionPrompt extends BaseTool {
       max_memories = 5,
       memory_types = ['working', 'episodic', 'semantic', 'procedural'],
       importance_threshold: _importance_threshold = 0.5,
-      project_id
+      project_id,
+      owner_id
     } = MemoryInjectionSchema.parse(params);
 
     try {
@@ -122,75 +128,33 @@ export class MemoryInjectionPrompt extends BaseTool {
         filteredMemoryTypes = validMemoryTypes;
       }
 
-      // 1. 관련 기억 검색
-      // importance_min은 MemorySearchFilters에 없으므로 제거
-      // importance 필터링은 검색 후 별도로 처리하거나 다른 방법 사용
-      // filteredMemoryTypes는 이미 validMemoryTypes로 변환되어 MemoryType[] 타입
-      const finalMemoryTypes: MemoryType[] | undefined = filteredMemoryTypes && filteredMemoryTypes.length > 0 
-        ? (filteredMemoryTypes.length === 4 ? undefined : filteredMemoryTypes as MemoryType[])
-        : undefined;
-      const searchResult = await context.services.hybridSearchEngine.search(context.db, {
-        query,
-        filters: {
-          type: finalMemoryTypes
+      const bundle = await buildKnowledgeContextBundle(
+        {
+          db: context.db,
+          hybridSearchEngine: context.services.hybridSearchEngine,
+          consolidationScoreService: context.services.consolidationScoreService,
+          writeCoalescingManager: context.services.writeCoalescingManager,
         },
-        limit: max_memories * 2, // 더 많은 후보를 가져와서 요약
-        vectorWeight: 0.7, // 의미적 유사성에 더 중점
-        textWeight: 0.3
-      });
-
-      emitTfidfFallbackWarningIfNeeded(
-        searchResult.fallback_used,
-        searchResult.query_embedding_providers,
-        searchResult.tfidf_query_embedding_fallback,
-        searchResult.tfidf_query_embedding_fallback_providers
+        {
+          query,
+          tokenBudget: token_budget,
+          maxMemories: max_memories,
+          memoryTypes: filteredMemoryTypes as MemoryType[],
+          projectId: project_id,
+          ownerId: owner_id,
+        },
       );
 
-      const memories = searchResult.items;
-      logger.debug('검색된 기억', {
-        count: memories.length
-      });
-
-      // Project-scoped memory filter (Issue #81)
-      const filteredMemories = project_id
-        ? memories.filter((m: any) => m.project_id != null && m.project_id === project_id)
-        : memories;
-
-      // Consolidation Score System 업데이트 (기능 플래그 확인)
-      if (mementoConfig.consolidationScoreEnabled && context.services.consolidationScoreService && filteredMemories.length > 0) {
-        await this.updateConsolidationScoreMetadata(
-          context.db,
-          context.services.consolidationScoreService,
-          context.services.writeCoalescingManager,
-          filteredMemories
-        );
-      }
-
-      if (filteredMemories.length === 0) {
-        return this.createSuccessResult({
-          message: '관련 기억을 찾을 수 없습니다.',
-          memories_used: 0,
-          token_estimate: 0,
-          query: query
-        });
-      }
-
-      // 2. 기억 요약 및 토큰 예산 관리
-      const summary = await this.summarizeMemories(filteredMemories, token_budget, max_memories);
-
-      // 3. 프롬프트 형식으로 포맷팅
-      const formattedPrompt = this.formatMemoryPrompt(summary, query);
-
       logger.info('Memory Injection 완료', {
-        memoryCount: summary.length,
-        tokenCount: this.estimateTokens(formattedPrompt)
+        memoryCount: bundle.itemCount,
+        tokenCount: bundle.tokenEstimate,
       });
 
       return this.createSuccessResult({
-        message: formattedPrompt,
-        memories_used: summary.length,
-        token_estimate: this.estimateTokens(formattedPrompt),
-        query: query
+        message: bundle.promptText,
+        memories_used: bundle.itemCount,
+        token_estimate: bundle.tokenEstimate,
+        query: bundle.query,
       });
 
     } catch (error) {
@@ -199,270 +163,6 @@ export class MemoryInjectionPrompt extends BaseTool {
         error: maskedError.message
       });
       throw error;
-    }
-  }
-
-  /**
-   * 기억들을 요약하여 토큰 예산 내에서 관리
-   */
-  private async summarizeMemories(
-    memories: any[], 
-    tokenBudget: number, 
-    maxMemories: number
-  ): Promise<Array<{id: string, content: string, type: string, importance: number, summary: string}>> {
-    const summaries: Array<{id: string, content: string, type: string, importance: number, summary: string}> = [];
-    let usedTokens = 0;
-    const maxTokensPerMemory = Math.floor(tokenBudget / maxMemories);
-
-    // 중요도와 점수 순으로 정렬
-    const sortedMemories = memories
-      .sort((a, b) => (b.finalScore + b.importance) - (a.finalScore + a.importance))
-      .slice(0, maxMemories);
-
-    for (const memory of sortedMemories) {
-      if (usedTokens >= tokenBudget) break;
-
-      // 기억 내용 요약
-      const summary = this.summarizeMemoryContent(memory.content, maxTokensPerMemory);
-      const summaryTokens = this.estimateTokens(summary);
-
-      if (usedTokens + summaryTokens <= tokenBudget) {
-        summaries.push({
-          id: memory.id,
-          content: memory.content,
-          type: memory.type,
-          importance: memory.importance,
-          summary
-        });
-        usedTokens += summaryTokens;
-      }
-    }
-
-    return summaries;
-  }
-
-  /**
-   * 개별 기억 내용 요약
-   */
-  private summarizeMemoryContent(content: string, maxTokens: number): string {
-    // 간단한 요약 로직 (실제로는 더 정교한 요약 알고리즘 사용 가능)
-    const words = content.split(' ');
-    const maxWords = Math.floor(maxTokens / 1.5); // 대략적인 단어 수 계산
-
-    if (words.length <= maxWords) {
-      return content;
-    }
-
-    // 중요도 기반 요약 (첫 문장 + 마지막 문장 + 중간 핵심 내용)
-    const sentences = content.split(/[.!?]+/).filter(s => s.trim().length > 0);
-    
-    if (sentences.length <= 2) {
-      return words.slice(0, maxWords).join(' ') + '...';
-    }
-
-    const firstSentence = sentences[0]?.trim() || '';
-    const lastSentence = sentences[sentences.length - 1]?.trim() || '';
-    const middleSentences = sentences.slice(1, -1);
-    
-    let summary = firstSentence;
-    let remainingWords = maxWords - firstSentence.split(' ').length;
-
-    if (remainingWords > 0 && middleSentences.length > 0) {
-      const middleText = middleSentences.join('. ');
-      const middleWords = middleText.split(' ');
-      const middleWordsToInclude = Math.min(remainingWords - lastSentence.split(' ').length, middleWords.length);
-      
-      if (middleWordsToInclude > 0) {
-        summary += ' ' + middleWords.slice(0, middleWordsToInclude).join(' ');
-        remainingWords -= middleWordsToInclude;
-      }
-    }
-
-    if (remainingWords > 0) {
-      summary += ' ' + lastSentence;
-    }
-
-    return summary + (summary.length < content.length ? '...' : '');
-  }
-
-  /**
-   * 프롬프트 형식으로 포맷팅
-   */
-  private formatMemoryPrompt(
-    summaries: Array<{id: string, content: string, type: string, importance: number, summary: string}>,
-    query: string
-  ): string {
-    if (summaries.length === 0) {
-      return '관련 기억을 찾을 수 없습니다.';
-    }
-
-    let prompt = `# 관련 기억 (${summaries.length}개)\n\n`;
-    prompt += `**검색 쿼리**: "${query}"\n\n`;
-
-    summaries.forEach((memory, index) => {
-      const typeEmoji = this.getMemoryTypeEmoji(memory.type);
-      const importanceStars = '★'.repeat(Math.ceil(memory.importance * 5));
-      
-      prompt += `## ${index + 1}. ${typeEmoji} ${memory.type.toUpperCase()} 기억\n`;
-      prompt += `**중요도**: ${importanceStars} (${memory.importance.toFixed(2)})\n`;
-      prompt += `**내용**: ${memory.summary}\n\n`;
-    });
-
-    prompt += '---\n';
-    prompt += '*이 기억들은 현재 대화와 관련된 맥락 정보입니다. 참고하여 더 정확하고 관련성 높은 답변을 제공하세요.*';
-
-    return prompt;
-  }
-
-  /**
-   * 기억 타입별 이모지
-   */
-  private getMemoryTypeEmoji(type: string): string {
-    const emojiMap: Record<string, string> = {
-      'working': '🧠',
-      'episodic': '📝',
-      'semantic': '📚',
-      'procedural': '⚙️'
-    };
-    return emojiMap[type] || '💭';
-  }
-
-  /**
-   * 토큰 수 추정 (간단한 추정)
-   */
-  private estimateTokens(text: string): number {
-    // 대략적인 토큰 수 추정 (실제로는 더 정확한 토크나이저 사용 가능)
-    return Math.ceil(text.length / 4);
-  }
-
-  /**
-   * Consolidation Score 메타데이터 업데이트
-   * 검색 결과로 반환된 메모리들의 recall_count, last_accessed_at, g_value 업데이트
-   * Write Coalescing을 사용하여 I/O 부하를 줄입니다.
-   * (recall-tool.ts와 동일한 로직)
-   * 
-   * @param db 데이터베이스 연결
-   * @param consolidationScoreService Consolidation Score 서비스
-   * @param writeCoalescingManager Write Coalescing Manager (선택적)
-   * @param searchItems 검색 결과 아이템 배열
-   */
-  private async updateConsolidationScoreMetadata(
-    db: any,
-    consolidationScoreService: IConsolidationScoreService,
-    writeCoalescingManager: WriteCoalescingManager | undefined,
-    searchItems: any[]
-  ): Promise<void> {
-    if (!searchItems || searchItems.length === 0) {
-      return;
-    }
-
-    try {
-      const now = new Date();
-      const nowISO = now.toISOString();
-
-      // 각 검색 결과에 대해 업데이트
-      for (const item of searchItems) {
-        const memoryId = item.id || item.memory_id;
-        if (!memoryId) {
-          continue; // ID가 없으면 스킵
-        }
-
-        try {
-          // 기존 메모리 정보 조회 (recall_count, last_accessed_at, g_value, created_at, type, pinned)
-          const memory = DatabaseUtils.get(
-            db,
-            `SELECT 
-              recall_count, 
-              last_accessed_at, 
-              g_value, 
-              created_at, 
-              type, 
-              pinned 
-            FROM memory_item 
-            WHERE id = ?`,
-            [memoryId]
-          ) as {
-            recall_count: number;
-            last_accessed_at: string | null;
-            g_value: number | null;
-            created_at: string;
-            type: MemoryType;
-            pinned: boolean | number;
-          } | undefined;
-
-          if (!memory) {
-            this.logWarning(`메모리를 찾을 수 없습니다: ${memoryId}`);
-            continue;
-          }
-
-          // recall_count 증가
-          const newRecallCount = (memory.recall_count || 0) + 1;
-
-          // 경과 시간 계산 (last_accessed_at이 있으면 사용, 없으면 created_at 사용)
-          const lastAccessedAt = memory.last_accessed_at 
-            ? new Date(memory.last_accessed_at) 
-            : new Date(memory.created_at);
-          const timeElapsed = consolidationScoreService.calculateTimeElapsed(
-            lastAccessedAt,
-            new Date(memory.created_at),
-            now
-          );
-
-          // g_value 업데이트
-          const newGValue = consolidationScoreService.updateGValueForRecall({
-            previousGValue: memory.g_value,
-            timeElapsed
-          });
-
-          // consolidation_score 계산
-          const scoreResult = consolidationScoreService.calculateScore({
-            recallCount: newRecallCount,
-            lastAccessedAt: now,
-            createdAt: new Date(memory.created_at),
-            gValue: newGValue,
-            type: memory.type,
-            pinned: memory.pinned === 1 || memory.pinned === true
-          });
-
-          // Write Coalescing 사용 여부 확인
-          if (writeCoalescingManager) {
-            // 버퍼에 추가 (주기적으로 flush됨)
-            writeCoalescingManager.addWrite({
-              memoryId,
-              fields: {
-                recall_count: newRecallCount,
-                last_accessed_at: nowISO,
-                g_value: newGValue,
-                consolidation_score: scoreResult.score
-              }
-            });
-          } else {
-            // Write Coalescing이 없으면 즉시 업데이트
-            DatabaseUtils.run(
-              db,
-              `UPDATE memory_item 
-               SET 
-                 recall_count = ?,
-                 last_accessed_at = ?,
-                 g_value = ?,
-                 consolidation_score = ?
-               WHERE id = ?`,
-              [newRecallCount, nowISO, newGValue, scoreResult.score, memoryId]
-            );
-          }
-
-        } catch (error) {
-          // 개별 메모리 업데이트 실패해도 다른 메모리는 계속 업데이트
-          this.logWarning(`메모리 업데이트 실패 (${memoryId})`, {
-            error: error instanceof Error ? error.message : String(error)
-          });
-        }
-      }
-    } catch (error) {
-      // 전체 업데이트 실패해도 검색 결과는 정상 반환
-      this.logError(error as Error, 'Consolidation Score 메타데이터 업데이트 실패', {
-        itemCount: searchItems.length
-      });
     }
   }
 }

--- a/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
+++ b/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
@@ -4,13 +4,13 @@
  */
 
 import { z } from 'zod';
-import { isMemoryItemType,type MemoryType } from '../../../shared/types/index.js';
 import { logger } from '../../../shared/utils/logger.js';
 import { PIIMasker } from '../../../shared/utils/pii-masker.js';
 import { BaseTool } from '../../../tools/base-tool.js';
 import type { ToolContext } from '../../../tools/types.js';
 import { CommonSchemas } from '../../../tools/types.js';
 import { buildKnowledgeContextBundle } from '../services/knowledge-context-bundle-builder.js';
+import { normalizeMemoryTypesForHybridItemSearch } from '../utils/normalize-memory-types-for-item-search.js';
 
 const MemoryInjectionSchema = z.object({
   query: z.string().describe('검색할 내용을 자연어 문장으로 입력하세요. 키워드 나열보다 문장 형태가 의미 기반 검색 품질을 높입니다.'),
@@ -104,29 +104,19 @@ export class MemoryInjectionPrompt extends BaseTool {
         throw new Error('하이브리드 검색 엔진이 사용할 수 없습니다');
       }
 
-      // memory_types 배열 전처리 ('core'/'vault' 제거)
-      let filteredMemoryTypes = memory_types;
-      if (memory_types && memory_types.length > 0) {
-        const invalidTypes = memory_types.filter(t => t === 'core' || t === 'vault');
-        if (invalidTypes.length > 0) {
-          this.logWarning('memory_types 배열에서 core/vault는 memory_item 검색에 사용할 수 없습니다. 자동으로 제거합니다.', {
+      const invalidTypes = memory_types.filter((t) => t === 'core' || t === 'vault');
+      if (invalidTypes.length > 0) {
+        this.logWarning(
+          'memory_types 배열에서 core/vault는 memory_item 검색에 사용할 수 없습니다. 자동으로 제거합니다.',
+          {
             invalid_types: invalidTypes,
             original_memory_types: memory_types,
-            suggestion: 'Core/Vault 조회는 recall Tool의 type 파라미터를 사용하세요.'
-          });
-          filteredMemoryTypes = memory_types.filter(t => t !== 'core' && t !== 'vault');
-          if (filteredMemoryTypes.length === 0) {
-            throw new Error("memory_types 배열에 유효한 타입이 없습니다. 'core'와 'vault'는 memory_types에서 사용할 수 없습니다.");
-          }
-        }
-        
-        // 타입 가드 적용: MemoryTypeRequest[] -> MemoryType[]
-        const validMemoryTypes = filteredMemoryTypes.filter(isMemoryItemType);
-        if (validMemoryTypes.length === 0) {
-          throw new Error("memory_types 배열에 유효한 타입이 없습니다.");
-        }
-        filteredMemoryTypes = validMemoryTypes;
+            suggestion: 'Core/Vault 조회는 recall Tool의 type 파라미터를 사용하세요.',
+          },
+        );
       }
+
+      const memoryTypesForBundle = normalizeMemoryTypesForHybridItemSearch(memory_types);
 
       const bundle = await buildKnowledgeContextBundle(
         {
@@ -139,7 +129,7 @@ export class MemoryInjectionPrompt extends BaseTool {
           query,
           tokenBudget: token_budget,
           maxMemories: max_memories,
-          memoryTypes: filteredMemoryTypes as MemoryType[],
+          memoryTypes: memoryTypesForBundle,
           projectId: project_id,
           ownerId: owner_id,
         },

--- a/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
+++ b/packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts
@@ -7,8 +7,7 @@ import { z } from 'zod';
 import { logger } from '../../../shared/utils/logger.js';
 import { PIIMasker } from '../../../shared/utils/pii-masker.js';
 import { BaseTool } from '../../../tools/base-tool.js';
-import type { ToolContext } from '../../../tools/types.js';
-import { CommonSchemas } from '../../../tools/types.js';
+import { CommonSchemas, type ToolContext, type ToolResult } from '../../../tools/types.js';
 import { buildKnowledgeContextBundle } from '../services/knowledge-context-bundle-builder.js';
 import { normalizeMemoryTypesForHybridItemSearch } from '../utils/normalize-memory-types-for-item-search.js';
 
@@ -79,7 +78,7 @@ export class MemoryInjectionPrompt extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<any> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     const {
       query,
       token_budget = 1000,

--- a/packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts
+++ b/packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts
@@ -1,0 +1,21 @@
+import { isMemoryItemType, type MemoryType, type MemoryTypeRequest } from '../../../shared/types/index.js';
+
+/**
+ * memory_injection / knowledge context 공통: core·vault 제거 후 memory_item 검색용 타입만 남긴다.
+ * `undefined`·빈 배열 → `undefined` (하이브리드 type 필터 생략).
+ */
+export function normalizeMemoryTypesForHybridItemSearch(
+  types: readonly MemoryTypeRequest[] | undefined | null,
+): MemoryType[] | undefined {
+  if (types == null || types.length === 0) {
+    return undefined;
+  }
+  const stripped = types.filter((t) => t !== 'core' && t !== 'vault');
+  const valid = stripped.filter(isMemoryItemType);
+  if (valid.length === 0) {
+    throw new Error(
+      "memory_types 배열에 유효한 타입이 없습니다. 'core'와 'vault'는 memory_types에서 사용할 수 없습니다.",
+    );
+  }
+  return valid;
+}

--- a/packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts
@@ -1,0 +1,57 @@
+import type Database from 'better-sqlite3';
+import { isMemoryItemType, type MemoryType } from '../../../shared/types/index.js';
+import type { ToolContext } from '../../../tools/types.js';
+import {
+  buildKnowledgeContextBundle,
+  type KnowledgeContextBundle,
+} from '../../memory/services/knowledge-context-bundle-builder.js';
+import type { IContextPort, KnowledgeContextRequest } from '../ports/context-port.js';
+import type { KnowledgeCandidate } from '../types/agent-types.js';
+
+function normalizeMemoryTypesForSearch(types?: MemoryType[]): MemoryType[] | undefined {
+  if (!types || types.length === 0) {
+    return undefined;
+  }
+  const valid = types.filter(isMemoryItemType);
+  if (valid.length === 0) {
+    throw new Error("memory_types 배열에 유효한 타입이 없습니다. 'core'와 'vault'는 memory_types에서 사용할 수 없습니다.");
+  }
+  return valid;
+}
+
+/**
+ * MCP `ToolContext`와 동일한 서비스 묶음으로 개인 지식용 컨텍스트 번들을 구성합니다.
+ */
+export class ToolContextKnowledgeContextAdapter implements IContextPort {
+  constructor(private readonly toolContext: ToolContext) {}
+
+  async buildContext(request: KnowledgeContextRequest): Promise<KnowledgeContextBundle> {
+    if (!this.toolContext.db) {
+      throw new Error('데이터베이스가 연결되지 않았습니다');
+    }
+    if (!this.toolContext.services?.hybridSearchEngine) {
+      throw new Error('하이브리드 검색 엔진이 사용할 수 없습니다');
+    }
+
+    return buildKnowledgeContextBundle(
+      {
+        db: this.toolContext.db as Database.Database,
+        hybridSearchEngine: this.toolContext.services.hybridSearchEngine,
+        consolidationScoreService: this.toolContext.services.consolidationScoreService,
+        writeCoalescingManager: this.toolContext.services.writeCoalescingManager,
+      },
+      {
+        query: request.userMessage,
+        tokenBudget: request.tokenBudget,
+        maxMemories: request.maxMemories,
+        memoryTypes: normalizeMemoryTypesForSearch(request.memoryTypes),
+        projectId: request.projectId,
+        ownerId: request.ownerId,
+      },
+    );
+  }
+
+  async proposeCandidates(_candidates: KnowledgeCandidate[]): Promise<void> {
+    // Issue #234에서 후보 제안 구현
+  }
+}

--- a/packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts
@@ -1,23 +1,12 @@
 import type Database from 'better-sqlite3';
-import { isMemoryItemType, type MemoryType } from '../../../shared/types/index.js';
 import type { ToolContext } from '../../../tools/types.js';
 import {
   buildKnowledgeContextBundle,
   type KnowledgeContextBundle,
 } from '../../memory/services/knowledge-context-bundle-builder.js';
+import { normalizeMemoryTypesForHybridItemSearch } from '../../memory/utils/normalize-memory-types-for-item-search.js';
 import type { IContextPort, KnowledgeContextRequest } from '../ports/context-port.js';
 import type { KnowledgeCandidate } from '../types/agent-types.js';
-
-function normalizeMemoryTypesForSearch(types?: MemoryType[]): MemoryType[] | undefined {
-  if (!types || types.length === 0) {
-    return undefined;
-  }
-  const valid = types.filter(isMemoryItemType);
-  if (valid.length === 0) {
-    throw new Error("memory_types 배열에 유효한 타입이 없습니다. 'core'와 'vault'는 memory_types에서 사용할 수 없습니다.");
-  }
-  return valid;
-}
 
 /**
  * MCP `ToolContext`와 동일한 서비스 묶음으로 개인 지식용 컨텍스트 번들을 구성합니다.
@@ -44,7 +33,7 @@ export class ToolContextKnowledgeContextAdapter implements IContextPort {
         query: request.userMessage,
         tokenBudget: request.tokenBudget,
         maxMemories: request.maxMemories,
-        memoryTypes: normalizeMemoryTypesForSearch(request.memoryTypes),
+        memoryTypes: normalizeMemoryTypesForHybridItemSearch(request.memoryTypes ?? undefined),
         projectId: request.projectId,
         ownerId: request.ownerId,
       },

--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -2,6 +2,7 @@ export type {
   KnowledgeCandidate,
   PersonalKnowledgeAgentInput,
   PersonalKnowledgeAgentResult,
+  PersonalKnowledgeContextMeta,
 } from './types/agent-types.js';
 
 export type {
@@ -10,7 +11,11 @@ export type {
   LLMProviderMetadata,
   ILLMPort,
 } from './ports/llm-port.js';
-export type { IContextPort } from './ports/context-port.js';
+export type {
+  IContextPort,
+  KnowledgeContextBundle,
+  KnowledgeContextRequest,
+} from './ports/context-port.js';
 export type { IPersistencePort } from './ports/persistence-port.js';
 
 export {
@@ -19,6 +24,10 @@ export {
 export type {
   DeterministicMockLlmAdapterOptions,
 } from './adapters/deterministic-mock-llm-adapter.js';
+
+export {
+  ToolContextKnowledgeContextAdapter,
+} from './adapters/tool-context-knowledge-context-adapter.js';
 
 export {
   PersonalKnowledgeAgentService,

--- a/packages/memento-core/src/domains/personal-agent/ports/context-port.ts
+++ b/packages/memento-core/src/domains/personal-agent/ports/context-port.ts
@@ -1,6 +1,20 @@
+import type { MemoryType } from '../../../shared/types/index.js';
 import type { KnowledgeCandidate } from '../types/agent-types.js';
+import type { KnowledgeContextBundle } from '../../memory/services/knowledge-context-bundle-builder.js';
+
+export type { KnowledgeContextBundle } from '../../memory/services/knowledge-context-bundle-builder.js';
+
+/** 인프로세스 context builder 입력 (#232) */
+export interface KnowledgeContextRequest {
+  userMessage: string;
+  projectId?: string;
+  ownerId?: string | string[];
+  tokenBudget?: number;
+  maxMemories?: number;
+  memoryTypes?: MemoryType[];
+}
 
 export interface IContextPort {
-  buildContext(userMessage: string, projectId?: string): Promise<string>;
+  buildContext(request: KnowledgeContextRequest): Promise<KnowledgeContextBundle>;
   proposeCandidates(candidates: KnowledgeCandidate[]): Promise<void>;
 }

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts
@@ -6,6 +6,14 @@ import type { IContextPort } from '../ports/context-port.js';
 import type { IPersistencePort } from '../ports/persistence-port.js';
 
 describe('PersonalKnowledgeAgentService', () => {
+  const mockBundle = {
+    promptText: '컨텍스트 텍스트',
+    itemCount: 1,
+    tokenEstimate: 10,
+    contextSummary: '관련 기억 1건 (episodic 1), 추정 토큰 10',
+    query: 'mock-query',
+  };
+
   function makeDeps() {
     const completeFn = vi.fn().mockResolvedValue({
       content: 'LLM 응답',
@@ -15,7 +23,10 @@ describe('PersonalKnowledgeAgentService', () => {
         requestId: 'mock-123',
       },
     });
-    const buildContextFn = vi.fn().mockResolvedValue('컨텍스트 텍스트');
+    const buildContextFn = vi.fn().mockImplementation(async (req: { userMessage: string }) => ({
+      ...mockBundle,
+      query: req.userMessage,
+    }));
     const proposeCandidatesFn = vi.fn().mockResolvedValue(undefined);
     const persistFn = vi.fn().mockResolvedValue(undefined);
 
@@ -40,6 +51,8 @@ describe('PersonalKnowledgeAgentService', () => {
     });
     expect(result.persisted).toBe(false);
     expect(result.candidates).toEqual([]);
+    expect(result.knowledgeContext.itemCount).toBe(1);
+    expect(result.knowledgeContext.tokenEstimate).toBe(10);
   });
 
   it('buildContext를 userMessage와 projectId로 호출한다', async () => {
@@ -48,16 +61,20 @@ describe('PersonalKnowledgeAgentService', () => {
 
     await svc.runOneTurn({ userMessage: '입력', projectId: 'proj-1' });
 
-    expect(buildContextFn).toHaveBeenCalledWith('입력', 'proj-1');
+    expect(buildContextFn).toHaveBeenCalledWith(
+      expect.objectContaining({ userMessage: '입력', projectId: 'proj-1' }),
+    );
   });
 
-  it('projectId 없을 때 buildContext를 undefined로 호출한다', async () => {
+  it('projectId 없을 때 buildContext에 projectId를 넣지 않는다', async () => {
     const { llm, context, persistence, buildContextFn } = makeDeps();
     const svc = new PersonalKnowledgeAgentService({ llm, context, persistence });
 
     await svc.runOneTurn({ userMessage: '입력' });
 
-    expect(buildContextFn).toHaveBeenCalledWith('입력', undefined);
+    expect(buildContextFn).toHaveBeenCalledWith(expect.objectContaining({ userMessage: '입력' }));
+    const call = buildContextFn.mock.calls[0][0] as { projectId?: string };
+    expect(call.projectId).toBeUndefined();
   });
 
   it('llm.complete를 system+user 메시지로 호출한다', async () => {
@@ -84,6 +101,7 @@ describe('PersonalKnowledgeAgentService', () => {
     const result = await svc.runOneTurn({ userMessage: '질문' });
 
     expect(result.llmResponse).toBe('fixture 기반 응답');
+    expect(result.knowledgeContext.summary).toContain('관련 기억');
     expect(result.llmMetadata).toEqual({
       provider: 'mock',
       model: 'deterministic-mock-v1',

--- a/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts
@@ -17,13 +17,17 @@ export class PersonalKnowledgeAgentService {
   constructor(private readonly deps: PersonalKnowledgeAgentDeps) {}
 
   async runOneTurn(input: PersonalKnowledgeAgentInput): Promise<PersonalKnowledgeAgentResult> {
-    const contextText = await this.deps.context.buildContext(
-      input.userMessage,
-      input.projectId,
-    );
+    const bundle = await this.deps.context.buildContext({
+      userMessage: input.userMessage,
+      projectId: input.projectId,
+      ownerId: input.ownerId,
+      tokenBudget: input.tokenBudget,
+      maxMemories: input.maxMemories,
+      memoryTypes: input.memoryTypes,
+    });
 
     const llmResult = await this.deps.llm.complete([
-      { role: 'system', content: contextText },
+      { role: 'system', content: bundle.promptText },
       { role: 'user', content: input.userMessage },
     ]);
 
@@ -39,6 +43,11 @@ export class PersonalKnowledgeAgentService {
       llmResponse: llmResult.content,
       llmMetadata: llmResult.metadata,
       persisted: false,
+      knowledgeContext: {
+        itemCount: bundle.itemCount,
+        tokenEstimate: bundle.tokenEstimate,
+        summary: bundle.contextSummary,
+      },
     };
   }
 }

--- a/packages/memento-core/src/domains/personal-agent/types/agent-types.ts
+++ b/packages/memento-core/src/domains/personal-agent/types/agent-types.ts
@@ -1,3 +1,4 @@
+import type { MemoryType } from '../../../shared/types/index.js';
 import type { LLMProviderMetadata } from '../ports/llm-port.js';
 
 export interface KnowledgeCandidate {
@@ -12,6 +13,17 @@ export interface PersonalKnowledgeAgentInput {
   userMessage: string;
   sessionId?: string;
   projectId?: string;
+  ownerId?: string | string[];
+  tokenBudget?: number;
+  maxMemories?: number;
+  memoryTypes?: MemoryType[];
+}
+
+/** Agent Loop에 넘길 수 있는 컨텍스트 메타 (#232) */
+export interface PersonalKnowledgeContextMeta {
+  itemCount: number;
+  tokenEstimate: number;
+  summary: string;
 }
 
 export interface PersonalKnowledgeAgentResult {
@@ -19,4 +31,5 @@ export interface PersonalKnowledgeAgentResult {
   llmResponse: string;
   llmMetadata?: LLMProviderMetadata;
   persisted: boolean;
+  knowledgeContext: PersonalKnowledgeContextMeta;
 }

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -51,7 +51,13 @@ export interface IEmbeddingService {
   searchBySimilarity(
     db: Database.Database,
     query: string,
-    options: { type?: MemoryType[]; limit?: number; threshold?: number }
+    options: {
+      type?: MemoryType[];
+      limit?: number;
+      threshold?: number;
+      project_id?: string;
+      owner_id?: string | string[];
+    }
   ): Promise<VectorSearchResult[] | SearchBySimilarityOutcome>;
   getEmbeddingStats(db: Database.Database): Promise<unknown>;
 }
@@ -76,7 +82,18 @@ export function resolveQueryUnifiedEmbeddingForHybridSearch(
 export interface IVectorSearchEngine {
   initialize(db: Database.Database): void;
   getIndexStatus(): { available: boolean };
-  search(vector: number[], options: { limit?: number; threshold?: number; types?: MemoryType[]; includeContent?: boolean }, provider?: string): Promise<Array<{ memory_id: string; content: string; type: string; importance: number; created_at: string; similarity: number }>>;
+  search(
+    vector: number[],
+    options: {
+      limit?: number;
+      threshold?: number;
+      types?: MemoryType[];
+      includeContent?: boolean;
+      project_id?: string;
+      owner_id?: string | string[];
+    },
+    provider?: string
+  ): Promise<Array<{ memory_id: string; content: string; type: string; importance: number; created_at: string; similarity: number; project_id?: string | null; owner_id?: string | null }>>;
 }
 
 export interface ISearchResultCombiner {
@@ -627,7 +644,13 @@ export class HybridSearchEngine {
         limit: (query.limit || 10) * HYBRID_SEARCH.VECTOR_SEARCH_LIMIT_MULTIPLIER,
         threshold: HYBRID_SEARCH.HYBRID_VECTOR_THRESHOLD,
         types: query.filters?.type,
-        includeContent: true
+        includeContent: true,
+        ...(typeof query.filters?.project_id === 'string' && query.filters.project_id.length > 0
+          ? { project_id: query.filters.project_id }
+          : {}),
+        ...(query.filters?.owner_id !== undefined && query.filters.owner_id !== null
+          ? { owner_id: query.filters.owner_id }
+          : {}),
       };
       
       const providerVectorDeps = this.getProviderVectorSearchDeps();
@@ -868,6 +891,12 @@ export class HybridSearchEngine {
       type: query.filters?.type as MemoryType[],
       limit: (query.limit || 10) * HYBRID_SEARCH.VECTOR_SEARCH_LIMIT_MULTIPLIER,
       threshold: HYBRID_SEARCH.HYBRID_VECTOR_THRESHOLD,
+      ...(typeof query.filters?.project_id === 'string' && query.filters.project_id.length > 0
+        ? { project_id: query.filters.project_id }
+        : {}),
+      ...(query.filters?.owner_id !== undefined && query.filters.owner_id !== null
+        ? { owner_id: query.filters.owner_id }
+        : {}),
     });
     const { results, query_embedding_providers } = normalizeSearchBySimilarityOutcome(raw);
     const fallbackTime = Number(process.hrtime.bigint() - fallbackStart) / 1_000_000;

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -325,6 +325,8 @@ export interface HybridSearchResult {
   score_breakdown?: ScoreBreakdown;
   // Project-scoped memory (Issue #81)
   project_id?: string | null;
+  /** Multi-agent (Issue #57 Phase 2 D) */
+  owner_id?: string | null;
 }
 
 export class HybridSearchEngine {

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts
@@ -42,6 +42,8 @@ export type ProviderVectorSearchOptions = {
   threshold: number;
   types?: MemoryType[];
   includeContent: boolean;
+  project_id?: string;
+  owner_id?: string | string[];
 };
 
 type VectorSearchRow = {
@@ -51,6 +53,8 @@ type VectorSearchRow = {
   importance: number;
   created_at: string;
   similarity: number;
+  project_id?: string | null;
+  owner_id?: string | null;
 };
 
 /** Injected from HybridSearchEngine so this module stays free of SearchError / engine imports. */
@@ -110,7 +114,9 @@ export async function runSingleProviderVectorSearch(
         pinned: false,
         score: result.similarity,
         similarity: result.similarity,
-        provider
+        provider,
+        ...(result.project_id !== undefined ? { project_id: result.project_id } : {}),
+        ...(result.owner_id !== undefined ? { owner_id: result.owner_id } : {}),
       })),
       success: true,
       timeMs: providerTime,

--- a/packages/memento-core/src/domains/search/algorithms/search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-engine.ts
@@ -194,7 +194,7 @@ export class SearchEngine {
             m.workflow_name, m.skill_name, m.trigger_conditions,
             m.version, m.version_series_id,
             m.privacy_scope, m.origin_source, m.owner_id, m.process_id, m.session_id,
-            m.num_times, m.last_mentioned_at,
+            m.num_times, m.last_mentioned_at, m.project_id,
             0 as fts_rank
           FROM memory_item m
         `;
@@ -264,6 +264,23 @@ export class SearchEngine {
       if (filters?.skill_name) {
         conditions.push(`m.skill_name = ?`);
         params.push(filters.skill_name);
+      }
+
+      if (filters?.project_id !== undefined && filters.project_id !== null && filters.project_id !== '') {
+        conditions.push(`m.project_id = ?`);
+        params.push(filters.project_id);
+      }
+
+      if (filters?.owner_id !== undefined && filters.owner_id !== null) {
+        if (Array.isArray(filters.owner_id)) {
+          if (filters.owner_id.length > 0) {
+            conditions.push(`m.owner_id IN (${filters.owner_id.map(() => '?').join(',')})`);
+            params.push(...filters.owner_id);
+          }
+        } else if (typeof filters.owner_id === 'string' && filters.owner_id.length > 0) {
+          conditions.push(`m.owner_id = ?`);
+          params.push(filters.owner_id);
+        }
       }
 
       // WHERE 절 추가

--- a/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
@@ -68,7 +68,7 @@ export class SearchResultCombiner implements ISearchResultCombiner {
         existing.recall_reason = this.generateHybridReason(existing.textScore, result.similarity);
       } else {
         // 벡터 검색에서만 발견된 결과를 추가하여 검색 포괄성을 확보합니다.
-        resultMap.set(result.id, {
+        const vectorOnly: HybridSearchResult = {
           id: result.id,
           content: result.content,
           type: result.type,
@@ -81,7 +81,10 @@ export class SearchResultCombiner implements ISearchResultCombiner {
           vectorScore: result.similarity,
           finalScore: result.similarity * vectorWeight,
           recall_reason: `벡터 유사도: ${result.similarity.toFixed(3)}`,
-        });
+        };
+        if (result.project_id !== undefined) vectorOnly.project_id = result.project_id;
+        if (result.owner_id !== undefined) vectorOnly.owner_id = result.owner_id;
+        resultMap.set(result.id, vectorOnly);
       }
     });
 

--- a/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
@@ -51,7 +51,7 @@ export class SearchResultCombiner implements ISearchResultCombiner {
       // Project-scoped memory (Issue #81): project_id 전달
       if (result.project_id !== undefined) entry.project_id = result.project_id;
       // 기타 extended 필드 전달
-      if (result.owner_id !== undefined) (entry as any).owner_id = result.owner_id;
+      if (result.owner_id !== undefined) entry.owner_id = result.owner_id;
       if (result.process_id !== undefined) (entry as any).process_id = result.process_id;
       if (result.session_id !== undefined) (entry as any).session_id = result.session_id;
       resultMap.set(result.id, entry);

--- a/packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/vector-search-engine.ts
@@ -26,6 +26,8 @@ export interface VectorSearchResult {
   last_accessed?: string;
   pinned: boolean;
   tags?: string[];
+  project_id?: string | null;
+  owner_id?: string | null;
 }
 
 export interface VectorSearchOptions {
@@ -34,6 +36,8 @@ export interface VectorSearchOptions {
   types?: string[];    // 특정 메모리 타입만 검색하여 정확한 결과를 제공하기 위한 다중 메모리 타입 필터
   includeContent?: boolean;
   includeMetadata?: boolean; // 상세한 분석을 위해 메타데이터 포함 여부를 제어합니다.
+  project_id?: string;
+  owner_id?: string | string[];
 }
 
 export interface VectorIndexStatus {

--- a/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
+++ b/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
@@ -30,6 +30,8 @@ interface RawVectorSearchResult {
   last_accessed_at?: string | null;
   pinned: number | boolean;
   tags?: string | null;
+  project_id?: string | null;
+  owner_id?: string | null;
   // 하이브리드 검색 결과에 포함될 수 있는 추가 필드
   vector_similarity?: number;
   text_similarity?: number;
@@ -157,7 +159,9 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       type,
       types,
       includeContent = true,
-      includeMetadata = false
+      includeMetadata = false,
+      project_id: scopeProjectId,
+      owner_id: scopeOwnerId,
     } = normalizedOptions;
 
     const runtimeContext = this.resolveRuntimeVectorContext(query.provider);
@@ -193,15 +197,32 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       ? types.filter(Boolean)
       : (type ? [type] : []);
 
+    const hasProjectScope = typeof scopeProjectId === 'string' && scopeProjectId.length > 0;
+    const hasOwnerStringScope = typeof scopeOwnerId === 'string' && scopeOwnerId.length > 0;
+    const ownerArrayScope = Array.isArray(scopeOwnerId) ? scopeOwnerId.filter(Boolean) : [];
+    const hasOwnerScope = hasOwnerStringScope || ownerArrayScope.length > 0;
+    const hasScopeFilter = hasProjectScope || hasOwnerScope;
+
     try {
       // SQL Injection 방지: 화이트리스트 검증은 getTableName()에서 수행됨
-      // 템플릿 리터럴 대신 문자열 연결 사용
-      const _typeClause = typeFilters.length > 0
-        ? `AND mi.type IN (${typeFilters.map(() => '?').join(',')})`
-        : '';
       // sqlite-vec의 vec0_knn은 MATCH 다음에 바로 LIMIT이 와야 함
       // 서브쿼리로 먼저 벡터 검색을 수행하고 LIMIT을 적용한 후 JOIN
-      const prefetchLimit = typeFilters.length > 0 ? limit * 5 : limit;
+      const prefetchLimit = typeFilters.length > 0 || hasScopeFilter ? limit * 5 : limit;
+
+      const whereParts: string[] = [];
+      if (typeFilters.length > 0) {
+        whereParts.push(`mi.type IN (${typeFilters.map(() => '?').join(',')})`);
+      }
+      if (hasProjectScope) {
+        whereParts.push('mi.project_id = ?');
+      }
+      if (hasOwnerStringScope) {
+        whereParts.push('mi.owner_id = ?');
+      } else if (ownerArrayScope.length > 0) {
+        whereParts.push(`mi.owner_id IN (${ownerArrayScope.map(() => '?').join(',')})`);
+      }
+      const outerWhereSql = whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')} ` : '';
+
       const vecQuery =
         'SELECT ' +
         '  me.memory_id as memory_id, ' +
@@ -213,6 +234,8 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
         '  COALESCE(mi.last_accessed_at, mi.last_accessed) as last_accessed_at, ' +
         '  mi.pinned, ' +
         '  mi.tags, ' +
+        '  mi.project_id, ' +
+        '  mi.owner_id, ' +
         '  mi.task_goal, ' +
         '  mi.steps, ' +
         '  mi.reflection_notes, ' +
@@ -228,14 +251,25 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
         ') t ' +
         'JOIN memory_embedding me ON t.rowid = me.id ' +
         'JOIN memory_item mi ON mi.id = me.memory_id AND (COALESCE(mi.is_deleted, 0) = 0) ' +
-        (typeFilters.length > 0 ? `WHERE mi.type IN (${typeFilters.map(() => '?').join(',')}) ` : '') +
+        outerWhereSql +
         'ORDER BY t.distance ASC ' +
         'LIMIT ?';
+
+      const scopeParams: SqlParam[] = [];
+      if (hasProjectScope) {
+        scopeParams.push(scopeProjectId as string);
+      }
+      if (hasOwnerStringScope) {
+        scopeParams.push(scopeOwnerId as string);
+      } else if (ownerArrayScope.length > 0) {
+        scopeParams.push(...(ownerArrayScope as SqlParam[]));
+      }
 
       const params = [
         JSON.stringify(effectiveQueryVector),
         prefetchLimit,
         ...typeFilters,
+        ...scopeParams,
         limit
       ];
       const statement = this.db.prepare(vecQuery);
@@ -261,7 +295,9 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
               ? (typeof result.last_accessed_at === 'string' ? result.last_accessed_at : undefined)
               : undefined,
             pinned: includeMetadata ? Boolean(result.pinned) : false,
-            tags: includeMetadata ? this.safeParseTags(result.tags) : undefined
+            tags: includeMetadata ? this.safeParseTags(result.tags) : undefined,
+            ...(result.project_id !== undefined ? { project_id: result.project_id } : {}),
+            ...(result.owner_id !== undefined ? { owner_id: result.owner_id } : {}),
           };
         })
         .filter(result => result.similarity >= threshold);

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -16,6 +16,18 @@ export function isMemoryItemType(type: MemoryTypeRequest): type is MemoryType {
   return type === 'working' || type === 'episodic' || type === 'semantic' || type === 'procedural';
 }
 
+/** memory_item 하이브리드 검색에 쓰이는 네 타입(멤버가 바뀌면 isFullMemoryItemTypeSet·필터 생략 판정도 함께 조정) */
+export const MEMORY_ITEM_TYPES: readonly MemoryType[] = ['working', 'episodic', 'semantic', 'procedural'];
+
+/** 네 타입을 모두 포함하면 type 필터 생략(undefined)과 동등하게 취급 */
+export function isFullMemoryItemTypeSet(types: readonly MemoryType[]): boolean {
+  if (types.length !== MEMORY_ITEM_TYPES.length) {
+    return false;
+  }
+  const set = new Set(types);
+  return MEMORY_ITEM_TYPES.every((t) => set.has(t));
+}
+
 export type PrivacyScope = 'private' | 'team' | 'public';
 
 /**

--- a/packages/memento-core/src/shared/types/vector-search.types.ts
+++ b/packages/memento-core/src/shared/types/vector-search.types.ts
@@ -15,6 +15,10 @@ export interface VectorSearchResult {
   last_accessed?: string;
   pinned: boolean;
   tags?: string[];
+  /** Project-scoped memory (Issue #81) — VEC/임베딩 경로에서 하이브리드 병합 시 전달 */
+  project_id?: string | null;
+  /** Multi-agent (Issue #57) */
+  owner_id?: string | null;
 }
 
 export interface VectorSearchOptions {
@@ -24,6 +28,8 @@ export interface VectorSearchOptions {
   types?: string[];   // 다중 타입 필터 (기존 엔진 호환성용)
   includeContent?: boolean;
   includeMetadata?: boolean;
+  project_id?: string;
+  owner_id?: string | string[];
 }
 
 export interface VectorSearchQuery {


### PR DESCRIPTION
## 변경 사항
GitHub #232 — 개인 지식 Agent Loop용 **context bundle**을 `memory_injection`과 동일한 검색·요약 경로로 구성합니다.

- `buildKnowledgeContextBundle` (`knowledge-context-bundle-builder.ts`): 하이브리드 검색 → `project_id` / `owner_id` 필터 → (옵션) consolidation → 토큰 예산 내 요약 → 프롬프트 텍스트
- `MemoryInjectionPrompt`는 위 빌더로 위임 (회귀 방지). MCP `memory_injection`에 선택 `owner_id` 추가
- `IContextPort.buildContext`: `KnowledgeContextRequest` → `KnowledgeContextBundle`
- `ToolContextKnowledgeContextAdapter`: MCP `ToolContext`로 빌더 연결
- `PersonalKnowledgeAgentService`: 입력에 `ownerId`, `tokenBudget`, `maxMemories`, `memoryTypes` 전달, 결과에 `knowledgeContext` 메타

## 변경 유형
- [x] 새로운 기능
- [x] 테스트 추가/수정
- [x] 리팩토링 (memory_injection 내부 중복 제거)

## 관련 이슈
- Closes #232

## 테스트
`npm run build -w @memento/core`, `npx vitest run` (해당 스펙 파일들), `npm run lint` 실행함.

## Breaking note
`IContextPort` 시그니처가 바뀌었습니다. 저장소 외부에서 커스텀 `IContextPort`를 쓰는 경우 `KnowledgeContextRequest` / `KnowledgeContextBundle`로 맞춰야 합니다.

## 지식 복리
해당 없음 (요구사항 구현 위주).

Made with [Cursor](https://cursor.com)