### PR TITLE
feat(cli): in-process memento agent ask (#236)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-issue-236-agent-ask-cli.md
+++ b/docs/superpowers/plans/2026-05-14-issue-236-agent-ask-cli.md
@@ -1,0 +1,106 @@
+# Issue #236 — `memento agent ask` CLI Implementation Plan
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add in-process `memento agent ask` nested command per `docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md`, without breaking HTTP-backed `recall|remember|forget|memory_injection`.
+
+**Architecture:** `cli.ts` detects `agent` + `ask` after global-flag stripping, dynamically imports `cli/agent-ask.ts` which calls `createMementoCore` + `createToolContext`, wires `PersonalKnowledgeAgentService` with mock LLM and tool-context adapters, emits JSON or TTY prompts, maps failures to exit codes 1–4 / 130.
+
+**Tech stack:** TypeScript, Vitest, `@memento/core` (`createMementoCore`, `createToolContext`, `mementoConfig`, personal-agent exports).
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `packages/memento-core/src/index.ts` | Re-export personal-agent service + adapters + mock LLM for `@memento/core` consumers. |
+| `packages/memento-server/src/cli/agent-ask.ts` | Parse `agent ask` tail, run core bootstrap, one-turn + optional persist, JSON/TTY I/O. |
+| `packages/memento-server/src/cli/agent-ask.spec.ts` | Unit tests for parser; integration with `:memory:` DB. |
+| `packages/memento-server/src/cli.ts` | Detect agent-ask / help branches before unknown-command; dynamic `import('./cli/agent-ask.js')`. |
+| `packages/memento-server/src/cli/cli-ac5-ac6.spec.ts` | Extend `--help` expectation to mention `agent ask` (optional substring). |
+
+---
+
+### Task 1: Core re-exports
+
+**Files:** Modify `packages/memento-core/src/index.ts`
+
+- [ ] Export `PersonalKnowledgeAgentService`, `DeterministicMockLlmAdapter`, `ToolContextKnowledgeContextAdapter`, `ToolContextRememberPersistenceAdapter`, and types `PersonalKnowledgeAgentDeps` from `./domains/personal-agent/index.js`.
+
+**Verify:** `npm run type-check -w @memento/core`
+
+---
+
+### Task 2: `agent-ask.ts` — parser + runner
+
+**Files:** Create `packages/memento-server/src/cli/agent-ask.ts`
+
+- [ ] Implement `stripGlobalCliArgs(argv: string[]): string[]` (same three global pairs as `cli.ts`).
+- [ ] Implement `parseAgentAskInvocation(argv)` → `{ userMessage, projectId?, tokenBudget?, json, noSave, llmMock }` or `{ kind:'help' }` or `{ kind:'error', message }`.
+  - Require token sequence `agent` `ask` then **first tail token is userMessage** (must not start with `-`).
+  - Parse remaining with `parseArgvToParams` from `option-map.ts`; support `--llm mock` (reject other values with usage error).
+- [ ] `resolveDbPath(pre: { dbPath?: string }): string` = `pre.dbPath?.trim() || process.env.DB_PATH?.trim() || mementoConfig.dbPath`.
+- [ ] `runAgentAskMain(preOptions, argv): Promise<number>`: `createMementoCore`, `createToolContext`, construct service, `runOneTurn`, build success payload; if interactive persist, `readline` loop `y|n|s|q`; `persistApprovedCandidates` when needed; always `closeDatabase` + sampler cleanup in `finally`.
+- [ ] JSON helpers: `jsonSuccess(obj)`, `jsonFailure(code, stage, message, details?)` one line stdout.
+- [ ] Exit codes per spec; `MEMENTO_DEBUG` prints stack on stderr for thrown errors.
+- [ ] SIGINT: no persist, stderr message, exit `130` (optional JSON line for `--json` only if clean single write — skip if risky).
+
+**Verify:** `npm run type-check -w memento-server`
+
+---
+
+### Task 3: Wire `cli.ts`
+
+**Files:** Modify `packages/memento-server/src/cli.ts`
+
+- [ ] Add `detectAgentAskForMain(argv, help: boolean)` returning discriminated union.
+- [ ] At start of `main()`, after `showHelp` computation: if `agent help` variants, print agent help text (options list) and `return 0`.
+- [ ] If `agent ask` run: `return (await import('./cli/agent-ask.js')).runAgentAskMain(preOptions, process.argv)` (adjust export name).
+- [ ] General `--help` text: add one line for `agent ask`.
+- [ ] Ensure `memento agent foo` hits unknown agent subcommand exit `1` before generic unknown.
+
+**Verify:** manual `node dist/cli.js --help` after build.
+
+---
+
+### Task 4: Vitest
+
+**Files:** Create `packages/memento-server/src/cli/agent-ask.spec.ts`
+
+- [ ] Test parser: valid `agent ask "hi" --json`, invalid `agent ask` (no message), invalid `--llm openai`.
+- [ ] Test integration: `createMementoCore({ dbPath: ':memory:' })` path via exported `runAgentAskFromArgv` or internal helper with synthetic `argv` array — **avoid** spawning `dist/cli.js` in this file to keep fast; optional one spawn test in separate slow describe gated by env.
+
+**Run:** `npm test -w memento-server -- --run src/cli/agent-ask.spec.ts`
+
+---
+
+### Task 5: Repo gates
+
+- [ ] `npm test && npm run lint` from monorepo root (per AGENTS.md).
+
+---
+
+### Task 6: Commit
+
+```bash
+git add packages/memento-core/src/index.ts packages/memento-server/src/cli.ts packages/memento-server/src/cli/agent-ask.ts packages/memento-server/src/cli/agent-ask.spec.ts docs/superpowers/plans/2026-05-14-issue-236-agent-ask-cli.md
+git commit -m "feat(cli): agent ask in-process 명령 (#236)"
+```
+
+---
+
+## Spec coverage (self-review)
+
+| Spec section | Task |
+|--------------|------|
+| In-process / no HTTP | Task 2 |
+| Nested `agent ask` | Task 2–3 |
+| Options + `--llm mock` | Task 2 |
+| TTY y/n/s/q | Task 2 |
+| `--json` / `--no-save` / non-TTY | Task 2 |
+| JSON schema + exit codes | Task 2 |
+| Core bootstrap | Task 2 (reuse `createMementoCore` + `createToolContext`; no new core helper unless file grows) |
+| Tests + regression | Task 4–5 |
+
+**Note:** Spec §9 “헬퍼 추가” — 구현에서는 `createMementoCore`+`createToolContext`가 이미 `experimental-example`과 동일 역할을 하므로 **별도 헬퍼 파일은 생략**한다. 중복이 커지면 후속 리팩터에서 승격한다.

--- a/docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
@@ -1,0 +1,196 @@
+# 설계: 이슈 #236 — `memento agent ask` CLI (개인 지식 Agent 진입점)
+
+**날짜**: 2026-05-14  
+**이슈**: [#236](https://github.com/jee1/memento/issues/236)  
+**부모**: [#82](https://github.com/jee1/memento/issues/82) 개인 지식 축적 Agent MVP  
+**선행(완료)**: [#231](https://github.com/jee1/memento/issues/231) 계약, [#232](https://github.com/jee1/memento/issues/232) context builder, [#233](https://github.com/jee1/memento/issues/233) mock LLM, [#234](https://github.com/jee1/memento/issues/234) 후보 추출, [#235](https://github.com/jee1/memento/issues/235) 승인 기반 persistence  
+**관련(별도 이슈)**: [#237](https://github.com/jee1/memento/issues/237) E2E·가이드, [#390](https://github.com/jee1/memento/issues/390) 서버 런타임 배선
+
+**핵심 결정 요약**: **In-process** 실행, **`memento agent ask` nested 서브커맨드**, **core 쪽 in-process tool context 부트스트랩 헬퍼** 사용 또는 추가, **stdout JSON 계약**과 **단계별 exit code**.
+
+---
+
+## 1. 목표
+
+1. `PersonalKnowledgeAgentService` 한 턴을 **CLI에서 end-to-end**로 실행해 MVP 루프를 검증한다.  
+2. **HTTP MCP 서버 없이** mock LLM·실제 DB 경로(또는 프로젝트가 정한 테스트 DB 관례)로 동작 가능하게 한다.  
+3. **기존** `recall` / `remember` / `forget` / `memory_injection` **동작·파싱·출력 관례를 깨지 않는다**.
+
+---
+
+## 2. 범위
+
+### 포함
+
+- 명령: **`memento agent ask`** (첫 토큰 `agent`, 둘째 `ask`).  
+- 사용자 질문: **`ask` 직후 positional 인자 1개**를 `userMessage`로 사용한다(따옴표로 공백 포함). `--query` 등 이중 표기는 **이번 이슈에서 도입하지 않는다**(혼동 방지; 필요 시 후속 이슈).  
+- 옵션(이슈 본문 + 브레인스토밍 합의):  
+  - `--project-id <string>`  
+  - `--token-budget <number>`  
+  - `--json`  
+  - `--no-save`  
+  - `--llm mock` — **값은 `mock`만 허용**. 다른 값은 사용 오류(exit `1`). 플래그 자체는 이후 provider 연결(#238)을 위한 자리 확보.  
+- 글로벌 옵션: 기존 CLI와 동일하게 **`--config-dir`**, deprecated **`--db-path`**, **`--env-file`** 을 **서브커맨드 앞·뒤** 모두에서 인식한다(기존 `parseGlobalFlags` / `subcommandArgvFrom` 패턴 재사용·확장).  
+- **Interactive(TTY)**: `KnowledgeCandidate`마다 순차 프롬프트 **`y` / `n` / `s` / `q`**.  
+  - **빈 줄**은 **`n`** 과 동일.  
+  - **`s`**: 남은 후보에 대한 질문을 건너뛰고, **지금까지 `y`로 승인한 id만** `persistApprovedCandidates` 호출 후 정상 종료.  
+  - **`q`**: 남은 후보를 묻지 않고, **`s`와 동일하게** 지금까지 `y`로 승인한 id만 `persistApprovedCandidates` 호출 후 정상 종료한다. 사용자에게 보이는 설명 문구만 다르게 할 수 있다(동작 동일).  
+- **Non-interactive**: `process.stdin.isTTY === false` 인 경우 **`--json` 또는 `--no-save` 중 하나 이상 필수**. 둘 다 없으면 **exit `1`**, stderr에 이유 한 줄 이상.  
+- **`--json`**: stdout에는 **JSON 한 줄**만(끝 `\n`). 성공 경로에서 stderr에 비-JSON 로그를 넣지 않는다.  
+- **`--json` 단독(TTY 여부 무관)**: **인터랙션 비활성화**이며 **`--no-save`와 동등**으로 동작(저장 단계 생략). stderr에 **한 줄 안내**(문구는 구현 시 고정 문자열로 명시).  
+- **`--json --no-save`**: 이슈 완료 기준 — **stdout에 JSON만**.  
+- **성공 시 JSON 스키마**: 단일 객체, 필드는 아래 **§6**.  
+- **실패 시 JSON 스키마**: **§7**.  
+- **Exit code**: **§8**.  
+- **부트스트랩**: `ToolContextKnowledgeContextAdapter` / `ToolContextRememberPersistenceAdapter`에 넣을 **in-process tool context** 생성을 `@memento/core`에 **팩토리 또는 헬퍼**로 둔다. `apps/experimental-example` 등 기존 in-process 사용처를 먼저 조사하고, **중복이면 헬퍼로 승격**, 없으면 **이번 작업 범위에서 추가**. CLI 파일은 표현·argv·TTY만 담당한다.  
+- **식별자**: 매 CLI 호출마다 `sessionId = randomUUID()`, `processId = "cli/agent-ask"`(상수). **`ownerId`는 설정하지 않는다**(undefined). `--session-id` 사용자 override는 **이번 이슈 범위에 넣지 않는다**.  
+- **후보 0개**: 승인 루프 생략. `persistApprovedCandidates`는 **`approvedCandidateIds`가 비어 있으면 호출하지 않는다**(#235 no-op과 정합).  
+- 테스트: Vitest로 `--json --no-save` stdout 파싱, 필수 필드, `ok === true`, mock 메타데이터; 기존 CLI 스펙 회귀.
+
+### 제외 (이슈 본문과 동일)
+
+- 웹 UI  
+- **MCP tool 추가**  
+- **실제 LLM provider** 연결 — [#238](https://github.com/jee1/memento/issues/238) 및 하위 이슈  
+- 서버 HTTP 경로로의 `agent ask` 위임 — [#390](https://github.com/jee1/memento/issues/390) 등 별도 트랙
+
+---
+
+## 3. 아키텍처 (채택안)
+
+| 대안 | 요지 | 채택 |
+|------|------|------|
+| A | CLI가 core를 in-process 부트스트랩 | **예** |
+| B | `callToolViaHttp`로 서버에 위임 | 아니오(MCP 제외·서버 미기동 요건과 충돌) |
+| C | context만 HTTP, 나머지 in-process | 아니오(MVP 복잡도) |
+
+**데이터 흐름**
+
+1. argv 파싱 → (기존과 동일) env 로드.  
+2. core 헬퍼로 SQLite·embedding 등 초기화 및 **tool context** 획득.  
+3. `PersonalKnowledgeAgentService` 인스턴스 생성(`DeterministicMockLlmAdapter`, context adapter, persistence adapter).  
+4. `runOneTurn(input)` — `input`에 `userMessage`, `projectId`, `tokenBudget` 등 반영.  
+5. `--no-save` 또는 `--json` 단독(자동 no-save)이면 **persist 단계를 생략**하고, JSON에 `persistence.attempted: false`.  
+6. 그 외 TTY: 후보별 순차 승인 → `persistApprovedCandidates({ candidates, approvedCandidateIds, projectId, sessionId, processId })`.
+
+---
+
+## 4. CLI 파싱·도움말
+
+- **도움말**: `memento --help`에 `agent ask` 한 줄 설명 추가. `memento agent --help` 또는 `memento agent ask --help`는 구현 계획에서 최소 한 경로는 제공(중복 시 하나만 유지).  
+- **알 수 없는 토큰**: 기존과 동일하게 stderr + exit `1`.  
+- **`agent` 뒤가 `ask`가 아님**: “알 수 없는 agent 서브커맨드” + exit `1`.
+
+---
+
+## 5. stdout / stderr 규칙
+
+| 모드 | stdout | stderr |
+|------|--------|--------|
+| `--json` 성공 | JSON 한 줄 | 비움 |
+| `--json` 실패 | JSON 한 줄(`ok: false`) | 비움(메시지는 JSON 내부) |
+| `--json` 단독 시 안내 | JSON 한 줄(성공 시) | **한 줄** `[info] --json은 인터랙션을 비활성화합니다(저장 생략).` 등 고정 문구 |
+| 사람 읽기 모드( `--json` 없음, TTY) | 구현 계획에서 **한 가지로 고정**(예: 최종 요약 JSON 한 줄만 stdout, 나머지 사람 읽기 텍스트는 stderr) — **기존 4개 서브커맨드는 항상 stdout에 JSON만**이므로, `agent ask`만 예외를 두면 문서·테스트에 명시한다. **권장**: 사람 읽기 모드에서도 **마지막에 성공 요약 JSON 한 줄을 stdout**에 붙여 파이프 일관성 유지, 진행 로그는 stderr. |
+| `--no-save`만 (TTY, `--json` 없음) | 위와 동일 정책 | 진행·후보 표시 |
+
+**상호 배타**: `--json` 성공 경로에서 stderr에 임의 로그를 섞지 않는다.
+
+---
+
+## 6. JSON 성공 스키마
+
+최상위 객체(한 줄 직렬화):
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `ok` | `true` | |
+| `sessionId` | `string` | 이번 호출의 `randomUUID()` |
+| `input` | `object` | `userMessage`, `projectId`, `tokenBudget` 등 실제 전달값 |
+| `knowledgeContext` | `object` | `itemCount`, `tokenEstimate`, `summary` (#232 메타와 대응) |
+| `llm` | `object` | `response: string`, `metadata` — mock provider 메타 포함 |
+| `candidates` | `array` | `KnowledgeCandidate` 전 필드; **`sourceContext` 있으면 포함** |
+| `persistence` | `object` | 아래 |
+
+`persistence`:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `attempted` | `boolean` | `persistApprovedCandidates` 호출 여부 |
+| `items` | `array` | #235 결과 항목과 동일 형태(후보별 `candidateId`, `status`, `memoryId?`, `errorMessage?`) |
+| `persistedCount` | `number` | |
+| `errorCount` | `number` | |
+
+`attempted === false` 인 경우: `items`는 `[]`, count는 `0`.
+
+---
+
+## 7. JSON 실패 스키마
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "MISSING_QUERY" | "INVALID_OPTION" | "BOOTSTRAP_FAILED" | "AGENT_RUN_FAILED" | "PERSIST_FAILED" | "INTERRUPTED" | "NON_INTERACTIVE",
+    "stage": "usage" | "bootstrap" | "run" | "persist",
+    "message": "string",
+    "details": {}
+  }
+}
+```
+
+- `PERSIST_FAILED` 시 `details`에 후보별 오류를 넣을 수 있다(구현 계획에서 필드명 고정).  
+- **비-JSON 모드** 실패: stderr에 `message` 한 줄 이상; exit code는 **§8**.
+
+---
+
+## 8. Exit code
+
+| 코드 | 조건 |
+|------|------|
+| `0` | 정상 종료 |
+| `1` | 사용 오류(인자 누락·잘못된 옵션·non-TTY 제약 위반 등) — `stage: usage` |
+| `2` | 부트스트랩 실패 — `stage: bootstrap` |
+| `3` | `runOneTurn` 실패 — `stage: run` |
+| `4` | persist 중 하나 이상 실패(부분 성공 포함) — `stage: persist` |
+| `130` | SIGINT(Ctrl+C) — **저장하지 않음**. **필수**: stderr에 중단 안내, exit `130`. **`--json` 모드**: 처리 비용이 낮으면 stdout에 완결된 한 줄 JSON(`ok: false`, `code: INTERRUPTED`)을 추가로 출력해도 좋다(권장). **금지**: stdout에 잘린 JSON만 남기는 것. |
+
+**부분 persist**: 성공한 `remember`는 유지하고 **롤백하지 않는다**(MVP).
+
+**스택 트레이스**: 기본 출력 금지. 환경 변수 **`MEMENTO_DEBUG=1`** 일 때만 stderr에 스택(또는 cause chain) 출력.
+
+---
+
+## 9. 구현 시 조사 항목 (필수)
+
+1. `apps/experimental-example` 및 core 내부에 **이미 동일한 in-process tool context** 생성 코드가 있는지 확인한다.  
+2. 없으면 `packages/memento-core` 적절한 모듈(예: `personal-agent` 또는 `infrastructure`)에 **`createPersonalAgentToolContext` 수준의 단일 진입점**을 추가하고, CLI는 그것만 호출한다.  
+3. DB 경로: 프로젝트의 기존 CLI·테스트가 사용하는 **`--config-dir` 해석**과 충돌하지 않게 맞춘다.
+
+---
+
+## 10. 테스트·회귀
+
+- **신규**: `agent ask` + `--json --no-save` 통합 테스트(임시 DB 파일 경로는 기존 Vitest 패턴 따름).  
+- **회귀**: `packages/memento-server/src/cli/cli-ac5-ac6.spec.ts` 등 기존 CLI 테스트 전부 통과.  
+- **수동**: 이슈 권장대로 `memento agent ask "..." --json --no-save` 한 번 이상.
+
+---
+
+## 11. 이슈 본문과의 정합
+
+| 이슈 요구 | 본 설계 |
+|-----------|---------|
+| `memento agent ask` | nested `agent` + `ask` |
+| `--project-id`, `--token-budget`, `--json`, `--no-save` | 포함 |
+| interactive 승인 | §2 |
+| non-interactive test mode | §2 non-TTY 규칙 |
+| `--json --no-save` → stdout JSON only | §5 |
+| mock E2E | in-process + `DeterministicMockLlmAdapter` |
+| 기존 4 명령 회귀 | §2, §10 |
+
+---
+
+## 12. 다음 단계
+
+- 사용자가 본 spec 파일을 검토·승인하면 **writing-plans** 스킬에 따라 `tasks.md` 수준의 구현 계획을 작성한다.  
+- 구현 시 본 문서 §5의 “사람 읽기 모드 stdout/stderr” 최종 한 가지 선택을 코드와 테스트에 반영한다.

--- a/docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
@@ -1,9 +1,9 @@
 # 설계: 이슈 #236 — `memento agent ask` CLI (개인 지식 Agent 진입점)
 
-**날짜**: 2026-05-14  
-**이슈**: [#236](https://github.com/jee1/memento/issues/236)  
-**부모**: [#82](https://github.com/jee1/memento/issues/82) 개인 지식 축적 Agent MVP  
-**선행(완료)**: [#231](https://github.com/jee1/memento/issues/231) 계약, [#232](https://github.com/jee1/memento/issues/232) context builder, [#233](https://github.com/jee1/memento/issues/233) mock LLM, [#234](https://github.com/jee1/memento/issues/234) 후보 추출, [#235](https://github.com/jee1/memento/issues/235) 승인 기반 persistence  
+**날짜**: 2026-05-14
+**이슈**: [#236](https://github.com/jee1/memento/issues/236)
+**부모**: [#82](https://github.com/jee1/memento/issues/82) 개인 지식 축적 Agent MVP
+**선행(완료)**: [#231](https://github.com/jee1/memento/issues/231) 계약, [#232](https://github.com/jee1/memento/issues/232) context builder, [#233](https://github.com/jee1/memento/issues/233) mock LLM, [#234](https://github.com/jee1/memento/issues/234) 후보 추출, [#235](https://github.com/jee1/memento/issues/235) 승인 기반 persistence
 **관련(별도 이슈)**: [#237](https://github.com/jee1/memento/issues/237) E2E·가이드, [#390](https://github.com/jee1/memento/issues/390) 서버 런타임 배선
 
 **핵심 결정 요약**: **In-process** 실행, **`memento agent ask` nested 서브커맨드**, **core 쪽 in-process tool context 부트스트랩 헬퍼** 사용 또는 추가, **stdout JSON 계약**과 **단계별 exit code**.
@@ -12,8 +12,8 @@
 
 ## 1. 목표
 
-1. `PersonalKnowledgeAgentService` 한 턴을 **CLI에서 end-to-end**로 실행해 MVP 루프를 검증한다.  
-2. **HTTP MCP 서버 없이** mock LLM·실제 DB 경로(또는 프로젝트가 정한 테스트 DB 관례)로 동작 가능하게 한다.  
+1. `PersonalKnowledgeAgentService` 한 턴을 **CLI에서 end-to-end**로 실행해 MVP 루프를 검증한다.
+2. **HTTP MCP 서버 없이** mock LLM·실제 DB 경로(또는 프로젝트가 정한 테스트 DB 관례)로 동작 가능하게 한다.
 3. **기존** `recall` / `remember` / `forget` / `memory_injection` **동작·파싱·출력 관례를 깨지 않는다**.
 
 ---
@@ -22,36 +22,36 @@
 
 ### 포함
 
-- 명령: **`memento agent ask`** (첫 토큰 `agent`, 둘째 `ask`).  
-- 사용자 질문: **`ask` 직후 positional 인자 1개**를 `userMessage`로 사용한다(따옴표로 공백 포함). `--query` 등 이중 표기는 **이번 이슈에서 도입하지 않는다**(혼동 방지; 필요 시 후속 이슈).  
-- 옵션(이슈 본문 + 브레인스토밍 합의):  
-  - `--project-id <string>`  
-  - `--token-budget <number>`  
-  - `--json`  
-  - `--no-save`  
-  - `--llm mock` — **값은 `mock`만 허용**. 다른 값은 사용 오류(exit `1`). 플래그 자체는 이후 provider 연결(#238)을 위한 자리 확보.  
-- 글로벌 옵션: 기존 CLI와 동일하게 **`--config-dir`**, deprecated **`--db-path`**, **`--env-file`** 을 **서브커맨드 앞·뒤** 모두에서 인식한다(기존 `parseGlobalFlags` / `subcommandArgvFrom` 패턴 재사용·확장).  
-- **Interactive(TTY)**: `KnowledgeCandidate`마다 순차 프롬프트 **`y` / `n` / `s` / `q`**.  
-  - **빈 줄**은 **`n`** 과 동일.  
-  - **`s`**: 남은 후보에 대한 질문을 건너뛰고, **지금까지 `y`로 승인한 id만** `persistApprovedCandidates` 호출 후 정상 종료.  
-  - **`q`**: 남은 후보를 묻지 않고, **`s`와 동일하게** 지금까지 `y`로 승인한 id만 `persistApprovedCandidates` 호출 후 정상 종료한다. 사용자에게 보이는 설명 문구만 다르게 할 수 있다(동작 동일).  
-- **Non-interactive**: `process.stdin.isTTY === false` 인 경우 **`--json` 또는 `--no-save` 중 하나 이상 필수**. 둘 다 없으면 **exit `1`**, stderr에 이유 한 줄 이상.  
-- **`--json`**: stdout에는 **JSON 한 줄**만(끝 `\n`). 성공 경로에서 stderr에 비-JSON 로그를 넣지 않는다.  
-- **`--json` 단독(TTY 여부 무관)**: **인터랙션 비활성화**이며 **`--no-save`와 동등**으로 동작(저장 단계 생략). stderr에 **한 줄 안내**(문구는 구현 시 고정 문자열로 명시).  
-- **`--json --no-save`**: 이슈 완료 기준 — **stdout에 JSON만**.  
-- **성공 시 JSON 스키마**: 단일 객체, 필드는 아래 **§6**.  
-- **실패 시 JSON 스키마**: **§7**.  
-- **Exit code**: **§8**.  
-- **부트스트랩**: `ToolContextKnowledgeContextAdapter` / `ToolContextRememberPersistenceAdapter`에 넣을 **in-process tool context** 생성을 `@memento/core`에 **팩토리 또는 헬퍼**로 둔다. `apps/experimental-example` 등 기존 in-process 사용처를 먼저 조사하고, **중복이면 헬퍼로 승격**, 없으면 **이번 작업 범위에서 추가**. CLI 파일은 표현·argv·TTY만 담당한다.  
-- **식별자**: 매 CLI 호출마다 `sessionId = randomUUID()`, `processId = "cli/agent-ask"`(상수). **`ownerId`는 설정하지 않는다**(undefined). `--session-id` 사용자 override는 **이번 이슈 범위에 넣지 않는다**.  
-- **후보 0개**: 승인 루프 생략. `persistApprovedCandidates`는 **`approvedCandidateIds`가 비어 있으면 호출하지 않는다**(#235 no-op과 정합).  
+- 명령: **`memento agent ask`** (첫 토큰 `agent`, 둘째 `ask`).
+- 사용자 질문: **`ask` 직후 positional 인자 1개**를 `userMessage`로 사용한다(따옴표로 공백 포함). `--query` 등 이중 표기는 **이번 이슈에서 도입하지 않는다**(혼동 방지; 필요 시 후속 이슈).
+- 옵션(이슈 본문 + 브레인스토밍 합의):
+  - `--project-id <string>`
+  - `--token-budget <number>`
+  - `--json`
+  - `--no-save`
+  - `--llm mock` — **값은 `mock`만 허용**. 다른 값은 사용 오류(exit `1`). 플래그 자체는 이후 provider 연결(#238)을 위한 자리 확보.
+- 글로벌 옵션: 기존 CLI와 동일하게 **`--config-dir`**, deprecated **`--db-path`**, **`--env-file`** 을 **서브커맨드 앞·뒤** 모두에서 인식한다(기존 `parseGlobalFlags` / `subcommandArgvFrom` 패턴 재사용·확장).
+- **Interactive(TTY)**: `KnowledgeCandidate`마다 순차 프롬프트 **`y` / `n` / `s` / `q`**.
+  - **빈 줄**은 **`n`** 과 동일.
+  - **`s`**: 남은 후보에 대한 질문을 건너뛰고, **지금까지 `y`로 승인한 id만** `persistApprovedCandidates` 호출 후 정상 종료.
+  - **`q`**: 남은 후보를 묻지 않고, **`s`와 동일하게** 지금까지 `y`로 승인한 id만 `persistApprovedCandidates` 호출 후 정상 종료한다. 사용자에게 보이는 설명 문구만 다르게 할 수 있다(동작 동일).
+- **Non-interactive**: `process.stdin.isTTY === false` 인 경우 **`--json` 또는 `--no-save` 중 하나 이상 필수**. 둘 다 없으면 **exit `1`**, stderr에 이유 한 줄 이상.
+- **`--json`**: stdout에는 **JSON 한 줄**만(끝 `\n`). 성공 경로에서 stderr에 비-JSON 로그를 넣지 않는다.
+- **`--json` 단독(TTY 여부 무관)**: **인터랙션 비활성화**이며 **`--no-save`와 동등**으로 동작(저장 단계 생략). stderr에 **한 줄 안내**(문구는 구현 시 고정 문자열로 명시).
+- **`--json --no-save`**: 이슈 완료 기준 — **stdout에 JSON만**.
+- **성공 시 JSON 스키마**: 단일 객체, 필드는 아래 **§6**.
+- **실패 시 JSON 스키마**: **§7**.
+- **Exit code**: **§8**.
+- **부트스트랩**: `ToolContextKnowledgeContextAdapter` / `ToolContextRememberPersistenceAdapter`에 넣을 **in-process tool context** 생성을 `@memento/core`에 **팩토리 또는 헬퍼**로 둔다. `apps/experimental-example` 등 기존 in-process 사용처를 먼저 조사하고, **중복이면 헬퍼로 승격**, 없으면 **이번 작업 범위에서 추가**. CLI 파일은 표현·argv·TTY만 담당한다.
+- **식별자**: 매 CLI 호출마다 `sessionId = randomUUID()`, `processId = "cli/agent-ask"`(상수). **`ownerId`는 설정하지 않는다**(undefined). `--session-id` 사용자 override는 **이번 이슈 범위에 넣지 않는다**.
+- **후보 0개**: 승인 루프 생략. `persistApprovedCandidates`는 **`approvedCandidateIds`가 비어 있으면 호출하지 않는다**(#235 no-op과 정합).
 - 테스트: Vitest로 `--json --no-save` stdout 파싱, 필수 필드, `ok === true`, mock 메타데이터; 기존 CLI 스펙 회귀.
 
 ### 제외 (이슈 본문과 동일)
 
-- 웹 UI  
-- **MCP tool 추가**  
-- **실제 LLM provider** 연결 — [#238](https://github.com/jee1/memento/issues/238) 및 하위 이슈  
+- 웹 UI
+- **MCP tool 추가**
+- **실제 LLM provider** 연결 — [#238](https://github.com/jee1/memento/issues/238) 및 하위 이슈
 - 서버 HTTP 경로로의 `agent ask` 위임 — [#390](https://github.com/jee1/memento/issues/390) 등 별도 트랙
 
 ---
@@ -66,19 +66,19 @@
 
 **데이터 흐름**
 
-1. argv 파싱 → (기존과 동일) env 로드.  
-2. core 헬퍼로 SQLite·embedding 등 초기화 및 **tool context** 획득.  
-3. `PersonalKnowledgeAgentService` 인스턴스 생성(`DeterministicMockLlmAdapter`, context adapter, persistence adapter).  
-4. `runOneTurn(input)` — `input`에 `userMessage`, `projectId`, `tokenBudget` 등 반영.  
-5. `--no-save` 또는 `--json` 단독(자동 no-save)이면 **persist 단계를 생략**하고, JSON에 `persistence.attempted: false`.  
+1. argv 파싱 → (기존과 동일) env 로드.
+2. core 헬퍼로 SQLite·embedding 등 초기화 및 **tool context** 획득.
+3. `PersonalKnowledgeAgentService` 인스턴스 생성(`DeterministicMockLlmAdapter`, context adapter, persistence adapter).
+4. `runOneTurn(input)` — `input`에 `userMessage`, `projectId`, `tokenBudget` 등 반영.
+5. `--no-save` 또는 `--json` 단독(자동 no-save)이면 **persist 단계를 생략**하고, JSON에 `persistence.attempted: false`.
 6. 그 외 TTY: 후보별 순차 승인 → `persistApprovedCandidates({ candidates, approvedCandidateIds, projectId, sessionId, processId })`.
 
 ---
 
 ## 4. CLI 파싱·도움말
 
-- **도움말**: `memento --help`에 `agent ask` 한 줄 설명 추가. `memento agent --help` 또는 `memento agent ask --help`는 구현 계획에서 최소 한 경로는 제공(중복 시 하나만 유지).  
-- **알 수 없는 토큰**: 기존과 동일하게 stderr + exit `1`.  
+- **도움말**: `memento --help`에 `agent ask` 한 줄 설명 추가. `memento agent --help` 또는 `memento agent ask --help`는 구현 계획에서 최소 한 경로는 제공(중복 시 하나만 유지).
+- **알 수 없는 토큰**: 기존과 동일하게 stderr + exit `1`.
 - **`agent` 뒤가 `ask`가 아님**: “알 수 없는 agent 서브커맨드” + exit `1`.
 
 ---
@@ -138,7 +138,7 @@
 }
 ```
 
-- `PERSIST_FAILED` 시 `details`에 후보별 오류를 넣을 수 있다(구현 계획에서 필드명 고정).  
+- `PERSIST_FAILED` 시 `details`에 후보별 오류를 넣을 수 있다(구현 계획에서 필드명 고정).
 - **비-JSON 모드** 실패: stderr에 `message` 한 줄 이상; exit code는 **§8**.
 
 ---
@@ -162,16 +162,16 @@
 
 ## 9. 구현 시 조사 항목 (필수)
 
-1. `apps/experimental-example` 및 core 내부에 **이미 동일한 in-process tool context** 생성 코드가 있는지 확인한다.  
-2. 없으면 `packages/memento-core` 적절한 모듈(예: `personal-agent` 또는 `infrastructure`)에 **`createPersonalAgentToolContext` 수준의 단일 진입점**을 추가하고, CLI는 그것만 호출한다.  
+1. `apps/experimental-example` 및 core 내부에 **이미 동일한 in-process tool context** 생성 코드가 있는지 확인한다.
+2. 없으면 `packages/memento-core` 적절한 모듈(예: `personal-agent` 또는 `infrastructure`)에 **`createPersonalAgentToolContext` 수준의 단일 진입점**을 추가하고, CLI는 그것만 호출한다.
 3. DB 경로: 프로젝트의 기존 CLI·테스트가 사용하는 **`--config-dir` 해석**과 충돌하지 않게 맞춘다.
 
 ---
 
 ## 10. 테스트·회귀
 
-- **신규**: `agent ask` + `--json --no-save` 통합 테스트(임시 DB 파일 경로는 기존 Vitest 패턴 따름).  
-- **회귀**: `packages/memento-server/src/cli/cli-ac5-ac6.spec.ts` 등 기존 CLI 테스트 전부 통과.  
+- **신규**: `agent ask` + `--json --no-save` 통합 테스트(임시 DB 파일 경로는 기존 Vitest 패턴 따름).
+- **회귀**: `packages/memento-server/src/cli/cli-ac5-ac6.spec.ts` 등 기존 CLI 테스트 전부 통과.
 - **수동**: 이슈 권장대로 `memento agent ask "..." --json --no-save` 한 번 이상.
 
 ---
@@ -192,5 +192,5 @@
 
 ## 12. 다음 단계
 
-- 사용자가 본 spec 파일을 검토·승인하면 **writing-plans** 스킬에 따라 `tasks.md` 수준의 구현 계획을 작성한다.  
+- 사용자가 본 spec 파일을 검토·승인하면 **writing-plans** 스킬에 따라 `tasks.md` 수준의 구현 계획을 작성한다.
 - 구현 시 본 문서 §5의 “사람 읽기 모드 stdout/stderr” 최종 한 가지 선택을 코드와 테스트에 반영한다.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-05-13)
+# Graph Report - .  (2026-05-14)
 
 ## Corpus Check
-- 979 files · ~1,572,683 words
+- 981 files · ~1,576,782 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4930 nodes · 6108 edges · 976 communities detected
+- 4944 nodes · 6131 edges · 978 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -986,6 +986,8 @@
 - [[_COMMUNITY_Community 973|Community 973]]
 - [[_COMMUNITY_Community 974|Community 974]]
 - [[_COMMUNITY_Community 975|Community 975]]
+- [[_COMMUNITY_Community 976|Community 976]]
+- [[_COMMUNITY_Community 977|Community 977]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -1441,424 +1443,424 @@ Cohesion: 0.22
 Nodes (5): buildEmbeddingMapResponse(), distSq(), EmbeddingMapBuildError, getCacheKey(), kMeans()
 
 ### Community 109 - "Community 109"
+Cohesion: 0.36
+Nodes (10): agentAskHelpText(), debugErr(), jsonFailure(), parseAgentAskInvocation(), promptApprove(), resolveDbPath(), runAgentAskMain(), stripGlobalCliArgs() (+2 more)
+
+### Community 110 - "Community 110"
 Cohesion: 0.18
 Nodes (5): AuthenticationError, ConnectionError, MementoError, NotFoundError, ValidationError
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.35
 Nodes (10): buildQuarantinePath(), extractPragmaMessages(), formatTimestamp(), isOkResult(), looksLikeCorruption(), maskError(), quarantineDatabaseFile(), runCheck() (+2 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.31
 Nodes (1): AriGraphSchemaExpansionMigration
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.27
 Nodes (1): ProceduralMemoryEnhancementMigration
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.33
 Nodes (1): AddCoreMemoryVersionMigration
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.27
 Nodes (1): QualityAssuranceSchemaMigration
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.29
 Nodes (1): TripleExtractionBatchJob
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.35
 Nodes (9): getMigrationStatus(), initializeMigrationStatusTable(), isMigrationCompleted(), isMigrationFailed(), isValidStatusTransition(), loadMigrationStatusToConfig(), prepareMigrationRetry(), setMigrationStatus() (+1 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.24
 Nodes (1): TripleCacheService
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.25
 Nodes (1): LoggingHelper
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (7): resolveBoolean(), resolveEnv(), resolveNumber(), resolveOptionalNumber(), resolveOptionalString(), resolveString(), toArray()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.18
 Nodes (1): AnchorCacheService
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.35
 Nodes (1): VectorSearchService
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (6): ConsolidationAlreadyRunningError, cosineSimilarity(), getMergeSimilarityThreshold(), mergeOriginSourceJson(), newSemanticId(), SleepConsolidationService
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.27
 Nodes (2): ModelAvailabilityService, now()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.36
 Nodes (1): QualityMetricsCollector
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.22
 Nodes (3): calculateDCG(), calculateIDCG(), calculateNDCGAtK()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.33
 Nodes (9): createManifest(), deriveBenchmarkVersion(), loadJsonArrayLength(), loadSourceMemories(), main(), parseArgs(), printHelp(), writeCorpus() (+1 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.33
 Nodes (10): calculateStats(), countLines(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+2 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.35
 Nodes (10): compareSnapshots(), createSnapshot(), extractNoConsoleViolations(), loadSnapshot(), main(), parseArgs(), printHelp(), printResults() (+2 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.49
 Nodes (9): checkDatabaseExists(), checkMigrationStatus(), log(), logError(), logInfo(), logSection(), logSuccess(), logWarning() (+1 more)
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.36
 Nodes (1): ConsolidationScoreService
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.29
 Nodes (2): MigrationHistoryService, normalizeDate()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (1): DatabaseLockMonitor
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (1): SchemaVersionManager
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.31
 Nodes (1): MirixSchemaExpansionMigration
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.24
 Nodes (1): WriteCoalescingManager
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.22
 Nodes (1): VectorSearchContainer
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (1): RememberTool
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.22
 Nodes (1): ConsolidationRepository
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.29
 Nodes (1): PredicateCanonicalizer
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (2): escapeHtml(), QualityReporter
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.31
 Nodes (6): countMagicNumbers(), findMagicNumbers(), getAllTsFiles(), isCoreModule(), isExcluded(), main()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.36
 Nodes (9): checkSqlInjection(), findFiles(), findSqlInjectionPatterns(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.36
 Nodes (9): countAnyTypes(), findAnyTypes(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.22
 Nodes (1): MementoAssistant
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
+Cohesion: 0.39
+Nodes (8): findSubcommandWithIndex(), main(), parseCli(), parseGlobalFlags(), stripGlobalArgvForAgentDetection(), subcommandArgvFrom(), writeStderr(), writeStdout()
+
+### Community 147 - "Community 147"
 Cohesion: 0.28
 Nodes (4): registerHandlers(), runHeavyInit(), Semaphore, startServer()
 
-### Community 146 - "Community 146"
+### Community 148 - "Community 148"
 Cohesion: 0.36
 Nodes (1): TripleExtractionLogger
 
-### Community 147 - "Community 147"
+### Community 149 - "Community 149"
 Cohesion: 0.31
 Nodes (1): MigrationRunner
 
-### Community 148 - "Community 148"
+### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (1): BackupManager
 
-### Community 149 - "Community 149"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (1): AnchorTableMigration
 
-### Community 150 - "Community 150"
+### Community 152 - "Community 152"
 Cohesion: 0.36
 Nodes (1): FactMetadataFieldsMigration
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
 Cohesion: 0.39
 Nodes (1): MemoryItemIsConsolidatedMigration
 
-### Community 152 - "Community 152"
+### Community 154 - "Community 154"
 Cohesion: 0.39
 Nodes (1): TripleExtractionFieldsMigration
 
-### Community 153 - "Community 153"
+### Community 155 - "Community 155"
 Cohesion: 0.42
 Nodes (1): FeedbackEventAttributionMigration
 
-### Community 154 - "Community 154"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (1): ProceduralVersionIndexesMigration
 
-### Community 155 - "Community 155"
+### Community 157 - "Community 157"
 Cohesion: 0.36
 Nodes (1): MemoryItemAttributionMigration
 
-### Community 156 - "Community 156"
+### Community 158 - "Community 158"
 Cohesion: 0.36
 Nodes (1): KgTripleTableMigration
 
-### Community 157 - "Community 157"
+### Community 159 - "Community 159"
 Cohesion: 0.39
 Nodes (1): SoftDeleteFieldsMigration
 
-### Community 158 - "Community 158"
+### Community 160 - "Community 160"
 Cohesion: 0.36
 Nodes (1): MemoryItemOwnerIdMigration
 
-### Community 159 - "Community 159"
+### Community 161 - "Community 161"
 Cohesion: 0.25
 Nodes (1): RetryManager
 
-### Community 160 - "Community 160"
+### Community 162 - "Community 162"
 Cohesion: 0.36
 Nodes (1): FileLogger
 
-### Community 161 - "Community 161"
+### Community 163 - "Community 163"
 Cohesion: 0.28
 Nodes (3): convertMemoryRowToItem(), isMemoryType(), isPrivacyScope()
 
-### Community 162 - "Community 162"
+### Community 164 - "Community 164"
 Cohesion: 0.31
 Nodes (1): LoggingRateLimiter
 
-### Community 163 - "Community 163"
+### Community 165 - "Community 165"
 Cohesion: 0.31
 Nodes (4): buildLogMessage(), formatTime(), logToStderr(), safeStringify()
 
-### Community 164 - "Community 164"
+### Community 166 - "Community 166"
 Cohesion: 0.36
 Nodes (7): canonicalizeHttpBindHostForListen(), formatHttpBindHostForUrl(), getMementoHttpSecurityStartupViolationMessage(), isHttpBindHostRemotelyReachable(), isIpv4Loopback127Block(), isIpv4MappedLoopback(), MementoHttpSecurityStartupError
 
-### Community 165 - "Community 165"
+### Community 167 - "Community 167"
 Cohesion: 0.22
 Nodes (2): DefaultSearchLogger, HybridSearchFactory
 
-### Community 166 - "Community 166"
+### Community 168 - "Community 168"
 Cohesion: 0.22
 Nodes (0): 
 
-### Community 167 - "Community 167"
+### Community 169 - "Community 169"
 Cohesion: 0.36
 Nodes (1): LlmProceduralExtractor
 
-### Community 168 - "Community 168"
+### Community 170 - "Community 170"
 Cohesion: 0.44
 Nodes (8): buildWindowCounts(), computeMemoryReviewQueueHealthLive(), countCandidates(), listMemoryReviewQueueHealthSnapshots(), maybeRecordMemoryReviewQueueHealthSnapshot(), memoryReviewQueueHealthSnapshotTableReady(), recordMemoryReviewQueueHealthSnapshot(), snapshotTableReady()
 
-### Community 169 - "Community 169"
+### Community 171 - "Community 171"
 Cohesion: 0.42
 Nodes (7): buildKnowledgeContextBundle(), estimateTokens(), filterByOwner(), formatMemoryPrompt(), summarizeMemories(), summarizeMemoryContent(), updateConsolidationScoreMetadata()
 
-### Community 170 - "Community 170"
+### Community 172 - "Community 172"
 Cohesion: 0.22
 Nodes (1): MockUnifiedEmbeddingService
 
-### Community 171 - "Community 171"
+### Community 173 - "Community 173"
 Cohesion: 0.39
 Nodes (1): RuleBasedRelationExtractor
 
-### Community 172 - "Community 172"
+### Community 174 - "Community 174"
 Cohesion: 0.39
 Nodes (1): RelationCache
 
-### Community 173 - "Community 173"
+### Community 175 - "Community 175"
 Cohesion: 0.36
 Nodes (1): EntityLinker
 
-### Community 174 - "Community 174"
+### Community 176 - "Community 176"
 Cohesion: 0.33
 Nodes (1): QualityThresholdManager
 
-### Community 175 - "Community 175"
+### Community 177 - "Community 177"
 Cohesion: 0.28
 Nodes (1): QualityEvaluator
 
-### Community 176 - "Community 176"
+### Community 178 - "Community 178"
 Cohesion: 0.42
 Nodes (8): benchmarkWeightCombinations(), compareWithBaseline(), generateBenchmarkGroundTruth(), generateTuningGuidelines(), loadBaselineSnapshot(), measureQualityWithWeights(), runConsolidationQualityBenchmark(), saveBaselineSnapshot()
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.42
 Nodes (6): loadBenchmarkCorpus(), loadBenchmarkGroundTruth(), loadBenchmarkManifest(), loadBenchmarkQueries(), readJsonFile(), resolveBenchmarkDir()
 
-### Community 178 - "Community 178"
-Cohesion: 0.42
-Nodes (8): checkAllFiles(), checkFile(), findFiles(), main(), parseArgs(), printHelp(), printResults(), shouldExclude()
-
-### Community 179 - "Community 179"
-Cohesion: 0.42
-Nodes (8): checkAllFiles(), checkFile(), findFiles(), main(), parseArgs(), printHelp(), printResults(), shouldExclude()
-
 ### Community 180 - "Community 180"
+Cohesion: 0.42
+Nodes (8): checkAllFiles(), checkFile(), findFiles(), main(), parseArgs(), printHelp(), printResults(), shouldExclude()
+
+### Community 181 - "Community 181"
+Cohesion: 0.42
+Nodes (8): checkAllFiles(), checkFile(), findFiles(), main(), parseArgs(), printHelp(), printResults(), shouldExclude()
+
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (5): countExternalAPICalls(), findExternalAPICalls(), getAllTsFiles(), isCoreModule(), main()
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 0.39
 Nodes (2): parseToolJson(), StdioTransport
 
-### Community 182 - "Community 182"
+### Community 184 - "Community 184"
 Cohesion: 0.25
 Nodes (1): MockTransport
 
-### Community 183 - "Community 183"
-Cohesion: 0.43
-Nodes (7): findSubcommandWithIndex(), main(), parseCli(), parseGlobalFlags(), subcommandArgvFrom(), writeStderr(), writeStdout()
-
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.36
 Nodes (4): deleteServerInfo(), readServerInfo(), serverInfoPath(), writeServerInfo()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.25
 Nodes (0): 
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.46
 Nodes (7): runTests(), setupTestDatabase(), testAdminAPIs(), testBasicEndpoints(), testMCPTools(), testSSE(), testWebSocket()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.39
 Nodes (1): ProcessAttributeTableMigration
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.39
 Nodes (1): AddProjectIdMigration
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.46
 Nodes (1): MemoryReviewCandidateSchemaMigration
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.39
 Nodes (1): TelemetryEventsEventTypeCreatedAtIndexMigration
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.39
 Nodes (1): FixTfidfDimensionTriggerMigration
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.43
 Nodes (1): FeedbackEventScoreBreakdownMigration
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.43
 Nodes (1): FeedbackEventCommentMigration
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.43
 Nodes (1): ProceduralVersionFieldsMigration
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.39
 Nodes (1): FeedbackEventMemoryCreatedAtIndexMigration
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.46
 Nodes (1): ReviewQueueHealthSnapshotMigration
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.32
 Nodes (1): BatchJobExecutionCoordinator
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.25
 Nodes (0): 
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.29
 Nodes (2): escapeDotString(), RelationVisualizer
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.46
 Nodes (6): getObjectSize(), limitArraySize(), mergeReflectionNotes(), normalizeNewReflectionNotes(), validateAndCleanupTotalSize(), validateSingleObjectSize()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (2): isPIIMaskingEnabled(), PIIMasker
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.25
 Nodes (0): 
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (1): LocalSearchService
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.32
 Nodes (1): ProceduralMemoryMatcher
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.29
 Nodes (2): MemoryNeighborService, MemoryNotFoundError
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.29
 Nodes (2): getMemoryReviewCandidateById(), mapRow()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.36
 Nodes (1): RelationExtractor
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.32
 Nodes (1): TripleExtractionStatisticsService
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.29
 Nodes (1): AlertNotificationService
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.32
 Nodes (1): QualityRecorder
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.39
 Nodes (1): MultiProviderSearchBenchmark
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.39
 Nodes (5): checkCode(), checkDocumentation(), checkGitHistory(), checkLegacyScriptUsage(), checkPackageJson()
-
-### Community 213 - "Community 213"
-Cohesion: 0.46
-Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateMarkdownReport(), loadTestDataset(), main(), parseArgs()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.46
@@ -1866,319 +1868,319 @@ Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateM
 
 ### Community 215 - "Community 215"
 Cohesion: 0.46
-Nodes (7): checkAllFiles(), checkRetryUsage(), getAllTsFiles(), main(), printResultsCSV(), printResultsJSON(), printResultsText()
+Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateMarkdownReport(), loadTestDataset(), main(), parseArgs()
 
 ### Community 216 - "Community 216"
+Cohesion: 0.46
+Nodes (7): checkAllFiles(), checkRetryUsage(), getAllTsFiles(), main(), printResultsCSV(), printResultsJSON(), printResultsText()
+
+### Community 217 - "Community 217"
 Cohesion: 0.36
 Nodes (1): GitHubIssueClient
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.38
 Nodes (1): HttpTransport
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.29
 Nodes (1): RetryQueue
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.52
 Nodes (6): buildReviewQueueBootInjectionHtml(), clampIntervalMs(), injectReviewQueueBootIntoDashboardHtml(), parseBackoffCsv(), parsePositiveIntMs(), resolveReviewQueueDashboardBootFromEnv()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.43
 Nodes (4): jsonSafeDetails(), recordManualBatchRunFailure(), recordManualBatchRunSuccess(), trimEntries()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.43
 Nodes (1): MigrationDetector
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.43
 Nodes (1): BackfillKgTripleFromMemoryItemMigration
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.38
 Nodes (3): parseJsonArray(), ProcessAttributeRepositorySqlite, stringifyJsonArray()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.48
 Nodes (6): computeJsonHash(), computeReflectionNotesCount(), createProceduralMemorySnapshot(), hasProceduralMemoryChanged(), isEqual(), normalizeJson()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.48
 Nodes (5): containsPathTraversal(), getAllowedDirs(), isAbsolutePath(), isWithinAllowedDirs(), validateFilePath()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.38
 Nodes (1): PromptTemplateLoader
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.29
 Nodes (1): QueryFilterService
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.29
 Nodes (2): MigrationValidator, VectorSearchEngineMigration
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.38
 Nodes (1): VectorPerformanceTester
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (1): VectorIndexManager
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.38
 Nodes (1): SemanticMemoryStatisticsService
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.48
 Nodes (1): ClusteringService
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.29
 Nodes (3): CyclicRelationError, DuplicateRelationError, RelationGraphError
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (2): createMockEmbeddingService(), getMockEmbeddingFunctions()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.48
 Nodes (4): checkOllamaModelInstalled(), extractRawWithOllama(), getStringField(), isRecord()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.38
 Nodes (3): executeTool(), resolveTelemetryOwnerId(), telemetryParamsContext()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.71
 Nodes (6): createAnchorTable(), expect(), runAllTests(), testAnchorSystemWorkflow(), testFallbackMechanism(), testMultiClientScenario()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.52
 Nodes (6): calculateRecency(), generateRecencyData(), main(), printConsoleGraph(), printCSV(), printKeyPoints()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.57
 Nodes (6): compareWithAndWithoutConsolidation(), convertToSearchResults(), generateGroundTruth(), measureSearchQuality(), testConsolidationSearchQuality(), verifyRankingOrder()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.57
 Nodes (6): buildReviewChecklistMarkdown(), findGroundTruth(), loadLabelCandidates(), renderCandidate(), renderRelevantEntry(), summarizeContent()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.48
 Nodes (4): expectExactScript(), normalizeCommand(), readScript(), splitSequentialCommands()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.48
 Nodes (5): buildMemoryIdToBenchmarkIdMap(), main(), parseArgs(), printHelp(), sampleDeterministicNegatives()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.52
 Nodes (6): assertRankingProfileFilesExist(), main(), mean(), pairedPermutationPValue(), parseArgs(), runProfile()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.52
 Nodes (6): extractKeywordsFromMemories(), generateGroundTruthFromSearch(), getMemoryIds(), main(), parseArgs(), printHelp()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.48
 Nodes (6): callHttpTool(), checkServerHealth(), getHttpTools(), handleRequest(), main(), sendResponse()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.52
 Nodes (6): booleanFromEnv(), defaultLogsRoot(), labelsFromEnv(), loadMonitorConfig(), numberFromEnv(), optionalString()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.33
 Nodes (1): CircuitBreaker
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.6
 Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkLinks(), buildNetworkNodesAndLinks()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (4): errorHandler(), isAppErrorContract(), resolveSeverityAndCategory(), resolveStatusCode()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.47
 Nodes (3): cleanupTestDatabase(), createTestDatabaseWithoutServices(), setupTestDatabase()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.4
 Nodes (2): createJsonRpcError(), processMcpMessage()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.47
 Nodes (4): getAdmin(), getEmbeddingMapHandler(), seedEmbeddings(), vecJson()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.6
 Nodes (5): forgetParams(), memoryInjectionParams(), parseArgvToParams(), recallParams(), rememberParams()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.53
 Nodes (1): DependencyValidator
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.33
 Nodes (1): TestMigration
 
-### Community 258 - "Community 258"
-Cohesion: 0.33
-Nodes (0): 
-
 ### Community 259 - "Community 259"
 Cohesion: 0.33
-Nodes (1): FlipConsolidationRelationDirectionsMigration
+Nodes (0): 
 
 ### Community 260 - "Community 260"
 Cohesion: 0.33
-Nodes (1): TelemetryDailyMetricsMigration
+Nodes (1): FlipConsolidationRelationDirectionsMigration
 
 ### Community 261 - "Community 261"
 Cohesion: 0.33
-Nodes (1): TelemetryEventsMigration
+Nodes (1): TelemetryDailyMetricsMigration
 
 ### Community 262 - "Community 262"
 Cohesion: 0.33
-Nodes (0): 
+Nodes (1): TelemetryEventsMigration
 
 ### Community 263 - "Community 263"
 Cohesion: 0.33
-Nodes (1): ExampleMigration
+Nodes (0): 
 
 ### Community 264 - "Community 264"
+Cohesion: 0.33
+Nodes (1): ExampleMigration
+
+### Community 265 - "Community 265"
 Cohesion: 0.4
 Nodes (1): FeedbackRepositorySQLite
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.47
 Nodes (2): generateId(), KgTripleRepositorySqlite
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (1): HealthChecker
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.47
 Nodes (3): validateProceduralMemoryFields(), validateTriggerConditions(), validateWorkflowOrSkillName()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (1): CacheKeyGenerator
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.53
 Nodes (4): getRankingWeights(), loadRankingWeights(), resolveRankingWeightsFilePath(), validateRankingWeights()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.53
 Nodes (4): getRetryOptions(), loadRetryOptions(), validateRetryConfig(), validateRetryOptions()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.33
 Nodes (1): VectorSearchFactory
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.47
 Nodes (3): defaultTfidfVecRegistry(), mockSqliteMaster(), sqliteMasterPreparedMock()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.47
 Nodes (1): VectorPerformanceRepositoryImpl
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.47
 Nodes (2): FeedbackTool, normalizeFeedbackCreatedAtToIso()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.53
 Nodes (1): SummarizationService
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.47
 Nodes (3): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.47
 Nodes (3): chunkSucceeded(), failureMessageFromResult(), TriplePipelineOrchestrator
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.6
 Nodes (5): executePerformanceAlerts(), handleList(), handleResolve(), handleSearch(), handleStats()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.47
 Nodes (1): RuntimeDiagnosticsLogger
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.47
 Nodes (1): MigrateEmbeddingsTool
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.6
 Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (5): readDockerLogs(), readJsonlFiles(), resolveDockerLogsRef(), runDocker(), splitJsonlLines()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (2): emptyState(), loadState()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.6
 Nodes (5): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), truncateTitle()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.8
 Nodes (5): buildRequestOptions(), getDashboardAuth(), mementoAdminFetch(), performFetch(), waitForSession()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.7
 Nodes (4): goToNext(), goToPrevious(), makeCurrent(), toggleClass()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.6
 Nodes (3): broadcastReviewCandidatesChanged(), buildReviewCandidatesChangedEnvelope(), parseReviewCandidatesChangedRelayUrls()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 289 - "Community 289"
-Cohesion: 0.6
-Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.6
-Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
 
 ### Community 291 - "Community 291"
+Cohesion: 0.6
+Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+
+### Community 292 - "Community 292"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 292 - "Community 292"
-Cohesion: 0.4
-Nodes (1): SseServer
-
 ### Community 293 - "Community 293"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): SseServer
 
 ### Community 294 - "Community 294"
 Cohesion: 0.4
@@ -2209,28 +2211,28 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 301 - "Community 301"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 302 - "Community 302"
 Cohesion: 0.5
 Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 305 - "Community 305"
-Cohesion: 0.5
-Nodes (2): getStopWords(), isStopWord()
 
 ### Community 306 - "Community 306"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): getStopWords(), isStopWord()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.4
@@ -2241,120 +2243,120 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 309 - "Community 309"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 310 - "Community 310"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 311 - "Community 311"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 312 - "Community 312"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 320 - "Community 320"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 321 - "Community 321"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 322 - "Community 322"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 324 - "Community 324"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): TokenBucketRateLimiter
 
 ### Community 326 - "Community 326"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 327 - "Community 327"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.7
 Nodes (4): recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 337 - "Community 337"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 338 - "Community 338"
 Cohesion: 0.5
@@ -2366,23 +2368,23 @@ Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 341 - "Community 341"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): BraveSearchProvider
 
 ### Community 342 - "Community 342"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 343 - "Community 343"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 343 - "Community 343"
-Cohesion: 0.5
-Nodes (1): DatabaseOptimizeTool
-
 ### Community 344 - "Community 344"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): DatabaseOptimizeTool
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
@@ -2406,171 +2408,171 @@ Nodes (0):
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
-Nodes (1): RelationValidatorExecutor
+Nodes (0): 
 
 ### Community 351 - "Community 351"
+Cohesion: 0.5
+Nodes (1): RelationValidatorExecutor
+
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (1): QualityMeasurementBatchJob
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (1): SleepConsolidationBatchJob
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (1): TelemetryCleanupBatchJob
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 358 - "Community 358"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
-Nodes (1): SearchResultCombiner
+Nodes (1): RestoreAnchorsTool
 
 ### Community 364 - "Community 364"
-Cohesion: 0.67
-Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
+Cohesion: 0.5
+Nodes (1): SearchResultCombiner
 
 ### Community 365 - "Community 365"
 Cohesion: 0.67
-Nodes (2): computeProcessAttributeFit(), toSet()
+Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
 ### Community 366 - "Community 366"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): computeProcessAttributeFit(), toSet()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
-Nodes (1): ForgettingStatsTool
+Nodes (0): 
 
 ### Community 368 - "Community 368"
 Cohesion: 0.5
-Nodes (1): GetTelemetrySummaryTool
+Nodes (1): ForgettingStatsTool
 
 ### Community 369 - "Community 369"
+Cohesion: 0.5
+Nodes (1): GetTelemetrySummaryTool
+
+### Community 370 - "Community 370"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.5
 Nodes (1): MemoryInjectionPrompt
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.5
 Nodes (1): GetMemoryNeighborsTool
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (1): ProceduralRollbackTool
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (1): CleanupMemoryTool
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (1): ProceduralDiffTool
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (1): GetIntrospectionSummaryTool
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (1): RememberProcedureTool
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 378 - "Community 378"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 380 - "Community 380"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 382 - "Community 382"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 390 - "Community 390"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
@@ -2582,15 +2584,15 @@ Nodes (0):
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
@@ -2605,20 +2607,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 400 - "Community 400"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 401 - "Community 401"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 402 - "Community 402"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 403 - "Community 403"
+### Community 401 - "Community 401"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 402 - "Community 402"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 403 - "Community 403"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 404 - "Community 404"
 Cohesion: 0.83
@@ -2630,59 +2632,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 407 - "Community 407"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 408 - "Community 408"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 409 - "Community 409"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 413 - "Community 413"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 414 - "Community 414"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 417 - "Community 417"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 418 - "Community 418"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 419 - "Community 419"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
@@ -2693,24 +2695,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 422 - "Community 422"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 423 - "Community 423"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 424 - "Community 424"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 425 - "Community 425"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 426 - "Community 426"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
@@ -2718,31 +2720,31 @@ Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 430 - "Community 430"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 432 - "Community 432"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 433 - "Community 433"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 434 - "Community 434"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
@@ -2753,12 +2755,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 437 - "Community 437"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 438 - "Community 438"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
@@ -2773,16 +2775,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 442 - "Community 442"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 443 - "Community 443"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 444 - "Community 444"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
@@ -2802,11 +2804,11 @@ Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Nodes (0): 
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
@@ -2822,19 +2824,19 @@ Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 456 - "Community 456"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 457 - "Community 457"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
@@ -2861,28 +2863,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 464 - "Community 464"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 465 - "Community 465"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 467 - "Community 467"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 468 - "Community 468"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 469 - "Community 469"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
@@ -2893,32 +2895,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 472 - "Community 472"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 473 - "Community 473"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 474 - "Community 474"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 475 - "Community 475"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 476 - "Community 476"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
@@ -4908,1004 +4910,1014 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 976 - "Community 976"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 977 - "Community 977"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 478`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 479`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 480`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 481`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 482`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 483`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 484`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 485`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 486`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 487`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 488`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 489`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 490`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 491`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 492`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 493`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 494`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 495`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 496`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 497`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 498`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 499`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 500`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 501`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 502`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 503`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 504`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 505`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 506`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 509`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 510`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 511`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 512`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 513`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 514`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 515`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 516`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 517`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 518`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 519`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 520`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 521`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 522`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 523`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 524`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 525`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 526`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 527`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 528`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 529`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 530`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 531`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 532`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 533`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 534`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 535`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 536`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 537`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 538`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 539`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 553`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 554`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 555`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 556`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 557`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 558`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 559`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 560`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 561`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 562`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 563`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 564`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 565`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 566`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 567`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 568`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 569`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 570`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 571`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 572`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 573`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 574`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 575`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 576`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 577`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 578`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 579`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 580`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 581`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 582`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 583`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 584`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 585`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 586`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 587`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 588`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 589`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 590`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 591`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 592`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 594`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 595`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 596`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 598`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 599`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 601`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 602`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 605`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 606`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 607`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 608`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 609`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 610`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 611`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 612`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 613`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 614`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 615`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 616`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 617`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 618`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 619`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 620`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 621`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 622`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 623`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 624`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 625`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 626`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 627`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 628`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 629`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 630`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 631`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 632`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 633`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 634`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 635`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 636`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 637`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 638`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 639`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 640`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 641`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 642`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 643`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 644`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 645`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 646`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 647`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 648`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 649`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 650`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 651`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 652`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 653`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 654`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 655`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 656`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 657`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 658`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 659`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 660`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 661`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 662`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 663`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 664`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 665`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 666`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 667`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 668`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 669`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 670`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 671`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 672`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 673`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `types.ts`
+- **Thin community `Community 674`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 675`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `index.ts`
+- **Thin community `Community 676`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 677`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 678`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `transport.ts`
+- **Thin community `Community 683`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `index.ts`
+- **Thin community `Community 684`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 697`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 711`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `context.ts`
+- **Thin community `Community 713`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `index.ts`
+- **Thin community `Community 718`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `types.ts`
+- **Thin community `Community 721`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 722`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 723`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 724`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 725`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 726`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 727`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 728`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 729`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 730`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 731`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 732`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `index.ts`
+- **Thin community `Community 733`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 734`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 735`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 736`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `types.ts`
+- **Thin community `Community 743`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 750`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 751`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 761`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 778`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 779`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 780`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 781`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 782`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 783`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 784`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 785`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 786`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 787`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 788`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `error-types.ts`
+- **Thin community `Community 789`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 790`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 791`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `search.types.ts`
+- **Thin community `Community 792`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 794`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `constants.ts`
+- **Thin community `Community 795`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 796`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 797`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 803`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 804`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 806`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 807`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 808`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 816`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 831`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 832`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `index.ts`
+- **Thin community `Community 834`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `database-types.ts`
+- **Thin community `Community 836`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `index.ts`
+- **Thin community `Community 856`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 857`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `index.ts`
+- **Thin community `Community 859`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 862`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 863`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `context-port.ts`
+- **Thin community `Community 864`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 865`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 868`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 869`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 870`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 871`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 872`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 873`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 874`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 875`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 876`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 877`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 879`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 889`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 890`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `index.ts`
+- **Thin community `Community 900`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 902`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 912`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `types.ts`
+- **Thin community `Community 922`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `types.ts`
+- **Thin community `Community 937`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 939`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 941`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 942`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 943`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 950`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 951`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 953`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 954`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 963`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `types.ts`
+- **Thin community `Community 964`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 977`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - .  (2026-05-14)
+# Graph Report - /home/jee1lee/git/memento  (2026-05-14)
 
 ## Corpus Check
-- 981 files · ~1,577,333 words
+- 981 files · ~1,577,389 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-14)
 
 ## Corpus Check
-- 981 files · ~1,576,782 words
+- 981 files · ~1,577,333 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4944 nodes · 6131 edges · 978 communities detected
+- 4946 nodes · 6135 edges · 978 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1367,84 +1367,84 @@ Cohesion: 0.23
 Nodes (1): EmbeddingMigration
 
 ### Community 90 - "Community 90"
+Cohesion: 0.31
+Nodes (12): agentAskHelpText(), debugErr(), jsonFailure(), parseAgentAskInvocation(), promptApprove(), resolveDbPath(), runAgentAskMain(), stripGlobalCliArgs() (+4 more)
+
+### Community 91 - "Community 91"
 Cohesion: 0.27
 Nodes (11): buildExactMatchQuery(), calculateSimilarity(), determineMergeStrategy(), extractProceduralMemory(), extractSkillName(), extractSteps(), extractWorkflowName(), generateTriggerConditions() (+3 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.19
 Nodes (1): AnchorManager
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.28
 Nodes (1): ForgettingAlgorithm
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.18
 Nodes (3): AdaptiveIntervalStrategy, ConservativeIntervalStrategy, DefaultIntervalStrategy
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.36
 Nodes (11): executeTelemetry(), fmt(), fmtMs(), fmtPct(), formatMemoryQuality(), formatSearchQuality(), formatSystemMetrics(), main() (+3 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.32
 Nodes (1): ConsolidationScoreWorker
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.29
 Nodes (1): WalCheckpointScheduler
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.26
 Nodes (1): MigrationMonitorService
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.27
 Nodes (1): RelationEngineSchemaMigration
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.2
 Nodes (2): SqliteCoreMemoryAdapter, SqliteCoreMemoryPreparedStatement
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.26
 Nodes (1): SpacedRepetitionAlgorithm
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.2
 Nodes (3): AdaptiveRecallProbabilityCalculator, DefaultRecallProbabilityCalculator, EnhancedRecallProbabilityCalculator
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (1): ConvertEpisodicToSemanticTool
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.27
 Nodes (1): PinTool
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.29
 Nodes (8): buildScoreBreakdown(), computeStaleDays(), isMemoryRowActive(), isNonEmptyDeletedAt(), isTruthyFlag(), parseSqliteInstant(), passesEligibility(), resolveStaleAnchor()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.35
 Nodes (8): a(), B(), D(), g(), i(), k(), Q(), y()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.35
 Nodes (10): batchProcessingExample(), benchmarkExample(), cachingExample(), compressedSearchExample(), memoryOptimizationExample(), parallelSearchExample(), processPageData(), realTimeMonitoringExample() (+2 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.31
 Nodes (7): cleanup(), getHttpAuthMissingAdminKeyWarning(), getHttpAuthTrustModelNotice(), initializeServer(), registerCleanupHandlers(), startServer(), writeRuntimeDiagnosticsEvent()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (5): buildEmbeddingMapResponse(), distSq(), EmbeddingMapBuildError, getCacheKey(), kMeans()
-
-### Community 109 - "Community 109"
-Cohesion: 0.36
-Nodes (10): agentAskHelpText(), debugErr(), jsonFailure(), parseAgentAskInvocation(), promptApprove(), resolveDbPath(), runAgentAskMain(), stripGlobalCliArgs() (+2 more)
 
 ### Community 110 - "Community 110"
 Cohesion: 0.18

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "block-navigation.js",
@@ -17,7 +17,7 @@
       "source_file": "coverage/block-navigation.js",
       "source_location": "L1",
       "id": "coverage_block_navigation_js",
-      "community": 286
+      "community": 287
     },
     {
       "label": "toggleClass()",
@@ -25,7 +25,7 @@
       "source_file": "coverage/block-navigation.js",
       "source_location": "L24",
       "id": "block_navigation_toggleclass",
-      "community": 286
+      "community": 287
     },
     {
       "label": "makeCurrent()",
@@ -33,7 +33,7 @@
       "source_file": "coverage/block-navigation.js",
       "source_location": "L31",
       "id": "block_navigation_makecurrent",
-      "community": 286
+      "community": 287
     },
     {
       "label": "goToPrevious()",
@@ -41,7 +41,7 @@
       "source_file": "coverage/block-navigation.js",
       "source_location": "L41",
       "id": "block_navigation_gotoprevious",
-      "community": 286
+      "community": 287
     },
     {
       "label": "goToNext()",
@@ -49,7 +49,7 @@
       "source_file": "coverage/block-navigation.js",
       "source_location": "L52",
       "id": "block_navigation_gotonext",
-      "community": 286
+      "community": 287
     },
     {
       "label": "prettify.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "assistant.ts",
@@ -289,7 +289,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_ts",
-      "community": 144
+      "community": 145
     },
     {
       "label": "MementoAssistant",
@@ -297,7 +297,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L21",
       "id": "assistant_mementoassistant",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".constructor()",
@@ -305,7 +305,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L34",
       "id": "assistant_mementoassistant_constructor",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".fromEnv()",
@@ -313,7 +313,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L46",
       "id": "assistant_mementoassistant_fromenv",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".beforeUserTurn()",
@@ -321,7 +321,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L61",
       "id": "assistant_mementoassistant_beforeuserturn",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".afterAssistantTurn()",
@@ -329,7 +329,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L67",
       "id": "assistant_mementoassistant_afterassistantturn",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".recall()",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L75",
       "id": "assistant_mementoassistant_recall",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".remember()",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L78",
       "id": "assistant_mementoassistant_remember",
-      "community": 144
+      "community": 145
     },
     {
       "label": ".close()",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L81",
       "id": "assistant_mementoassistant_close",
-      "community": 144
+      "community": 145
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 412
+      "community": 413
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 412
+      "community": 413
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 478
+      "community": 479
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 413
+      "community": 414
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 413
+      "community": 414
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 479
+      "community": 480
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 480
+      "community": 481
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 414
+      "community": 415
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 414
+      "community": 415
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "http-transport.ts",
@@ -521,7 +521,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_ts",
-      "community": 217
+      "community": 218
     },
     {
       "label": "HttpTransport",
@@ -529,7 +529,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L10",
       "id": "http_transport_httptransport",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".constructor()",
@@ -537,7 +537,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L15",
       "id": "http_transport_httptransport_constructor",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".connect()",
@@ -545,7 +545,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L20",
       "id": "http_transport_httptransport_connect",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".recall()",
@@ -553,7 +553,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L30",
       "id": "http_transport_httptransport_recall",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".remember()",
@@ -561,7 +561,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L38",
       "id": "http_transport_httptransport_remember",
-      "community": 217
+      "community": 218
     },
     {
       "label": ".close()",
@@ -569,7 +569,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L52",
       "id": "http_transport_httptransport_close",
-      "community": 217
+      "community": 218
     },
     {
       "label": "stdio-transport.spec.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 481
+      "community": 482
     },
     {
       "label": "stdio-transport.ts",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_ts",
-      "community": 181
+      "community": 183
     },
     {
       "label": "StdioTransport",
@@ -641,7 +641,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L13",
       "id": "stdio_transport_stdiotransport",
-      "community": 181
+      "community": 183
     },
     {
       "label": ".constructor()",
@@ -649,7 +649,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L19",
       "id": "stdio_transport_stdiotransport_constructor",
-      "community": 181
+      "community": 183
     },
     {
       "label": ".connect()",
@@ -657,7 +657,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L21",
       "id": "stdio_transport_stdiotransport_connect",
-      "community": 181
+      "community": 183
     },
     {
       "label": ".recall()",
@@ -665,7 +665,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L45",
       "id": "stdio_transport_stdiotransport_recall",
-      "community": 181
+      "community": 183
     },
     {
       "label": ".remember()",
@@ -673,7 +673,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L55",
       "id": "stdio_transport_stdiotransport_remember",
-      "community": 181
+      "community": 183
     },
     {
       "label": ".close()",
@@ -681,7 +681,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L67",
       "id": "stdio_transport_stdiotransport_close",
-      "community": 181
+      "community": 183
     },
     {
       "label": "parseToolJson()",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L76",
       "id": "stdio_transport_parsetooljson",
-      "community": 181
+      "community": 183
     },
     {
       "label": "factory.spec.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 685
+      "community": 687
     },
     {
       "label": "mock-transport.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_ts",
-      "community": 182
+      "community": 184
     },
     {
       "label": "MockTransport",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L4",
       "id": "mock_transport_mocktransport",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".fixture()",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L12",
       "id": "mock_transport_mocktransport_fixture",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".throwOnNextRecall()",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L16",
       "id": "mock_transport_mocktransport_throwonnextrecall",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".throwOnNextRemember()",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L17",
       "id": "mock_transport_mocktransport_throwonnextremember",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".recall()",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L19",
       "id": "mock_transport_mocktransport_recall",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".remember()",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L28",
       "id": "mock_transport_mocktransport_remember",
-      "community": 182
+      "community": 184
     },
     {
       "label": ".close()",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.ts",
       "source_location": "L37",
       "id": "mock_transport_mocktransport_close",
-      "community": 182
+      "community": 184
     },
     {
       "label": "circuit-breaker.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_ts",
-      "community": 248
+      "community": 249
     },
     {
       "label": "CircuitBreaker",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L8",
       "id": "circuit_breaker_circuitbreaker",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".constructor()",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L12",
       "id": "circuit_breaker_circuitbreaker_constructor",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".canPass()",
@@ -793,7 +793,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L14",
       "id": "circuit_breaker_circuitbreaker_canpass",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".recordSuccess()",
@@ -801,7 +801,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L27",
       "id": "circuit_breaker_circuitbreaker_recordsuccess",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".recordFailure()",
@@ -809,7 +809,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L32",
       "id": "circuit_breaker_circuitbreaker_recordfailure",
-      "community": 248
+      "community": 249
     },
     {
       "label": "logger.ts",
@@ -817,7 +817,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 334
+      "community": 335
     },
     {
       "label": "createRateLimitedLogger()",
@@ -825,7 +825,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 334
+      "community": 335
     },
     {
       "label": "levelFromEnv()",
@@ -833,7 +833,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 334
+      "community": 335
     },
     {
       "label": "consoleSink()",
@@ -841,7 +841,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 334
+      "community": 335
     },
     {
       "label": "logger.spec.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "retry-queue.ts",
@@ -873,7 +873,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_ts",
-      "community": 218
+      "community": 219
     },
     {
       "label": "RetryQueue",
@@ -881,7 +881,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L13",
       "id": "retry_queue_retryqueue",
-      "community": 218
+      "community": 219
     },
     {
       "label": ".constructor()",
@@ -889,7 +889,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L16",
       "id": "retry_queue_retryqueue_constructor",
-      "community": 218
+      "community": 219
     },
     {
       "label": ".enqueue()",
@@ -897,7 +897,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L18",
       "id": "retry_queue_retryqueue_enqueue",
-      "community": 218
+      "community": 219
     },
     {
       "label": ".size()",
@@ -905,7 +905,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L30",
       "id": "retry_queue_retryqueue_size",
-      "community": 218
+      "community": 219
     },
     {
       "label": ".run()",
@@ -913,7 +913,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L34",
       "id": "retry_queue_retryqueue_run",
-      "community": 218
+      "community": 219
     },
     {
       "label": ".remove()",
@@ -921,7 +921,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L53",
       "id": "retry_queue_retryqueue_remove",
-      "community": 218
+      "community": 219
     },
     {
       "label": "degraded-fallback.e2e.spec.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "start-http-server.ts",
@@ -985,7 +985,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "startTestHttpServer()",
@@ -993,7 +993,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 335
+      "community": 336
     },
     {
       "label": "findFreePort()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 335
+      "community": 336
     },
     {
       "label": "waitForHealth()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 335
+      "community": 336
     },
     {
       "label": "http-server-runner.js",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 696
+      "community": 698
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 482
+      "community": 483
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 482
+      "community": 483
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 483
+      "community": 484
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 484
+      "community": 485
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 485
+      "community": 486
     },
     {
       "label": "telemetry-cli.ts",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_ts",
-      "community": 183
+      "community": 146
     },
     {
       "label": "writeStdout()",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L7",
       "id": "cli_writestdout",
-      "community": 183
+      "community": 146
     },
     {
       "label": "writeStderr()",
@@ -1865,47 +1865,55 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L19",
       "id": "cli_writestderr",
-      "community": 183
+      "community": 146
+    },
+    {
+      "label": "stripGlobalArgvForAgentDetection()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli.ts",
+      "source_location": "L45",
+      "id": "cli_stripglobalargvforagentdetection",
+      "community": 146
     },
     {
       "label": "parseGlobalFlags()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L45",
+      "source_location": "L59",
       "id": "cli_parseglobalflags",
-      "community": 183
+      "community": 146
     },
     {
       "label": "findSubcommandWithIndex()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L61",
+      "source_location": "L75",
       "id": "cli_findsubcommandwithindex",
-      "community": 183
+      "community": 146
     },
     {
       "label": "subcommandArgvFrom()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L77",
+      "source_location": "L91",
       "id": "cli_subcommandargvfrom",
-      "community": 183
+      "community": 146
     },
     {
       "label": "parseCli()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L92",
+      "source_location": "L106",
       "id": "cli_parsecli",
-      "community": 183
+      "community": 146
     },
     {
       "label": "main()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L136",
+      "source_location": "L150",
       "id": "cli_main",
-      "community": 183
+      "community": 146
     },
     {
       "label": "check-migration-status.ts",
@@ -1913,7 +1921,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_scripts_check_migration_status_ts",
-      "community": 129
+      "community": 130
     },
     {
       "label": "log()",
@@ -1921,7 +1929,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L42",
       "id": "check_migration_status_log",
-      "community": 129
+      "community": 130
     },
     {
       "label": "logSection()",
@@ -1929,7 +1937,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L46",
       "id": "check_migration_status_logsection",
-      "community": 129
+      "community": 130
     },
     {
       "label": "logInfo()",
@@ -1937,7 +1945,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L52",
       "id": "check_migration_status_loginfo",
-      "community": 129
+      "community": 130
     },
     {
       "label": "logSuccess()",
@@ -1945,7 +1953,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L57",
       "id": "check_migration_status_logsuccess",
-      "community": 129
+      "community": 130
     },
     {
       "label": "logWarning()",
@@ -1953,7 +1961,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L61",
       "id": "check_migration_status_logwarning",
-      "community": 129
+      "community": 130
     },
     {
       "label": "logError()",
@@ -1961,7 +1969,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L65",
       "id": "check_migration_status_logerror",
-      "community": 129
+      "community": 130
     },
     {
       "label": "checkDatabaseExists()",
@@ -1969,7 +1977,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L72",
       "id": "check_migration_status_checkdatabaseexists",
-      "community": 129
+      "community": 130
     },
     {
       "label": "tableExists()",
@@ -1977,7 +1985,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L83",
       "id": "check_migration_status_tableexists",
-      "community": 129
+      "community": 130
     },
     {
       "label": "checkMigrationStatus()",
@@ -1985,7 +1993,7 @@
       "source_file": "packages/memento-server/src/scripts/check-migration-status.ts",
       "source_location": "L98",
       "id": "check_migration_status_checkmigrationstatus",
-      "community": 129
+      "community": 130
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1993,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2001,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2137,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_programmatic_auth_integration_spec_ts",
-      "community": 219
+      "community": 220
     },
     {
       "label": "postJson()",
@@ -2145,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L21",
       "id": "programmatic_auth_integration_spec_postjson",
-      "community": 219
+      "community": 220
     },
     {
       "label": "getRequest()",
@@ -2153,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L62",
       "id": "programmatic_auth_integration_spec_getrequest",
-      "community": 219
+      "community": 220
     },
     {
       "label": "optionsRequest()",
@@ -2161,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L97",
       "id": "programmatic_auth_integration_spec_optionsrequest",
-      "community": 219
+      "community": 220
     },
     {
       "label": "openMcpStream()",
@@ -2169,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L132",
       "id": "programmatic_auth_integration_spec_openmcpstream",
-      "community": 219
+      "community": 220
     },
     {
       "label": "extractSessionPath()",
@@ -2177,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L192",
       "id": "programmatic_auth_integration_spec_extractsessionpath",
-      "community": 219
+      "community": 220
     },
     {
       "label": "startRealHttpServer()",
@@ -2185,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L202",
       "id": "programmatic_auth_integration_spec_startrealhttpserver",
-      "community": 219
+      "community": 220
     },
     {
       "label": "env-config.spec.ts",
@@ -2193,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "getRepoRoot()",
@@ -2201,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 336
+      "community": 337
     },
     {
       "label": "collectEnvKeys()",
@@ -2209,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 336
+      "community": 337
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2217,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 336
+      "community": 337
     },
     {
       "label": "server-info.ts",
@@ -2225,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_ts",
-      "community": 184
+      "community": 185
     },
     {
       "label": "serverInfoPath()",
@@ -2233,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L16",
       "id": "server_info_serverinfopath",
-      "community": 184
+      "community": 185
     },
     {
       "label": "resolveServerInfoConfigDir()",
@@ -2241,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L20",
       "id": "server_info_resolveserverinfoconfigdir",
-      "community": 184
+      "community": 185
     },
     {
       "label": "writeServerInfo()",
@@ -2249,7 +2257,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L38",
       "id": "server_info_writeserverinfo",
-      "community": 184
+      "community": 185
     },
     {
       "label": "readServerInfo()",
@@ -2257,7 +2265,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L46",
       "id": "server_info_readserverinfo",
-      "community": 184
+      "community": 185
     },
     {
       "label": "deleteServerInfo()",
@@ -2265,7 +2273,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L64",
       "id": "server_info_deleteserverinfo",
-      "community": 184
+      "community": 185
     },
     {
       "label": "isServerAlive()",
@@ -2273,7 +2281,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L73",
       "id": "server_info_isserveralive",
-      "community": 184
+      "community": 185
     },
     {
       "label": "callToolViaHttp()",
@@ -2281,7 +2289,7 @@
       "source_file": "packages/memento-server/src/server/server-info.ts",
       "source_location": "L91",
       "id": "server_info_calltoolviahttp",
-      "community": 184
+      "community": 185
     },
     {
       "label": "mcp-logger.spec.ts",
@@ -2289,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2297,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "createMockResponse()",
@@ -2305,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 415
+      "community": 416
     },
     {
       "label": "sendOptions()",
@@ -2313,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 415
+      "community": 416
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2321,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "index-factory.spec.ts",
@@ -2329,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "context.spec.ts",
@@ -2337,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2345,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "server-factory.ts",
@@ -2353,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "createServerFactory()",
@@ -2361,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 486
+      "community": 487
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2369,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "readRepoFile()",
@@ -2377,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 416
+      "community": 417
     },
     {
       "label": "sectionBetween()",
@@ -2385,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 416
+      "community": 417
     },
     {
       "label": "http-server.spec.ts",
@@ -2393,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2401,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2409,7 +2417,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_ts",
-      "community": 287
+      "community": 288
     },
     {
       "label": "parseReviewCandidatesChangedRelayUrls()",
@@ -2417,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L36",
       "id": "review_candidates_changed_fanout_parsereviewcandidateschangedrelayurls",
-      "community": 287
+      "community": 288
     },
     {
       "label": "buildReviewCandidatesChangedEnvelope()",
@@ -2425,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L47",
       "id": "review_candidates_changed_fanout_buildreviewcandidateschangedenvelope",
-      "community": 287
+      "community": 288
     },
     {
       "label": "relayPost()",
@@ -2433,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L70",
       "id": "review_candidates_changed_fanout_relaypost",
-      "community": 287
+      "community": 288
     },
     {
       "label": "broadcastReviewCandidatesChanged()",
@@ -2441,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L108",
       "id": "review_candidates_changed_fanout_broadcastreviewcandidateschanged",
-      "community": 287
+      "community": 288
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2449,7 +2457,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
-      "community": 220
+      "community": 221
     },
     {
       "label": "parsePositiveIntMs()",
@@ -2457,7 +2465,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L22",
       "id": "review_queue_dashboard_boot_parsepositiveintms",
-      "community": 220
+      "community": 221
     },
     {
       "label": "clampIntervalMs()",
@@ -2465,7 +2473,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L33",
       "id": "review_queue_dashboard_boot_clampintervalms",
-      "community": 220
+      "community": 221
     },
     {
       "label": "parseBackoffCsv()",
@@ -2473,7 +2481,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L37",
       "id": "review_queue_dashboard_boot_parsebackoffcsv",
-      "community": 220
+      "community": 221
     },
     {
       "label": "resolveReviewQueueDashboardBootFromEnv()",
@@ -2481,7 +2489,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L52",
       "id": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
-      "community": 220
+      "community": 221
     },
     {
       "label": "buildReviewQueueBootInjectionHtml()",
@@ -2489,7 +2497,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L66",
       "id": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
-      "community": 220
+      "community": 221
     },
     {
       "label": "injectReviewQueueBootIntoDashboardHtml()",
@@ -2497,7 +2505,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L71",
       "id": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
-      "community": 220
+      "community": 221
     },
     {
       "label": "stdio-server-impl.ts",
@@ -2505,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "startStdioServer()",
@@ -2513,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 487
+      "community": 488
     },
     {
       "label": "server-factory.spec.ts",
@@ -2521,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "server-state.spec.ts",
@@ -2529,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2537,7 +2545,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_integration_spec_ts",
-      "community": 288
+      "community": 289
     },
     {
       "label": "postJson()",
@@ -2545,7 +2553,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L11",
       "id": "auth_session_integration_spec_postjson",
-      "community": 288
+      "community": 289
     },
     {
       "label": "getJson()",
@@ -2553,7 +2561,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L52",
       "id": "auth_session_integration_spec_getjson",
-      "community": 288
+      "community": 289
     },
     {
       "label": "deleteRequest()",
@@ -2561,7 +2569,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L87",
       "id": "auth_session_integration_spec_deleterequest",
-      "community": 288
+      "community": 289
     },
     {
       "label": "startRealHttpServer()",
@@ -2569,7 +2577,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L126",
       "id": "auth_session_integration_spec_startrealhttpserver",
-      "community": 288
+      "community": 289
     },
     {
       "label": "mcp.routes.streamable-http.spec.ts",
@@ -2577,7 +2585,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2585,7 +2593,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 337
+      "community": 338
     },
     {
       "label": "postJsonRpc()",
@@ -2593,7 +2601,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 337
+      "community": 338
     },
     {
       "label": "openSse()",
@@ -2601,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 337
+      "community": 338
     },
     {
       "label": "index.ts",
@@ -2609,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_ts",
-      "community": 145
+      "community": 147
     },
     {
       "label": "Semaphore",
@@ -2617,7 +2625,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L52",
       "id": "index_semaphore",
-      "community": 145
+      "community": 147
     },
     {
       "label": ".constructor()",
@@ -2625,7 +2633,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L55",
       "id": "index_semaphore_constructor",
-      "community": 145
+      "community": 147
     },
     {
       "label": ".acquire()",
@@ -2633,7 +2641,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L56",
       "id": "index_semaphore_acquire",
-      "community": 145
+      "community": 147
     },
     {
       "label": ".release()",
@@ -2641,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L60",
       "id": "index_semaphore_release",
-      "community": 145
+      "community": 147
     },
     {
       "label": "runHeavyInit()",
@@ -2649,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L87",
       "id": "index_runheavyinit",
-      "community": 145
+      "community": 147
     },
     {
       "label": "registerHandlers()",
@@ -2657,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L106",
       "id": "index_registerhandlers",
-      "community": 145
+      "community": 147
     },
     {
       "label": "startServer()",
@@ -2665,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L135",
       "id": "index_startserver",
-      "community": 145
+      "community": 147
     },
     {
       "label": "cleanup()",
@@ -2673,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L173",
       "id": "index_cleanup",
-      "community": 145
+      "community": 147
     },
     {
       "label": "server-info.spec.ts",
@@ -2681,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2689,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2697,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 488
+      "community": 489
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2705,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "createMockResponse()",
@@ -2713,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 417
+      "community": 418
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2721,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 417
+      "community": 418
     },
     {
       "label": "server-state.ts",
@@ -2857,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "bootstrap.ts",
@@ -2865,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2873,7 +2881,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_sse_hub_ts",
-      "community": 289
+      "community": 290
     },
     {
       "label": "resetReviewCandidatesSseHubForTests()",
@@ -2881,7 +2889,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L12",
       "id": "review_candidates_sse_hub_resetreviewcandidatesssehubfortests",
-      "community": 289
+      "community": 290
     },
     {
       "label": "writeSafe()",
@@ -2889,7 +2897,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L23",
       "id": "review_candidates_sse_hub_writesafe",
-      "community": 289
+      "community": 290
     },
     {
       "label": "attachReviewCandidatesSse()",
@@ -2897,7 +2905,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L39",
       "id": "review_candidates_sse_hub_attachreviewcandidatessse",
-      "community": 289
+      "community": 290
     },
     {
       "label": "notifyReviewCandidatesChanged()",
@@ -2905,7 +2913,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L69",
       "id": "review_candidates_sse_hub_notifyreviewcandidateschanged",
-      "community": 289
+      "community": 290
     },
     {
       "label": "index.spec.ts",
@@ -2913,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "sse-server-impl.ts",
@@ -2921,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "startSseServer()",
@@ -2929,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 338
+      "community": 339
     },
     {
       "label": "stopSseServer()",
@@ -2937,7 +2945,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 338
+      "community": 339
     },
     {
       "label": "cleanupSseServer()",
@@ -2945,7 +2953,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 338
+      "community": 339
     },
     {
       "label": "http-server.ts",
@@ -3041,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "batch-run-history.ts",
@@ -3049,7 +3057,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_batch_run_history_ts",
-      "community": 221
+      "community": 222
     },
     {
       "label": "trimEntries()",
@@ -3057,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L26",
       "id": "batch_run_history_trimentries",
-      "community": 221
+      "community": 222
     },
     {
       "label": "jsonSafeDetails()",
@@ -3065,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L32",
       "id": "batch_run_history_jsonsafedetails",
-      "community": 221
+      "community": 222
     },
     {
       "label": "recordManualBatchRunSuccess()",
@@ -3073,7 +3081,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L44",
       "id": "batch_run_history_recordmanualbatchrunsuccess",
-      "community": 221
+      "community": 222
     },
     {
       "label": "recordManualBatchRunFailure()",
@@ -3081,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L99",
       "id": "batch_run_history_recordmanualbatchrunfailure",
-      "community": 221
+      "community": 222
     },
     {
       "label": "getManualBatchRunHistory()",
@@ -3089,7 +3097,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L121",
       "id": "batch_run_history_getmanualbatchrunhistory",
-      "community": 221
+      "community": 222
     },
     {
       "label": "resetBatchRunHistoryForTests()",
@@ -3097,7 +3105,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L126",
       "id": "batch_run_history_resetbatchrunhistoryfortests",
-      "community": 221
+      "community": 222
     },
     {
       "label": "mcp-logger.ts",
@@ -3185,7 +3193,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_instance_lock_ts",
-      "community": 290
+      "community": 291
     },
     {
       "label": "isProcessAlive()",
@@ -3193,7 +3201,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L21",
       "id": "instance_lock_isprocessalive",
-      "community": 290
+      "community": 291
     },
     {
       "label": "getLockFilePath()",
@@ -3201,7 +3209,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L33",
       "id": "instance_lock_getlockfilepath",
-      "community": 290
+      "community": 291
     },
     {
       "label": "tryAcquireLock()",
@@ -3209,7 +3217,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L45",
       "id": "instance_lock_tryacquirelock",
-      "community": 290
+      "community": 291
     },
     {
       "label": "releaseLock()",
@@ -3217,7 +3225,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L70",
       "id": "instance_lock_releaselock",
-      "community": 290
+      "community": 291
     },
     {
       "label": "cors-policy.ts",
@@ -3225,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3233,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 418
+      "community": 419
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3241,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 418
+      "community": 419
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3249,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3257,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "community": 249
+      "community": 250
     },
     {
       "label": "buildAnchorMapData()",
@@ -3265,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L57",
       "id": "anchor_map_handler_buildanchormapdata",
-      "community": 249
+      "community": 250
     },
     {
       "label": "buildNetworkNodesAndLinks()",
@@ -3273,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L101",
       "id": "anchor_map_handler_buildnetworknodesandlinks",
-      "community": 249
+      "community": 250
     },
     {
       "label": "buildNetworkLinks()",
@@ -3281,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L201",
       "id": "anchor_map_handler_buildnetworklinks",
-      "community": 249
+      "community": 250
     },
     {
       "label": "broadcastToSubscribers()",
@@ -3289,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L249",
       "id": "anchor_map_handler_broadcasttosubscribers",
-      "community": 249
+      "community": 250
     },
     {
       "label": "broadcastAnchorMapUpdate()",
@@ -3297,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L272",
       "id": "anchor_map_handler_broadcastanchormapupdate",
-      "community": 249
+      "community": 250
     },
     {
       "label": "tool-context-meta-memory-injection.spec.ts",
@@ -3305,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3313,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3321,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3329,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "makeMocks()",
@@ -3337,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 489
+      "community": 490
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3345,7 +3353,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
-      "community": 250
+      "community": 251
     },
     {
       "label": "writeDisabledResponse()",
@@ -3353,7 +3361,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L7",
       "id": "programmatic_auth_middleware_writedisabledresponse",
-      "community": 250
+      "community": 251
     },
     {
       "label": "writeUnauthorized()",
@@ -3361,7 +3369,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L15",
       "id": "programmatic_auth_middleware_writeunauthorized",
-      "community": 250
+      "community": 251
     },
     {
       "label": "readBearerToken()",
@@ -3369,7 +3377,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L23",
       "id": "programmatic_auth_middleware_readbearertoken",
-      "community": 250
+      "community": 251
     },
     {
       "label": "readApiKeyHeader()",
@@ -3377,7 +3385,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L33",
       "id": "programmatic_auth_middleware_readapikeyheader",
-      "community": 250
+      "community": 251
     },
     {
       "label": "createProgrammaticAuthMiddleware()",
@@ -3385,7 +3393,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L43",
       "id": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
-      "community": 250
+      "community": 251
     },
     {
       "label": "error-handler.middleware.ts",
@@ -3393,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_error_handler_middleware_ts",
-      "community": 251
+      "community": 252
     },
     {
       "label": "isAppErrorContract()",
@@ -3401,7 +3409,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L21",
       "id": "error_handler_middleware_isapperrorcontract",
-      "community": 251
+      "community": 252
     },
     {
       "label": "resolveSeverityAndCategory()",
@@ -3409,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L26",
       "id": "error_handler_middleware_resolveseverityandcategory",
-      "community": 251
+      "community": 252
     },
     {
       "label": "resolveStatusCode()",
@@ -3417,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L64",
       "id": "error_handler_middleware_resolvestatuscode",
-      "community": 251
+      "community": 252
     },
     {
       "label": "errorHandler()",
@@ -3425,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L84",
       "id": "error_handler_middleware_errorhandler",
-      "community": 251
+      "community": 252
     },
     {
       "label": "asyncHandler()",
@@ -3433,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L135",
       "id": "error_handler_middleware_asynchandler",
-      "community": 251
+      "community": 252
     },
     {
       "label": "tool-context.middleware.ts",
@@ -3441,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3449,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 490
+      "community": 491
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3457,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createMockResponse()",
@@ -3465,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 491
+      "community": 492
     },
     {
       "label": "index.ts",
@@ -3473,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3481,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "readCookie()",
@@ -3489,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 339
+      "community": 340
     },
     {
       "label": "writeUnauthorized()",
@@ -3497,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3505,7 +3513,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 339
+      "community": 340
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3513,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createServiceInjector()",
@@ -3521,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 492
+      "community": 493
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3529,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3537,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 493
+      "community": 494
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3545,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "createMockResponse()",
@@ -3553,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 494
+      "community": 495
     },
     {
       "label": "session-store.spec.ts",
@@ -3561,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "session-store.ts",
@@ -3569,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createSessionStore()",
@@ -3577,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 495
+      "community": 496
     },
     {
       "label": "stdio-server.ts",
@@ -3585,7 +3593,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 291
+      "community": 292
     },
     {
       "label": "StdioServer",
@@ -3593,7 +3601,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".start()",
@@ -3601,7 +3609,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".stop()",
@@ -3609,7 +3617,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".cleanup()",
@@ -3617,7 +3625,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 291
+      "community": 292
     },
     {
       "label": "sse-server.ts",
@@ -3625,7 +3633,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 292
+      "community": 293
     },
     {
       "label": "SseServer",
@@ -3633,7 +3641,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".start()",
@@ -3641,7 +3649,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".stop()",
@@ -3649,7 +3657,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".cleanup()",
@@ -3657,7 +3665,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 292
+      "community": 293
     },
     {
       "label": "test-database.ts",
@@ -3665,7 +3673,7 @@
       "source_file": "packages/memento-server/src/server/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_test_helpers_test_database_ts",
-      "community": 252
+      "community": 253
     },
     {
       "label": "setupTestDatabase()",
@@ -3673,7 +3681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L14",
       "id": "test_database_setuptestdatabase",
-      "community": 252
+      "community": 253
     },
     {
       "label": "cleanupTestDatabase()",
@@ -3681,7 +3689,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L263",
       "id": "test_database_cleanuptestdatabase",
-      "community": 252
+      "community": 253
     },
     {
       "label": "quality.routes.spec.ts",
@@ -3689,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "admin.routes.ts",
@@ -3697,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createAdminRouter()",
@@ -3705,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 496
+      "community": 497
     },
     {
       "label": "auth.routes.ts",
@@ -3713,7 +3721,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 293
+      "community": 294
     },
     {
       "label": "readBearerToken()",
@@ -3721,7 +3729,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 293
+      "community": 294
     },
     {
       "label": "readApiKeyHeader()",
@@ -3729,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 293
+      "community": 294
     },
     {
       "label": "readCookie()",
@@ -3737,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 293
+      "community": 294
     },
     {
       "label": "createAuthRouter()",
@@ -3745,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 293
+      "community": 294
     },
     {
       "label": "mcp.routes.ts",
@@ -3753,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_routes_ts",
-      "community": 253
+      "community": 254
     },
     {
       "label": "isJsonRpcNotification()",
@@ -3761,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L49",
       "id": "mcp_routes_isjsonrpcnotification",
-      "community": 253
+      "community": 254
     },
     {
       "label": "isInitializeRequest()",
@@ -3769,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L53",
       "id": "mcp_routes_isinitializerequest",
-      "community": 253
+      "community": 254
     },
     {
       "label": "createJsonRpcError()",
@@ -3777,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L57",
       "id": "mcp_routes_createjsonrpcerror",
-      "community": 253
+      "community": 254
     },
     {
       "label": "processMcpMessage()",
@@ -3785,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L74",
       "id": "mcp_routes_processmcpmessage",
-      "community": 253
+      "community": 254
     },
     {
       "label": "createMcpRouter()",
@@ -3793,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L413",
       "id": "mcp_routes_createmcprouter",
-      "community": 253
+      "community": 254
     },
     {
       "label": "admin.routes.spec.ts",
@@ -3801,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_spec_ts",
-      "community": 185
+      "community": 186
     },
     {
       "label": "listen()",
@@ -3809,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L28",
       "id": "admin_routes_spec_listen",
-      "community": 185
+      "community": 186
     },
     {
       "label": "postAdminJson()",
@@ -3817,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L43",
       "id": "admin_routes_spec_postadminjson",
-      "community": 185
+      "community": 186
     },
     {
       "label": "getAdmin()",
@@ -3825,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L79",
       "id": "admin_routes_spec_getadmin",
-      "community": 185
+      "community": 186
     },
     {
       "label": "deleteAdmin()",
@@ -3833,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L105",
       "id": "admin_routes_spec_deleteadmin",
-      "community": 185
+      "community": 186
     },
     {
       "label": "makeApp()",
@@ -3841,7 +3849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L597",
       "id": "admin_routes_spec_makeapp",
-      "community": 185
+      "community": 186
     },
     {
       "label": "createBaseSchema()",
@@ -3849,7 +3857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L949",
       "id": "admin_routes_spec_createbaseschema",
-      "community": 185
+      "community": 186
     },
     {
       "label": "readStreamUntil()",
@@ -3857,7 +3865,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1050",
       "id": "admin_routes_spec_readstreamuntil",
-      "community": 185
+      "community": 186
     },
     {
       "label": "tools.routes.ts",
@@ -3865,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createToolsRouter()",
@@ -3873,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 497
+      "community": 498
     },
     {
       "label": "api.routes.ts",
@@ -3881,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createApiRouter()",
@@ -3889,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 498
+      "community": 499
     },
     {
       "label": "quality.routes.ts",
@@ -3897,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createQualityRouter()",
@@ -3905,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 499
+      "community": 500
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3913,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3921,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 419
+      "community": 420
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3929,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 419
+      "community": 420
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3937,7 +3945,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_response_spec_ts",
-      "community": 254
+      "community": 255
     },
     {
       "label": "getEmbeddingMapHandler()",
@@ -3945,7 +3953,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L33",
       "id": "admin_embedding_map_response_spec_getembeddingmaphandler",
-      "community": 254
+      "community": 255
     },
     {
       "label": "getAdmin()",
@@ -3953,7 +3961,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L43",
       "id": "admin_embedding_map_response_spec_getadmin",
-      "community": 254
+      "community": 255
     },
     {
       "label": "createMinimalSchema()",
@@ -3961,7 +3969,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L82",
       "id": "admin_embedding_map_response_spec_createminimalschema",
-      "community": 254
+      "community": 255
     },
     {
       "label": "vecJson()",
@@ -3969,7 +3977,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L107",
       "id": "admin_embedding_map_response_spec_vecjson",
-      "community": 254
+      "community": 255
     },
     {
       "label": "seedEmbeddings()",
@@ -3977,7 +3985,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L115",
       "id": "admin_embedding_map_response_spec_seedembeddings",
-      "community": 254
+      "community": 255
     },
     {
       "label": "admin-embedding-map.routes.ts",
@@ -3985,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "parseParams()",
@@ -3993,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 420
+      "community": 421
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4001,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 420
+      "community": 421
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4009,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4017,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 500
+      "community": 501
     },
     {
       "label": "admin-graph-response.ts",
@@ -4025,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "buildGraphResponse()",
@@ -4033,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 501
+      "community": 502
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4041,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4049,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 502
+      "community": 503
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4057,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4065,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 503
+      "community": 504
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4073,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4081,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4089,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "parseCleanupParams()",
@@ -4097,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 421
+      "community": 422
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4105,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 421
+      "community": 422
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4113,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4121,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4129,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4137,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4145,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4153,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4161,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4169,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4260,12 +4268,28 @@
       "community": 108
     },
     {
+      "label": "agent-ask.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
+      "community": 510
+    },
+    {
+      "label": "argv()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
+      "source_location": "L4",
+      "id": "agent_ask_spec_argv",
+      "community": 510
+    },
+    {
       "label": "env-loader.ts",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "resolveEnvPath()",
@@ -4273,7 +4297,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 422
+      "community": 423
     },
     {
       "label": "loadEnv()",
@@ -4281,7 +4305,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 422
+      "community": 423
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4289,7 +4313,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 509
+      "community": 511
     },
     {
       "label": "runCli()",
@@ -4297,7 +4321,95 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 509
+      "community": 511
+    },
+    {
+      "label": "agent-ask.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_cli_agent_ask_ts",
+      "community": 109
+    },
+    {
+      "label": "stripGlobalCliArgs()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L35",
+      "id": "agent_ask_stripglobalcliargs",
+      "community": 109
+    },
+    {
+      "label": "parseAgentAskInvocation()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L65",
+      "id": "agent_ask_parseagentaskinvocation",
+      "community": 109
+    },
+    {
+      "label": "resolveDbPath()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L136",
+      "id": "agent_ask_resolvedbpath",
+      "community": 109
+    },
+    {
+      "label": "jsonFailure()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L153",
+      "id": "agent_ask_jsonfailure",
+      "community": 109
+    },
+    {
+      "label": "writeOut()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L165",
+      "id": "agent_ask_writeout",
+      "community": 109
+    },
+    {
+      "label": "writeErr()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L171",
+      "id": "agent_ask_writeerr",
+      "community": 109
+    },
+    {
+      "label": "debugErr()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L177",
+      "id": "agent_ask_debugerr",
+      "community": 109
+    },
+    {
+      "label": "promptApprove()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L183",
+      "id": "agent_ask_promptapprove",
+      "community": 109
+    },
+    {
+      "label": "runAgentAskMain()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L208",
+      "id": "agent_ask_runagentaskmain",
+      "community": 109
+    },
+    {
+      "label": "agentAskHelpText()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L456",
+      "id": "agent_ask_agentaskhelptext",
+      "community": 109
     },
     {
       "label": "option-map.ts",
@@ -4305,7 +4417,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_option_map_ts",
-      "community": 255
+      "community": 256
     },
     {
       "label": "parseArgvToParams()",
@@ -4313,7 +4425,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L9",
       "id": "option_map_parseargvtoparams",
-      "community": 255
+      "community": 256
     },
     {
       "label": "recallParams()",
@@ -4321,7 +4433,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L41",
       "id": "option_map_recallparams",
-      "community": 255
+      "community": 256
     },
     {
       "label": "rememberParams()",
@@ -4329,7 +4441,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L67",
       "id": "option_map_rememberparams",
-      "community": 255
+      "community": 256
     },
     {
       "label": "forgetParams()",
@@ -4337,7 +4449,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L83",
       "id": "option_map_forgetparams",
-      "community": 255
+      "community": 256
     },
     {
       "label": "memoryInjectionParams()",
@@ -4345,7 +4457,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L96",
       "id": "option_map_memoryinjectionparams",
-      "community": 255
+      "community": 256
     },
     {
       "label": "types.ts",
@@ -4353,7 +4465,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4361,7 +4473,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4369,7 +4481,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 423
+      "community": 424
     },
     {
       "label": "runQualityMeasurement()",
@@ -4377,7 +4489,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 423
+      "community": 424
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4385,7 +4497,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 510
+      "community": 512
     },
     {
       "label": "testSimpleAlerts()",
@@ -4393,7 +4505,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 510
+      "community": 512
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4401,7 +4513,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 511
+      "community": 513
     },
     {
       "label": "testBasicFunctionality()",
@@ -4409,7 +4521,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 511
+      "community": 513
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4417,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 512
+      "community": 514
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4425,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 512
+      "community": 514
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4433,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "compareServices()",
@@ -4441,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 424
+      "community": 425
     },
     {
       "label": "testServerSynchronization()",
@@ -4449,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 424
+      "community": 425
     },
     {
       "label": "test-error-logging.ts",
@@ -4457,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 513
+      "community": 515
     },
     {
       "label": "testErrorLogging()",
@@ -4465,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 513
+      "community": 515
     },
     {
       "label": "debug-http-v2.ts",
@@ -4473,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 514
+      "community": 516
     },
     {
       "label": "testFetch()",
@@ -4481,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 514
+      "community": 516
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4489,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 515
+      "community": 517
     },
     {
       "label": "initializeTestDatabase()",
@@ -4497,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 515
+      "community": 517
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4505,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4513,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4521,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 516
+      "community": 518
     },
     {
       "label": "testReflexionE2E()",
@@ -4529,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 516
+      "community": 518
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4537,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 517
+      "community": 519
     },
     {
       "label": "testAlertsDirect()",
@@ -4545,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 517
+      "community": 519
     },
     {
       "label": "test-client.ts",
@@ -4553,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "assert()",
@@ -4561,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 425
+      "community": 426
     },
     {
       "label": "testMementoClient()",
@@ -4569,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 425
+      "community": 426
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4577,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 723
+      "community": 725
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4585,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_ts",
-      "community": 186
+      "community": 187
     },
     {
       "label": "setupTestDatabase()",
@@ -4593,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L24",
       "id": "test_http_server_v2_setuptestdatabase",
-      "community": 186
+      "community": 187
     },
     {
       "label": "testBasicEndpoints()",
@@ -4601,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L169",
       "id": "test_http_server_v2_testbasicendpoints",
-      "community": 186
+      "community": 187
     },
     {
       "label": "testMCPTools()",
@@ -4609,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L205",
       "id": "test_http_server_v2_testmcptools",
-      "community": 186
+      "community": 187
     },
     {
       "label": "testAdminAPIs()",
@@ -4617,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L317",
       "id": "test_http_server_v2_testadminapis",
-      "community": 186
+      "community": 187
     },
     {
       "label": "testWebSocket()",
@@ -4625,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L376",
       "id": "test_http_server_v2_testwebsocket",
-      "community": 186
+      "community": 187
     },
     {
       "label": "testSSE()",
@@ -4633,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L458",
       "id": "test_http_server_v2_testsse",
-      "community": 186
+      "community": 187
     },
     {
       "label": "runTests()",
@@ -4641,7 +4753,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L560",
       "id": "test_http_server_v2_runtests",
-      "community": 186
+      "community": 187
     },
     {
       "label": "test-performance-alerts.ts",
@@ -4649,7 +4761,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 518
+      "community": 520
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4657,7 +4769,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 518
+      "community": 520
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4665,7 +4777,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 519
+      "community": 521
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4673,7 +4785,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 519
+      "community": 521
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4681,7 +4793,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 520
+      "community": 522
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4689,7 +4801,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 520
+      "community": 522
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4697,7 +4809,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4705,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createBaseSchema()",
@@ -4713,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createTestMemory()",
@@ -4721,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 426
+      "community": 427
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4729,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4737,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 427
+      "community": 428
     },
     {
       "label": "findNodeForAnchor()",
@@ -4745,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 427
+      "community": 428
     },
     {
       "label": "vitest.config.ts",
@@ -4753,7 +4865,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4761,7 +4873,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "brave-search-provider.ts",
@@ -4769,7 +4881,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "BraveSearchProvider",
@@ -4777,7 +4889,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 340
+      "community": 341
     },
     {
       "label": ".constructor()",
@@ -4785,7 +4897,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 340
+      "community": 341
     },
     {
       "label": ".search()",
@@ -4793,7 +4905,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 340
+      "community": 341
     },
     {
       "label": "noop-search-provider.ts",
@@ -4801,7 +4913,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "NoopSearchProvider",
@@ -4809,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 428
+      "community": 429
     },
     {
       "label": ".search()",
@@ -4817,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 428
+      "community": 429
     },
     {
       "label": "search-factory.ts",
@@ -4825,7 +4937,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 521
+      "community": 523
     },
     {
       "label": "createSearchProvider()",
@@ -4833,7 +4945,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 521
+      "community": 523
     },
     {
       "label": "search-provider.ts",
@@ -4841,7 +4953,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "llm-provider.ts",
@@ -4849,7 +4961,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "claude-provider.spec.ts",
@@ -4857,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "types.ts",
@@ -4865,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 522
+      "community": 524
     },
     {
       "label": "loadAgentConfig()",
@@ -4873,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 522
+      "community": 524
     },
     {
       "label": "system-prompt.ts",
@@ -4881,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "vitest.config.ts",
@@ -4889,7 +5001,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "utils.spec.ts",
@@ -4897,7 +5009,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 523
+      "community": 525
     },
     {
       "label": "buildMemory()",
@@ -4905,7 +5017,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 523
+      "community": 525
     },
     {
       "label": "context-injector.ts",
@@ -5065,7 +5177,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_types_ts",
-      "community": 109
+      "community": 110
     },
     {
       "label": "MementoError",
@@ -5073,7 +5185,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L265",
       "id": "types_mementoerror",
-      "community": 109
+      "community": 110
     },
     {
       "label": ".constructor()",
@@ -5081,7 +5193,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L266",
       "id": "types_mementoerror_constructor",
-      "community": 109
+      "community": 110
     },
     {
       "label": "ConnectionError",
@@ -5089,7 +5201,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L277",
       "id": "types_connectionerror",
-      "community": 109
+      "community": 110
     },
     {
       "label": ".constructor()",
@@ -5097,7 +5209,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L278",
       "id": "types_connectionerror_constructor",
-      "community": 109
+      "community": 110
     },
     {
       "label": "AuthenticationError",
@@ -5105,7 +5217,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L284",
       "id": "types_authenticationerror",
-      "community": 109
+      "community": 110
     },
     {
       "label": ".constructor()",
@@ -5113,7 +5225,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L285",
       "id": "types_authenticationerror_constructor",
-      "community": 109
+      "community": 110
     },
     {
       "label": "ValidationError",
@@ -5121,7 +5233,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L291",
       "id": "types_validationerror",
-      "community": 109
+      "community": 110
     },
     {
       "label": ".constructor()",
@@ -5129,7 +5241,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L292",
       "id": "types_validationerror_constructor",
-      "community": 109
+      "community": 110
     },
     {
       "label": "NotFoundError",
@@ -5137,7 +5249,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L298",
       "id": "types_notfounderror",
-      "community": 109
+      "community": 110
     },
     {
       "label": ".constructor()",
@@ -5145,7 +5257,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L299",
       "id": "types_notfounderror_constructor",
-      "community": 109
+      "community": 110
     },
     {
       "label": "memory-manager.ts",
@@ -5729,7 +5841,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 732
+      "community": 734
     },
     {
       "label": "logger.ts",
@@ -5737,7 +5849,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "shouldLog()",
@@ -5745,7 +5857,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 429
+      "community": 430
     },
     {
       "label": "log()",
@@ -5753,7 +5865,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 429
+      "community": 430
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5761,7 +5873,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "constructor()",
@@ -5769,7 +5881,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L231",
       "id": "bootstrap_spec_constructor",
-      "community": 341
+      "community": 342
     },
     {
       "label": "loadBootstrap()",
@@ -5777,7 +5889,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L254",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 341
+      "community": 342
     },
     {
       "label": "installTimeoutSpy()",
@@ -5785,7 +5897,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L258",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 341
+      "community": 342
     },
     {
       "label": "index.ts",
@@ -5793,7 +5905,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "createMementoCore()",
@@ -5801,7 +5913,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 430
+      "community": 431
     },
     {
       "label": "closeDatabase()",
@@ -5809,7 +5921,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 430
+      "community": 431
     },
     {
       "label": "bootstrap.ts",
@@ -5817,7 +5929,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 524
+      "community": 526
     },
     {
       "label": "initializeServices()",
@@ -5825,7 +5937,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 524
+      "community": 526
     },
     {
       "label": "context.ts",
@@ -5833,7 +5945,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createServerContext()",
@@ -5841,7 +5953,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L15",
       "id": "context_createservercontext",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createToolContext()",
@@ -5849,7 +5961,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L24",
       "id": "context_createtoolcontext",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -5857,7 +5969,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L37",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 342
+      "community": 343
     },
     {
       "label": "write-and-meta.ts",
@@ -5865,7 +5977,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 525
+      "community": 527
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -5873,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 525
+      "community": 527
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -5881,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 526
+      "community": 528
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -5889,7 +6001,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 526
+      "community": 528
     },
     {
       "label": "anchor-stack.ts",
@@ -5897,7 +6009,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 527
+      "community": 529
     },
     {
       "label": "createAnchorStack()",
@@ -5905,7 +6017,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 527
+      "community": 529
     },
     {
       "label": "failure-reflexion.ts",
@@ -5913,7 +6025,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 528
+      "community": 530
     },
     {
       "label": "startFailureAndReflexion()",
@@ -5921,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 528
+      "community": 530
     },
     {
       "label": "search-and-embedding.ts",
@@ -5929,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 529
+      "community": 531
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -5937,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 529
+      "community": 531
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -5945,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 530
+      "community": 532
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -5953,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 530
+      "community": 532
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -5961,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 531
+      "community": 533
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -5969,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 531
+      "community": 533
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6777,7 +6889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 532
+      "community": 534
     },
     {
       "label": "createInput()",
@@ -6785,7 +6897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 532
+      "community": 534
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -6793,7 +6905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 294
+      "community": 295
     },
     {
       "label": "extract()",
@@ -6801,7 +6913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 294
+      "community": 295
     },
     {
       "label": "waitForEventProcessing()",
@@ -6809,7 +6921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createProceduralMemory()",
@@ -6817,7 +6929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 294
+      "community": 295
     },
     {
       "label": "createFailureEvent()",
@@ -6825,7 +6937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 294
+      "community": 295
     },
     {
       "label": "relation-graph-factory.ts",
@@ -6833,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 533
+      "community": 535
     },
     {
       "label": "createRelationGraph()",
@@ -6841,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 533
+      "community": 535
     },
     {
       "label": "consolidation-score-service.ts",
@@ -6849,7 +6961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_ts",
-      "community": 130
+      "community": 131
     },
     {
       "label": "ConsolidationScoreService",
@@ -6857,7 +6969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L43",
       "id": "consolidation_score_service_consolidationscoreservice",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".calculateS()",
@@ -6865,7 +6977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L50",
       "id": "consolidation_score_service_consolidationscoreservice_calculates",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".updateGValue()",
@@ -6873,7 +6985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L68",
       "id": "consolidation_score_service_consolidationscoreservice_updategvalue",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".getRBaseForType()",
@@ -6881,7 +6993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L87",
       "id": "consolidation_score_service_consolidationscoreservice_getrbasefortype",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".calculateRecallProbability()",
@@ -6889,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L100",
       "id": "consolidation_score_service_consolidationscoreservice_calculaterecallprobability",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".calculateTimeElapsed()",
@@ -6897,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L132",
       "id": "consolidation_score_service_consolidationscoreservice_calculatetimeelapsed",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".recalculateGValue()",
@@ -6905,7 +7017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L151",
       "id": "consolidation_score_service_consolidationscoreservice_recalculategvalue",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".calculateScore()",
@@ -6913,7 +7025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L178",
       "id": "consolidation_score_service_consolidationscoreservice_calculatescore",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".updateGValueForRecall()",
@@ -6921,7 +7033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.ts",
       "source_location": "L227",
       "id": "consolidation_score_service_consolidationscoreservice_updategvalueforrecall",
-      "community": 130
+      "community": 131
     },
     {
       "label": "triple-extraction-logger.spec.ts",
@@ -6929,7 +7041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -6937,7 +7049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_ts",
-      "community": 146
+      "community": 148
     },
     {
       "label": "TripleExtractionLogger",
@@ -6945,7 +7057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L61",
       "id": "triple_extraction_logger_tripleextractionlogger",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".constructor()",
@@ -6953,7 +7065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L65",
       "id": "triple_extraction_logger_tripleextractionlogger_constructor",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".logExtraction()",
@@ -6961,7 +7073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L91",
       "id": "triple_extraction_logger_tripleextractionlogger_logextraction",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".createLogEntry()",
@@ -6969,7 +7081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L128",
       "id": "triple_extraction_logger_tripleextractionlogger_createlogentry",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".ensureLogDirectory()",
@@ -6977,7 +7089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L191",
       "id": "triple_extraction_logger_tripleextractionlogger_ensurelogdirectory",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".getLogFilePath()",
@@ -6985,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L207",
       "id": "triple_extraction_logger_tripleextractionlogger_getlogfilepath",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".listLogFiles()",
@@ -6993,7 +7105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L233",
       "id": "triple_extraction_logger_tripleextractionlogger_listlogfiles",
-      "community": 146
+      "community": 148
     },
     {
       "label": ".deleteOldLogs()",
@@ -7001,7 +7113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L266",
       "id": "triple_extraction_logger_tripleextractionlogger_deleteoldlogs",
-      "community": 146
+      "community": 148
     },
     {
       "label": "database-optimize-tool.ts",
@@ -7009,7 +7121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -7017,7 +7129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".constructor()",
@@ -7025,7 +7137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 343
+      "community": 344
     },
     {
       "label": ".handle()",
@@ -7033,7 +7145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 343
+      "community": 344
     },
     {
       "label": "migration-history-service.ts",
@@ -7041,7 +7153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_migration_history_service_ts",
-      "community": 131
+      "community": 132
     },
     {
       "label": "normalizeDate()",
@@ -7049,7 +7161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L16",
       "id": "migration_history_service_normalizedate",
-      "community": 131
+      "community": 132
     },
     {
       "label": "MigrationHistoryService",
@@ -7057,7 +7169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L26",
       "id": "migration_history_service_migrationhistoryservice",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".recordHistory()",
@@ -7065,7 +7177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L27",
       "id": "migration_history_service_migrationhistoryservice_recordhistory",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".listHistory()",
@@ -7073,7 +7185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L104",
       "id": "migration_history_service_migrationhistoryservice_listhistory",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".getHistoryById()",
@@ -7081,7 +7193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L175",
       "id": "migration_history_service_migrationhistoryservice_gethistorybyid",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".getSummary()",
@@ -7089,7 +7201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L211",
       "id": "migration_history_service_migrationhistoryservice_getsummary",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".pruneHistory()",
@@ -7097,7 +7209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L233",
       "id": "migration_history_service_migrationhistoryservice_prunehistory",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".logHistory()",
@@ -7105,7 +7217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L287",
       "id": "migration_history_service_migrationhistoryservice_loghistory",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".mapRow()",
@@ -7113,7 +7225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-history-service.ts",
       "source_location": "L294",
       "id": "migration_history_service_migrationhistoryservice_maprow",
-      "community": 131
+      "community": 132
     },
     {
       "label": "database-lock-monitor.ts",
@@ -7121,7 +7233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_ts",
-      "community": 132
+      "community": 133
     },
     {
       "label": "DatabaseLockMonitor",
@@ -7129,7 +7241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L75",
       "id": "database_lock_monitor_databaselockmonitor",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".constructor()",
@@ -7137,7 +7249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L83",
       "id": "database_lock_monitor_databaselockmonitor_constructor",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".start()",
@@ -7145,7 +7257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L95",
       "id": "database_lock_monitor_databaselockmonitor_start",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".stop()",
@@ -7153,7 +7265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L116",
       "id": "database_lock_monitor_databaselockmonitor_stop",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".monitor()",
@@ -7161,7 +7273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L141",
       "id": "database_lock_monitor_databaselockmonitor_monitor",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".updateBusyStatistics()",
@@ -7169,7 +7281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L161",
       "id": "database_lock_monitor_databaselockmonitor_updatebusystatistics",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".checkLockStatus()",
@@ -7177,7 +7289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L191",
       "id": "database_lock_monitor_databaselockmonitor_checklockstatus",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".handleLockStatus()",
@@ -7185,7 +7297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L295",
       "id": "database_lock_monitor_databaselockmonitor_handlelockstatus",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".writeDiagnosticsEvent()",
@@ -7193,7 +7305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.ts",
       "source_location": "L379",
       "id": "database_lock_monitor_databaselockmonitor_writediagnosticsevent",
-      "community": 132
+      "community": 133
     },
     {
       "label": "database-optimizer.ts",
@@ -7353,7 +7465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "createBaseSchema()",
@@ -7361,7 +7473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 431
+      "community": 432
     },
     {
       "label": "measureTime()",
@@ -7369,7 +7481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 431
+      "community": 432
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7377,7 +7489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 534
+      "community": 536
     },
     {
       "label": "createBaseSchema()",
@@ -7385,7 +7497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 534
+      "community": 536
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7489,7 +7601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 535
+      "community": 537
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7497,7 +7609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 535
+      "community": 537
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7601,7 +7713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 536
+      "community": 538
     },
     {
       "label": "openLockTestDatabase()",
@@ -7609,7 +7721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 536
+      "community": 538
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7617,7 +7729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -7625,7 +7737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createPlan()",
@@ -7633,7 +7745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createResult()",
@@ -7641,7 +7753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 344
+      "community": 345
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -7649,7 +7761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 537
+      "community": 539
     },
     {
       "label": "createProgress()",
@@ -7657,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 537
+      "community": 539
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7665,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7673,7 +7785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7681,7 +7793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 538
+      "community": 540
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7689,7 +7801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 538
+      "community": 540
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7697,7 +7809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7705,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 539
+      "community": 541
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7713,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 539
+      "community": 541
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7721,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "addMissingColumn()",
@@ -7729,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 432
+      "community": 433
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7737,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 432
+      "community": 433
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7745,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -7753,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
-      "community": 110
+      "community": 111
     },
     {
       "label": "shouldSkipPreflight()",
@@ -7761,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L16",
       "id": "db_integrity_preflight_shouldskippreflight",
-      "community": 110
+      "community": 111
     },
     {
       "label": "extractPragmaMessages()",
@@ -7769,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L20",
       "id": "db_integrity_preflight_extractpragmamessages",
-      "community": 110
+      "community": 111
     },
     {
       "label": "runCheck()",
@@ -7777,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L26",
       "id": "db_integrity_preflight_runcheck",
-      "community": 110
+      "community": 111
     },
     {
       "label": "formatTimestamp()",
@@ -7785,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L31",
       "id": "db_integrity_preflight_formattimestamp",
-      "community": 110
+      "community": 111
     },
     {
       "label": "buildQuarantinePath()",
@@ -7793,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L35",
       "id": "db_integrity_preflight_buildquarantinepath",
-      "community": 110
+      "community": 111
     },
     {
       "label": "quarantineDatabaseFile()",
@@ -7801,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L43",
       "id": "db_integrity_preflight_quarantinedatabasefile",
-      "community": 110
+      "community": 111
     },
     {
       "label": "maskError()",
@@ -7809,7 +7921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L50",
       "id": "db_integrity_preflight_maskerror",
-      "community": 110
+      "community": 111
     },
     {
       "label": "isOkResult()",
@@ -7817,7 +7929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L56",
       "id": "db_integrity_preflight_isokresult",
-      "community": 110
+      "community": 111
     },
     {
       "label": "looksLikeCorruption()",
@@ -7825,7 +7937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L60",
       "id": "db_integrity_preflight_lookslikecorruption",
-      "community": 110
+      "community": 111
     },
     {
       "label": "runDatabaseIntegrityPreflight()",
@@ -7833,7 +7945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L65",
       "id": "db_integrity_preflight_rundatabaseintegritypreflight",
-      "community": 110
+      "community": 111
     },
     {
       "label": "init.spec.ts",
@@ -7841,7 +7953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "init.ts",
@@ -7961,7 +8073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 540
+      "community": 542
     },
     {
       "label": "createDbPath()",
@@ -7969,7 +8081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 540
+      "community": 542
     },
     {
       "label": "migrate.spec.ts",
@@ -7977,7 +8089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 739
+      "community": 741
     },
     {
       "label": "migrate.ts",
@@ -7985,7 +8097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "isDuplicateColumnError()",
@@ -7993,7 +8105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 433
+      "community": 434
     },
     {
       "label": "migrateDatabase()",
@@ -8001,7 +8113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 433
+      "community": 434
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8009,7 +8121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "migration-runner.ts",
@@ -8017,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_ts",
-      "community": 147
+      "community": 149
     },
     {
       "label": "MigrationRunner",
@@ -8025,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L19",
       "id": "migration_runner_migrationrunner",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".constructor()",
@@ -8033,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L24",
       "id": "migration_runner_migrationrunner_constructor",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".runMigration()",
@@ -8041,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L33",
       "id": "migration_runner_migrationrunner_runmigration",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".rollbackMigration()",
@@ -8049,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L174",
       "id": "migration_runner_migrationrunner_rollbackmigration",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".runMigrations()",
@@ -8057,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L199",
       "id": "migration_runner_migrationrunner_runmigrations",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".calculateChecksum()",
@@ -8065,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L222",
       "id": "migration_runner_migrationrunner_calculatechecksum",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".getBackupManager()",
@@ -8073,7 +8185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L231",
       "id": "migration_runner_migrationrunner_getbackupmanager",
-      "community": 147
+      "community": 149
     },
     {
       "label": ".getVersionManager()",
@@ -8081,7 +8193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L238",
       "id": "migration_runner_migrationrunner_getversionmanager",
-      "community": 147
+      "community": 149
     },
     {
       "label": "migration-runner.integration.spec.ts",
@@ -8089,7 +8201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 541
+      "community": 543
     },
     {
       "label": "createBaseSchema()",
@@ -8097,7 +8209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 541
+      "community": 543
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8105,7 +8217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "migration-detector.ts",
@@ -8113,7 +8225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_ts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "MigrationDetector",
@@ -8121,7 +8233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L63",
       "id": "migration_detector_migrationdetector",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".constructor()",
@@ -8129,7 +8241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L66",
       "id": "migration_detector_migrationdetector_constructor",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".detectAllMigrations()",
@@ -8137,7 +8249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L73",
       "id": "migration_detector_migrationdetector_detectallmigrations",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".detectPendingMigrations()",
@@ -8145,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L177",
       "id": "migration_detector_migrationdetector_detectpendingmigrations",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".parseVersionNumber()",
@@ -8153,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L208",
       "id": "migration_detector_migrationdetector_parseversionnumber",
-      "community": 222
+      "community": 223
     },
     {
       "label": ".findMigrationByVersion()",
@@ -8161,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L222",
       "id": "migration_detector_migrationdetector_findmigrationbyversion",
-      "community": 222
+      "community": 223
     },
     {
       "label": "migration-logger.ts",
@@ -8297,7 +8409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8305,7 +8417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "backup-manager.ts",
@@ -8313,7 +8425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_ts",
-      "community": 148
+      "community": 150
     },
     {
       "label": "BackupManager",
@@ -8321,7 +8433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L37",
       "id": "backup_manager_backupmanager",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".constructor()",
@@ -8329,7 +8441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L40",
       "id": "backup_manager_backupmanager_constructor",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".ensureBackupsDirectory()",
@@ -8337,7 +8449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L50",
       "id": "backup_manager_backupmanager_ensurebackupsdirectory",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".createBackup()",
@@ -8345,7 +8457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L68",
       "id": "backup_manager_backupmanager_createbackup",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".restoreBackup()",
@@ -8353,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L132",
       "id": "backup_manager_backupmanager_restorebackup",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".cleanupOldBackups()",
@@ -8361,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L165",
       "id": "backup_manager_backupmanager_cleanupoldbackups",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".findLatestBackup()",
@@ -8369,7 +8481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L210",
       "id": "backup_manager_backupmanager_findlatestbackup",
-      "community": 148
+      "community": 150
     },
     {
       "label": ".getBackupsDirectory()",
@@ -8377,7 +8489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L244",
       "id": "backup_manager_backupmanager_getbackupsdirectory",
-      "community": 148
+      "community": 150
     },
     {
       "label": "backup-manager.spec.ts",
@@ -8385,7 +8497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "dependency-validator.ts",
@@ -8393,7 +8505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_ts",
-      "community": 256
+      "community": 257
     },
     {
       "label": "DependencyValidator",
@@ -8401,7 +8513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L53",
       "id": "dependency_validator_dependencyvalidator",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".validateAll()",
@@ -8409,7 +8521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L57",
       "id": "dependency_validator_dependencyvalidator_validateall",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".validateMemoryEmbeddingForeignKey()",
@@ -8417,7 +8529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L81",
       "id": "dependency_validator_dependencyvalidator_validatememoryembeddingforeignkey",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".validateFTS5Triggers()",
@@ -8425,7 +8537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L169",
       "id": "dependency_validator_dependencyvalidator_validatefts5triggers",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".validateVECTriggers()",
@@ -8433,7 +8545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L241",
       "id": "dependency_validator_dependencyvalidator_validatevectriggers",
-      "community": 256
+      "community": 257
     },
     {
       "label": "migration-runner.spec.ts",
@@ -8441,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_spec_ts",
-      "community": 257
+      "community": 258
     },
     {
       "label": "TestMigration",
@@ -8449,7 +8561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L19",
       "id": "migration_runner_spec_testmigration",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".up()",
@@ -8457,7 +8569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L24",
       "id": "migration_runner_spec_testmigration_up",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".down()",
@@ -8465,7 +8577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L33",
       "id": "migration_runner_spec_testmigration_down",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".validateBefore()",
@@ -8473,7 +8585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L37",
       "id": "migration_runner_spec_testmigration_validatebefore",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".validateAfter()",
@@ -8481,7 +8593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L47",
       "id": "migration_runner_spec_testmigration_validateafter",
-      "community": 257
+      "community": 258
     },
     {
       "label": "dependency-validator.spec.ts",
@@ -8489,7 +8601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "schema-version-manager.ts",
@@ -8497,7 +8609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_ts",
-      "community": 133
+      "community": 134
     },
     {
       "label": "SchemaVersionManager",
@@ -8505,7 +8617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L16",
       "id": "schema_version_manager_schemaversionmanager",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".constructor()",
@@ -8513,7 +8625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L17",
       "id": "schema_version_manager_schemaversionmanager_constructor",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".ensureVersionTable()",
@@ -8521,7 +8633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L24",
       "id": "schema_version_manager_schemaversionmanager_ensureversiontable",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".getCurrentVersion()",
@@ -8529,7 +8641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L49",
       "id": "schema_version_manager_schemaversionmanager_getcurrentversion",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".getAppliedVersions()",
@@ -8537,7 +8649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L68",
       "id": "schema_version_manager_schemaversionmanager_getappliedversions",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".isVersionApplied()",
@@ -8545,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L85",
       "id": "schema_version_manager_schemaversionmanager_isversionapplied",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".recordVersion()",
@@ -8553,7 +8665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L102",
       "id": "schema_version_manager_schemaversionmanager_recordversion",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".removeVersion()",
@@ -8561,7 +8673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L128",
       "id": "schema_version_manager_schemaversionmanager_removeversion",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".getAllVersions()",
@@ -8569,7 +8681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts",
       "source_location": "L148",
       "id": "schema_version_manager_schemaversionmanager_getallversions",
-      "community": 133
+      "community": 134
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -8577,7 +8689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createMemoryItemTable()",
@@ -8585,7 +8697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 345
+      "community": 346
     },
     {
       "label": "columnExists()",
@@ -8593,7 +8705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 345
+      "community": 346
     },
     {
       "label": "indexExists()",
@@ -8601,7 +8713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 345
+      "community": 346
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -8609,7 +8721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_ts",
-      "community": 111
+      "community": 112
     },
     {
       "label": "AriGraphSchemaExpansionMigration",
@@ -8617,7 +8729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L27",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".loadSQLFile()",
@@ -8625,7 +8737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L35",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_loadsqlfile",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".executeSQL()",
@@ -8633,7 +8745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L44",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_executesql",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".tableExists()",
@@ -8641,7 +8753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L69",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_tableexists",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".columnExists()",
@@ -8649,7 +8761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L80",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_columnexists",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".indexExists()",
@@ -8657,7 +8769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L88",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_indexexists",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".validateBefore()",
@@ -8665,7 +8777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L99",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_validatebefore",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".up()",
@@ -8673,7 +8785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L175",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_up",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".down()",
@@ -8681,7 +8793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L192",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_down",
-      "community": 111
+      "community": 112
     },
     {
       "label": ".validateAfter()",
@@ -8689,7 +8801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L219",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_validateafter",
-      "community": 111
+      "community": 112
     },
     {
       "label": "004-anchor-table.ts",
@@ -8697,7 +8809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_ts",
-      "community": 149
+      "community": 151
     },
     {
       "label": "AnchorTableMigration",
@@ -8705,7 +8817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L20",
       "id": "004_anchor_table_anchortablemigration",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".executeSQL()",
@@ -8713,7 +8825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L29",
       "id": "004_anchor_table_anchortablemigration_executesql",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".tableExists()",
@@ -8721,7 +8833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L54",
       "id": "004_anchor_table_anchortablemigration_tableexists",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".indexExists()",
@@ -8729,7 +8841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L65",
       "id": "004_anchor_table_anchortablemigration_indexexists",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".validateBefore()",
@@ -8737,7 +8849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L76",
       "id": "004_anchor_table_anchortablemigration_validatebefore",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".up()",
@@ -8745,7 +8857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L102",
       "id": "004_anchor_table_anchortablemigration_up",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".down()",
@@ -8753,7 +8865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L136",
       "id": "004_anchor_table_anchortablemigration_down",
-      "community": 149
+      "community": 151
     },
     {
       "label": ".validateAfter()",
@@ -8761,7 +8873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L158",
       "id": "004_anchor_table_anchortablemigration_validateafter",
-      "community": 149
+      "community": 151
     },
     {
       "label": "020-process-attribute-table.ts",
@@ -8769,7 +8881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_ts",
-      "community": 187
+      "community": 188
     },
     {
       "label": "ProcessAttributeTableMigration",
@@ -8777,7 +8889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L17",
       "id": "020_process_attribute_table_processattributetablemigration",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".tableExists()",
@@ -8785,7 +8897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L22",
       "id": "020_process_attribute_table_processattributetablemigration_tableexists",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".columnExists()",
@@ -8793,7 +8905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L29",
       "id": "020_process_attribute_table_processattributetablemigration_columnexists",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".validateBefore()",
@@ -8801,7 +8913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L34",
       "id": "020_process_attribute_table_processattributetablemigration_validatebefore",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".up()",
@@ -8809,7 +8921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L49",
       "id": "020_process_attribute_table_processattributetablemigration_up",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".down()",
@@ -8817,7 +8929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L62",
       "id": "020_process_attribute_table_processattributetablemigration_down",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".validateAfter()",
@@ -8825,7 +8937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L69",
       "id": "020_process_attribute_table_processattributetablemigration_validateafter",
-      "community": 187
+      "community": 188
     },
     {
       "label": "017-fact-metadata-fields.ts",
@@ -8833,7 +8945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_ts",
-      "community": 150
+      "community": 152
     },
     {
       "label": "FactMetadataFieldsMigration",
@@ -8841,7 +8953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L18",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".tableExists()",
@@ -8849,7 +8961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L23",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_tableexists",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".columnExists()",
@@ -8857,7 +8969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L30",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_columnexists",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".indexExists()",
@@ -8865,7 +8977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L35",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_indexexists",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".validateBefore()",
@@ -8873,7 +8985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L42",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validatebefore",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".up()",
@@ -8881,7 +8993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L59",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_up",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".down()",
@@ -8889,7 +9001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L68",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_down",
-      "community": 150
+      "community": 152
     },
     {
       "label": ".validateAfter()",
@@ -8897,7 +9009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L96",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validateafter",
-      "community": 150
+      "community": 152
     },
     {
       "label": "032-add-project-id.ts",
@@ -8905,7 +9017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_ts",
-      "community": 188
+      "community": 189
     },
     {
       "label": "AddProjectIdMigration",
@@ -8913,7 +9025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L8",
       "id": "032_add_project_id_addprojectidmigration",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".columnExists()",
@@ -8921,7 +9033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L13",
       "id": "032_add_project_id_addprojectidmigration_columnexists",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".indexExists()",
@@ -8929,7 +9041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L18",
       "id": "032_add_project_id_addprojectidmigration_indexexists",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".validateBefore()",
@@ -8937,7 +9049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L25",
       "id": "032_add_project_id_addprojectidmigration_validatebefore",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".up()",
@@ -8945,7 +9057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L27",
       "id": "032_add_project_id_addprojectidmigration_up",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".down()",
@@ -8953,7 +9065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L40",
       "id": "032_add_project_id_addprojectidmigration_down",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".validateAfter()",
@@ -8961,7 +9073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L44",
       "id": "032_add_project_id_addprojectidmigration_validateafter",
-      "community": 188
+      "community": 189
     },
     {
       "label": "016-memory-item-attribution.spec.ts",
@@ -8969,7 +9081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createMemoryItemTable()",
@@ -8977,7 +9089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createSchemaVersionTable()",
@@ -8985,7 +9097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 295
+      "community": 296
     },
     {
       "label": "columnExists()",
@@ -8993,7 +9105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 295
+      "community": 296
     },
     {
       "label": "indexExists()",
@@ -9001,7 +9113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 295
+      "community": 296
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -9009,7 +9121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_025_memory_item_is_consolidated_ts",
-      "community": 151
+      "community": 153
     },
     {
       "label": "MemoryItemIsConsolidatedMigration",
@@ -9017,7 +9129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L9",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".tableExists()",
@@ -9025,7 +9137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L14",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_tableexists",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".columnExists()",
@@ -9033,7 +9145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L21",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_columnexists",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".indexExists()",
@@ -9041,7 +9153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L26",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_indexexists",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".validateBefore()",
@@ -9049,7 +9161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L33",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validatebefore",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".up()",
@@ -9057,7 +9169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L35",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_up",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".down()",
@@ -9065,7 +9177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L49",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_down",
-      "community": 151
+      "community": 153
     },
     {
       "label": ".validateAfter()",
@@ -9073,7 +9185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L58",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validateafter",
-      "community": 151
+      "community": 153
     },
     {
       "label": "030-triple-extraction-fields.spec.ts",
@@ -9081,7 +9193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createMemoryItemTable()",
@@ -9089,7 +9201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9097,7 +9209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "columnExists()",
@@ -9105,7 +9217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "indexExists()",
@@ -9113,7 +9225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -9121,7 +9233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_spec_ts",
-      "community": 258
+      "community": 259
     },
     {
       "label": "createBaseSchema()",
@@ -9129,7 +9241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L19",
       "id": "018_kg_triple_table_spec_createbaseschema",
-      "community": 258
+      "community": 259
     },
     {
       "label": "tableExists()",
@@ -9137,7 +9249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L67",
       "id": "018_kg_triple_table_spec_tableexists",
-      "community": 258
+      "community": 259
     },
     {
       "label": "columnExists()",
@@ -9145,7 +9257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L74",
       "id": "018_kg_triple_table_spec_columnexists",
-      "community": 258
+      "community": 259
     },
     {
       "label": "indexExists()",
@@ -9153,7 +9265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L79",
       "id": "018_kg_triple_table_spec_indexexists",
-      "community": 258
+      "community": 259
     },
     {
       "label": "uniqueConstraintExists()",
@@ -9161,7 +9273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L86",
       "id": "018_kg_triple_table_spec_uniqueconstraintexists",
-      "community": 258
+      "community": 259
     },
     {
       "label": "033-memory-review-candidate-schema.ts",
@@ -9169,7 +9281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_ts",
-      "community": 189
+      "community": 190
     },
     {
       "label": "MemoryReviewCandidateSchemaMigration",
@@ -9177,7 +9289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".tableExists()",
@@ -9185,7 +9297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L14",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_tableexists",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".indexExists()",
@@ -9193,7 +9305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_indexexists",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".validateBefore()",
@@ -9201,7 +9313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L28",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_validatebefore",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".up()",
@@ -9209,7 +9321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L34",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_up",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".down()",
@@ -9217,7 +9329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L69",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_down",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".validateAfter()",
@@ -9225,7 +9337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L78",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_validateafter",
-      "community": 189
+      "community": 190
     },
     {
       "label": "029-telemetry-events-event-type-created-at-index.ts",
@@ -9233,7 +9345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_029_telemetry_events_event_type_created_at_index_ts",
-      "community": 190
+      "community": 191
     },
     {
       "label": "TelemetryEventsEventTypeCreatedAtIndexMigration",
@@ -9241,7 +9353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L9",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".tableExists()",
@@ -9249,7 +9361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L15",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_tableexists",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".indexExists()",
@@ -9257,7 +9369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L22",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_indexexists",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".validateBefore()",
@@ -9265,7 +9377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L29",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_validatebefore",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".up()",
@@ -9273,7 +9385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L31",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_up",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".down()",
@@ -9281,7 +9393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L40",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_down",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".validateAfter()",
@@ -9289,7 +9401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L47",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_validateafter",
-      "community": 190
+      "community": 191
     },
     {
       "label": "026-flip-consolidation-relation-directions.ts",
@@ -9297,7 +9409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_026_flip_consolidation_relation_directions_ts",
-      "community": 259
+      "community": 260
     },
     {
       "label": "FlipConsolidationRelationDirectionsMigration",
@@ -9305,7 +9417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L19",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration",
-      "community": 259
+      "community": 260
     },
     {
       "label": ".validateBefore()",
@@ -9313,7 +9425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L25",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_validatebefore",
-      "community": 259
+      "community": 260
     },
     {
       "label": ".validateAfter()",
@@ -9321,7 +9433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L27",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_validateafter",
-      "community": 259
+      "community": 260
     },
     {
       "label": ".up()",
@@ -9329,7 +9441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L29",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_up",
-      "community": 259
+      "community": 260
     },
     {
       "label": ".down()",
@@ -9337,7 +9449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L90",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_down",
-      "community": 259
+      "community": 260
     },
     {
       "label": "008-arigraph-schema-expansion.spec.ts",
@@ -9345,7 +9457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 542
+      "community": 544
     },
     {
       "label": "createBaseSchema()",
@@ -9353,7 +9465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 542
+      "community": 544
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9473,7 +9585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_012_fix_tfidf_dimension_trigger_ts",
-      "community": 191
+      "community": 192
     },
     {
       "label": "FixTfidfDimensionTriggerMigration",
@@ -9481,7 +9593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L26",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".triggerExists()",
@@ -9489,7 +9601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L37",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_triggerexists",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".tableExists()",
@@ -9497,7 +9609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L53",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_tableexists",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".validateBefore()",
@@ -9505,7 +9617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L66",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_validatebefore",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".up()",
@@ -9513,7 +9625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L100",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_up",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".down()",
@@ -9521,7 +9633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L224",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_down",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".validateAfter()",
@@ -9529,7 +9641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L298",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_validateafter",
-      "community": 191
+      "community": 192
     },
     {
       "label": "011-meta-memory-stats-schema.spec.ts",
@@ -9537,7 +9649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 543
+      "community": 545
     },
     {
       "label": "createBaseSchema()",
@@ -9545,7 +9657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 543
+      "community": 545
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -9553,7 +9665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_ts",
-      "community": 134
+      "community": 135
     },
     {
       "label": "MirixSchemaExpansionMigration",
@@ -9561,7 +9673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L27",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".loadSQLFile()",
@@ -9569,7 +9681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L35",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_loadsqlfile",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".executeSQL()",
@@ -9577,7 +9689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L44",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_executesql",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".tableExists()",
@@ -9585,7 +9697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L69",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_tableexists",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".columnExists()",
@@ -9593,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L80",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_columnexists",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".validateBefore()",
@@ -9601,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L88",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_validatebefore",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".up()",
@@ -9609,7 +9721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L109",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_up",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".down()",
@@ -9617,7 +9729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L133",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_down",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".validateAfter()",
@@ -9625,7 +9737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.ts",
       "source_location": "L155",
       "id": "002_mirix_schema_expansion_mirixschemaexpansionmigration_validateafter",
-      "community": 134
+      "community": 135
     },
     {
       "label": "019-backfill-kg-triple-from-memory-item.ts",
@@ -9633,7 +9745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_ts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "BackfillKgTripleFromMemoryItemMigration",
@@ -9641,7 +9753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".tableExists()",
@@ -9649,7 +9761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L23",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_tableexists",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".validateBefore()",
@@ -9657,7 +9769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L30",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validatebefore",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".up()",
@@ -9665,7 +9777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L47",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_up",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".down()",
@@ -9673,7 +9785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L94",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_down",
-      "community": 223
+      "community": 224
     },
     {
       "label": ".validateAfter()",
@@ -9681,7 +9793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L101",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validateafter",
-      "community": 223
+      "community": 224
     },
     {
       "label": "023-feedback-event-score-breakdown.ts",
@@ -9689,7 +9801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_023_feedback_event_score_breakdown_ts",
-      "community": 192
+      "community": 193
     },
     {
       "label": "FeedbackEventScoreBreakdownMigration",
@@ -9697,7 +9809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L9",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".tableExists()",
@@ -9705,7 +9817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L14",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_tableexists",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".columnExists()",
@@ -9713,7 +9825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L21",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_columnexists",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".validateBefore()",
@@ -9721,7 +9833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L26",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_validatebefore",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".up()",
@@ -9729,7 +9841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L28",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_up",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".down()",
@@ -9737,7 +9849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L37",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_down",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".validateAfter()",
@@ -9745,7 +9857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L48",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_validateafter",
-      "community": 192
+      "community": 193
     },
     {
       "label": "007-procedural-memory-enhancement.ts",
@@ -9753,7 +9865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_ts",
-      "community": 112
+      "community": 113
     },
     {
       "label": "ProceduralMemoryEnhancementMigration",
@@ -9761,7 +9873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L26",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".loadSQLFile()",
@@ -9769,7 +9881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L34",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_loadsqlfile",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".executeSQL()",
@@ -9777,7 +9889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L43",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_executesql",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".tableExists()",
@@ -9785,7 +9897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L68",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_tableexists",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".columnExists()",
@@ -9793,7 +9905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L79",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_columnexists",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".indexExists()",
@@ -9801,7 +9913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L89",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_indexexists",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".validateBefore()",
@@ -9809,7 +9921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L100",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_validatebefore",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".up()",
@@ -9817,7 +9929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L153",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_up",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".down()",
@@ -9825,7 +9937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L248",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_down",
-      "community": 112
+      "community": 113
     },
     {
       "label": ".validateAfter()",
@@ -9833,7 +9945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L306",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_validateafter",
-      "community": 112
+      "community": 113
     },
     {
       "label": "009-quality-assurance-schema.spec.ts",
@@ -9841,7 +9953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 544
+      "community": 546
     },
     {
       "label": "createBaseSchema()",
@@ -9849,7 +9961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 544
+      "community": 546
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -9857,7 +9969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "createMemoryItemTable()",
@@ -9865,7 +9977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 297
+      "community": 298
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9873,7 +9985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 297
+      "community": 298
     },
     {
       "label": "columnExists()",
@@ -9881,7 +9993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 297
+      "community": 298
     },
     {
       "label": "indexExists()",
@@ -9889,7 +10001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 297
+      "community": 298
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -9897,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_ts",
-      "community": 113
+      "community": 114
     },
     {
       "label": "AddCoreMemoryVersionMigration",
@@ -9905,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L27",
       "id": "010_add_core_memory_version_addcorememoryversionmigration",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".loadSQLFile()",
@@ -9913,7 +10025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L38",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_loadsqlfile",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".executeSQL()",
@@ -9921,7 +10033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L64",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_executesql",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".tableExists()",
@@ -9929,7 +10041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L89",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_tableexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".indexExists()",
@@ -9937,7 +10049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L100",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_indexexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".columnExists()",
@@ -9945,7 +10057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L111",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_columnexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".validateBefore()",
@@ -9953,7 +10065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L119",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_validatebefore",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".up()",
@@ -9961,7 +10073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L137",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_up",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".down()",
@@ -9969,7 +10081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L149",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_down",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".validateAfter()",
@@ -9977,7 +10089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L181",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_validateafter",
-      "community": 113
+      "community": 114
     },
     {
       "label": "030-triple-extraction-fields.ts",
@@ -9985,7 +10097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_ts",
-      "community": 152
+      "community": 154
     },
     {
       "label": "TripleExtractionFieldsMigration",
@@ -9993,7 +10105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".tableExists()",
@@ -10001,7 +10113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L15",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_tableexists",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".columnExists()",
@@ -10009,7 +10121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L22",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_columnexists",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".indexExists()",
@@ -10017,7 +10129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L27",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_indexexists",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".validateBefore()",
@@ -10025,7 +10137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L34",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validatebefore",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".up()",
@@ -10033,7 +10145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L36",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_up",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".down()",
@@ -10041,7 +10153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L61",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_down",
-      "community": 152
+      "community": 154
     },
     {
       "label": ".validateAfter()",
@@ -10049,7 +10161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L69",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validateafter",
-      "community": 152
+      "community": 154
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -10057,7 +10169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_021_feedback_event_attribution_ts",
-      "community": 153
+      "community": 155
     },
     {
       "label": "FeedbackEventAttributionMigration",
@@ -10065,7 +10177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L9",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".tableExists()",
@@ -10073,7 +10185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L14",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_tableexists",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".columnExists()",
@@ -10081,7 +10193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L21",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_columnexists",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".indexExists()",
@@ -10089,7 +10201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L26",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_indexexists",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".validateBefore()",
@@ -10097,7 +10209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L33",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validatebefore",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".up()",
@@ -10105,7 +10217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L57",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_up",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".down()",
@@ -10113,7 +10225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L89",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_down",
-      "community": 153
+      "community": 155
     },
     {
       "label": ".validateAfter()",
@@ -10121,7 +10233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L107",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validateafter",
-      "community": 153
+      "community": 155
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -10129,7 +10241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_ts",
-      "community": 114
+      "community": 115
     },
     {
       "label": "QualityAssuranceSchemaMigration",
@@ -10137,7 +10249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L27",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".loadSQLFile()",
@@ -10145,7 +10257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L35",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_loadsqlfile",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".executeSQL()",
@@ -10153,7 +10265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L44",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_executesql",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".tableExists()",
@@ -10161,7 +10273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L69",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_tableexists",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".indexExists()",
@@ -10169,7 +10281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L80",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_indexexists",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".columnExists()",
@@ -10177,7 +10289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L91",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_columnexists",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".validateBefore()",
@@ -10185,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L99",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_validatebefore",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".up()",
@@ -10193,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L130",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_up",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".down()",
@@ -10201,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L142",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_down",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".validateAfter()",
@@ -10209,7 +10321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L172",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_validateafter",
-      "community": 114
+      "community": 115
     },
     {
       "label": "033-memory-review-candidate-schema.spec.ts",
@@ -10217,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "createMemoryItemTable()",
@@ -10225,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 434
+      "community": 435
     },
     {
       "label": "tableExists()",
@@ -10233,7 +10345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 434
+      "community": 435
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10241,7 +10353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_028_telemetry_daily_metrics_ts",
-      "community": 260
+      "community": 261
     },
     {
       "label": "TelemetryDailyMetricsMigration",
@@ -10249,7 +10361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L10",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration",
-      "community": 260
+      "community": 261
     },
     {
       "label": ".validateBefore()",
@@ -10257,7 +10369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L15",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_validatebefore",
-      "community": 260
+      "community": 261
     },
     {
       "label": ".validateAfter()",
@@ -10265,7 +10377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L17",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_validateafter",
-      "community": 260
+      "community": 261
     },
     {
       "label": ".up()",
@@ -10273,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L19",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_up",
-      "community": 260
+      "community": 261
     },
     {
       "label": ".down()",
@@ -10281,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L39",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_down",
-      "community": 260
+      "community": 261
     },
     {
       "label": "022-feedback-event-comment.ts",
@@ -10289,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_022_feedback_event_comment_ts",
-      "community": 193
+      "community": 194
     },
     {
       "label": "FeedbackEventCommentMigration",
@@ -10297,7 +10409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L9",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".tableExists()",
@@ -10305,7 +10417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L14",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_tableexists",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".columnExists()",
@@ -10313,7 +10425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L21",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_columnexists",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".validateBefore()",
@@ -10321,7 +10433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L26",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_validatebefore",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".up()",
@@ -10329,7 +10441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L28",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_up",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".down()",
@@ -10337,7 +10449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L37",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_down",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".validateAfter()",
@@ -10345,7 +10457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L48",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_validateafter",
-      "community": 193
+      "community": 194
     },
     {
       "label": "011-meta-memory-stats-schema.ts",
@@ -10473,7 +10585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "createMemoryItemTable()",
@@ -10481,7 +10593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 435
+      "community": 436
     },
     {
       "label": "tableExists()",
@@ -10489,7 +10601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 435
+      "community": 436
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10497,7 +10609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_ts",
-      "community": 154
+      "community": 156
     },
     {
       "label": "ProceduralVersionIndexesMigration",
@@ -10505,7 +10617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L18",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".columnExists()",
@@ -10513,7 +10625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L23",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_columnexists",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".tableExists()",
@@ -10521,7 +10633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L28",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_tableexists",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".indexExists()",
@@ -10529,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L35",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_indexexists",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".validateBefore()",
@@ -10537,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L42",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validatebefore",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".up()",
@@ -10545,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L62",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_up",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".down()",
@@ -10553,7 +10665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L73",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_down",
-      "community": 154
+      "community": 156
     },
     {
       "label": ".validateAfter()",
@@ -10561,7 +10673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L81",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validateafter",
-      "community": 154
+      "community": 156
     },
     {
       "label": "002-mirix-schema-expansion.spec.ts",
@@ -10569,7 +10681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 545
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -10577,7 +10689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 545
+      "community": 547
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10681,7 +10793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 546
+      "community": 548
     },
     {
       "label": "createSchemaWith018()",
@@ -10689,7 +10801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 546
+      "community": 548
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10697,7 +10809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 547
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -10705,7 +10817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 547
+      "community": 549
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -10713,7 +10825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -10721,7 +10833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 346
+      "community": 347
     },
     {
       "label": "createMemoryLinkTable()",
@@ -10729,7 +10841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 346
+      "community": 347
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10737,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 346
+      "community": 347
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -10745,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_ts",
-      "community": 155
+      "community": 157
     },
     {
       "label": "MemoryItemAttributionMigration",
@@ -10753,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L18",
       "id": "016_memory_item_attribution_memoryitemattributionmigration",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".tableExists()",
@@ -10761,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L23",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_tableexists",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".columnExists()",
@@ -10769,7 +10881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L30",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_columnexists",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".indexExists()",
@@ -10777,7 +10889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L35",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_indexexists",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".validateBefore()",
@@ -10785,7 +10897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L42",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validatebefore",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".up()",
@@ -10793,7 +10905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L62",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_up",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".down()",
@@ -10801,7 +10913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L69",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_down",
-      "community": 155
+      "community": 157
     },
     {
       "label": ".validateAfter()",
@@ -10809,7 +10921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L87",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validateafter",
-      "community": 155
+      "community": 157
     },
     {
       "label": "027-telemetry-events.ts",
@@ -10817,7 +10929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_027_telemetry_events_ts",
-      "community": 261
+      "community": 262
     },
     {
       "label": "TelemetryEventsMigration",
@@ -10825,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L9",
       "id": "027_telemetry_events_telemetryeventsmigration",
-      "community": 261
+      "community": 262
     },
     {
       "label": ".validateBefore()",
@@ -10833,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L14",
       "id": "027_telemetry_events_telemetryeventsmigration_validatebefore",
-      "community": 261
+      "community": 262
     },
     {
       "label": ".validateAfter()",
@@ -10841,7 +10953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L16",
       "id": "027_telemetry_events_telemetryeventsmigration_validateafter",
-      "community": 261
+      "community": 262
     },
     {
       "label": ".up()",
@@ -10849,7 +10961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L18",
       "id": "027_telemetry_events_telemetryeventsmigration_up",
-      "community": 261
+      "community": 262
     },
     {
       "label": ".down()",
@@ -10857,7 +10969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L41",
       "id": "027_telemetry_events_telemetryeventsmigration_down",
-      "community": 261
+      "community": 262
     },
     {
       "label": "013-procedural-version-fields.ts",
@@ -10865,7 +10977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_ts",
-      "community": 194
+      "community": 195
     },
     {
       "label": "ProceduralVersionFieldsMigration",
@@ -10873,7 +10985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L18",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".columnExists()",
@@ -10881,7 +10993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L23",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_columnexists",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".tableExists()",
@@ -10889,7 +11001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L28",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_tableexists",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".validateBefore()",
@@ -10897,7 +11009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L35",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_validatebefore",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".up()",
@@ -10905,7 +11017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L55",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_up",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".down()",
@@ -10913,7 +11025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L143",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_down",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".validateAfter()",
@@ -10921,7 +11033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L161",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_validateafter",
-      "community": 194
+      "community": 195
     },
     {
       "label": "015-memory-item-owner-id.spec.ts",
@@ -10929,7 +11041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "createMemoryItemTable()",
@@ -10937,7 +11049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 298
+      "community": 299
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10945,7 +11057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 298
+      "community": 299
     },
     {
       "label": "columnExists()",
@@ -10953,7 +11065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 298
+      "community": 299
     },
     {
       "label": "indexExists()",
@@ -10961,7 +11073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 298
+      "community": 299
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -10969,7 +11081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_ts",
-      "community": 156
+      "community": 158
     },
     {
       "label": "KgTripleTableMigration",
@@ -10977,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L17",
       "id": "018_kg_triple_table_kgtripletablemigration",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".tableExists()",
@@ -10985,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L22",
       "id": "018_kg_triple_table_kgtripletablemigration_tableexists",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".columnExists()",
@@ -10993,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L29",
       "id": "018_kg_triple_table_kgtripletablemigration_columnexists",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".indexExists()",
@@ -11001,7 +11113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L34",
       "id": "018_kg_triple_table_kgtripletablemigration_indexexists",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".validateBefore()",
@@ -11009,7 +11121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L41",
       "id": "018_kg_triple_table_kgtripletablemigration_validatebefore",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".up()",
@@ -11017,7 +11129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L58",
       "id": "018_kg_triple_table_kgtripletablemigration_up",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".down()",
@@ -11025,7 +11137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L80",
       "id": "018_kg_triple_table_kgtripletablemigration_down",
-      "community": 156
+      "community": 158
     },
     {
       "label": ".validateAfter()",
@@ -11033,7 +11145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L91",
       "id": "018_kg_triple_table_kgtripletablemigration_validateafter",
-      "community": 156
+      "community": 158
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -11041,7 +11153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "createMemoryItemTable()",
@@ -11049,7 +11161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 299
+      "community": 300
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11057,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 299
+      "community": 300
     },
     {
       "label": "columnExists()",
@@ -11065,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 299
+      "community": 300
     },
     {
       "label": "indexExists()",
@@ -11073,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 299
+      "community": 300
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -11201,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_024_feedback_event_memory_created_at_index_ts",
-      "community": 195
+      "community": 196
     },
     {
       "label": "FeedbackEventMemoryCreatedAtIndexMigration",
@@ -11209,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L9",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".tableExists()",
@@ -11217,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L15",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_tableexists",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".indexExists()",
@@ -11225,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L22",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_indexexists",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".validateBefore()",
@@ -11233,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L29",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_validatebefore",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".up()",
@@ -11241,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L31",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_up",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".down()",
@@ -11249,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L40",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_down",
-      "community": 195
+      "community": 196
     },
     {
       "label": ".validateAfter()",
@@ -11257,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L47",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_validateafter",
-      "community": 195
+      "community": 196
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -11265,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_ts",
-      "community": 196
+      "community": 197
     },
     {
       "label": "ReviewQueueHealthSnapshotMigration",
@@ -11273,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L8",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".tableExists()",
@@ -11281,7 +11393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L14",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_tableexists",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".indexExists()",
@@ -11289,7 +11401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L21",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_indexexists",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".validateBefore()",
@@ -11297,7 +11409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L28",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_validatebefore",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".up()",
@@ -11305,7 +11417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L36",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_up",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".down()",
@@ -11313,7 +11425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L65",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_down",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".validateAfter()",
@@ -11321,7 +11433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L73",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_validateafter",
-      "community": 196
+      "community": 197
     },
     {
       "label": "010-add-core-memory-version.spec.ts",
@@ -11329,7 +11441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 548
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -11337,7 +11449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 548
+      "community": 550
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11345,7 +11457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_ts",
-      "community": 157
+      "community": 159
     },
     {
       "label": "SoftDeleteFieldsMigration",
@@ -11353,7 +11465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_softdeletefieldsmigration",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".tableExists()",
@@ -11361,7 +11473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L14",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_tableexists",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".columnExists()",
@@ -11369,7 +11481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L21",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_columnexists",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".indexExists()",
@@ -11377,7 +11489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L26",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_indexexists",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".validateBefore()",
@@ -11385,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L33",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validatebefore",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".up()",
@@ -11393,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_up",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".down()",
@@ -11401,7 +11513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L52",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_down",
-      "community": 157
+      "community": 159
     },
     {
       "label": ".validateAfter()",
@@ -11409,7 +11521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L59",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validateafter",
-      "community": 157
+      "community": 159
     },
     {
       "label": "006-fts5-reflection-notes.spec.ts",
@@ -11417,7 +11529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_006_fts5_reflection_notes_spec_ts",
-      "community": 262
+      "community": 263
     },
     {
       "label": "createBaseSchema()",
@@ -11425,7 +11537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L28",
       "id": "006_fts5_reflection_notes_spec_createbaseschema",
-      "community": 262
+      "community": 263
     },
     {
       "label": "step1CreateNewTable()",
@@ -11433,7 +11545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L208",
       "id": "006_fts5_reflection_notes_spec_step1createnewtable",
-      "community": 262
+      "community": 263
     },
     {
       "label": "step2ReindexData()",
@@ -11441,7 +11553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L233",
       "id": "006_fts5_reflection_notes_spec_step2reindexdata",
-      "community": 262
+      "community": 263
     },
     {
       "label": "step3CreateDualTriggers()",
@@ -11449,7 +11561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L268",
       "id": "006_fts5_reflection_notes_spec_step3createdualtriggers",
-      "community": 262
+      "community": 263
     },
     {
       "label": "setupMigrationSteps()",
@@ -11457,7 +11569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L496",
       "id": "006_fts5_reflection_notes_spec_setupmigrationsteps",
-      "community": 262
+      "community": 263
     },
     {
       "label": "007-procedural-memory-enhancement.spec.ts",
@@ -11465,7 +11577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 549
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -11473,7 +11585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 549
+      "community": 551
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11481,7 +11593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "createBaseSchema()",
@@ -11489,7 +11601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 436
+      "community": 437
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11497,7 +11609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 436
+      "community": 437
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11505,7 +11617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_ts",
-      "community": 158
+      "community": 160
     },
     {
       "label": "MemoryItemOwnerIdMigration",
@@ -11513,7 +11625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L17",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".tableExists()",
@@ -11521,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L22",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_tableexists",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".columnExists()",
@@ -11529,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L29",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_columnexists",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".indexExists()",
@@ -11537,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L34",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_indexexists",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".validateBefore()",
@@ -11545,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L41",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validatebefore",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".up()",
@@ -11553,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L58",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_up",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".down()",
@@ -11561,7 +11673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L63",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_down",
-      "community": 158
+      "community": 160
     },
     {
       "label": ".validateAfter()",
@@ -11569,7 +11681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L75",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validateafter",
-      "community": 158
+      "community": 160
     },
     {
       "label": "003-consolidation-score-fields.spec.ts",
@@ -11577,7 +11689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 550
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -11585,7 +11697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 550
+      "community": 552
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11593,7 +11705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -11601,7 +11713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 347
+      "community": 348
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11609,7 +11721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 347
+      "community": 348
     },
     {
       "label": "getIndexNames()",
@@ -11617,7 +11729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 347
+      "community": 348
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -11625,7 +11737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "createSchemaWith019()",
@@ -11633,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 348
+      "community": 349
     },
     {
       "label": "tableExists()",
@@ -11641,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 348
+      "community": 349
     },
     {
       "label": "columnExists()",
@@ -11649,7 +11761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 348
+      "community": 349
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -11657,7 +11769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_tests_migration_runner_api_example_spec_ts",
-      "community": 263
+      "community": 264
     },
     {
       "label": "ExampleMigration",
@@ -11665,7 +11777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L19",
       "id": "migration_runner_api_example_spec_examplemigration",
-      "community": 263
+      "community": 264
     },
     {
       "label": ".up()",
@@ -11673,7 +11785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L24",
       "id": "migration_runner_api_example_spec_examplemigration_up",
-      "community": 263
+      "community": 264
     },
     {
       "label": ".down()",
@@ -11681,7 +11793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L34",
       "id": "migration_runner_api_example_spec_examplemigration_down",
-      "community": 263
+      "community": 264
     },
     {
       "label": ".validateBefore()",
@@ -11689,7 +11801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L38",
       "id": "migration_runner_api_example_spec_examplemigration_validatebefore",
-      "community": 263
+      "community": 264
     },
     {
       "label": ".validateAfter()",
@@ -11697,7 +11809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L49",
       "id": "migration_runner_api_example_spec_examplemigration_validateafter",
-      "community": 263
+      "community": 264
     },
     {
       "label": "sqlite-core-memory-adapter.ts",
@@ -11801,7 +11913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -11809,7 +11921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_feedback_repository_sqlite_impl_ts",
-      "community": 264
+      "community": 265
     },
     {
       "label": "FeedbackRepositorySQLite",
@@ -11817,7 +11929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L11",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".constructor()",
@@ -11825,7 +11937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L12",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_constructor",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".insertFeedback()",
@@ -11833,7 +11945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L14",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_insertfeedback",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".getNetScores()",
@@ -11841,7 +11953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L36",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_getnetscores",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".getNetScoreRows()",
@@ -11849,7 +11961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L72",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_getnetscorerows",
-      "community": 264
+      "community": 265
     },
     {
       "label": "core-memory-repository-sqlite.impl.ts",
@@ -11985,7 +12097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_process_attribute_repository_sqlite_impl_ts",
-      "community": 224
+      "community": 225
     },
     {
       "label": "parseJsonArray()",
@@ -11993,7 +12105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L14",
       "id": "process_attribute_repository_sqlite_impl_parsejsonarray",
-      "community": 224
+      "community": 225
     },
     {
       "label": "stringifyJsonArray()",
@@ -12001,7 +12113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L24",
       "id": "process_attribute_repository_sqlite_impl_stringifyjsonarray",
-      "community": 224
+      "community": 225
     },
     {
       "label": "ProcessAttributeRepositorySqlite",
@@ -12009,7 +12121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L32",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".constructor()",
@@ -12017,7 +12129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L35",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_constructor",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".getByProcessId()",
@@ -12025,7 +12137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L42",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_getbyprocessid",
-      "community": 224
+      "community": 225
     },
     {
       "label": ".upsert()",
@@ -12033,7 +12145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L63",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_upsert",
-      "community": 224
+      "community": 225
     },
     {
       "label": "knowledge-vault-repository-sqlite.impl.ts",
@@ -12185,7 +12297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_kg_triple_repository_sqlite_impl_ts",
-      "community": 265
+      "community": 266
     },
     {
       "label": "generateId()",
@@ -12193,7 +12305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L12",
       "id": "kg_triple_repository_sqlite_impl_generateid",
-      "community": 265
+      "community": 266
     },
     {
       "label": "KgTripleRepositorySqlite",
@@ -12201,7 +12313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L18",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite",
-      "community": 265
+      "community": 266
     },
     {
       "label": ".constructor()",
@@ -12209,7 +12321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L21",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_constructor",
-      "community": 265
+      "community": 266
     },
     {
       "label": ".upsertTriple()",
@@ -12217,7 +12329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L29",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_upserttriple",
-      "community": 265
+      "community": 266
     },
     {
       "label": ".getBySubjectPredicateObject()",
@@ -12225,7 +12337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L52",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_getbysubjectpredicateobject",
-      "community": 265
+      "community": 266
     },
     {
       "label": "core-memory-repository-sqlite.impl.spec.ts",
@@ -12233,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "cache-service.ts",
@@ -12561,7 +12673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "batch-scheduler.ts",
@@ -12945,7 +13057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -12953,7 +13065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 349
+      "community": 350
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -12961,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 349
+      "community": 350
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -12969,7 +13081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 349
+      "community": 350
     },
     {
       "label": "health-checker.ts",
@@ -12977,7 +13089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_health_checker_ts",
-      "community": 266
+      "community": 267
     },
     {
       "label": "HealthChecker",
@@ -12985,7 +13097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L33",
       "id": "health_checker_healthchecker",
-      "community": 266
+      "community": 267
     },
     {
       "label": ".constructor()",
@@ -12993,7 +13105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L37",
       "id": "health_checker_healthchecker_constructor",
-      "community": 266
+      "community": 267
     },
     {
       "label": ".setStartTime()",
@@ -13001,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L51",
       "id": "health_checker_healthchecker_setstarttime",
-      "community": 266
+      "community": 267
     },
     {
       "label": ".check()",
@@ -13009,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L64",
       "id": "health_checker_healthchecker_check",
-      "community": 266
+      "community": 267
     },
     {
       "label": ".triggerGarbageCollection()",
@@ -13017,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L120",
       "id": "health_checker_healthchecker_triggergarbagecollection",
-      "community": 266
+      "community": 267
     },
     {
       "label": "batch-scheduler-default-config.ts",
@@ -13025,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 551
+      "community": 553
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13033,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 551
+      "community": 553
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13041,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 552
+      "community": 554
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13049,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 552
+      "community": 554
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13057,7 +13169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "readInsertedUpdated()",
@@ -13065,7 +13177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 437
+      "community": 438
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13073,7 +13185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 437
+      "community": 438
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13081,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_relation_validator_executor_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "RelationValidatorExecutor",
@@ -13089,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L31",
       "id": "relation_validator_executor_relationvalidatorexecutor",
-      "community": 350
+      "community": 351
     },
     {
       "label": ".constructor()",
@@ -13097,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L34",
       "id": "relation_validator_executor_relationvalidatorexecutor_constructor",
-      "community": 350
+      "community": 351
     },
     {
       "label": ".execute()",
@@ -13105,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L49",
       "id": "relation_validator_executor_relationvalidatorexecutor_execute",
-      "community": 350
+      "community": 351
     },
     {
       "label": "batch-scheduler-types.ts",
@@ -13113,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13121,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 553
+      "community": 555
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13129,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 553
+      "community": 555
     },
     {
       "label": "retry-manager.ts",
@@ -13137,7 +13249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_retry_manager_ts",
-      "community": 159
+      "community": 161
     },
     {
       "label": "RetryManager",
@@ -13145,7 +13257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L103",
       "id": "retry_manager_retrymanager",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".constructor()",
@@ -13153,7 +13265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L107",
       "id": "retry_manager_retrymanager_constructor",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".shouldRetry()",
@@ -13161,7 +13273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L119",
       "id": "retry_manager_retrymanager_shouldretry",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".resetErrorCount()",
@@ -13169,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L158",
       "id": "retry_manager_retrymanager_reseterrorcount",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".incrementErrorCount()",
@@ -13177,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L168",
       "id": "retry_manager_retrymanager_incrementerrorcount",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".getErrorCount()",
@@ -13185,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L181",
       "id": "retry_manager_retrymanager_geterrorcount",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".clearAllErrorCounts()",
@@ -13193,7 +13305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L188",
       "id": "retry_manager_retrymanager_clearallerrorcounts",
-      "community": 159
+      "community": 161
     },
     {
       "label": ".retry()",
@@ -13201,7 +13313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L218",
       "id": "retry_manager_retrymanager_retry",
-      "community": 159
+      "community": 161
     },
     {
       "label": "batch-job-execution-coordinator.ts",
@@ -13209,7 +13321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_execution_coordinator_ts",
-      "community": 197
+      "community": 198
     },
     {
       "label": "BatchJobExecutionCoordinator",
@@ -13217,7 +13329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L22",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".constructor()",
@@ -13225,7 +13337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L23",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_constructor",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".addJobToQueue()",
@@ -13233,7 +13345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L25",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_addjobtoqueue",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".afterEnqueueAttempt()",
@@ -13241,7 +13353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L32",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_afterenqueueattempt",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".startJobProcessor()",
@@ -13249,7 +13361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L67",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_startjobprocessor",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".executeJobWithRetry()",
@@ -13257,7 +13369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L89",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_executejobwithretry",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".executeWithTimeout()",
@@ -13265,7 +13377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L214",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_executewithtimeout",
-      "community": 197
+      "community": 198
     },
     {
       "label": "file-logger.ts",
@@ -13273,7 +13385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_file_logger_ts",
-      "community": 160
+      "community": 162
     },
     {
       "label": "FileLogger",
@@ -13281,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L38",
       "id": "file_logger_filelogger",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".constructor()",
@@ -13289,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L42",
       "id": "file_logger_filelogger_constructor",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".log()",
@@ -13297,7 +13409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L81",
       "id": "file_logger_filelogger_log",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".logWarn()",
@@ -13305,7 +13417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L128",
       "id": "file_logger_filelogger_logwarn",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".logError()",
@@ -13313,7 +13425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L160",
       "id": "file_logger_filelogger_logerror",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".sanitizeData()",
@@ -13321,7 +13433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L194",
       "id": "file_logger_filelogger_sanitizedata",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".getLogFilePath()",
@@ -13329,7 +13441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L211",
       "id": "file_logger_filelogger_getlogfilepath",
-      "community": 160
+      "community": 162
     },
     {
       "label": ".setEnabled()",
@@ -13337,7 +13449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L220",
       "id": "file_logger_filelogger_setenabled",
-      "community": 160
+      "community": 162
     },
     {
       "label": "job-queue.ts",
@@ -13585,7 +13697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -13593,7 +13705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 300
+      "community": 301
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -13601,7 +13713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 300
+      "community": 301
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -13609,7 +13721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L113",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 300
+      "community": 301
     },
     {
       "label": "runLogRotation()",
@@ -13617,7 +13729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L168",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 300
+      "community": 301
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -13625,7 +13737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13633,7 +13745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13641,7 +13753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 438
+      "community": 439
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13649,7 +13761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 438
+      "community": 439
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13657,7 +13769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13665,7 +13777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 439
+      "community": 440
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13673,7 +13785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 439
+      "community": 440
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13681,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -13689,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L16",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 351
+      "community": 352
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -13697,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L46",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 351
+      "community": 352
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -13705,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L83",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 351
+      "community": 352
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -13713,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -13721,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runMemoryCleanup()",
@@ -13729,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runMonitoring()",
@@ -13737,7 +13849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runHealthCheck()",
@@ -13745,7 +13857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 301
+      "community": 302
     },
     {
       "label": "file-logger.spec.ts",
@@ -13753,7 +13865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13761,7 +13873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_spec_ts",
-      "community": 198
+      "community": 199
     },
     {
       "label": "executionCoordinator()",
@@ -13769,7 +13881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L17",
       "id": "batch_scheduler_spec_executioncoordinator",
-      "community": 198
+      "community": 199
     },
     {
       "label": "failingJob()",
@@ -13777,7 +13889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1628",
       "id": "batch_scheduler_spec_failingjob",
-      "community": 198
+      "community": 199
     },
     {
       "label": "longRunningJob()",
@@ -13785,7 +13897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1760",
       "id": "batch_scheduler_spec_longrunningjob",
-      "community": 198
+      "community": 199
     },
     {
       "label": "testJob()",
@@ -13793,7 +13905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1856",
       "id": "batch_scheduler_spec_testjob",
-      "community": 198
+      "community": 199
     },
     {
       "label": "highPriorityJob()",
@@ -13801,7 +13913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1910",
       "id": "batch_scheduler_spec_highpriorityjob",
-      "community": 198
+      "community": 199
     },
     {
       "label": "immediateJob()",
@@ -13809,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L1913",
       "id": "batch_scheduler_spec_immediatejob",
-      "community": 198
+      "community": 199
     },
     {
       "label": "jobWithRetryCount()",
@@ -13817,7 +13929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler.spec.ts",
       "source_location": "L2051",
       "id": "batch_scheduler_spec_jobwithretrycount",
-      "community": 198
+      "community": 199
     },
     {
       "label": "health-checker.spec.ts",
@@ -13825,7 +13937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "retry-manager.spec.ts",
@@ -13833,7 +13945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 554
+      "community": 556
     },
     {
       "label": "shouldRetry()",
@@ -13841,7 +13953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 554
+      "community": 556
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -13849,7 +13961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 555
+      "community": 557
     },
     {
       "label": "baseResult()",
@@ -13857,7 +13969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 555
+      "community": 557
     },
     {
       "label": "job-queue.spec.ts",
@@ -13865,7 +13977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "job()",
@@ -13873,7 +13985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 302
+      "community": 303
     },
     {
       "label": "job1()",
@@ -13881,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 302
+      "community": 303
     },
     {
       "label": "job2()",
@@ -13889,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 302
+      "community": 303
     },
     {
       "label": "job3()",
@@ -13897,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 302
+      "community": 303
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -13905,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -13913,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 556
+      "community": 558
     },
     {
       "label": "initializeTestDatabase()",
@@ -13921,7 +14033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 556
+      "community": 558
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -13929,7 +14041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_ts",
-      "community": 115
+      "community": 116
     },
     {
       "label": "TripleExtractionBatchJob",
@@ -13937,7 +14049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L100",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".constructor()",
@@ -13945,7 +14057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L105",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_constructor",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".execute()",
@@ -13953,7 +14065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L138",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_execute",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".splitIntoChunks()",
@@ -13961,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L396",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_splitintochunks",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".processChunk()",
@@ -13969,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L420",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_processchunk",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".getTargetMemories()",
@@ -13977,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L601",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_gettargetmemories",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".shouldRetry()",
@@ -13985,7 +14097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L670",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_shouldretry",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".getRetryCount()",
@@ -13993,7 +14105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L725",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_getretrycount",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".updateMemoryStatus()",
@@ -14001,7 +14113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L771",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_updatememorystatus",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".calculateAverageConfidence()",
@@ -14009,7 +14121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L824",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_calculateaverageconfidence",
-      "community": 115
+      "community": 116
     },
     {
       "label": "telemetry-cleanup-batch-job.spec.ts",
@@ -14017,7 +14129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14025,7 +14137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -14033,7 +14145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 352
+      "community": 353
     },
     {
       "label": ".constructor()",
@@ -14041,7 +14153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 352
+      "community": 353
     },
     {
       "label": ".execute()",
@@ -14049,7 +14161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 352
+      "community": 353
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -14057,7 +14169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14065,7 +14177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -14073,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".constructor()",
@@ -14081,7 +14193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".execute()",
@@ -14089,7 +14201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 353
+      "community": 354
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -14097,7 +14209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -14105,7 +14217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".constructor()",
@@ -14113,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".execute()",
@@ -14121,7 +14233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 354
+      "community": 355
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -14129,7 +14241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "generateId()",
@@ -14137,7 +14249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 440
+      "community": 441
     },
     {
       "label": "initializeTestDatabase()",
@@ -14145,7 +14257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 440
+      "community": 441
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14153,7 +14265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 557
+      "community": 559
     },
     {
       "label": "createQualityTables()",
@@ -14161,7 +14273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 557
+      "community": 559
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14169,7 +14281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "generateId()",
@@ -14177,7 +14289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 441
+      "community": 442
     },
     {
       "label": "initializeTestDatabase()",
@@ -14185,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 441
+      "community": 442
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14193,7 +14305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "stopwords.spec.ts",
@@ -14201,7 +14313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "type-guards.ts",
@@ -14209,7 +14321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_guards_ts",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isMemoryRow()",
@@ -14217,7 +14329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L32",
       "id": "type_guards_ismemoryrow",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isMemoryType()",
@@ -14225,7 +14337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L53",
       "id": "type_guards_ismemorytype",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isPrivacyScope()",
@@ -14233,7 +14345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L63",
       "id": "type_guards_isprivacyscope",
-      "community": 161
+      "community": 163
     },
     {
       "label": "convertMemoryRowToItem()",
@@ -14241,7 +14353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L74",
       "id": "type_guards_convertmemoryrowtoitem",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isRelationRow()",
@@ -14249,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L144",
       "id": "type_guards_isrelationrow",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isExistingRelationRow()",
@@ -14257,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L176",
       "id": "type_guards_isexistingrelationrow",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isMetadataRow()",
@@ -14265,7 +14377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L201",
       "id": "type_guards_ismetadatarow",
-      "community": 161
+      "community": 163
     },
     {
       "label": "isSqlParam()",
@@ -14273,7 +14385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L216",
       "id": "type_guards_issqlparam",
-      "community": 161
+      "community": 163
     },
     {
       "label": "procedural-memory-extractor.ts",
@@ -14385,7 +14497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "validateTableName()",
@@ -14393,7 +14505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 442
+      "community": 443
     },
     {
       "label": "getVectorTableName()",
@@ -14401,7 +14513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 442
+      "community": 443
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14409,7 +14521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 558
+      "community": 560
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14417,7 +14529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 558
+      "community": 560
     },
     {
       "label": "environment-check.ts",
@@ -14425,7 +14537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "isTestEnvironment()",
@@ -14433,7 +14545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 355
+      "community": 356
     },
     {
       "label": "isValidationDisabled()",
@@ -14441,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 355
+      "community": 356
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -14449,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 355
+      "community": 356
     },
     {
       "label": "db-path.spec.ts",
@@ -14457,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14465,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14473,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -14481,7 +14593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 303
+      "community": 304
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -14489,7 +14601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 303
+      "community": 304
     },
     {
       "label": "extractKeyTokens()",
@@ -14497,7 +14609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 303
+      "community": 304
     },
     {
       "label": "getSearchQueryExamples()",
@@ -14505,7 +14617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 303
+      "community": 304
     },
     {
       "label": "relation-type-converter.ts",
@@ -14513,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "toDbRelationType()",
@@ -14521,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 304
+      "community": 305
     },
     {
       "label": "fromDbRelationType()",
@@ -14529,7 +14641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 304
+      "community": 305
     },
     {
       "label": "isValidDbRelationType()",
@@ -14537,7 +14649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 304
+      "community": 305
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -14545,7 +14657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 304
+      "community": 305
     },
     {
       "label": "db-path.ts",
@@ -14553,7 +14665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 559
+      "community": 561
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14561,7 +14673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 559
+      "community": 561
     },
     {
       "label": "error-handling.spec.ts",
@@ -14569,7 +14681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 560
+      "community": 562
     },
     {
       "label": "operation()",
@@ -14577,7 +14689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 560
+      "community": 562
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14585,7 +14697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_ts",
-      "community": 225
+      "community": 226
     },
     {
       "label": "normalizeJson()",
@@ -14593,7 +14705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L104",
       "id": "procedural_memory_change_detector_normalizejson",
-      "community": 225
+      "community": 226
     },
     {
       "label": "computeJsonHash()",
@@ -14601,7 +14713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L168",
       "id": "procedural_memory_change_detector_computejsonhash",
-      "community": 225
+      "community": 226
     },
     {
       "label": "computeReflectionNotesCount()",
@@ -14609,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L221",
       "id": "procedural_memory_change_detector_computereflectionnotescount",
-      "community": 225
+      "community": 226
     },
     {
       "label": "createProceduralMemorySnapshot()",
@@ -14617,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L254",
       "id": "procedural_memory_change_detector_createproceduralmemorysnapshot",
-      "community": 225
+      "community": 226
     },
     {
       "label": "isEqual()",
@@ -14625,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L325",
       "id": "procedural_memory_change_detector_isequal",
-      "community": 225
+      "community": 226
     },
     {
       "label": "hasProceduralMemoryChanged()",
@@ -14633,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L357",
       "id": "procedural_memory_change_detector_hasproceduralmemorychanged",
-      "community": 225
+      "community": 226
     },
     {
       "label": "logging-rate-limiter.ts",
@@ -14641,7 +14753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_rate_limiter_ts",
-      "community": 162
+      "community": 164
     },
     {
       "label": "LoggingRateLimiter",
@@ -14649,7 +14761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L31",
       "id": "logging_rate_limiter_loggingratelimiter",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".constructor()",
@@ -14657,7 +14769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L38",
       "id": "logging_rate_limiter_loggingratelimiter_constructor",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".canSend()",
@@ -14665,7 +14777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L52",
       "id": "logging_rate_limiter_loggingratelimiter_cansend",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".consume()",
@@ -14673,7 +14785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L61",
       "id": "logging_rate_limiter_loggingratelimiter_consume",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".refill()",
@@ -14681,7 +14793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L76",
       "id": "logging_rate_limiter_loggingratelimiter_refill",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".getDroppedCount()",
@@ -14689,7 +14801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L88",
       "id": "logging_rate_limiter_loggingratelimiter_getdroppedcount",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".resetDroppedCount()",
@@ -14697,7 +14809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L95",
       "id": "logging_rate_limiter_loggingratelimiter_resetdroppedcount",
-      "community": 162
+      "community": 164
     },
     {
       "label": ".getAvailableTokens()",
@@ -14705,7 +14817,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L102",
       "id": "logging_rate_limiter_loggingratelimiter_getavailabletokens",
-      "community": 162
+      "community": 164
     },
     {
       "label": "type-param-validator.ts",
@@ -14713,7 +14825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_ts",
-      "community": 267
+      "community": 268
     },
     {
       "label": "validateTypeParam()",
@@ -14721,7 +14833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L32",
       "id": "type_param_validator_validatetypeparam",
-      "community": 267
+      "community": 268
     },
     {
       "label": "parseTypeParamMode()",
@@ -14729,7 +14841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L100",
       "id": "type_param_validator_parsetypeparammode",
-      "community": 267
+      "community": 268
     },
     {
       "label": "validateTriggerConditions()",
@@ -14737,7 +14849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L126",
       "id": "type_param_validator_validatetriggerconditions",
-      "community": 267
+      "community": 268
     },
     {
       "label": "validateWorkflowOrSkillName()",
@@ -14745,7 +14857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L168",
       "id": "type_param_validator_validateworkfloworskillname",
-      "community": 267
+      "community": 268
     },
     {
       "label": "validateProceduralMemoryFields()",
@@ -14753,7 +14865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L194",
       "id": "type_param_validator_validateproceduralmemoryfields",
-      "community": 267
+      "community": 268
     },
     {
       "label": "procedural-memory-extractor.types.ts",
@@ -14761,7 +14873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "relation-visualizer.ts",
@@ -14769,7 +14881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_visualizer_ts",
-      "community": 199
+      "community": 200
     },
     {
       "label": "escapeDotString()",
@@ -14777,7 +14889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L12",
       "id": "relation_visualizer_escapedotstring",
-      "community": 199
+      "community": 200
     },
     {
       "label": "RelationVisualizer",
@@ -14785,7 +14897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L68",
       "id": "relation_visualizer_relationvisualizer",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".visualizeAsText()",
@@ -14793,7 +14905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L76",
       "id": "relation_visualizer_relationvisualizer_visualizeastext",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".visualizeSubgraph()",
@@ -14801,7 +14913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L140",
       "id": "relation_visualizer_relationvisualizer_visualizesubgraph",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".visualizeSimple()",
@@ -14809,7 +14921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L324",
       "id": "relation_visualizer_relationvisualizer_visualizesimple",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".visualizeAsJSON()",
@@ -14817,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L346",
       "id": "relation_visualizer_relationvisualizer_visualizeasjson",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".visualizeAsDot()",
@@ -14825,7 +14937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L368",
       "id": "relation_visualizer_relationvisualizer_visualizeasdot",
-      "community": 199
+      "community": 200
     },
     {
       "label": "fts5-migration-status.ts",
@@ -14833,7 +14945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_ts",
-      "community": 116
+      "community": 117
     },
     {
       "label": "initializeMigrationStatusTable()",
@@ -14841,7 +14953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L21",
       "id": "fts5_migration_status_initializemigrationstatustable",
-      "community": 116
+      "community": 117
     },
     {
       "label": "getMigrationStatus()",
@@ -14849,7 +14961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L65",
       "id": "fts5_migration_status_getmigrationstatus",
-      "community": 116
+      "community": 117
     },
     {
       "label": "setMigrationStatus()",
@@ -14857,7 +14969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L115",
       "id": "fts5_migration_status_setmigrationstatus",
-      "community": 116
+      "community": 117
     },
     {
       "label": "isValidStatusTransition()",
@@ -14865,7 +14977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L194",
       "id": "fts5_migration_status_isvalidstatustransition",
-      "community": 116
+      "community": 117
     },
     {
       "label": "loadMigrationStatusToConfig()",
@@ -14873,7 +14985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L219",
       "id": "fts5_migration_status_loadmigrationstatustoconfig",
-      "community": 116
+      "community": 117
     },
     {
       "label": "isMigrationCompleted()",
@@ -14881,7 +14993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L237",
       "id": "fts5_migration_status_ismigrationcompleted",
-      "community": 116
+      "community": 117
     },
     {
       "label": "isMigrationFailed()",
@@ -14889,7 +15001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L251",
       "id": "fts5_migration_status_ismigrationfailed",
-      "community": 116
+      "community": 117
     },
     {
       "label": "shouldUseFallback()",
@@ -14897,7 +15009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L265",
       "id": "fts5_migration_status_shouldusefallback",
-      "community": 116
+      "community": 117
     },
     {
       "label": "prepareMigrationRetry()",
@@ -14905,7 +15017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L287",
       "id": "fts5_migration_status_preparemigrationretry",
-      "community": 116
+      "community": 117
     },
     {
       "label": "forceSetMigrationStatus()",
@@ -14913,7 +15025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.ts",
       "source_location": "L304",
       "id": "fts5_migration_status_forcesetmigrationstatus",
-      "community": 116
+      "community": 117
     },
     {
       "label": "triple-cache.ts",
@@ -14921,7 +15033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_triple_cache_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "TripleCacheService",
@@ -14929,7 +15041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L19",
       "id": "triple_cache_triplecacheservice",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".constructor()",
@@ -14937,7 +15049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L28",
       "id": "triple_cache_triplecacheservice_constructor",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".generateCacheKey()",
@@ -14945,7 +15057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L44",
       "id": "triple_cache_triplecacheservice_generatecachekey",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".get()",
@@ -14953,7 +15065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L61",
       "id": "triple_cache_triplecacheservice_get",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".set()",
@@ -14961,7 +15073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L76",
       "id": "triple_cache_triplecacheservice_set",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".delete()",
@@ -14969,7 +15081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L91",
       "id": "triple_cache_triplecacheservice_delete",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".clear()",
@@ -14977,7 +15089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L99",
       "id": "triple_cache_triplecacheservice_clear",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".getStats()",
@@ -14985,7 +15097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L108",
       "id": "triple_cache_triplecacheservice_getstats",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".cleanup()",
@@ -14993,7 +15105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L121",
       "id": "triple_cache_triplecacheservice_cleanup",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".size()",
@@ -15001,7 +15113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L132",
       "id": "triple_cache_triplecacheservice_size",
-      "community": 117
+      "community": 118
     },
     {
       "label": "database.ts",
@@ -15161,7 +15273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "issue()",
@@ -15169,7 +15281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 443
+      "community": 444
     },
     {
       "label": "validateConfiguration()",
@@ -15177,7 +15289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 443
+      "community": 444
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15185,7 +15297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "cache-key-generator.ts",
@@ -15193,7 +15305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_cache_key_generator_ts",
-      "community": 268
+      "community": 269
     },
     {
       "label": "CacheKeyGenerator",
@@ -15201,7 +15313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L31",
       "id": "cache_key_generator_cachekeygenerator",
-      "community": 268
+      "community": 269
     },
     {
       "label": ".generateRelationGraphKey()",
@@ -15209,7 +15321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L39",
       "id": "cache_key_generator_cachekeygenerator_generaterelationgraphkey",
-      "community": 268
+      "community": 269
     },
     {
       "label": ".generateRelationExtractionKey()",
@@ -15217,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L61",
       "id": "cache_key_generator_cachekeygenerator_generaterelationextractionkey",
-      "community": 268
+      "community": 269
     },
     {
       "label": ".generateLLMRelationExtractionKey()",
@@ -15225,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L95",
       "id": "cache_key_generator_cachekeygenerator_generatellmrelationextractionkey",
-      "community": 268
+      "community": 269
     },
     {
       "label": ".generateEmbeddingKey()",
@@ -15233,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L110",
       "id": "cache_key_generator_cachekeygenerator_generateembeddingkey",
-      "community": 268
+      "community": 269
     },
     {
       "label": "database.spec.ts",
@@ -15241,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "transactionFn()",
@@ -15249,7 +15361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 444
+      "community": 445
     },
     {
       "label": "outerTransaction()",
@@ -15257,7 +15369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 444
+      "community": 445
     },
     {
       "label": "write-coalescing.ts",
@@ -15265,7 +15377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_ts",
-      "community": 135
+      "community": 136
     },
     {
       "label": "WriteCoalescingManager",
@@ -15273,7 +15385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L33",
       "id": "write_coalescing_writecoalescingmanager",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".constructor()",
@@ -15281,7 +15393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L45",
       "id": "write_coalescing_writecoalescingmanager_constructor",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".addWrite()",
@@ -15289,7 +15401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L59",
       "id": "write_coalescing_writecoalescingmanager_addwrite",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".addWrites()",
@@ -15297,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L90",
       "id": "write_coalescing_writecoalescingmanager_addwrites",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".startFlushTimer()",
@@ -15305,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L99",
       "id": "write_coalescing_writecoalescingmanager_startflushtimer",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".flush()",
@@ -15313,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L134",
       "id": "write_coalescing_writecoalescingmanager_flush",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".getBufferSize()",
@@ -15321,7 +15433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L174",
       "id": "write_coalescing_writecoalescingmanager_getbuffersize",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".isEmpty()",
@@ -15329,7 +15441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L181",
       "id": "write_coalescing_writecoalescingmanager_isempty",
-      "community": 135
+      "community": 136
     },
     {
       "label": ".destroy()",
@@ -15337,7 +15449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.ts",
       "source_location": "L189",
       "id": "write_coalescing_writecoalescingmanager_destroy",
-      "community": 135
+      "community": 136
     },
     {
       "label": "reflection-notes-schema.ts",
@@ -15345,7 +15457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "validateReflectionNote()",
@@ -15353,7 +15465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 356
+      "community": 357
     },
     {
       "label": "validateReflectionNotes()",
@@ -15361,7 +15473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 356
+      "community": 357
     },
     {
       "label": "formatValidationErrors()",
@@ -15369,7 +15481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 356
+      "community": 357
     },
     {
       "label": "environment-check.spec.ts",
@@ -15377,7 +15489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "path-validator.ts",
@@ -15385,7 +15497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_path_validator_ts",
-      "community": 226
+      "community": 227
     },
     {
       "label": "getAllowedDirs()",
@@ -15393,7 +15505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L22",
       "id": "path_validator_getalloweddirs",
-      "community": 226
+      "community": 227
     },
     {
       "label": "isAbsolutePath()",
@@ -15401,7 +15513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L45",
       "id": "path_validator_isabsolutepath",
-      "community": 226
+      "community": 227
     },
     {
       "label": "containsPathTraversal()",
@@ -15409,7 +15521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L55",
       "id": "path_validator_containspathtraversal",
-      "community": 226
+      "community": 227
     },
     {
       "label": "isWithinAllowedDirs()",
@@ -15417,7 +15529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L78",
       "id": "path_validator_iswithinalloweddirs",
-      "community": 226
+      "community": 227
     },
     {
       "label": "validateFilePath()",
@@ -15425,7 +15537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L117",
       "id": "path_validator_validatefilepath",
-      "community": 226
+      "community": 227
     },
     {
       "label": "sanitizeFileName()",
@@ -15433,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L159",
       "id": "path_validator_sanitizefilename",
-      "community": 226
+      "community": 227
     },
     {
       "label": "ensure-memory-review-candidate-schema.ts",
@@ -15441,7 +15553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 561
+      "community": 563
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15449,7 +15561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 561
+      "community": 563
     },
     {
       "label": "error-handling.ts",
@@ -15457,7 +15569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 562
+      "community": 564
     },
     {
       "label": "withErrorHandling()",
@@ -15465,7 +15577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 562
+      "community": 564
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15473,7 +15585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15481,7 +15593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15489,7 +15601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_ts",
-      "community": 200
+      "community": 201
     },
     {
       "label": "getObjectSize()",
@@ -15497,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L55",
       "id": "reflection_notes_merge_getobjectsize",
-      "community": 200
+      "community": 201
     },
     {
       "label": "validateSingleObjectSize()",
@@ -15505,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L70",
       "id": "reflection_notes_merge_validatesingleobjectsize",
-      "community": 200
+      "community": 201
     },
     {
       "label": "limitArraySize()",
@@ -15513,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L85",
       "id": "reflection_notes_merge_limitarraysize",
-      "community": 200
+      "community": 201
     },
     {
       "label": "validateAndCleanupTotalSize()",
@@ -15521,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L109",
       "id": "reflection_notes_merge_validateandcleanuptotalsize",
-      "community": 200
+      "community": 201
     },
     {
       "label": "normalizeNewReflectionNotes()",
@@ -15529,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L167",
       "id": "reflection_notes_merge_normalizenewreflectionnotes",
-      "community": 200
+      "community": 201
     },
     {
       "label": "mergeReflectionNotes()",
@@ -15537,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L207",
       "id": "reflection_notes_merge_mergereflectionnotes",
-      "community": 200
+      "community": 201
     },
     {
       "label": "serializeReflectionNotes()",
@@ -15545,7 +15657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L286",
       "id": "reflection_notes_merge_serializereflectionnotes",
-      "community": 200
+      "community": 201
     },
     {
       "label": "prompt-template-loader.ts",
@@ -15553,7 +15665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_prompt_template_loader_ts",
-      "community": 227
+      "community": 228
     },
     {
       "label": "PromptTemplateLoader",
@@ -15561,7 +15673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L29",
       "id": "prompt_template_loader_prompttemplateloader",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".loadTemplate()",
@@ -15569,7 +15681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L40",
       "id": "prompt_template_loader_prompttemplateloader_loadtemplate",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".renderTemplate()",
@@ -15577,7 +15689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L76",
       "id": "prompt_template_loader_prompttemplateloader_rendertemplate",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".loadAndRender()",
@@ -15585,7 +15697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L95",
       "id": "prompt_template_loader_prompttemplateloader_loadandrender",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".clearCache()",
@@ -15593,7 +15705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L103",
       "id": "prompt_template_loader_prompttemplateloader_clearcache",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".getTemplatePath()",
@@ -15601,7 +15713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L113",
       "id": "prompt_template_loader_prompttemplateloader_gettemplatepath",
-      "community": 227
+      "community": 228
     },
     {
       "label": "logger.ts",
@@ -15609,7 +15721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_ts",
-      "community": 163
+      "community": 165
     },
     {
       "label": "validateLogMetadata()",
@@ -15617,7 +15729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L54",
       "id": "logger_validatelogmetadata",
-      "community": 163
+      "community": 165
     },
     {
       "label": "isMCPMode()",
@@ -15625,7 +15737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L160",
       "id": "logger_ismcpmode",
-      "community": 163
+      "community": 165
     },
     {
       "label": "safeStringify()",
@@ -15633,7 +15745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L173",
       "id": "logger_safestringify",
-      "community": 163
+      "community": 165
     },
     {
       "label": "formatTime()",
@@ -15641,7 +15753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L181",
       "id": "logger_formattime",
-      "community": 163
+      "community": 165
     },
     {
       "label": "buildLogMessage()",
@@ -15649,7 +15761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L191",
       "id": "logger_buildlogmessage",
-      "community": 163
+      "community": 165
     },
     {
       "label": "logToStderr()",
@@ -15657,7 +15769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L209",
       "id": "logger_logtostderr",
-      "community": 163
+      "community": 165
     },
     {
       "label": "logWithMCPLogger()",
@@ -15665,7 +15777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L240",
       "id": "logger_logwithmcplogger",
-      "community": 163
+      "community": 165
     },
     {
       "label": "isCliQuiet()",
@@ -15673,7 +15785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L294",
       "id": "logger_iscliquiet",
-      "community": 163
+      "community": 165
     },
     {
       "label": "ensure-meta-memory-stats-schema.ts",
@@ -15681,7 +15793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 563
+      "community": 565
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15689,7 +15801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 563
+      "community": 565
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15697,7 +15809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createValidReflectionNote()",
@@ -15705,7 +15817,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createLargeNote()",
@@ -15713,7 +15825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 445
+      "community": 446
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15721,7 +15833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 564
+      "community": 566
     },
     {
       "label": "initializeTestDatabase()",
@@ -15729,7 +15841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 564
+      "community": 566
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15737,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 565
+      "community": 567
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15745,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 565
+      "community": 567
     },
     {
       "label": "logging-helpers.ts",
@@ -15753,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_helpers_ts",
-      "community": 118
+      "community": 119
     },
     {
       "label": "LoggingHelper",
@@ -15761,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L49",
       "id": "logging_helpers_logginghelper",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".constructor()",
@@ -15769,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L52",
       "id": "logging_helpers_logginghelper_constructor",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".updateContext()",
@@ -15777,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L59",
       "id": "logging_helpers_logginghelper_updatecontext",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".getContext()",
@@ -15785,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L66",
       "id": "logging_helpers_logginghelper_getcontext",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".mergeContext()",
@@ -15793,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L73",
       "id": "logging_helpers_logginghelper_mergecontext",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".debug()",
@@ -15801,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L83",
       "id": "logging_helpers_logginghelper_debug",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".info()",
@@ -15809,7 +15921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L90",
       "id": "logging_helpers_logginghelper_info",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".warn()",
@@ -15817,7 +15929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L97",
       "id": "logging_helpers_logginghelper_warn",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".error()",
@@ -15825,7 +15937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L104",
       "id": "logging_helpers_logginghelper_error",
-      "community": 118
+      "community": 119
     },
     {
       "label": "createLogger()",
@@ -15833,7 +15945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L191",
       "id": "logging_helpers_createlogger",
-      "community": 118
+      "community": 119
     },
     {
       "label": "logger.spec.ts",
@@ -15841,7 +15953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "pii-masker.ts",
@@ -15849,7 +15961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_pii_masker_ts",
-      "community": 201
+      "community": 202
     },
     {
       "label": "isPIIMaskingEnabled()",
@@ -15857,7 +15969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L53",
       "id": "pii_masker_ispiimaskingenabled",
-      "community": 201
+      "community": 202
     },
     {
       "label": "PIIMasker",
@@ -15865,7 +15977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L67",
       "id": "pii_masker_piimasker",
-      "community": 201
+      "community": 202
     },
     {
       "label": ".mask()",
@@ -15873,7 +15985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L78",
       "id": "pii_masker_piimasker_mask",
-      "community": 201
+      "community": 202
     },
     {
       "label": ".hasPII()",
@@ -15881,7 +15993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L258",
       "id": "pii_masker_piimasker_haspii",
-      "community": 201
+      "community": 202
     },
     {
       "label": ".detectPIITypes()",
@@ -15889,7 +16001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L273",
       "id": "pii_masker_piimasker_detectpiitypes",
-      "community": 201
+      "community": 202
     },
     {
       "label": ".maskObject()",
@@ -15897,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L293",
       "id": "pii_masker_piimasker_maskobject",
-      "community": 201
+      "community": 202
     },
     {
       "label": ".maskError()",
@@ -15905,7 +16017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L346",
       "id": "pii_masker_piimasker_maskerror",
-      "community": 201
+      "community": 202
     },
     {
       "label": "stopwords.ts",
@@ -15913,7 +16025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getStopWords()",
@@ -15921,7 +16033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getEnglishStopWords()",
@@ -15929,7 +16041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getKoreanStopWords()",
@@ -15937,7 +16049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 305
+      "community": 306
     },
     {
       "label": "isStopWord()",
@@ -15945,7 +16057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 305
+      "community": 306
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -15953,7 +16065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -15961,7 +16073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "path-validator.spec.ts",
@@ -15969,7 +16081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "triple-cache.spec.ts",
@@ -15977,7 +16089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15985,7 +16097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -15993,7 +16105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16001,7 +16113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16009,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16017,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16025,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 566
+      "community": 568
     },
     {
       "label": "initializeTestDatabase()",
@@ -16033,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 566
+      "community": 568
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16041,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16049,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "benchmark.types.ts",
@@ -16057,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 567
+      "community": 569
     },
     {
       "label": "assertMacroCategory()",
@@ -16065,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 567
+      "community": 569
     },
     {
       "label": "migration.types.ts",
@@ -16073,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16081,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "consolidation.types.ts",
@@ -16089,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "vector-search.types.ts",
@@ -16097,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16105,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "procedural-versioning.ts",
@@ -16113,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "triple-extraction.ts",
@@ -16121,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "feedback.types.ts",
@@ -16129,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "embedding.types.ts",
@@ -16137,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "relation-graph.ts",
@@ -16145,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "failure-event.ts",
@@ -16153,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "index.ts",
@@ -16161,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "isMemoryItemType()",
@@ -16169,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 446
+      "community": 447
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16177,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 446
+      "community": 447
     },
     {
       "label": "error-types.ts",
@@ -16185,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "ranking.types.ts",
@@ -16193,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "alerts.types.ts",
@@ -16201,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "relation.ts",
@@ -16209,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "isApplicableRelationType()",
@@ -16217,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L151",
       "id": "relation_isapplicablerelationtype",
-      "community": 357
+      "community": 358
     },
     {
       "label": "getRelationCategory()",
@@ -16225,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L161",
       "id": "relation_getrelationcategory",
-      "community": 357
+      "community": 358
     },
     {
       "label": "getRelationBoost()",
@@ -16233,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L168",
       "id": "relation_getrelationboost",
-      "community": 357
+      "community": 358
     },
     {
       "label": "search.types.ts",
@@ -16241,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "index.spec.ts",
@@ -16249,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16257,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "constants.ts",
@@ -16265,7 +16377,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "environment.ts",
@@ -16273,7 +16385,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_environment_ts",
-      "community": 119
+      "community": 120
     },
     {
       "label": "toArray()",
@@ -16281,7 +16393,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L68",
       "id": "environment_toarray",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveEnv()",
@@ -16289,7 +16401,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L71",
       "id": "environment_resolveenv",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveString()",
@@ -16297,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L99",
       "id": "environment_resolvestring",
-      "community": 119
+      "community": 120
     },
     {
       "label": "expandHomeDirPath()",
@@ -16305,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L106",
       "id": "environment_expandhomedirpath",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveOptionalString()",
@@ -16313,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L118",
       "id": "environment_resolveoptionalstring",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveNumber()",
@@ -16321,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L139",
       "id": "environment_resolvenumber",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveOptionalNumber()",
@@ -16329,7 +16441,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L165",
       "id": "environment_resolveoptionalnumber",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveBoolean()",
@@ -16337,7 +16449,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L193",
       "id": "environment_resolveboolean",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveValidatedNumber()",
@@ -16345,7 +16457,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L220",
       "id": "environment_resolvevalidatednumber",
-      "community": 119
+      "community": 120
     },
     {
       "label": "getRawEnvValue()",
@@ -16353,7 +16465,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L246",
       "id": "environment_getrawenvvalue",
-      "community": 119
+      "community": 120
     },
     {
       "label": "ranking-weights-loader.ts",
@@ -16361,7 +16473,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_ts",
-      "community": 269
+      "community": 270
     },
     {
       "label": "resolveRankingWeightsFilePath()",
@@ -16369,7 +16481,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L56",
       "id": "ranking_weights_loader_resolverankingweightsfilepath",
-      "community": 269
+      "community": 270
     },
     {
       "label": "loadRankingWeights()",
@@ -16377,7 +16489,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L78",
       "id": "ranking_weights_loader_loadrankingweights",
-      "community": 269
+      "community": 270
     },
     {
       "label": "validateRankingWeights()",
@@ -16385,7 +16497,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L138",
       "id": "ranking_weights_loader_validaterankingweights",
-      "community": 269
+      "community": 270
     },
     {
       "label": "getRankingWeights()",
@@ -16393,7 +16505,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L182",
       "id": "ranking_weights_loader_getrankingweights",
-      "community": 269
+      "community": 270
     },
     {
       "label": "resetRankingWeightsCache()",
@@ -16401,7 +16513,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L190",
       "id": "ranking_weights_loader_resetrankingweightscache",
-      "community": 269
+      "community": 270
     },
     {
       "label": "vector-search.config.ts",
@@ -16409,7 +16521,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "retry-options-loader.ts",
@@ -16417,7 +16529,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_retry_options_loader_ts",
-      "community": 270
+      "community": 271
     },
     {
       "label": "loadRetryOptions()",
@@ -16425,7 +16537,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L47",
       "id": "retry_options_loader_loadretryoptions",
-      "community": 270
+      "community": 271
     },
     {
       "label": "validateRetryOptions()",
@@ -16433,7 +16545,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L129",
       "id": "retry_options_loader_validateretryoptions",
-      "community": 270
+      "community": 271
     },
     {
       "label": "validateRetryConfig()",
@@ -16441,7 +16553,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L156",
       "id": "retry_options_loader_validateretryconfig",
-      "community": 270
+      "community": 271
     },
     {
       "label": "getRetryOptions()",
@@ -16449,7 +16561,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L180",
       "id": "retry_options_loader_getretryoptions",
-      "community": 270
+      "community": 271
     },
     {
       "label": "resetRetryOptionsCache()",
@@ -16457,7 +16569,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L190",
       "id": "retry_options_loader_resetretryoptionscache",
-      "community": 270
+      "community": 271
     },
     {
       "label": "index.ts",
@@ -16465,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 568
+      "community": 570
     },
     {
       "label": "validateConfig()",
@@ -16473,7 +16585,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 568
+      "community": 570
     },
     {
       "label": "config-loader-utils.ts",
@@ -16481,7 +16593,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_config_loader_utils_ts",
-      "community": 202
+      "community": 203
     },
     {
       "label": "findProjectRoot()",
@@ -16489,7 +16601,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L50",
       "id": "config_loader_utils_findprojectroot",
-      "community": 202
+      "community": 203
     },
     {
       "label": "loadTOMLConfig()",
@@ -16497,7 +16609,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L113",
       "id": "config_loader_utils_loadtomlconfig",
-      "community": 202
+      "community": 203
     },
     {
       "label": "validateConfig()",
@@ -16505,7 +16617,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L140",
       "id": "config_loader_utils_validateconfig",
-      "community": 202
+      "community": 203
     },
     {
       "label": "mergeWithDefaults()",
@@ -16513,7 +16625,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L201",
       "id": "config_loader_utils_mergewithdefaults",
-      "community": 202
+      "community": 203
     },
     {
       "label": "getCachedConfig()",
@@ -16521,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L234",
       "id": "config_loader_utils_getcachedconfig",
-      "community": 202
+      "community": 203
     },
     {
       "label": "clearConfigCache()",
@@ -16529,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L246",
       "id": "config_loader_utils_clearconfigcache",
-      "community": 202
+      "community": 203
     },
     {
       "label": "clearConfigCacheByPrefix()",
@@ -16537,7 +16649,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L257",
       "id": "config_loader_utils_clearconfigcachebyprefix",
-      "community": 202
+      "community": 203
     },
     {
       "label": "ranking-weights-loader.spec.ts",
@@ -16545,7 +16657,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "constants.spec.ts",
@@ -16553,7 +16665,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "config-validation.spec.ts",
@@ -16561,7 +16673,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16569,7 +16681,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16577,7 +16689,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16585,7 +16697,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "relation-constants.ts",
@@ -16593,7 +16705,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "introspection-constants.ts",
@@ -16601,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16609,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "http-bind-policy.ts",
@@ -16617,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_ts",
-      "community": 164
+      "community": 166
     },
     {
       "label": "MementoHttpSecurityStartupError",
@@ -16625,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L5",
       "id": "http_bind_policy_mementohttpsecuritystartuperror",
-      "community": 164
+      "community": 166
     },
     {
       "label": ".constructor()",
@@ -16633,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L8",
       "id": "http_bind_policy_mementohttpsecuritystartuperror_constructor",
-      "community": 164
+      "community": 166
     },
     {
       "label": "isIpv4Loopback127Block()",
@@ -16641,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L17",
       "id": "http_bind_policy_isipv4loopback127block",
-      "community": 164
+      "community": 166
     },
     {
       "label": "isIpv4MappedLoopback()",
@@ -16649,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L32",
       "id": "http_bind_policy_isipv4mappedloopback",
-      "community": 164
+      "community": 166
     },
     {
       "label": "canonicalizeHttpBindHostForListen()",
@@ -16657,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L53",
       "id": "http_bind_policy_canonicalizehttpbindhostforlisten",
-      "community": 164
+      "community": 166
     },
     {
       "label": "formatHttpBindHostForUrl()",
@@ -16665,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L64",
       "id": "http_bind_policy_formathttpbindhostforurl",
-      "community": 164
+      "community": 166
     },
     {
       "label": "isHttpBindHostRemotelyReachable()",
@@ -16673,7 +16785,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L72",
       "id": "http_bind_policy_ishttpbindhostremotelyreachable",
-      "community": 164
+      "community": 166
     },
     {
       "label": "getMementoHttpSecurityStartupViolationMessage()",
@@ -16681,7 +16793,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L87",
       "id": "http_bind_policy_getmementohttpsecuritystartupviolationmessage",
-      "community": 164
+      "community": 166
     },
     {
       "label": "reflexion-worker.interface.ts",
@@ -16689,7 +16801,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16697,7 +16809,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "cache.interface.ts",
@@ -16705,7 +16817,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16713,7 +16825,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "error-logging.interface.ts",
@@ -16721,7 +16833,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16729,7 +16841,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16737,7 +16849,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "database.interface.ts",
@@ -16745,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16753,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16761,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "llm-client-initializer.ts",
@@ -16945,7 +17057,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "getMockMementoConfig()",
@@ -16953,7 +17065,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 447
+      "community": 448
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -16961,7 +17073,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 447
+      "community": 448
     },
     {
       "label": "initialize.spec.ts",
@@ -16969,7 +17081,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "openai-client.spec.ts",
@@ -16977,7 +17089,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -16985,7 +17097,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -16993,7 +17105,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17001,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17009,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17017,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17025,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17033,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17041,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "search-local-tool.ts",
@@ -17049,7 +17161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "SearchLocalTool",
@@ -17057,7 +17169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 358
+      "community": 359
     },
     {
       "label": ".constructor()",
@@ -17065,7 +17177,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 358
+      "community": 359
     },
     {
       "label": ".handle()",
@@ -17073,7 +17185,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 358
+      "community": 359
     },
     {
       "label": "get-anchor-tool.ts",
@@ -17081,7 +17193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "GetAnchorTool",
@@ -17089,7 +17201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".constructor()",
@@ -17097,7 +17209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".handle()",
@@ -17105,7 +17217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 359
+      "community": 360
     },
     {
       "label": "set-anchor-tool.ts",
@@ -17113,7 +17225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "SetAnchorTool",
@@ -17121,7 +17233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".constructor()",
@@ -17129,7 +17241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".handle()",
@@ -17137,7 +17249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 360
+      "community": 361
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -17145,7 +17257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "ClearAnchorTool",
@@ -17153,7 +17265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".constructor()",
@@ -17161,7 +17273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".handle()",
@@ -17169,7 +17281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 361
+      "community": 362
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -17177,7 +17289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "RestoreAnchorsTool",
@@ -17185,7 +17297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".constructor()",
@@ -17193,7 +17305,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".handle()",
@@ -17201,7 +17313,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 362
+      "community": 363
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -17209,7 +17321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "initializeTestDatabase()",
@@ -17217,7 +17329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 306
+      "community": 307
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17225,7 +17337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 306
+      "community": 307
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17233,7 +17345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 306
+      "community": 307
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17241,7 +17353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 306
+      "community": 307
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -17249,7 +17361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "initializeTestDatabase()",
@@ -17257,7 +17369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17265,7 +17377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17273,7 +17385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17281,7 +17393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 307
+      "community": 308
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -17289,7 +17401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "initializeTestDatabase()",
@@ -17297,7 +17409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17305,7 +17417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17313,7 +17425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17321,7 +17433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 308
+      "community": 309
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -17329,7 +17441,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 569
+      "community": 571
     },
     {
       "label": "initializeTestDatabase()",
@@ -17337,7 +17449,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 569
+      "community": 571
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17345,7 +17457,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 570
+      "community": 572
     },
     {
       "label": "initializeTestDatabase()",
@@ -17353,7 +17465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 570
+      "community": 572
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17361,7 +17473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17369,7 +17481,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "QueryFilterStrategy",
@@ -17377,7 +17489,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".constructor()",
@@ -17385,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".filter()",
@@ -17393,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".execute()",
@@ -17401,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 309
+      "community": 310
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -17409,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17417,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "local-search-service.ts",
@@ -17425,7 +17537,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_ts",
-      "community": 203
+      "community": 204
     },
     {
       "label": "LocalSearchService",
@@ -17433,7 +17545,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L24",
       "id": "local_search_service_localsearchservice",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".constructor()",
@@ -17441,7 +17553,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L31",
       "id": "local_search_service_localsearchservice_constructor",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".setDatabase()",
@@ -17449,7 +17561,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L46",
       "id": "local_search_service_localsearchservice_setdatabase",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".getAnchorWithEmbedding()",
@@ -17457,7 +17569,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L56",
       "id": "local_search_service_localsearchservice_getanchorwithembedding",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".performNHopSearch()",
@@ -17465,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L90",
       "id": "local_search_service_localsearchservice_performnhopsearch",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".applyQueryFilter()",
@@ -17473,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L113",
       "id": "local_search_service_localsearchservice_applyqueryfilter",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".handleFallback()",
@@ -17481,7 +17593,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L128",
       "id": "local_search_service_localsearchservice_handlefallback",
-      "community": 203
+      "community": 204
     },
     {
       "label": "query-filter-service.spec.ts",
@@ -17489,7 +17601,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17497,7 +17609,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17625,7 +17737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17633,7 +17745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 571
+      "community": 573
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17641,7 +17753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 571
+      "community": 573
     },
     {
       "label": "embedding-types.ts",
@@ -17649,7 +17761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17657,7 +17769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -17665,7 +17777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "NHopSearchStrategy",
@@ -17673,7 +17785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".constructor()",
@@ -17681,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".search()",
@@ -17689,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".execute()",
@@ -17697,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 310
+      "community": 311
     },
     {
       "label": "query-filter-service.ts",
@@ -17705,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_ts",
-      "community": 228
+      "community": 229
     },
     {
       "label": "QueryFilterService",
@@ -17713,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L41",
       "id": "query_filter_service_queryfilterservice",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".constructor()",
@@ -17721,7 +17833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L45",
       "id": "query_filter_service_queryfilterservice_constructor",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".filterByQuery()",
@@ -17729,7 +17841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L53",
       "id": "query_filter_service_queryfilterservice_filterbyquery",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".cosineSimilarity()",
@@ -17737,7 +17849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L151",
       "id": "query_filter_service_queryfilterservice_cosinesimilarity",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".calculateTextSimilarity()",
@@ -17745,7 +17857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L175",
       "id": "query_filter_service_queryfilterservice_calculatetextsimilarity",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".calculateBaseRankingScore()",
@@ -17753,7 +17865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L186",
       "id": "query_filter_service_queryfilterservice_calculatebaserankingscore",
-      "community": 228
+      "community": 229
     },
     {
       "label": "anchor-manager.ts",
@@ -17865,7 +17977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 311
+      "community": 312
     },
     {
       "label": "FallbackSearchService",
@@ -17873,7 +17985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".setDatabase()",
@@ -17881,7 +17993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -17889,7 +18001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -17897,7 +18009,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 311
+      "community": 312
     },
     {
       "label": "index.ts",
@@ -17905,7 +18017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "fallback-strategy.ts",
@@ -17913,7 +18025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "FallbackStrategy",
@@ -17921,7 +18033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".constructor()",
@@ -17929,7 +18041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".fallback()",
@@ -17937,7 +18049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".execute()",
@@ -17945,7 +18057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 312
+      "community": 313
     },
     {
       "label": "anchor-search-service.ts",
@@ -18089,7 +18201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18097,7 +18209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_ts",
-      "community": 120
+      "community": 121
     },
     {
       "label": "AnchorCacheService",
@@ -18105,7 +18217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L15",
       "id": "anchor_cache_service_anchorcacheservice",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".constructor()",
@@ -18113,7 +18225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L28",
       "id": "anchor_cache_service_anchorcacheservice_constructor",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".setDatabase()",
@@ -18121,7 +18233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L37",
       "id": "anchor_cache_service_anchorcacheservice_setdatabase",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".setEmbeddingService()",
@@ -18129,7 +18241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L47",
       "id": "anchor_cache_service_anchorcacheservice_setembeddingservice",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".getAnchorEmbedding()",
@@ -18137,7 +18249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L59",
       "id": "anchor_cache_service_anchorcacheservice_getanchorembedding",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".restoreCacheFromDB()",
@@ -18145,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L148",
       "id": "anchor_cache_service_anchorcacheservice_restorecachefromdb",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".updateCache()",
@@ -18153,7 +18265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L206",
       "id": "anchor_cache_service_anchorcacheservice_updatecache",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".getCachedAnchor()",
@@ -18161,7 +18273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L221",
       "id": "anchor_cache_service_anchorcacheservice_getcachedanchor",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".getCachedMemoryId()",
@@ -18169,7 +18281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L231",
       "id": "anchor_cache_service_anchorcacheservice_getcachedmemoryid",
-      "community": 120
+      "community": 121
     },
     {
       "label": ".deleteCache()",
@@ -18177,7 +18289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L240",
       "id": "anchor_cache_service_anchorcacheservice_deletecache",
-      "community": 120
+      "community": 121
     },
     {
       "label": "n-hop-search-service.ts",
@@ -18337,7 +18449,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18345,7 +18457,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18353,7 +18465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "vector-search.factory.ts",
@@ -18361,7 +18473,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_vector_search_factory_ts",
-      "community": 271
+      "community": 272
     },
     {
       "label": "VectorSearchFactory",
@@ -18369,7 +18481,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L12",
       "id": "vector_search_factory_vectorsearchfactory",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".createFacade()",
@@ -18377,7 +18489,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L16",
       "id": "vector_search_factory_vectorsearchfactory_createfacade",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".createSearchService()",
@@ -18385,7 +18497,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L35",
       "id": "vector_search_factory_vectorsearchfactory_createsearchservice",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".createIndexManager()",
@@ -18393,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L44",
       "id": "vector_search_factory_vectorsearchfactory_createindexmanager",
-      "community": 271
+      "community": 272
     },
     {
       "label": ".createPerformanceTester()",
@@ -18401,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L53",
       "id": "vector_search_factory_vectorsearchfactory_createperformancetester",
-      "community": 271
+      "community": 272
     },
     {
       "label": "hybrid-search.factory.ts",
@@ -18409,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_hybrid_search_factory_ts",
-      "community": 165
+      "community": 167
     },
     {
       "label": "DefaultSearchLogger",
@@ -18417,7 +18529,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L27",
       "id": "hybrid_search_factory_defaultsearchlogger",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".logSearchStart()",
@@ -18425,7 +18537,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L28",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstart",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".logSearchStep()",
@@ -18433,7 +18545,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L32",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstep",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".logSearchComplete()",
@@ -18441,7 +18553,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L36",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchcomplete",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".logSearchError()",
@@ -18449,7 +18561,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L48",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearcherror",
-      "community": 165
+      "community": 167
     },
     {
       "label": "HybridSearchFactory",
@@ -18457,7 +18569,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L58",
       "id": "hybrid_search_factory_hybridsearchfactory",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".createDefaultEngine()",
@@ -18465,7 +18577,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L62",
       "id": "hybrid_search_factory_hybridsearchfactory_createdefaultengine",
-      "community": 165
+      "community": 167
     },
     {
       "label": ".createEngine()",
@@ -18473,7 +18585,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L91",
       "id": "hybrid_search_factory_hybridsearchfactory_createengine",
-      "community": 165
+      "community": 167
     },
     {
       "label": "hybrid-search.factory.spec.ts",
@@ -18481,7 +18593,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 572
+      "community": 574
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18489,7 +18601,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 572
+      "community": 574
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18497,7 +18609,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "search-result-combiner.ts",
@@ -18505,7 +18617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 363
+      "community": 364
     },
     {
       "label": "SearchResultCombiner",
@@ -18513,7 +18625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L19",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".combine()",
@@ -18521,7 +18633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L31",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".generateHybridReason()",
@@ -18529,7 +18641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L103",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 363
+      "community": 364
     },
     {
       "label": "search-engine.ts",
@@ -18681,7 +18793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 364
+      "community": 365
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -18689,7 +18801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 364
+      "community": 365
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -18697,7 +18809,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 364
+      "community": 365
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -18705,7 +18817,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 364
+      "community": 365
     },
     {
       "label": "search-ranking.ts",
@@ -19513,7 +19625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_migration_ts",
-      "community": 229
+      "community": 230
     },
     {
       "label": "VectorSearchEngineMigration",
@@ -19521,7 +19633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L16",
       "id": "vector_search_engine_migration_vectorsearchenginemigration",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".migrate()",
@@ -19529,7 +19641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L23",
       "id": "vector_search_engine_migration_vectorsearchenginemigration_migrate",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".createAdapter()",
@@ -19537,7 +19649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L43",
       "id": "vector_search_engine_migration_vectorsearchenginemigration_createadapter",
-      "community": 229
+      "community": 230
     },
     {
       "label": "MigrationValidator",
@@ -19545,7 +19657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L137",
       "id": "vector_search_engine_migration_migrationvalidator",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".validateCompatibility()",
@@ -19553,7 +19665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L141",
       "id": "vector_search_engine_migration_migrationvalidator_validatecompatibility",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".comparePerformance()",
@@ -19561,7 +19673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts",
       "source_location": "L180",
       "id": "vector_search_engine_migration_migrationvalidator_compareperformance",
-      "community": 229
+      "community": 230
     },
     {
       "label": "hybrid-search-outcome-utils.ts",
@@ -19569,7 +19681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 573
+      "community": 575
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19577,7 +19689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 573
+      "community": 575
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19585,7 +19697,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_spec_ts",
-      "community": 272
+      "community": 273
     },
     {
       "label": "sqliteMasterPreparedMock()",
@@ -19593,7 +19705,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L21",
       "id": "vector_search_engine_spec_sqlitemasterpreparedmock",
-      "community": 272
+      "community": 273
     },
     {
       "label": "createMockVectorRows()",
@@ -19601,7 +19713,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L40",
       "id": "vector_search_engine_spec_createmockvectorrows",
-      "community": 272
+      "community": 273
     },
     {
       "label": "createMockImplementation()",
@@ -19609,7 +19721,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L54",
       "id": "vector_search_engine_spec_createmockimplementation",
-      "community": 272
+      "community": 273
     },
     {
       "label": "mockSqliteMaster()",
@@ -19617,7 +19729,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L92",
       "id": "vector_search_engine_spec_mocksqlitemaster",
-      "community": 272
+      "community": 273
     },
     {
       "label": "defaultTfidfVecRegistry()",
@@ -19625,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L96",
       "id": "vector_search_engine_spec_defaulttfidfvecregistry",
-      "community": 272
+      "community": 273
     },
     {
       "label": "procedural-memory-matcher.ts",
@@ -19633,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_procedural_memory_matcher_ts",
-      "community": 204
+      "community": 205
     },
     {
       "label": "ProceduralMemoryMatcher",
@@ -19641,7 +19753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L21",
       "id": "procedural_memory_matcher_proceduralmemorymatcher",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".extractQueryInfo()",
@@ -19649,7 +19761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L30",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_extractqueryinfo",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".fetchProceduralMemoryRows()",
@@ -19657,7 +19769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L58",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_fetchproceduralmemoryrows",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".matchWorkflowName()",
@@ -19665,7 +19777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L94",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchworkflowname",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".matchSkillName()",
@@ -19673,7 +19785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L125",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchskillname",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".matchTriggerConditions()",
@@ -19681,7 +19793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L157",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchtriggerconditions",
-      "community": 204
+      "community": 205
     },
     {
       "label": ".fetchProceduralMemoryMatches()",
@@ -19689,7 +19801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L243",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_fetchproceduralmemorymatches",
-      "community": 204
+      "community": 205
     },
     {
       "label": "process-attribute-fit.ts",
@@ -19697,7 +19809,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 365
+      "community": 366
     },
     {
       "label": "normalize()",
@@ -19705,7 +19817,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 365
+      "community": 366
     },
     {
       "label": "toSet()",
@@ -19713,7 +19825,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 365
+      "community": 366
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -19721,7 +19833,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 365
+      "community": 366
     },
     {
       "label": "procedural-memory-matcher.spec.ts",
@@ -19729,7 +19841,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19737,7 +19849,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19745,7 +19857,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "initializeTestDatabase()",
@@ -19753,7 +19865,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 448
+      "community": 449
     },
     {
       "label": "createValidReflectionNote()",
@@ -19761,7 +19873,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 448
+      "community": 449
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -19769,7 +19881,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_spec_ts",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockTextSearchEngine()",
@@ -19777,7 +19889,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L44",
       "id": "hybrid_search_engine_spec_createmocktextsearchengine",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockEmbeddingService()",
@@ -19785,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L48",
       "id": "hybrid_search_engine_spec_createmockembeddingservice",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -19793,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L54",
       "id": "hybrid_search_engine_spec_createmockvectorsearchengine",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockResultCombiner()",
@@ -19801,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L60",
       "id": "hybrid_search_engine_spec_createmockresultcombiner",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockWeightCalculator()",
@@ -19809,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L64",
       "id": "hybrid_search_engine_spec_createmockweightcalculator",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createMockLogger()",
@@ -19817,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L68",
       "id": "hybrid_search_engine_spec_createmocklogger",
-      "community": 166
+      "community": 168
     },
     {
       "label": "createTestMemory()",
@@ -19825,7 +19937,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L536",
       "id": "hybrid_search_engine_spec_createtestmemory",
-      "community": 166
+      "community": 168
     },
     {
       "label": "p95()",
@@ -19833,7 +19945,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L2621",
       "id": "hybrid_search_engine_spec_p95",
-      "community": 166
+      "community": 168
     },
     {
       "label": "hybrid-search-engine-consolidation.spec.ts",
@@ -19841,7 +19953,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -19849,7 +19961,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "search-engine.spec.ts",
@@ -19857,7 +19969,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 366
+      "community": 367
     },
     {
       "label": "createCountingSearchDb()",
@@ -19865,7 +19977,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 366
+      "community": 367
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -19873,7 +19985,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 366
+      "community": 367
     },
     {
       "label": "createSearchRows()",
@@ -19881,7 +19993,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 366
+      "community": 367
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -19889,7 +20001,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "vector-search.repository.ts",
@@ -20033,7 +20145,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_performance_repository_ts",
-      "community": 273
+      "community": 274
     },
     {
       "label": "VectorPerformanceRepositoryImpl",
@@ -20041,7 +20153,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L13",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".constructor()",
@@ -20049,7 +20161,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L17",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_constructor",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".checkVecAvailability()",
@@ -20057,7 +20169,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L25",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_checkvecavailability",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".runPerformanceTest()",
@@ -20065,7 +20177,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L85",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_runperformancetest",
-      "community": 273
+      "community": 274
     },
     {
       "label": ".executeSearch()",
@@ -20073,7 +20185,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L139",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_executesearch",
-      "community": 273
+      "community": 274
     },
     {
       "label": "vector-performance.repository.spec.ts",
@@ -20081,7 +20193,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20089,7 +20201,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "vector-search.service.ts",
@@ -20097,7 +20209,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_ts",
-      "community": 121
+      "community": 122
     },
     {
       "label": "VectorSearchService",
@@ -20105,7 +20217,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L20",
       "id": "vector_search_service_vectorsearchservice",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".constructor()",
@@ -20113,7 +20225,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L21",
       "id": "vector_search_service_vectorsearchservice_constructor",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".search()",
@@ -20121,7 +20233,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L29",
       "id": "vector_search_service_vectorsearchservice_search",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".hybridSearch()",
@@ -20129,7 +20241,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L42",
       "id": "vector_search_service_vectorsearchservice_hybridsearch",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".providerHybridSearch()",
@@ -20137,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L52",
       "id": "vector_search_service_vectorsearchservice_providerhybridsearch",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".unifiedSearch()",
@@ -20145,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L131",
       "id": "vector_search_service_vectorsearchservice_unifiedsearch",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".validateQuery()",
@@ -20153,7 +20265,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L146",
       "id": "vector_search_service_vectorsearchservice_validatequery",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".validateProviderHybridQuery()",
@@ -20161,7 +20273,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L157",
       "id": "vector_search_service_vectorsearchservice_validateproviderhybridquery",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".getExpectedDimensions()",
@@ -20169,7 +20281,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L164",
       "id": "vector_search_service_vectorsearchservice_getexpecteddimensions",
-      "community": 121
+      "community": 122
     },
     {
       "label": ".applyDefaultOptions()",
@@ -20177,7 +20289,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L175",
       "id": "vector_search_service_vectorsearchservice_applydefaultoptions",
-      "community": 121
+      "community": 122
     },
     {
       "label": "vector-performance-tester.spec.ts",
@@ -20185,7 +20297,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 574
+      "community": 576
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20193,7 +20305,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 574
+      "community": 576
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20201,7 +20313,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_ts",
-      "community": 230
+      "community": 231
     },
     {
       "label": "VectorPerformanceTester",
@@ -20209,7 +20321,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L12",
       "id": "vector_performance_tester_vectorperformancetester",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".constructor()",
@@ -20217,7 +20329,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L13",
       "id": "vector_performance_tester_vectorperformancetester_constructor",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".runPerformanceTest()",
@@ -20225,7 +20337,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L18",
       "id": "vector_performance_tester_vectorperformancetester_runperformancetest",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".validateTestParameters()",
@@ -20233,7 +20345,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L44",
       "id": "vector_performance_tester_vectorperformancetester_validatetestparameters",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".analyzeResults()",
@@ -20241,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L57",
       "id": "vector_performance_tester_vectorperformancetester_analyzeresults",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".generateReport()",
@@ -20249,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L87",
       "id": "vector_performance_tester_vectorperformancetester_generatereport",
-      "community": 230
+      "community": 231
     },
     {
       "label": "vector-search.service.spec.ts",
@@ -20257,7 +20369,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 575
+      "community": 577
     },
     {
       "label": "createMockRepository()",
@@ -20265,7 +20377,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 575
+      "community": 577
     },
     {
       "label": "vector-index-manager.ts",
@@ -20273,7 +20385,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_ts",
-      "community": 231
+      "community": 232
     },
     {
       "label": "VectorIndexManager",
@@ -20281,7 +20393,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L12",
       "id": "vector_index_manager_vectorindexmanager",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".constructor()",
@@ -20289,7 +20401,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L13",
       "id": "vector_index_manager_vectorindexmanager_constructor",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".getIndexStatus()",
@@ -20297,7 +20409,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L21",
       "id": "vector_index_manager_vectorindexmanager_getindexstatus",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".rebuildIndex()",
@@ -20305,7 +20417,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L54",
       "id": "vector_index_manager_vectorindexmanager_rebuildindex",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".isAvailable()",
@@ -20313,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L72",
       "id": "vector_index_manager_vectorindexmanager_isavailable",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".getStatusSummary()",
@@ -20321,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L87",
       "id": "vector_index_manager_vectorindexmanager_getstatussummary",
-      "community": 231
+      "community": 232
     },
     {
       "label": "vector-search-facade.ts",
@@ -20449,7 +20561,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_container_ts",
-      "community": 136
+      "community": 137
     },
     {
       "label": "VectorSearchContainer",
@@ -20457,7 +20569,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L11",
       "id": "vector_search_container_vectorsearchcontainer",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".constructor()",
@@ -20465,7 +20577,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L16",
       "id": "vector_search_container_vectorsearchcontainer_constructor",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".getInstance()",
@@ -20473,7 +20585,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L21",
       "id": "vector_search_container_vectorsearchcontainer_getinstance",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".setDatabase()",
@@ -20481,7 +20593,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L31",
       "id": "vector_search_container_vectorsearchcontainer_setdatabase",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".getFacade()",
@@ -20489,7 +20601,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L39",
       "id": "vector_search_container_vectorsearchcontainer_getfacade",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".createFacade()",
@@ -20497,7 +20609,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L52",
       "id": "vector_search_container_vectorsearchcontainer_createfacade",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".reset()",
@@ -20505,7 +20617,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L70",
       "id": "vector_search_container_vectorsearchcontainer_reset",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".isConnected()",
@@ -20513,7 +20625,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L78",
       "id": "vector_search_container_vectorsearchcontainer_isconnected",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".isFacadeReady()",
@@ -20521,7 +20633,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L85",
       "id": "vector_search_container_vectorsearchcontainer_isfacadeready",
-      "community": 136
+      "community": 137
     },
     {
       "label": "vector-search-result-normalizer.ts",
@@ -20529,7 +20641,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "selectScore()",
@@ -20537,7 +20649,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 313
+      "community": 314
     },
     {
       "label": "computeNormalizationRange()",
@@ -20545,7 +20657,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 313
+      "community": 314
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -20553,7 +20665,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".normalize()",
@@ -20561,7 +20673,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 313
+      "community": 314
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -20569,7 +20681,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 576
+      "community": 578
     },
     {
       "label": "createMockRepositories()",
@@ -20577,7 +20689,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 576
+      "community": 578
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20585,7 +20697,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20593,7 +20705,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 577
+      "community": 579
     },
     {
       "label": "createMockIndexRepository()",
@@ -20601,7 +20713,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 577
+      "community": 579
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20777,7 +20889,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20785,7 +20897,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20793,7 +20905,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "spaced-repetition.ts",
@@ -21121,7 +21233,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21129,7 +21241,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 367
+      "community": 368
     },
     {
       "label": "ForgettingStatsTool",
@@ -21137,7 +21249,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".constructor()",
@@ -21145,7 +21257,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".handle()",
@@ -21153,7 +21265,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 367
+      "community": 368
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -21161,7 +21273,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21297,7 +21409,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21305,7 +21417,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22185,7 +22297,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "recall-probability.service.ts",
@@ -22289,7 +22401,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "telemetry.types.ts",
@@ -22297,7 +22409,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22305,7 +22417,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 578
+      "community": 580
     },
     {
       "label": "openTelemetryDb()",
@@ -22313,7 +22425,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 578
+      "community": 580
     },
     {
       "label": "telemetry-repository.ts",
@@ -22473,7 +22585,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "makeSearchQuality()",
@@ -22481,7 +22593,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 314
+      "community": 315
     },
     {
       "label": "makeMemoryQuality()",
@@ -22489,7 +22601,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 314
+      "community": 315
     },
     {
       "label": "makeConsolidationQuality()",
@@ -22497,7 +22609,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 314
+      "community": 315
     },
     {
       "label": "makeContext()",
@@ -22505,7 +22617,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 314
+      "community": 315
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -22513,7 +22625,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 368
+      "community": 369
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -22521,7 +22633,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".constructor()",
@@ -22529,7 +22641,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".handle()",
@@ -22537,7 +22649,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 368
+      "community": 369
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -22545,7 +22657,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "telemetry-service.ts",
@@ -22673,7 +22785,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22681,7 +22793,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22689,7 +22801,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22697,7 +22809,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 579
+      "community": 581
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22705,7 +22817,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 579
+      "community": 581
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22713,7 +22825,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 369
+      "community": 370
     },
     {
       "label": "baseTags()",
@@ -22721,7 +22833,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 369
+      "community": 370
     },
     {
       "label": "pushUnique()",
@@ -22729,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 369
+      "community": 370
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -22737,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 369
+      "community": 370
     },
     {
       "label": "llm-port.ts",
@@ -22745,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "persistence-port.ts",
@@ -22753,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "context-port.ts",
@@ -22761,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "agent-types.ts",
@@ -22769,7 +22881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -22777,7 +22889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -22785,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "parseRememberSuccess()",
@@ -22793,7 +22905,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 315
+      "community": 316
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -22801,7 +22913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".constructor()",
@@ -22809,7 +22921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".persistApproved()",
@@ -22817,7 +22929,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 315
+      "community": 316
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -22825,7 +22937,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -22833,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".constructor()",
@@ -22841,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".buildContext()",
@@ -22849,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".proposeCandidates()",
@@ -22857,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 316
+      "community": 317
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -22865,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 317
+      "community": 318
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -22873,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".constructor()",
@@ -22881,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".complete()",
@@ -22889,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".createRequestId()",
@@ -22897,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 317
+      "community": 318
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -22905,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -22913,7 +23025,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 580
+      "community": 582
     },
     {
       "label": "baseCandidate()",
@@ -22921,7 +23033,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 580
+      "community": 582
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -22929,7 +23041,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 318
+      "community": 319
     },
     {
       "label": "normalizeOwnerId()",
@@ -22937,7 +23049,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 318
+      "community": 319
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -22945,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 318
+      "community": 319
     },
     {
       "label": "assertUnreachable()",
@@ -22953,7 +23065,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 318
+      "community": 319
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -22961,7 +23073,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 318
+      "community": 319
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -22969,7 +23081,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 581
+      "community": 583
     },
     {
       "label": "makeDeps()",
@@ -22977,7 +23089,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 581
+      "community": 583
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -22985,7 +23097,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 319
+      "community": 320
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -22993,7 +23105,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".constructor()",
@@ -23001,7 +23113,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".runOneTurn()",
@@ -23009,7 +23121,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 319
+      "community": 320
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -23017,7 +23129,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 319
+      "community": 320
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -23025,7 +23137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 582
+      "community": 584
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23033,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 582
+      "community": 584
     },
     {
       "label": "core-memory-repository.ts",
@@ -23041,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23049,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23057,7 +23169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23065,7 +23177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23073,7 +23185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "feedback-repository.ts",
@@ -23081,7 +23193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23089,7 +23201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 449
+      "community": 450
     },
     {
       "label": "FeedbackRepository",
@@ -23097,7 +23209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 449
+      "community": 450
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23105,7 +23217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23113,7 +23225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23121,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23129,7 +23241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23137,7 +23249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23145,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 583
+      "community": 585
     },
     {
       "label": "createKgTripleTable()",
@@ -23153,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 583
+      "community": 585
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23161,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 584
+      "community": 586
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23169,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 584
+      "community": 586
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23177,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23185,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 585
+      "community": 587
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23193,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23201,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 586
+      "community": 588
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23209,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 586
+      "community": 588
     },
     {
       "label": "remember-tool.ts",
@@ -23217,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
-      "community": 137
+      "community": 138
     },
     {
       "label": "RememberTool",
@@ -23225,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L135",
       "id": "remember_tool_remembertool",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".constructor()",
@@ -23233,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L136",
       "id": "remember_tool_remembertool_constructor",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".validateReflectionNotesJson()",
@@ -23241,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L249",
       "id": "remember_tool_remembertool_validatereflectionnotesjson",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getExistingReflectionNotes()",
@@ -23249,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L265",
       "id": "remember_tool_remembertool_getexistingreflectionnotes",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".parseReflectionNotes()",
@@ -23257,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L319",
       "id": "remember_tool_remembertool_parsereflectionnotes",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".handle()",
@@ -23265,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L369",
       "id": "remember_tool_remembertool_handle",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".findExistingProceduralMemory()",
@@ -23273,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1536",
       "id": "remember_tool_remembertool_findexistingproceduralmemory",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getExistingMemoriesForRelationExtraction()",
@@ -23281,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1609",
       "id": "remember_tool_remembertool_getexistingmemoriesforrelationextraction",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getMemoryById()",
@@ -23289,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1657",
       "id": "remember_tool_remembertool_getmemorybyid",
-      "community": 137
+      "community": 138
     },
     {
       "label": "recall-tool-validation.ts",
@@ -23297,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "validateRecallQuery()",
@@ -23305,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 450
+      "community": 451
     },
     {
       "label": "validateRecallFilters()",
@@ -23313,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 450
+      "community": 451
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23321,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 587
+      "community": 589
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23329,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 587
+      "community": 589
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23337,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 370
+      "community": 371
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23345,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 370
+      "community": 371
     },
     {
       "label": ".constructor()",
@@ -23353,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 370
+      "community": 371
     },
     {
       "label": ".handle()",
@@ -23361,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 370
+      "community": 371
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23369,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 371
+      "community": 372
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23377,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".constructor()",
@@ -23385,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".handle()",
@@ -23393,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 371
+      "community": 372
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23401,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 372
+      "community": 373
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23409,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".constructor()",
@@ -23417,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".handle()",
@@ -23425,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 372
+      "community": 373
     },
     {
       "label": "feedback-tool.ts",
@@ -23433,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_feedback_tool_ts",
-      "community": 274
+      "community": 275
     },
     {
       "label": "normalizeFeedbackCreatedAtToIso()",
@@ -23441,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L14",
       "id": "feedback_tool_normalizefeedbackcreatedattoiso",
-      "community": 274
+      "community": 275
     },
     {
       "label": "FeedbackTool",
@@ -23449,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L63",
       "id": "feedback_tool_feedbacktool",
-      "community": 274
+      "community": 275
     },
     {
       "label": ".constructor()",
@@ -23457,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L64",
       "id": "feedback_tool_feedbacktool_constructor",
-      "community": 274
+      "community": 275
     },
     {
       "label": ".feedbackContractError()",
@@ -23465,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L106",
       "id": "feedback_tool_feedbacktool_feedbackcontracterror",
-      "community": 274
+      "community": 275
     },
     {
       "label": ".handle()",
@@ -23473,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L119",
       "id": "feedback_tool_feedbacktool_handle",
-      "community": 274
+      "community": 275
     },
     {
       "label": "cleanup-memory-tool.ts",
@@ -23481,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "CleanupMemoryTool",
@@ -23489,7 +23601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".constructor()",
@@ -23497,7 +23609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".handle()",
@@ -23505,7 +23617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 373
+      "community": 374
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23513,7 +23625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23521,7 +23633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 451
+      "community": 452
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23529,7 +23641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 451
+      "community": 452
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -23729,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "ProceduralDiffTool",
@@ -23737,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23745,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -23753,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 374
+      "community": 375
     },
     {
       "label": "unpin-tool.ts",
@@ -23873,7 +23985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -23881,7 +23993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23889,7 +24001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23897,7 +24009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -23905,7 +24017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "RememberProcedureTool",
@@ -23913,7 +24025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -23921,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -23929,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -23937,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 320
+      "community": 321
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -23945,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 320
+      "community": 321
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -23953,7 +24065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 320
+      "community": 321
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -23961,7 +24073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 320
+      "community": 321
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -23969,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 320
+      "community": 321
     },
     {
       "label": "recall-tool-results.ts",
@@ -23977,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 588
+      "community": 590
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -23985,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 588
+      "community": 590
     },
     {
       "label": "recall-tool.ts",
@@ -24121,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "forget-tool.ts",
@@ -24265,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 589
+      "community": 591
     },
     {
       "label": "createSchema()",
@@ -24273,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 589
+      "community": 591
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24281,7 +24393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24289,7 +24401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "initializeTestDatabase()",
@@ -24297,7 +24409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 452
+      "community": 453
     },
     {
       "label": "createValidReflectionNote()",
@@ -24305,7 +24417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 452
+      "community": 453
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24313,7 +24425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24321,7 +24433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 590
+      "community": 592
     },
     {
       "label": "createSchema()",
@@ -24329,7 +24441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 590
+      "community": 592
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24337,7 +24449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "generateId()",
@@ -24345,7 +24457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 377
+      "community": 378
     },
     {
       "label": "initializeTestDatabase()",
@@ -24353,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 377
+      "community": 378
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24361,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 377
+      "community": 378
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24369,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24377,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24385,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 591
+      "community": 593
     },
     {
       "label": "initializeTestDatabase()",
@@ -24393,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 591
+      "community": 593
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24401,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 592
+      "community": 594
     },
     {
       "label": "parseData()",
@@ -24409,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 592
+      "community": 594
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24417,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24425,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "initializeTestDatabase()",
@@ -24433,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 453
+      "community": 454
     },
     {
       "label": "createValidReflectionNote()",
@@ -24441,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 453
+      "community": 454
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24449,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24457,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24465,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "meta-memory-service.ts",
@@ -24593,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "fieldDiff()",
@@ -24601,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 378
+      "community": 379
     },
     {
       "label": "parseStepsJson()",
@@ -24609,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 378
+      "community": 379
     },
     {
       "label": "computeProceduralDiff()",
@@ -24617,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 378
+      "community": 379
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24625,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -24633,7 +24745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 321
+      "community": 322
     },
     {
       "label": ".constructor()",
@@ -24641,7 +24753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 321
+      "community": 322
     },
     {
       "label": ".notFound()",
@@ -24649,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 321
+      "community": 322
     },
     {
       "label": ".notActionable()",
@@ -24657,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 321
+      "community": 322
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -24665,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24673,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 379
+      "community": 380
     },
     {
       "label": "parsePositiveInt()",
@@ -24681,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 379
+      "community": 380
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24689,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 379
+      "community": 380
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -24697,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 593
+      "community": 595
     },
     {
       "label": "createBaseSchema()",
@@ -24705,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 593
+      "community": 595
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -24713,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_llm_extractor_ts",
-      "community": 167
+      "community": 169
     },
     {
       "label": "LlmProceduralExtractor",
@@ -24721,7 +24833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L31",
       "id": "procedural_llm_extractor_llmproceduralextractor",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".constructor()",
@@ -24729,7 +24841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L37",
       "id": "procedural_llm_extractor_llmproceduralextractor_constructor",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".extract()",
@@ -24737,7 +24849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L47",
       "id": "procedural_llm_extractor_llmproceduralextractor_extract",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".buildMessages()",
@@ -24745,7 +24857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L68",
       "id": "procedural_llm_extractor_llmproceduralextractor_buildmessages",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".callLLM()",
@@ -24753,7 +24865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L83",
       "id": "procedural_llm_extractor_llmproceduralextractor_callllm",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".callOpenAI()",
@@ -24761,7 +24873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L102",
       "id": "procedural_llm_extractor_llmproceduralextractor_callopenai",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".callGemini()",
@@ -24769,7 +24881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L132",
       "id": "procedural_llm_extractor_llmproceduralextractor_callgemini",
-      "community": 167
+      "community": 169
     },
     {
       "label": ".parseResponse()",
@@ -24777,7 +24889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L171",
       "id": "procedural_llm_extractor_llmproceduralextractor_parseresponse",
-      "community": 167
+      "community": 169
     },
     {
       "label": "memory-review-candidate-selection-scoring.spec.ts",
@@ -24785,7 +24897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 594
+      "community": 596
     },
     {
       "label": "baseRow()",
@@ -24793,7 +24905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 594
+      "community": 596
     },
     {
       "label": "procedural-versioning.ts",
@@ -24801,7 +24913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "getVersionChain()",
@@ -24809,7 +24921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 380
+      "community": 381
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -24817,7 +24929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 380
+      "community": 381
     },
     {
       "label": "getNextVersionNumber()",
@@ -24825,7 +24937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 380
+      "community": 381
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -24833,7 +24945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -24841,7 +24953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 454
+      "community": 455
     },
     {
       "label": ".runScan()",
@@ -24849,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 454
+      "community": 455
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -24857,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "generateMemoryId()",
@@ -24865,7 +24977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 455
+      "community": 456
     },
     {
       "label": "rollbackToVersion()",
@@ -24873,7 +24985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 455
+      "community": 456
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -24881,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_neighbor_service_ts",
-      "community": 205
+      "community": 206
     },
     {
       "label": "MemoryNotFoundError",
@@ -24889,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L53",
       "id": "memory_neighbor_service_memorynotfounderror",
-      "community": 205
+      "community": 206
     },
     {
       "label": ".constructor()",
@@ -24897,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L54",
       "id": "memory_neighbor_service_memorynotfounderror_constructor",
-      "community": 205
+      "community": 206
     },
     {
       "label": "MemoryNeighborService",
@@ -24905,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L64",
       "id": "memory_neighbor_service_memoryneighborservice",
-      "community": 205
+      "community": 206
     },
     {
       "label": ".constructor()",
@@ -24913,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L75",
       "id": "memory_neighbor_service_memoryneighborservice_constructor",
-      "community": 205
+      "community": 206
     },
     {
       "label": ".setDatabase()",
@@ -24921,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L97",
       "id": "memory_neighbor_service_memoryneighborservice_setdatabase",
-      "community": 205
+      "community": 206
     },
     {
       "label": ".getNeighbors()",
@@ -24929,7 +25041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L116",
       "id": "memory_neighbor_service_memoryneighborservice_getneighbors",
-      "community": 205
+      "community": 206
     },
     {
       "label": ".updateNeighborsForNewMemory()",
@@ -24937,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L331",
       "id": "memory_neighbor_service_memoryneighborservice_updateneighborsfornewmemory",
-      "community": 205
+      "community": 206
     },
     {
       "label": "memory-review-candidate-selection-service.ts",
@@ -24945,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "selectionWindowLimit()",
@@ -24953,7 +25065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 456
+      "community": 457
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -24961,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 456
+      "community": 457
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -24969,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "IntrospectionScanCache",
@@ -24977,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".set()",
@@ -24985,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".get()",
@@ -24993,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".clear()",
@@ -25001,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 322
+      "community": 323
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -25009,7 +25121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25017,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 595
+      "community": 597
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25025,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 595
+      "community": 597
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25033,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 596
+      "community": 598
     },
     {
       "label": "openDb()",
@@ -25041,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 596
+      "community": 598
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25329,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
-      "community": 206
+      "community": 207
     },
     {
       "label": "upsertPendingMemoryReviewCandidates()",
@@ -25337,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L12",
       "id": "memory_review_candidate_persistence_service_upsertpendingmemoryreviewcandidates",
-      "community": 206
+      "community": 207
     },
     {
       "label": "mapRow()",
@@ -25345,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L74",
       "id": "memory_review_candidate_persistence_service_maprow",
-      "community": 206
+      "community": 207
     },
     {
       "label": "getMemoryReviewCandidateById()",
@@ -25353,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L90",
       "id": "memory_review_candidate_persistence_service_getmemoryreviewcandidatebyid",
-      "community": 206
+      "community": 207
     },
     {
       "label": "listMemoryReviewCandidates()",
@@ -25361,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L101",
       "id": "memory_review_candidate_persistence_service_listmemoryreviewcandidates",
-      "community": 206
+      "community": 207
     },
     {
       "label": "markMemoryReviewCandidateReviewed()",
@@ -25369,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L122",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidatereviewed",
-      "community": 206
+      "community": 207
     },
     {
       "label": "markMemoryReviewCandidateDismissed()",
@@ -25377,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L157",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidatedismissed",
-      "community": 206
+      "community": 207
     },
     {
       "label": "markMemoryReviewCandidateExpired()",
@@ -25385,7 +25497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L185",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidateexpired",
-      "community": 206
+      "community": 207
     },
     {
       "label": "memory-review-queue-health-service.ts",
@@ -25393,7 +25505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_ts",
-      "community": 168
+      "community": 170
     },
     {
       "label": "snapshotTableReady()",
@@ -25401,7 +25513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L45",
       "id": "memory_review_queue_health_service_snapshottableready",
-      "community": 168
+      "community": 170
     },
     {
       "label": "countCandidates()",
@@ -25409,7 +25521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L54",
       "id": "memory_review_queue_health_service_countcandidates",
-      "community": 168
+      "community": 170
     },
     {
       "label": "buildWindowCounts()",
@@ -25417,7 +25529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L61",
       "id": "memory_review_queue_health_service_buildwindowcounts",
-      "community": 168
+      "community": 170
     },
     {
       "label": "computeMemoryReviewQueueHealthLive()",
@@ -25425,7 +25537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L84",
       "id": "memory_review_queue_health_service_computememoryreviewqueuehealthlive",
-      "community": 168
+      "community": 170
     },
     {
       "label": "memoryReviewQueueHealthSnapshotTableReady()",
@@ -25433,7 +25545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L105",
       "id": "memory_review_queue_health_service_memoryreviewqueuehealthsnapshottableready",
-      "community": 168
+      "community": 170
     },
     {
       "label": "recordMemoryReviewQueueHealthSnapshot()",
@@ -25441,7 +25553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L112",
       "id": "memory_review_queue_health_service_recordmemoryreviewqueuehealthsnapshot",
-      "community": 168
+      "community": 170
     },
     {
       "label": "listMemoryReviewQueueHealthSnapshots()",
@@ -25449,7 +25561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L162",
       "id": "memory_review_queue_health_service_listmemoryreviewqueuehealthsnapshots",
-      "community": 168
+      "community": 170
     },
     {
       "label": "maybeRecordMemoryReviewQueueHealthSnapshot()",
@@ -25457,7 +25569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.ts",
       "source_location": "L176",
       "id": "memory_review_queue_health_service_mayberecordmemoryreviewqueuehealthsnapshot",
-      "community": 168
+      "community": 170
     },
     {
       "label": "memory-embedding-service.ts",
@@ -25633,7 +25745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 597
+      "community": 599
     },
     {
       "label": "createBaseSchema()",
@@ -25641,7 +25753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 597
+      "community": 599
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -25649,7 +25761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_knowledge_context_bundle_builder_ts",
-      "community": 169
+      "community": 171
     },
     {
       "label": "estimateTokens()",
@@ -25657,7 +25769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L44",
       "id": "knowledge_context_bundle_builder_estimatetokens",
-      "community": 169
+      "community": 171
     },
     {
       "label": "getMemoryTypeEmoji()",
@@ -25665,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L48",
       "id": "knowledge_context_bundle_builder_getmemorytypeemoji",
-      "community": 169
+      "community": 171
     },
     {
       "label": "summarizeMemoryContent()",
@@ -25673,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L58",
       "id": "knowledge_context_bundle_builder_summarizememorycontent",
-      "community": 169
+      "community": 171
     },
     {
       "label": "summarizeMemories()",
@@ -25681,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L97",
       "id": "knowledge_context_bundle_builder_summarizememories",
-      "community": 169
+      "community": 171
     },
     {
       "label": "formatMemoryPrompt()",
@@ -25689,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L129",
       "id": "knowledge_context_bundle_builder_formatmemoryprompt",
-      "community": 169
+      "community": 171
     },
     {
       "label": "updateConsolidationScoreMetadata()",
@@ -25697,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L155",
       "id": "knowledge_context_bundle_builder_updateconsolidationscoremetadata",
-      "community": 169
+      "community": 171
     },
     {
       "label": "filterByOwner()",
@@ -25705,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L264",
       "id": "knowledge_context_bundle_builder_filterbyowner",
-      "community": 169
+      "community": 171
     },
     {
       "label": "buildKnowledgeContextBundle()",
@@ -25713,7 +25825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/knowledge-context-bundle-builder.ts",
       "source_location": "L275",
       "id": "knowledge_context_bundle_builder_buildknowledgecontextbundle",
-      "community": 169
+      "community": 171
     },
     {
       "label": "core-memory-cache-service.ts",
@@ -25905,7 +26017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -25913,7 +26025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -25921,7 +26033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 457
+      "community": 458
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -25929,7 +26041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 457
+      "community": 458
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -25937,7 +26049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -25945,7 +26057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "core-memory-service.ts",
@@ -26105,7 +26217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 598
+      "community": 600
     },
     {
       "label": "createBaseSchema()",
@@ -26113,7 +26225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 598
+      "community": 600
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26121,7 +26233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 599
+      "community": 601
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26129,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 599
+      "community": 601
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26137,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_integration_spec_ts",
-      "community": 170
+      "community": 172
     },
     {
       "label": "MockUnifiedEmbeddingService",
@@ -26145,7 +26257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L12",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice",
-      "community": 170
+      "community": 172
     },
     {
       "label": ".isAvailable()",
@@ -26153,7 +26265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L13",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice_isavailable",
-      "community": 170
+      "community": 172
     },
     {
       "label": ".generateEmbedding()",
@@ -26161,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L17",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice_generateembedding",
-      "community": 170
+      "community": 172
     },
     {
       "label": ".searchSimilar()",
@@ -26169,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L29",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice_searchsimilar",
-      "community": 170
+      "community": 172
     },
     {
       "label": ".getModelInfo()",
@@ -26177,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L33",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice_getmodelinfo",
-      "community": 170
+      "community": 172
     },
     {
       "label": ".getCurrentProviderName()",
@@ -26185,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L41",
       "id": "memory_embedding_service_integration_spec_mockunifiedembeddingservice_getcurrentprovidername",
-      "community": 170
+      "community": 172
     },
     {
       "label": "setMockEmbedding()",
@@ -26193,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L46",
       "id": "memory_embedding_service_integration_spec_setmockembedding",
-      "community": 170
+      "community": 172
     },
     {
       "label": "createDbStub()",
@@ -26201,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts",
       "source_location": "L288",
       "id": "memory_embedding_service_integration_spec_createdbstub",
-      "community": 170
+      "community": 172
     },
     {
       "label": "procedural-llm-extractor.spec.ts",
@@ -26209,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26217,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26225,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 600
+      "community": 602
     },
     {
       "label": "createSchema()",
@@ -26233,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 600
+      "community": 602
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26241,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26249,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 601
+      "community": 603
     },
     {
       "label": "createSchema()",
@@ -26257,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 601
+      "community": 603
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26265,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26273,7 +26385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 602
+      "community": 604
     },
     {
       "label": "createBaseSchema()",
@@ -26281,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 602
+      "community": 604
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26289,7 +26401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26297,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 603
+      "community": 605
     },
     {
       "label": "createSchema()",
@@ -26305,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 603
+      "community": 605
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26313,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26321,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26441,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26449,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_statistics_ts",
-      "community": 232
+      "community": 233
     },
     {
       "label": "SemanticMemoryStatisticsService",
@@ -26457,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L43",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".constructor()",
@@ -26465,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L48",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_constructor",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".initializeStatistics()",
@@ -26473,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L55",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_initializestatistics",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".recordUpdate()",
@@ -26481,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L86",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_recordupdate",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".getStatistics()",
@@ -26489,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L154",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_getstatistics",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".reset()",
@@ -26497,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L161",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_reset",
-      "community": 232
+      "community": 233
     },
     {
       "label": "semantic-memory-update-service.ts",
@@ -26705,7 +26817,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26713,7 +26825,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 604
+      "community": 606
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26721,7 +26833,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 604
+      "community": 606
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26729,7 +26841,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "consolidation-repository.ts",
@@ -26737,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_ts",
-      "community": 138
+      "community": 139
     },
     {
       "label": "ConsolidationRepository",
@@ -26745,7 +26857,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L25",
       "id": "consolidation_repository_consolidationrepository",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".constructor()",
@@ -26753,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L26",
       "id": "consolidation_repository_consolidationrepository_constructor",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".getLookbackDays()",
@@ -26761,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L28",
       "id": "consolidation_repository_consolidationrepository_getlookbackdays",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".findEpisodicCandidates()",
@@ -26769,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L37",
       "id": "consolidation_repository_consolidationrepository_findepisodiccandidates",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".findSemanticsByOwner()",
@@ -26777,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L87",
       "id": "consolidation_repository_consolidationrepository_findsemanticsbyowner",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".updateSemanticMemory()",
@@ -26785,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L103",
       "id": "consolidation_repository_consolidationrepository_updatesemanticmemory",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".loadEmbeddingsMap()",
@@ -26793,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L118",
       "id": "consolidation_repository_consolidationrepository_loadembeddingsmap",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".insertSemanticMemory()",
@@ -26801,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L151",
       "id": "consolidation_repository_consolidationrepository_insertsemanticmemory",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".markEpisodicsConsolidated()",
@@ -26809,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L177",
       "id": "consolidation_repository_consolidationrepository_markepisodicsconsolidated",
-      "community": 138
+      "community": 139
     },
     {
       "label": "sleep-consolidation-service.ts",
@@ -26817,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
-      "community": 122
+      "community": 123
     },
     {
       "label": "ConsolidationAlreadyRunningError",
@@ -26825,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L24",
       "id": "sleep_consolidation_service_consolidationalreadyrunningerror",
-      "community": 122
+      "community": 123
     },
     {
       "label": ".constructor()",
@@ -26833,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L25",
       "id": "sleep_consolidation_service_consolidationalreadyrunningerror_constructor",
-      "community": 122
+      "community": 123
     },
     {
       "label": "newSemanticId()",
@@ -26841,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L43",
       "id": "sleep_consolidation_service_newsemanticid",
-      "community": 122
+      "community": 123
     },
     {
       "label": "cosineSimilarity()",
@@ -26849,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L50",
       "id": "sleep_consolidation_service_cosinesimilarity",
-      "community": 122
+      "community": 123
     },
     {
       "label": "getMergeSimilarityThreshold()",
@@ -26857,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L68",
       "id": "sleep_consolidation_service_getmergesimilaritythreshold",
-      "community": 122
+      "community": 123
     },
     {
       "label": "mergeOriginSourceJson()",
@@ -26865,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L74",
       "id": "sleep_consolidation_service_mergeoriginsourcejson",
-      "community": 122
+      "community": 123
     },
     {
       "label": "SleepConsolidationService",
@@ -26873,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L101",
       "id": "sleep_consolidation_service_sleepconsolidationservice",
-      "community": 122
+      "community": 123
     },
     {
       "label": ".constructor()",
@@ -26881,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L112",
       "id": "sleep_consolidation_service_sleepconsolidationservice_constructor",
-      "community": 122
+      "community": 123
     },
     {
       "label": ".isRunning()",
@@ -26889,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L127",
       "id": "sleep_consolidation_service_sleepconsolidationservice_isrunning",
-      "community": 122
+      "community": 123
     },
     {
       "label": ".run()",
@@ -26897,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L131",
       "id": "sleep_consolidation_service_sleepconsolidationservice_run",
-      "community": 122
+      "community": 123
     },
     {
       "label": "clustering-service.ts",
@@ -26905,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_ts",
-      "community": 233
+      "community": 234
     },
     {
       "label": "ClusteringService",
@@ -26913,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L16",
       "id": "clustering_service_clusteringservice",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".getSimilarityThreshold()",
@@ -26921,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L17",
       "id": "clustering_service_clusteringservice_getsimilaritythreshold",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".getMinClusterSize()",
@@ -26929,7 +27041,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L23",
       "id": "clustering_service_clusteringservice_getminclustersize",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".cosineSimilarity()",
@@ -26937,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L29",
       "id": "clustering_service_clusteringservice_cosinesimilarity",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".clusterGroup()",
@@ -26945,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L50",
       "id": "clustering_service_clusteringservice_clustergroup",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".buildClusters()",
@@ -26953,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L117",
       "id": "clustering_service_clusteringservice_buildclusters",
-      "community": 233
+      "community": 234
     },
     {
       "label": "summarization-service.spec.ts",
@@ -26961,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 605
+      "community": 607
     },
     {
       "label": "row()",
@@ -26969,7 +27081,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 605
+      "community": 607
     },
     {
       "label": "summarization-service.ts",
@@ -26977,7 +27089,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "SummarizationService",
@@ -26985,7 +27097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L16",
       "id": "summarization_service_summarizationservice",
-      "community": 275
+      "community": 276
     },
     {
       "label": ".hasLlmConfigured()",
@@ -26993,7 +27105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L17",
       "id": "summarization_service_summarizationservice_hasllmconfigured",
-      "community": 275
+      "community": 276
     },
     {
       "label": ".extractiveFallback()",
@@ -27001,7 +27113,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L23",
       "id": "summarization_service_summarizationservice_extractivefallback",
-      "community": 275
+      "community": 276
     },
     {
       "label": ".summarizeCluster()",
@@ -27009,7 +27121,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L36",
       "id": "summarization_service_summarizationservice_summarizecluster",
-      "community": 275
+      "community": 276
     },
     {
       "label": ".summarizeMergeForConsolidation()",
@@ -27017,7 +27129,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L118",
       "id": "summarization_service_summarizationservice_summarizemergeforconsolidation",
-      "community": 275
+      "community": 276
     },
     {
       "label": "sleep-consolidation-service.spec.ts",
@@ -27025,7 +27137,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 323
+      "community": 324
     },
     {
       "label": "insertEpisodic()",
@@ -27033,7 +27145,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 323
+      "community": 324
     },
     {
       "label": "insertEmbedding()",
@@ -27041,7 +27153,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 323
+      "community": 324
     },
     {
       "label": "FailingRepo",
@@ -27049,7 +27161,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".insertSemanticMemory()",
@@ -27057,7 +27169,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 323
+      "community": 324
     },
     {
       "label": "clustering-service.spec.ts",
@@ -27065,7 +27177,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 606
+      "community": 608
     },
     {
       "label": "ep()",
@@ -27073,7 +27185,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 606
+      "community": 608
     },
     {
       "label": "relation-graph.port.ts",
@@ -27081,7 +27193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "get-relations-tool.ts",
@@ -27089,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "GetRelationsTool",
@@ -27097,7 +27209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 381
+      "community": 382
     },
     {
       "label": ".constructor()",
@@ -27105,7 +27217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 381
+      "community": 382
     },
     {
       "label": ".handle()",
@@ -27113,7 +27225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 381
+      "community": 382
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27121,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 607
+      "community": 609
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27129,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 607
+      "community": 609
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27137,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27145,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 382
+      "community": 383
     },
     {
       "label": ".constructor()",
@@ -27153,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 382
+      "community": 383
     },
     {
       "label": ".handle()",
@@ -27161,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 382
+      "community": 383
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27169,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "RemoveRelationTool",
@@ -27177,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".constructor()",
@@ -27185,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".handle()",
@@ -27193,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 383
+      "community": 384
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27201,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "ExtractRelationsTool",
@@ -27209,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".constructor()",
@@ -27217,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".handle()",
@@ -27225,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 384
+      "community": 385
     },
     {
       "label": "add-relation-tool.ts",
@@ -27233,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "AddRelationTool",
@@ -27241,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".constructor()",
@@ -27249,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".handle()",
@@ -27257,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 385
+      "community": 386
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27265,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_ts",
-      "community": 276
+      "community": 277
     },
     {
       "label": "resolveExtractTriplesOwner()",
@@ -27273,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L37",
       "id": "extract_triples_tool_resolveextracttriplesowner",
-      "community": 276
+      "community": 277
     },
     {
       "label": "normalizeChunkOverlapForPipeline()",
@@ -27281,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L42",
       "id": "extract_triples_tool_normalizechunkoverlapforpipeline",
-      "community": 276
+      "community": 277
     },
     {
       "label": "ExtractTriplesTool",
@@ -27289,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L52",
       "id": "extract_triples_tool_extracttriplestool",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".constructor()",
@@ -27297,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L53",
       "id": "extract_triples_tool_extracttriplestool_constructor",
-      "community": 276
+      "community": 277
     },
     {
       "label": ".handle()",
@@ -27305,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L84",
       "id": "extract_triples_tool_extracttriplestool_handle",
-      "community": 276
+      "community": 277
     },
     {
       "label": "get-relations-tool.spec.ts",
@@ -27313,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createBaseSchema()",
@@ -27321,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createTestMemory()",
@@ -27329,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 458
+      "community": 459
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27337,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createBaseSchema()",
@@ -27345,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createTestMemory()",
@@ -27353,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 459
+      "community": 460
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27361,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createBaseSchema()",
@@ -27369,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createTestMemory()",
@@ -27377,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 460
+      "community": 461
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27385,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27393,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createBaseSchema()",
@@ -27401,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createTestMemory()",
@@ -27409,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 461
+      "community": 462
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27417,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "RelationRetryManager",
@@ -27425,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27433,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".retry()",
@@ -27441,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 386
+      "community": 387
     },
     {
       "label": "relation-errors.ts",
@@ -27449,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_errors_ts",
-      "community": 234
+      "community": 235
     },
     {
       "label": "RelationGraphError",
@@ -27457,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L3",
       "id": "relation_errors_relationgrapherror",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".constructor()",
@@ -27465,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L4",
       "id": "relation_errors_relationgrapherror_constructor",
-      "community": 234
+      "community": 235
     },
     {
       "label": "DuplicateRelationError",
@@ -27473,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L10",
       "id": "relation_errors_duplicaterelationerror",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".constructor()",
@@ -27481,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L11",
       "id": "relation_errors_duplicaterelationerror_constructor",
-      "community": 234
+      "community": 235
     },
     {
       "label": "CyclicRelationError",
@@ -27489,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L25",
       "id": "relation_errors_cyclicrelationerror",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".constructor()",
@@ -27497,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L26",
       "id": "relation_errors_cyclicrelationerror_constructor",
-      "community": 234
+      "community": 235
     },
     {
       "label": "rule-based-relation-extractor.ts",
@@ -27505,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_rule_based_relation_extractor_ts",
-      "community": 171
+      "community": 173
     },
     {
       "label": "RuleBasedRelationExtractor",
@@ -27513,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L162",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".matchKoreanKeyword()",
@@ -27521,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L171",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_matchkoreankeyword",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".matchEnglishKeyword()",
@@ -27529,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L183",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_matchenglishkeyword",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".isKoreanKeyword()",
@@ -27537,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L194",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_iskoreankeyword",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".findPatternMatch()",
@@ -27545,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L205",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_findpatternmatch",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".escapeRegex()",
@@ -27553,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L245",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_escaperegex",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".calculateConfidence()",
@@ -27561,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L256",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_calculateconfidence",
-      "community": 171
+      "community": 173
     },
     {
       "label": ".extractRelations()",
@@ -27569,7 +27681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/rule-based-relation-extractor.ts",
       "source_location": "L271",
       "id": "rule_based_relation_extractor_rulebasedrelationextractor_extractrelations",
-      "community": 171
+      "community": 173
     },
     {
       "label": "relation-cache.ts",
@@ -27577,7 +27689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_cache_ts",
-      "community": 172
+      "community": 174
     },
     {
       "label": "RelationCache",
@@ -27585,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L10",
       "id": "relation_cache_relationcache",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".constructor()",
@@ -27593,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L13",
       "id": "relation_cache_relationcache_constructor",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".get()",
@@ -27601,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L18",
       "id": "relation_cache_relationcache_get",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".set()",
@@ -27609,7 +27721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L33",
       "id": "relation_cache_relationcache_set",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".delete()",
@@ -27617,7 +27729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L49",
       "id": "relation_cache_relationcache_delete",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".keys()",
@@ -27625,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L53",
       "id": "relation_cache_relationcache_keys",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".evictLeastRecentlyUsed()",
@@ -27633,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L58",
       "id": "relation_cache_relationcache_evictleastrecentlyused",
-      "community": 172
+      "community": 174
     },
     {
       "label": ".pruneExpired()",
@@ -27641,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-cache.ts",
       "source_location": "L74",
       "id": "relation_cache_relationcache_pruneexpired",
-      "community": 172
+      "community": 174
     },
     {
       "label": "relation-graph.ts",
@@ -27953,7 +28065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_extractor_ts",
-      "community": 207
+      "community": 208
     },
     {
       "label": "RelationExtractor",
@@ -27961,7 +28073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L30",
       "id": "relation_extractor_relationextractor",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".constructor()",
@@ -27969,7 +28081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L35",
       "id": "relation_extractor_relationextractor_constructor",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".extractRelations()",
@@ -27977,7 +28089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L55",
       "id": "relation_extractor_relationextractor_extractrelations",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".getApplicableRelationTypes()",
@@ -27985,7 +28097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L189",
       "id": "relation_extractor_relationextractor_getapplicablerelationtypes",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".mergeCandidates()",
@@ -27993,7 +28105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L212",
       "id": "relation_extractor_relationextractor_mergecandidates",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".generateCacheKey()",
@@ -28001,7 +28113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L247",
       "id": "relation_extractor_relationextractor_generatecachekey",
-      "community": 207
+      "community": 208
     },
     {
       "label": ".extractRelationsBatch()",
@@ -28009,7 +28121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L270",
       "id": "relation_extractor_relationextractor_extractrelationsbatch",
-      "community": 207
+      "community": 208
     },
     {
       "label": "llm-based-relation-extractor.ts",
@@ -28193,7 +28305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "loadTestDataset()",
@@ -28201,7 +28313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 387
+      "community": 388
     },
     {
       "label": "createBaseSchema()",
@@ -28209,7 +28321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 387
+      "community": 388
     },
     {
       "label": "createTestMemory()",
@@ -28217,7 +28329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 387
+      "community": 388
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28225,7 +28337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28233,7 +28345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createBaseSchema()",
@@ -28241,7 +28353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createTestMemory()",
@@ -28249,7 +28361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28257,7 +28369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 608
+      "community": 610
     },
     {
       "label": "createTestMemory()",
@@ -28265,7 +28377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 608
+      "community": 610
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28273,7 +28385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createBaseSchema()",
@@ -28281,7 +28393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createTestMemory()",
@@ -28289,7 +28401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createBulkMemories()",
@@ -28297,7 +28409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 388
+      "community": 389
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28305,7 +28417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 609
+      "community": 611
     },
     {
       "label": "createTestMemory()",
@@ -28313,7 +28425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 609
+      "community": 611
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28321,7 +28433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_based_relation_extractor_spec_ts",
-      "community": 235
+      "community": 236
     },
     {
       "label": "getMockEmbeddingFunctions()",
@@ -28329,7 +28441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L97",
       "id": "llm_based_relation_extractor_spec_getmockembeddingfunctions",
-      "community": 235
+      "community": 236
     },
     {
       "label": "createMockConfig()",
@@ -28337,7 +28449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L106",
       "id": "llm_based_relation_extractor_spec_createmockconfig",
-      "community": 235
+      "community": 236
     },
     {
       "label": "createTestMemory()",
@@ -28345,7 +28457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L161",
       "id": "llm_based_relation_extractor_spec_createtestmemory",
-      "community": 235
+      "community": 236
     },
     {
       "label": "createMockEmbeddingService()",
@@ -28353,7 +28465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L182",
       "id": "llm_based_relation_extractor_spec_createmockembeddingservice",
-      "community": 235
+      "community": 236
     },
     {
       "label": "generateEmbedding()",
@@ -28361,7 +28473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L231",
       "id": "llm_based_relation_extractor_spec_generateembedding",
-      "community": 235
+      "community": 236
     },
     {
       "label": "searchSimilar()",
@@ -28369,7 +28481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L232",
       "id": "llm_based_relation_extractor_spec_searchsimilar",
-      "community": 235
+      "community": 236
     },
     {
       "label": "provider-auto.spec.ts",
@@ -28377,7 +28489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28385,7 +28497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28393,7 +28505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "getMockMementoConfig()",
@@ -28401,7 +28513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 463
+      "community": 464
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28409,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 463
+      "community": 464
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28417,7 +28529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28425,7 +28537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28433,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28441,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28449,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 324
+      "community": 325
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -28457,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".constructor()",
@@ -28465,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".consume()",
@@ -28473,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".refill()",
@@ -28481,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 324
+      "community": 325
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -28489,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28497,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 389
+      "community": 390
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28505,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28513,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 389
+      "community": 390
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -28521,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "chunkSucceeded()",
@@ -28529,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L20",
       "id": "triple_pipeline_orchestrator_chunksucceeded",
-      "community": 277
+      "community": 278
     },
     {
       "label": "failureMessageFromResult()",
@@ -28537,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L27",
       "id": "triple_pipeline_orchestrator_failuremessagefromresult",
-      "community": 277
+      "community": 278
     },
     {
       "label": "TriplePipelineOrchestrator",
@@ -28545,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L35",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".constructor()",
@@ -28553,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L36",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_constructor",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".run()",
@@ -28561,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L40",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_run",
-      "community": 277
+      "community": 278
     },
     {
       "label": "triple-extraction-statistics.ts",
@@ -28569,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_statistics_ts",
-      "community": 208
+      "community": 209
     },
     {
       "label": "TripleExtractionStatisticsService",
@@ -28577,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L54",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".constructor()",
@@ -28585,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L58",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_constructor",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".initializeStatistics()",
@@ -28593,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L65",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_initializestatistics",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".recordExtraction()",
@@ -28601,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L99",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_recordextraction",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".getStatistics()",
@@ -28609,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L181",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_getstatistics",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".reset()",
@@ -28617,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L191",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_reset",
-      "community": 208
+      "community": 209
     },
     {
       "label": ".getFailureReasonStatistics()",
@@ -28625,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L201",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_getfailurereasonstatistics",
-      "community": 208
+      "community": 209
     },
     {
       "label": "entity-linker.ts",
@@ -28633,7 +28745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_ts",
-      "community": 173
+      "community": 175
     },
     {
       "label": "EntityLinker",
@@ -28641,7 +28753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L37",
       "id": "entity_linker_entitylinker",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".constructor()",
@@ -28649,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L41",
       "id": "entity_linker_entitylinker_constructor",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".buildReverseIndex()",
@@ -28657,7 +28769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L50",
       "id": "entity_linker_entitylinker_buildreverseindex",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".normalizeKey()",
@@ -28665,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L68",
       "id": "entity_linker_entitylinker_normalizekey",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".isStructuredEntity()",
@@ -28673,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L76",
       "id": "entity_linker_entitylinker_isstructuredentity",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".link()",
@@ -28681,7 +28793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L106",
       "id": "entity_linker_entitylinker_link",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".linkBatch()",
@@ -28689,7 +28801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L164",
       "id": "entity_linker_entitylinker_linkbatch",
-      "community": 173
+      "community": 175
     },
     {
       "label": ".addEntity()",
@@ -28697,7 +28809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.ts",
       "source_location": "L174",
       "id": "entity_linker_entitylinker_addentity",
-      "community": 173
+      "community": 175
     },
     {
       "label": "triple-extraction-llm-providers.ts",
@@ -28705,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_providers_ts",
-      "community": 236
+      "community": 237
     },
     {
       "label": "isRecord()",
@@ -28713,7 +28825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L25",
       "id": "triple_extraction_llm_providers_isrecord",
-      "community": 236
+      "community": 237
     },
     {
       "label": "getStringField()",
@@ -28721,7 +28833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L29",
       "id": "triple_extraction_llm_providers_getstringfield",
-      "community": 236
+      "community": 237
     },
     {
       "label": "extractRawWithOpenAI()",
@@ -28729,7 +28841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L34",
       "id": "triple_extraction_llm_providers_extractrawwithopenai",
-      "community": 236
+      "community": 237
     },
     {
       "label": "extractRawWithGemini()",
@@ -28737,7 +28849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L92",
       "id": "triple_extraction_llm_providers_extractrawwithgemini",
-      "community": 236
+      "community": 237
     },
     {
       "label": "extractRawWithOllama()",
@@ -28745,7 +28857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L148",
       "id": "triple_extraction_llm_providers_extractrawwithollama",
-      "community": 236
+      "community": 237
     },
     {
       "label": "checkOllamaModelInstalled()",
@@ -28753,7 +28865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L275",
       "id": "triple_extraction_llm_providers_checkollamamodelinstalled",
-      "community": 236
+      "community": 237
     },
     {
       "label": "triple-pipeline-orchestrator.spec.ts",
@@ -28761,7 +28873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 610
+      "community": 612
     },
     {
       "label": "extract()",
@@ -28769,7 +28881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 610
+      "community": 612
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -28777,7 +28889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "tripleDedupeKey()",
@@ -28785,7 +28897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 464
+      "community": 465
     },
     {
       "label": "mergeTripleLists()",
@@ -28793,7 +28905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 464
+      "community": 465
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -28801,7 +28913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -28809,7 +28921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 325
+      "community": 326
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -28817,7 +28929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 325
+      "community": 326
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -28825,7 +28937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L38",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 325
+      "community": 326
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -28833,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L71",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 325
+      "community": 326
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -28841,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L105",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 325
+      "community": 326
     },
     {
       "label": "triple-extraction-service.ts",
@@ -28985,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -28993,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29001,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "triple-extractor.ts",
@@ -29145,7 +29257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "TripleNormalizer",
@@ -29153,7 +29265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".constructor()",
@@ -29161,7 +29273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".normalize()",
@@ -29169,7 +29281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 390
+      "community": 391
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29177,7 +29289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29185,7 +29297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29193,7 +29305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 391
+      "community": 392
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29201,7 +29313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 391
+      "community": 392
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29209,7 +29321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 391
+      "community": 392
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29217,7 +29329,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "triple-parser.ts",
@@ -29225,7 +29337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 326
+      "community": 327
     },
     {
       "label": "TripleParser",
@@ -29233,7 +29345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 326
+      "community": 327
     },
     {
       "label": ".parse()",
@@ -29241,7 +29353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 326
+      "community": 327
     },
     {
       "label": ".extractJSON()",
@@ -29249,7 +29361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 326
+      "community": 327
     },
     {
       "label": ".isValidTriple()",
@@ -29257,7 +29369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 326
+      "community": 327
     },
     {
       "label": "triple-text-chunker.ts",
@@ -29265,7 +29377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 611
+      "community": 613
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29273,7 +29385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 611
+      "community": 613
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29281,7 +29393,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 612
+      "community": 614
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29289,7 +29401,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 612
+      "community": 614
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29297,7 +29409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_ts",
-      "community": 139
+      "community": 140
     },
     {
       "label": "PredicateCanonicalizer",
@@ -29305,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L95",
       "id": "predicate_canonicalizer_predicatecanonicalizer",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".constructor()",
@@ -29313,7 +29425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L99",
       "id": "predicate_canonicalizer_predicatecanonicalizer_constructor",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".buildReverseIndex()",
@@ -29321,7 +29433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L107",
       "id": "predicate_canonicalizer_predicatecanonicalizer_buildreverseindex",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".normalizeKey()",
@@ -29329,7 +29441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L125",
       "id": "predicate_canonicalizer_predicatecanonicalizer_normalizekey",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".canonicalize()",
@@ -29337,7 +29449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L135",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalize",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".canonicalizeBatch()",
@@ -29345,7 +29457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L177",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalizebatch",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".addPredicate()",
@@ -29353,7 +29465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L187",
       "id": "predicate_canonicalizer_predicatecanonicalizer_addpredicate",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".getDictionary()",
@@ -29361,7 +29473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L206",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getdictionary",
-      "community": 139
+      "community": 140
     },
     {
       "label": ".getCanonicalPredicates()",
@@ -29369,7 +29481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L213",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getcanonicalpredicates",
-      "community": 139
+      "community": 140
     },
     {
       "label": "entity-linker.spec.ts",
@@ -29377,7 +29489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29385,7 +29497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "interfaces.spec.ts",
@@ -29393,7 +29505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29401,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29409,7 +29521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29417,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 613
+      "community": 615
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29425,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 613
+      "community": 615
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29433,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 614
+      "community": 616
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29441,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 614
+      "community": 616
     },
     {
       "label": "types.ts",
@@ -29449,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29457,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "checkOllamaModel()",
@@ -29465,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 392
+      "community": 393
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29473,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 392
+      "community": 393
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29481,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 392
+      "community": 393
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29489,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 615
+      "community": 617
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29497,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 615
+      "community": 617
     },
     {
       "label": "provider-selection.ts",
@@ -29505,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29513,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 465
+      "community": 466
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29521,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 465
+      "community": 466
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29529,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 616
+      "community": 618
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29537,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 616
+      "community": 618
     },
     {
       "label": "llm-response-parse.ts",
@@ -29545,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -29553,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 327
+      "community": 328
     },
     {
       "label": "trimToValidJsonObject()",
@@ -29561,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 327
+      "community": 328
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -29569,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 327
+      "community": 328
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -29577,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 327
+      "community": 328
     },
     {
       "label": "embedding-provider-factory.ts",
@@ -29729,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_model_availability_service_ts",
-      "community": 123
+      "community": 124
     },
     {
       "label": "now()",
@@ -29737,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L11",
       "id": "model_availability_service_now",
-      "community": 123
+      "community": 124
     },
     {
       "label": "ModelAvailabilityService",
@@ -29745,7 +29857,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L22",
       "id": "model_availability_service_modelavailabilityservice",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".constructor()",
@@ -29753,7 +29865,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L28",
       "id": "model_availability_service_modelavailabilityservice_constructor",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".checkProviderHealth()",
@@ -29761,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L33",
       "id": "model_availability_service_modelavailabilityservice_checkproviderhealth",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".getLastStatus()",
@@ -29769,7 +29881,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L107",
       "id": "model_availability_service_modelavailabilityservice_getlaststatus",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".getAllStatuses()",
@@ -29777,7 +29889,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L111",
       "id": "model_availability_service_modelavailabilityservice_getallstatuses",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".subscribe()",
@@ -29785,7 +29897,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L117",
       "id": "model_availability_service_modelavailabilityservice_subscribe",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".selectBestProvider()",
@@ -29793,7 +29905,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L125",
       "id": "model_availability_service_modelavailabilityservice_selectbestprovider",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".getPriorityList()",
@@ -29801,7 +29913,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L167",
       "id": "model_availability_service_modelavailabilityservice_getprioritylist",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".broadcast()",
@@ -29809,7 +29921,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/model-availability-service.ts",
       "source_location": "L171",
       "id": "model_availability_service_modelavailabilityservice_broadcast",
-      "community": 123
+      "community": 124
     },
     {
       "label": "model-availability-service.spec.ts",
@@ -29817,7 +29929,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "createMockService()",
@@ -29825,7 +29937,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 393
+      "community": 394
     },
     {
       "label": "resolver()",
@@ -29833,7 +29945,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 393
+      "community": 394
     },
     {
       "label": "priority()",
@@ -29841,7 +29953,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 393
+      "community": 394
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -29849,7 +29961,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "embedding-service.ts",
@@ -30961,7 +31073,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -30969,7 +31081,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -30977,7 +31089,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createSchema()",
@@ -30985,7 +31097,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 466
+      "community": 467
     },
     {
       "label": "seedMemoryItem()",
@@ -30993,7 +31105,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 466
+      "community": 467
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31001,7 +31113,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31009,7 +31121,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31017,7 +31129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31025,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31033,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 394
+      "community": 395
     },
     {
       "label": ".constructor()",
@@ -31041,7 +31153,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 394
+      "community": 395
     },
     {
       "label": ".handle()",
@@ -31049,7 +31161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 394
+      "community": 395
     },
     {
       "label": "performance-alerts.ts",
@@ -31057,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_alerts_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "executePerformanceAlerts()",
@@ -31065,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L66",
       "id": "performance_alerts_executeperformancealerts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "handleStats()",
@@ -31073,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L113",
       "id": "performance_alerts_handlestats",
-      "community": 278
+      "community": 279
     },
     {
       "label": "handleList()",
@@ -31081,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L145",
       "id": "performance_alerts_handlelist",
-      "community": 278
+      "community": 279
     },
     {
       "label": "handleSearch()",
@@ -31089,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L183",
       "id": "performance_alerts_handlesearch",
-      "community": 278
+      "community": 279
     },
     {
       "label": "handleResolve()",
@@ -31097,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L208",
       "id": "performance_alerts_handleresolve",
-      "community": 278
+      "community": 279
     },
     {
       "label": "performance-stats-tool.ts",
@@ -31105,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "PerformanceStatsTool",
@@ -31113,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".constructor()",
@@ -31121,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".handle()",
@@ -31129,7 +31241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 395
+      "community": 396
     },
     {
       "label": "resolve-error.ts",
@@ -31137,7 +31249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 617
+      "community": 619
     },
     {
       "label": "executeResolveError()",
@@ -31145,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 617
+      "community": 619
     },
     {
       "label": "error-stats.ts",
@@ -31153,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 618
+      "community": 620
     },
     {
       "label": "executeErrorStats()",
@@ -31161,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 618
+      "community": 620
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31169,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31177,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31185,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 619
+      "community": 621
     },
     {
       "label": "createBaseSchema()",
@@ -31193,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 619
+      "community": 621
     },
     {
       "label": "error-stats.spec.ts",
@@ -31201,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "performance-monitor.ts",
@@ -31881,7 +31993,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_alert_notification_service_ts",
-      "community": 209
+      "community": 210
     },
     {
       "label": "AlertNotificationService",
@@ -31889,7 +32001,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L6",
       "id": "alert_notification_service_alertnotificationservice",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".emitAlert()",
@@ -31897,7 +32009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L10",
       "id": "alert_notification_service_alertnotificationservice_emitalert",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".getAlerts()",
@@ -31905,7 +32017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L23",
       "id": "alert_notification_service_alertnotificationservice_getalerts",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".getActiveAlerts()",
@@ -31913,7 +32025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L29",
       "id": "alert_notification_service_alertnotificationservice_getactivealerts",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".acknowledgeAlert()",
@@ -31921,7 +32033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L33",
       "id": "alert_notification_service_alertnotificationservice_acknowledgealert",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".subscribe()",
@@ -31929,7 +32041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L45",
       "id": "alert_notification_service_alertnotificationservice_subscribe",
-      "community": 209
+      "community": 210
     },
     {
       "label": ".clear()",
@@ -31937,7 +32049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L52",
       "id": "alert_notification_service_alertnotificationservice_clear",
-      "community": 209
+      "community": 210
     },
     {
       "label": "runtime-diagnostics-logger.ts",
@@ -31945,7 +32057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_runtime_diagnostics_logger_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "RuntimeDiagnosticsLogger",
@@ -31953,7 +32065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L4",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".constructor()",
@@ -31961,7 +32073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L5",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_constructor",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".writeSample()",
@@ -31969,7 +32081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L10",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writesample",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".writeEvent()",
@@ -31977,7 +32089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writeevent",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".appendJsonl()",
@@ -31985,7 +32097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L26",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_appendjsonl",
-      "community": 279
+      "community": 280
     },
     {
       "label": "error-logging-service.ts",
@@ -32113,7 +32225,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32121,7 +32233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32129,7 +32241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32137,7 +32249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32145,7 +32257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "toBytes()",
@@ -32153,7 +32265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 328
+      "community": 329
     },
     {
       "label": "createMetrics()",
@@ -32161,7 +32273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 328
+      "community": 329
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -32169,7 +32281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 328
+      "community": 329
     },
     {
       "label": "makeMonitor()",
@@ -32177,7 +32289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 328
+      "community": 329
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -32185,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 620
+      "community": 622
     },
     {
       "label": "restoreEnvValue()",
@@ -32193,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 620
+      "community": 622
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32201,7 +32313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32209,7 +32321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32217,7 +32329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32225,7 +32337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 396
+      "community": 397
     },
     {
       "label": "quality-recorder.ts",
@@ -32233,7 +32345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_ts",
-      "community": 210
+      "community": 211
     },
     {
       "label": "QualityRecorder",
@@ -32241,7 +32353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L55",
       "id": "quality_recorder_qualityrecorder",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".constructor()",
@@ -32249,7 +32361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L56",
       "id": "quality_recorder_qualityrecorder_constructor",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".generateId()",
@@ -32257,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L65",
       "id": "quality_recorder_qualityrecorder_generateid",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".recordMeasurement()",
@@ -32265,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L81",
       "id": "quality_recorder_qualityrecorder_recordmeasurement",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".recordAllMeasurements()",
@@ -32273,7 +32385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L229",
       "id": "quality_recorder_qualityrecorder_recordallmeasurements",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".getMeasurementHistory()",
@@ -32281,7 +32393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L269",
       "id": "quality_recorder_qualityrecorder_getmeasurementhistory",
-      "community": 210
+      "community": 211
     },
     {
       "label": ".getLatestMetrics()",
@@ -32289,7 +32401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L340",
       "id": "quality_recorder_qualityrecorder_getlatestmetrics",
-      "community": 210
+      "community": 211
     },
     {
       "label": "quality-evaluator.spec.ts",
@@ -32297,7 +32409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 621
+      "community": 623
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32305,7 +32417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 621
+      "community": 623
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32313,7 +32425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_ts",
-      "community": 174
+      "community": 176
     },
     {
       "label": "QualityThresholdManager",
@@ -32321,7 +32433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L85",
       "id": "quality_threshold_manager_qualitythresholdmanager",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".constructor()",
@@ -32329,7 +32441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L86",
       "id": "quality_threshold_manager_qualitythresholdmanager_constructor",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".getThreshold()",
@@ -32337,7 +32449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L100",
       "id": "quality_threshold_manager_qualitythresholdmanager_getthreshold",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".getAllThresholds()",
@@ -32345,7 +32457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L129",
       "id": "quality_threshold_manager_qualitythresholdmanager_getallthresholds",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".setThreshold()",
@@ -32353,7 +32465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L173",
       "id": "quality_threshold_manager_qualitythresholdmanager_setthreshold",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".deleteThreshold()",
@@ -32361,7 +32473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L235",
       "id": "quality_threshold_manager_qualitythresholdmanager_deletethreshold",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".initializeDefaultThresholds()",
@@ -32369,7 +32481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L264",
       "id": "quality_threshold_manager_qualitythresholdmanager_initializedefaultthresholds",
-      "community": 174
+      "community": 176
     },
     {
       "label": ".validateThreshold()",
@@ -32377,7 +32489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.ts",
       "source_location": "L304",
       "id": "quality_threshold_manager_qualitythresholdmanager_validatethreshold",
-      "community": 174
+      "community": 176
     },
     {
       "label": "quality-threshold-manager.spec.ts",
@@ -32385,7 +32497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 622
+      "community": 624
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32393,7 +32505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 622
+      "community": 624
     },
     {
       "label": "quality-reporter.ts",
@@ -32401,7 +32513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_ts",
-      "community": 140
+      "community": 141
     },
     {
       "label": "escapeHtml()",
@@ -32409,7 +32521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L24",
       "id": "quality_reporter_escapehtml",
-      "community": 140
+      "community": 141
     },
     {
       "label": "QualityReporter",
@@ -32417,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L175",
       "id": "quality_reporter_qualityreporter",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".constructor()",
@@ -32425,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L179",
       "id": "quality_reporter_qualityreporter_constructor",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".collectReportData()",
@@ -32433,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L193",
       "id": "quality_reporter_qualityreporter_collectreportdata",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".generateMarkdownReport()",
@@ -32441,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L354",
       "id": "quality_reporter_qualityreporter_generatemarkdownreport",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".generateJsonReport()",
@@ -32449,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L435",
       "id": "quality_reporter_qualityreporter_generatejsonreport",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".generateHtmlReport()",
@@ -32457,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L445",
       "id": "quality_reporter_qualityreporter_generatehtmlreport",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".generateReport()",
@@ -32465,7 +32577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L731",
       "id": "quality_reporter_qualityreporter_generatereport",
-      "community": 140
+      "community": 141
     },
     {
       "label": ".saveReportToFile()",
@@ -32473,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L765",
       "id": "quality_reporter_qualityreporter_savereporttofile",
-      "community": 140
+      "community": 141
     },
     {
       "label": "quality-reporter.spec.ts",
@@ -32481,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32489,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32497,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32505,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32513,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "quality-assurance-service.ts",
@@ -32633,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_ts",
-      "community": 124
+      "community": 125
     },
     {
       "label": "QualityMetricsCollector",
@@ -32641,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L187",
       "id": "quality_metrics_collector_qualitymetricscollector",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".constructor()",
@@ -32649,7 +32761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L188",
       "id": "quality_metrics_collector_qualitymetricscollector_constructor",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".calculateMRR()",
@@ -32657,7 +32769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L202",
       "id": "quality_metrics_collector_qualitymetricscollector_calculatemrr",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectSearchMetrics()",
@@ -32665,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L248",
       "id": "quality_metrics_collector_qualitymetricscollector_collectsearchmetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectRelationMetrics()",
@@ -32673,7 +32785,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L616",
       "id": "quality_metrics_collector_qualitymetricscollector_collectrelationmetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectConsolidationMetrics()",
@@ -32681,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L784",
       "id": "quality_metrics_collector_qualitymetricscollector_collectconsolidationmetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectStorageMetrics()",
@@ -32689,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1022",
       "id": "quality_metrics_collector_qualitymetricscollector_collectstoragemetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectAllMetrics()",
@@ -32697,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1293",
       "id": "quality_metrics_collector_qualitymetricscollector_collectallmetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectMetricsByNamespace()",
@@ -32705,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1311",
       "id": "quality_metrics_collector_qualitymetricscollector_collectmetricsbynamespace",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".collectCategoryMetrics()",
@@ -32713,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1332",
       "id": "quality_metrics_collector_qualitymetricscollector_collectcategorymetrics",
-      "community": 124
+      "community": 125
     },
     {
       "label": "quality-evaluator.ts",
@@ -32721,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_ts",
-      "community": 175
+      "community": 177
     },
     {
       "label": "QualityEvaluator",
@@ -32729,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L124",
       "id": "quality_evaluator_qualityevaluator",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".constructor()",
@@ -32737,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L127",
       "id": "quality_evaluator_qualityevaluator_constructor",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".evaluateMetric()",
@@ -32745,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L143",
       "id": "quality_evaluator_qualityevaluator_evaluatemetric",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".evaluateMetrics()",
@@ -32753,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L187",
       "id": "quality_evaluator_qualityevaluator_evaluatemetrics",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".evaluateAllMetrics()",
@@ -32761,7 +32873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L276",
       "id": "quality_evaluator_qualityevaluator_evaluateallmetrics",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".determineOverallStatus()",
@@ -32769,7 +32881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L291",
       "id": "quality_evaluator_qualityevaluator_determineoverallstatus",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".generateWarningInfo()",
@@ -32777,7 +32889,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L318",
       "id": "quality_evaluator_qualityevaluator_generatewarninginfo",
-      "community": 175
+      "community": 177
     },
     {
       "label": ".logWarningToFile()",
@@ -32785,7 +32897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.ts",
       "source_location": "L351",
       "id": "quality_evaluator_qualityevaluator_logwarningtofile",
-      "community": 175
+      "community": 177
     },
     {
       "label": "quality-recorder.spec.ts",
@@ -32793,7 +32905,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32801,7 +32913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32809,7 +32921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32817,7 +32929,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -32825,7 +32937,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_migrate_embeddings_tool_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "MigrateEmbeddingsTool",
@@ -32833,7 +32945,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L38",
       "id": "migrate_embeddings_tool_migrateembeddingstool",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".constructor()",
@@ -32841,7 +32953,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L42",
       "id": "migrate_embeddings_tool_migrateembeddingstool_constructor",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".loadVecExtension()",
@@ -32849,7 +32961,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L82",
       "id": "migrate_embeddings_tool_migrateembeddingstool_loadvecextension",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".createAndStoreEmbeddingForProvider()",
@@ -32857,7 +32969,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L95",
       "id": "migrate_embeddings_tool_migrateembeddingstool_createandstoreembeddingforprovider",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".handle()",
@@ -32865,7 +32977,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L183",
       "id": "migrate_embeddings_tool_migrateembeddingstool_handle",
-      "community": 280
+      "community": 281
     },
     {
       "label": "tool-registry.ts",
@@ -33009,7 +33121,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "base-tool.ts",
@@ -33137,7 +33249,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_index_ts",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getToolRegistry()",
@@ -33145,7 +33257,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L58",
       "id": "index_gettoolregistry",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getTool()",
@@ -33153,7 +33265,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L62",
       "id": "index_gettool",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getAllTools()",
@@ -33161,7 +33273,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L66",
       "id": "index_getalltools",
-      "community": 237
+      "community": 238
     },
     {
       "label": "telemetryParamsContext()",
@@ -33169,7 +33281,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L71",
       "id": "index_telemetryparamscontext",
-      "community": 237
+      "community": 238
     },
     {
       "label": "resolveTelemetryOwnerId()",
@@ -33177,7 +33289,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L89",
       "id": "index_resolvetelemetryownerid",
-      "community": 237
+      "community": 238
     },
     {
       "label": "executeTool()",
@@ -33185,7 +33297,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L110",
       "id": "index_executetool",
-      "community": 237
+      "community": 238
     },
     {
       "label": "performance-benchmark.ts",
@@ -33305,7 +33417,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 623
+      "community": 625
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33313,7 +33425,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 623
+      "community": 625
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33321,7 +33433,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 624
+      "community": 626
     },
     {
       "label": "measureRecall()",
@@ -33329,7 +33441,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 624
+      "community": 626
     },
     {
       "label": "test-embedding.ts",
@@ -33337,7 +33449,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 625
+      "community": 627
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33345,7 +33457,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 625
+      "community": 627
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33353,7 +33465,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "compareToolResults()",
@@ -33361,7 +33473,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 467
+      "community": 468
     },
     {
       "label": "testToolConsistency()",
@@ -33369,7 +33481,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 467
+      "community": 468
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33377,7 +33489,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "createQualityTables()",
@@ -33385,7 +33497,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 468
+      "community": 469
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33393,7 +33505,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 468
+      "community": 469
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33401,7 +33513,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "PerformanceBenchmark",
@@ -33409,7 +33521,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 329
+      "community": 330
     },
     {
       "label": ".measureOperation()",
@@ -33417,7 +33529,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 329
+      "community": 330
     },
     {
       "label": ".getResults()",
@@ -33425,7 +33537,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 329
+      "community": 330
     },
     {
       "label": ".getSummary()",
@@ -33433,7 +33545,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 329
+      "community": 330
     },
     {
       "label": "test-search.ts",
@@ -33441,7 +33553,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 626
+      "community": 628
     },
     {
       "label": "testSearchFunctionality()",
@@ -33449,7 +33561,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 626
+      "community": 628
     },
     {
       "label": "test-forgetting.ts",
@@ -33457,7 +33569,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 627
+      "community": 629
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33465,7 +33577,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 627
+      "community": 629
     },
     {
       "label": "mock-database.spec.ts",
@@ -33473,7 +33585,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "test-m1-completion.ts",
@@ -33481,7 +33593,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 628
+      "community": 630
     },
     {
       "label": "testM1Completion()",
@@ -33489,7 +33601,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 628
+      "community": 630
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33497,7 +33609,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 629
+      "community": 631
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33505,7 +33617,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 629
+      "community": 631
     },
     {
       "label": "vitest.setup.ts",
@@ -33513,7 +33625,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33521,7 +33633,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 630
+      "community": 632
     },
     {
       "label": "parseItems()",
@@ -33529,7 +33641,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 630
+      "community": 632
     },
     {
       "label": "test-memory-resource.ts",
@@ -33537,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "setupResourceHandlers()",
@@ -33545,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 469
+      "community": 470
     },
     {
       "label": "createTestMemories()",
@@ -33553,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 469
+      "community": 470
     },
     {
       "label": "test-regression.ts",
@@ -33561,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 631
+      "community": 633
     },
     {
       "label": "testRegression()",
@@ -33569,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 631
+      "community": 633
     },
     {
       "label": "test-anchor-system.ts",
@@ -33577,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_anchor_system_ts",
-      "community": 238
+      "community": 239
     },
     {
       "label": "createAnchorTable()",
@@ -33585,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L16",
       "id": "test_anchor_system_createanchortable",
-      "community": 238
+      "community": 239
     },
     {
       "label": "testAnchorSystemWorkflow()",
@@ -33593,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L35",
       "id": "test_anchor_system_testanchorsystemworkflow",
-      "community": 238
+      "community": 239
     },
     {
       "label": "testMultiClientScenario()",
@@ -33601,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L179",
       "id": "test_anchor_system_testmulticlientscenario",
-      "community": 238
+      "community": 239
     },
     {
       "label": "testFallbackMechanism()",
@@ -33609,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L316",
       "id": "test_anchor_system_testfallbackmechanism",
-      "community": 238
+      "community": 239
     },
     {
       "label": "expect()",
@@ -33617,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L431",
       "id": "test_anchor_system_expect",
-      "community": 238
+      "community": 239
     },
     {
       "label": "runAllTests()",
@@ -33625,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L471",
       "id": "test_anchor_system_runalltests",
-      "community": 238
+      "community": 239
     },
     {
       "label": "test-vector-search-quality-with-consolidation.spec.ts",
@@ -33633,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33641,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_multi_provider_search_performance_benchmark_ts",
-      "community": 211
+      "community": 212
     },
     {
       "label": "MultiProviderSearchBenchmark",
@@ -33649,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L46",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".constructor()",
@@ -33657,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L51",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_constructor",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".prepareTestData()",
@@ -33665,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L60",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_preparetestdata",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".benchmarkSingleProvider()",
@@ -33673,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L116",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_benchmarksingleprovider",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".benchmarkMultiProvider()",
@@ -33681,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L161",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_benchmarkmultiprovider",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".runBenchmark()",
@@ -33689,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L214",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_runbenchmark",
-      "community": 211
+      "community": 212
     },
     {
       "label": ".generateReport()",
@@ -33697,7 +33809,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L277",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_generatereport",
-      "community": 211
+      "community": 212
     },
     {
       "label": "test-single-provider-regression.ts",
@@ -33705,7 +33817,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 632
+      "community": 634
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33713,7 +33825,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 632
+      "community": 634
     },
     {
       "label": "visualize-recency.ts",
@@ -33721,7 +33833,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_visualize_recency_ts",
-      "community": 239
+      "community": 240
     },
     {
       "label": "calculateRecency()",
@@ -33729,7 +33841,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L21",
       "id": "visualize_recency_calculaterecency",
-      "community": 239
+      "community": 240
     },
     {
       "label": "generateRecencyData()",
@@ -33737,7 +33849,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L28",
       "id": "visualize_recency_generaterecencydata",
-      "community": 239
+      "community": 240
     },
     {
       "label": "printConsoleGraph()",
@@ -33745,7 +33857,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L55",
       "id": "visualize_recency_printconsolegraph",
-      "community": 239
+      "community": 240
     },
     {
       "label": "printKeyPoints()",
@@ -33753,7 +33865,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L133",
       "id": "visualize_recency_printkeypoints",
-      "community": 239
+      "community": 240
     },
     {
       "label": "printCSV()",
@@ -33761,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L164",
       "id": "visualize_recency_printcsv",
-      "community": 239
+      "community": 240
     },
     {
       "label": "main()",
@@ -33769,7 +33881,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L180",
       "id": "visualize_recency_main",
-      "community": 239
+      "community": 240
     },
     {
       "label": "embedding-integration-test.ts",
@@ -33777,7 +33889,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -33785,7 +33897,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_consolidation_search_quality_ts",
-      "community": 240
+      "community": 241
     },
     {
       "label": "generateGroundTruth()",
@@ -33793,7 +33905,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L44",
       "id": "test_consolidation_search_quality_generategroundtruth",
-      "community": 240
+      "community": 241
     },
     {
       "label": "convertToSearchResults()",
@@ -33801,7 +33913,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L67",
       "id": "test_consolidation_search_quality_converttosearchresults",
-      "community": 240
+      "community": 241
     },
     {
       "label": "measureSearchQuality()",
@@ -33809,7 +33921,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L79",
       "id": "test_consolidation_search_quality_measuresearchquality",
-      "community": 240
+      "community": 241
     },
     {
       "label": "compareWithAndWithoutConsolidation()",
@@ -33817,7 +33929,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L130",
       "id": "test_consolidation_search_quality_comparewithandwithoutconsolidation",
-      "community": 240
+      "community": 241
     },
     {
       "label": "verifyRankingOrder()",
@@ -33825,7 +33937,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L174",
       "id": "test_consolidation_search_quality_verifyrankingorder",
-      "community": 240
+      "community": 241
     },
     {
       "label": "testConsolidationSearchQuality()",
@@ -33833,7 +33945,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L197",
       "id": "test_consolidation_search_quality_testconsolidationsearchquality",
-      "community": 240
+      "community": 241
     },
     {
       "label": "test-vector-search-engine.ts",
@@ -33841,7 +33953,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 633
+      "community": 635
     },
     {
       "label": "constructor()",
@@ -33849,7 +33961,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 633
+      "community": 635
     },
     {
       "label": "mock-database.ts",
@@ -34009,7 +34121,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_consolidation_search_quality_benchmark_ts",
-      "community": 176
+      "community": 178
     },
     {
       "label": "generateBenchmarkGroundTruth()",
@@ -34017,7 +34129,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L52",
       "id": "consolidation_search_quality_benchmark_generatebenchmarkgroundtruth",
-      "community": 176
+      "community": 178
     },
     {
       "label": "measureQualityWithWeights()",
@@ -34025,7 +34137,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L70",
       "id": "consolidation_search_quality_benchmark_measurequalitywithweights",
-      "community": 176
+      "community": 178
     },
     {
       "label": "benchmarkWeightCombinations()",
@@ -34033,7 +34145,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L112",
       "id": "consolidation_search_quality_benchmark_benchmarkweightcombinations",
-      "community": 176
+      "community": 178
     },
     {
       "label": "saveBaselineSnapshot()",
@@ -34041,7 +34153,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L156",
       "id": "consolidation_search_quality_benchmark_savebaselinesnapshot",
-      "community": 176
+      "community": 178
     },
     {
       "label": "loadBaselineSnapshot()",
@@ -34049,7 +34161,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L189",
       "id": "consolidation_search_quality_benchmark_loadbaselinesnapshot",
-      "community": 176
+      "community": 178
     },
     {
       "label": "compareWithBaseline()",
@@ -34057,7 +34169,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L206",
       "id": "consolidation_search_quality_benchmark_comparewithbaseline",
-      "community": 176
+      "community": 178
     },
     {
       "label": "generateTuningGuidelines()",
@@ -34065,7 +34177,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L245",
       "id": "consolidation_search_quality_benchmark_generatetuningguidelines",
-      "community": 176
+      "community": 178
     },
     {
       "label": "runConsolidationQualityBenchmark()",
@@ -34073,7 +34185,7 @@
       "source_file": "packages/memento-core/src/test/consolidation-search-quality-benchmark.ts",
       "source_location": "L298",
       "id": "consolidation_search_quality_benchmark_runconsolidationqualitybenchmark",
-      "community": 176
+      "community": 178
     },
     {
       "label": "test-batch-scheduler.ts",
@@ -34081,7 +34193,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34089,7 +34201,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "telemetryDb()",
@@ -34097,7 +34209,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 399
+      "community": 400
     },
     {
       "label": "percentile95()",
@@ -34105,7 +34217,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 399
+      "community": 400
     },
     {
       "label": "run()",
@@ -34113,7 +34225,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 399
+      "community": 400
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34121,7 +34233,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 634
+      "community": 636
     },
     {
       "label": "createTestMemories()",
@@ -34129,7 +34241,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 634
+      "community": 636
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34137,7 +34249,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 635
+      "community": 637
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34145,7 +34257,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 635
+      "community": 637
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34153,7 +34265,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34161,7 +34273,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 636
+      "community": 638
     },
     {
       "label": "seedCluster()",
@@ -34169,7 +34281,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 636
+      "community": 638
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34177,7 +34289,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "readSource()",
@@ -34185,7 +34297,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 470
+      "community": 471
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34193,7 +34305,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 470
+      "community": 471
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34201,7 +34313,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34209,7 +34321,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 400
+      "community": 401
     },
     {
       "label": "normalizeTags()",
@@ -34217,7 +34329,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 400
+      "community": 401
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34225,7 +34337,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 400
+      "community": 401
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34233,7 +34345,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 637
+      "community": 639
     },
     {
       "label": "writeFixtureDir()",
@@ -34241,7 +34353,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 637
+      "community": 639
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34249,7 +34361,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_metrics_ts",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculatePrecisionAtK()",
@@ -34257,7 +34369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L27",
       "id": "search_quality_metrics_calculateprecisionatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateRecallAtK()",
@@ -34265,7 +34377,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L50",
       "id": "search_quality_metrics_calculaterecallatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateDCG()",
@@ -34273,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L72",
       "id": "search_quality_metrics_calculatedcg",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateIDCG()",
@@ -34281,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L100",
       "id": "search_quality_metrics_calculateidcg",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateNDCGAtK()",
@@ -34289,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L121",
       "id": "search_quality_metrics_calculatendcgatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateMeanPrecisionAtK()",
@@ -34297,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L144",
       "id": "search_quality_metrics_calculatemeanprecisionatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateMeanRecallAtK()",
@@ -34305,7 +34417,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L170",
       "id": "search_quality_metrics_calculatemeanrecallatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateMeanNDCGAtK()",
@@ -34313,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L196",
       "id": "search_quality_metrics_calculatemeanndcgatk",
-      "community": 125
+      "community": 126
     },
     {
       "label": "calculateRankingAccuracy()",
@@ -34321,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L222",
       "id": "search_quality_metrics_calculaterankingaccuracy",
-      "community": 125
+      "community": 126
     },
     {
       "label": "generateQualityReport()",
@@ -34329,7 +34441,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-metrics.ts",
       "source_location": "L256",
       "id": "search_quality_metrics_generatequalityreport",
-      "community": 125
+      "community": 126
     },
     {
       "label": "search-quality-review-checklist.spec.ts",
@@ -34337,7 +34449,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34345,7 +34457,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_ts",
-      "community": 241
+      "community": 242
     },
     {
       "label": "loadLabelCandidates()",
@@ -34353,7 +34465,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L19",
       "id": "search_quality_review_checklist_loadlabelcandidates",
-      "community": 241
+      "community": 242
     },
     {
       "label": "summarizeContent()",
@@ -34361,7 +34473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L33",
       "id": "search_quality_review_checklist_summarizecontent",
-      "community": 241
+      "community": 242
     },
     {
       "label": "findGroundTruth()",
@@ -34369,7 +34481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L42",
       "id": "search_quality_review_checklist_findgroundtruth",
-      "community": 241
+      "community": 242
     },
     {
       "label": "renderCandidate()",
@@ -34377,7 +34489,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L48",
       "id": "search_quality_review_checklist_rendercandidate",
-      "community": 241
+      "community": 242
     },
     {
       "label": "renderRelevantEntry()",
@@ -34385,7 +34497,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L65",
       "id": "search_quality_review_checklist_renderrelevantentry",
-      "community": 241
+      "community": 242
     },
     {
       "label": "buildReviewChecklistMarkdown()",
@@ -34393,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L82",
       "id": "search_quality_review_checklist_buildreviewchecklistmarkdown",
-      "community": 241
+      "community": 242
     },
     {
       "label": "benchmark-search-database.ts",
@@ -34401,7 +34513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "normalizeMemoryType()",
@@ -34409,7 +34521,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34417,7 +34529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 401
+      "community": 402
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34425,7 +34537,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 401
+      "community": 402
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34433,7 +34545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34441,7 +34553,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "test-database.ts",
@@ -34449,7 +34561,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_test_database_ts",
-      "community": 252
+      "community": 253
     },
     {
       "label": "createTestDatabaseWithoutServices()",
@@ -34457,7 +34569,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L198",
       "id": "test_database_createtestdatabasewithoutservices",
-      "community": 252
+      "community": 253
     },
     {
       "label": "createTestMemory()",
@@ -34465,7 +34577,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L209",
       "id": "test_database_createtestmemory",
-      "community": 252
+      "community": 253
     },
     {
       "label": "search-quality-candidate-builder.ts",
@@ -34473,7 +34585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 638
+      "community": 640
     },
     {
       "label": "mergeCandidateIds()",
@@ -34481,7 +34593,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 638
+      "community": 640
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34489,7 +34601,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34497,7 +34609,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 471
+      "community": 472
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34505,7 +34617,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 471
+      "community": 472
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34513,7 +34625,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34521,7 +34633,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34529,7 +34641,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_ts",
-      "community": 177
+      "community": 179
     },
     {
       "label": "resolveBenchmarkDir()",
@@ -34537,7 +34649,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L48",
       "id": "search_quality_benchmark_fixtures_resolvebenchmarkdir",
-      "community": 177
+      "community": 179
     },
     {
       "label": "readJsonFile()",
@@ -34545,7 +34657,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L52",
       "id": "search_quality_benchmark_fixtures_readjsonfile",
-      "community": 177
+      "community": 179
     },
     {
       "label": "loadBenchmarkManifest()",
@@ -34553,7 +34665,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L64",
       "id": "search_quality_benchmark_fixtures_loadbenchmarkmanifest",
-      "community": 177
+      "community": 179
     },
     {
       "label": "assertStrictBenchmark()",
@@ -34561,7 +34673,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L77",
       "id": "search_quality_benchmark_fixtures_assertstrictbenchmark",
-      "community": 177
+      "community": 179
     },
     {
       "label": "loadBenchmarkQueries()",
@@ -34569,7 +34681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L101",
       "id": "search_quality_benchmark_fixtures_loadbenchmarkqueries",
-      "community": 177
+      "community": 179
     },
     {
       "label": "buildBenchmarkQueryLookup()",
@@ -34577,7 +34689,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L114",
       "id": "search_quality_benchmark_fixtures_buildbenchmarkquerylookup",
-      "community": 177
+      "community": 179
     },
     {
       "label": "loadBenchmarkGroundTruth()",
@@ -34585,7 +34697,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L121",
       "id": "search_quality_benchmark_fixtures_loadbenchmarkgroundtruth",
-      "community": 177
+      "community": 179
     },
     {
       "label": "loadBenchmarkCorpus()",
@@ -34593,7 +34705,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.ts",
       "source_location": "L140",
       "id": "search_quality_benchmark_fixtures_loadbenchmarkcorpus",
-      "community": 177
+      "community": 179
     },
     {
       "label": "consolidation-test-data.ts",
@@ -34721,7 +34833,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "query-counter.ts",
@@ -34729,7 +34841,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "extractQueryType()",
@@ -34737,7 +34849,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 402
+      "community": 403
     },
     {
       "label": "isExcluded()",
@@ -34745,7 +34857,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQueryCounter()",
@@ -34753,7 +34865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 402
+      "community": 403
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35121,7 +35233,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 639
+      "community": 641
     },
     {
       "label": "copyDir()",
@@ -35129,7 +35241,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 639
+      "community": 641
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35137,7 +35249,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 640
+      "community": 642
     },
     {
       "label": "readRootPackageJson()",
@@ -35145,7 +35257,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 640
+      "community": 642
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35153,7 +35265,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 641
+      "community": 643
     },
     {
       "label": "readJson()",
@@ -35161,7 +35273,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 641
+      "community": 643
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35169,7 +35281,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 642
+      "community": 644
     },
     {
       "label": "readWorkflow()",
@@ -35177,7 +35289,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 642
+      "community": 644
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35185,7 +35297,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L1",
       "id": "tests_root_quality_gates_spec_ts",
-      "community": 242
+      "community": 243
     },
     {
       "label": "readJson()",
@@ -35193,7 +35305,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L21",
       "id": "root_quality_gates_spec_readjson",
-      "community": 242
+      "community": 243
     },
     {
       "label": "normalizeCommand()",
@@ -35201,7 +35313,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L27",
       "id": "root_quality_gates_spec_normalizecommand",
-      "community": 242
+      "community": 243
     },
     {
       "label": "readScript()",
@@ -35209,7 +35321,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L31",
       "id": "root_quality_gates_spec_readscript",
-      "community": 242
+      "community": 243
     },
     {
       "label": "expectExactScript()",
@@ -35217,7 +35329,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L39",
       "id": "root_quality_gates_spec_expectexactscript",
-      "community": 242
+      "community": 243
     },
     {
       "label": "splitSequentialCommands()",
@@ -35225,7 +35337,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L43",
       "id": "root_quality_gates_spec_splitsequentialcommands",
-      "community": 242
+      "community": 243
     },
     {
       "label": "ruleSeverity()",
@@ -35233,7 +35345,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L47",
       "id": "root_quality_gates_spec_ruleseverity",
-      "community": 242
+      "community": 243
     },
     {
       "label": "static-design-contracts.spec.ts",
@@ -35241,7 +35353,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 643
+      "community": 645
     },
     {
       "label": "readStaticFile()",
@@ -35249,7 +35361,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 643
+      "community": 645
     },
     {
       "label": "smoke.spec.ts",
@@ -35257,7 +35369,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 644
+      "community": 646
     },
     {
       "label": "extractFencedBlocks()",
@@ -35265,7 +35377,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 644
+      "community": 646
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35273,7 +35385,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L1",
       "id": "scripts_check_legacy_script_usage_ts",
-      "community": 212
+      "community": 213
     },
     {
       "label": "checkGitHistory()",
@@ -35281,7 +35393,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L47",
       "id": "check_legacy_script_usage_checkgithistory",
-      "community": 212
+      "community": 213
     },
     {
       "label": "checkDocumentation()",
@@ -35289,7 +35401,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L67",
       "id": "check_legacy_script_usage_checkdocumentation",
-      "community": 212
+      "community": 213
     },
     {
       "label": "checkCode()",
@@ -35297,7 +35409,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L120",
       "id": "check_legacy_script_usage_checkcode",
-      "community": 212
+      "community": 213
     },
     {
       "label": "checkPackageJson()",
@@ -35305,7 +35417,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L159",
       "id": "check_legacy_script_usage_checkpackagejson",
-      "community": 212
+      "community": 213
     },
     {
       "label": "checkLegacyScriptUsage()",
@@ -35313,7 +35425,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L187",
       "id": "check_legacy_script_usage_checklegacyscriptusage",
-      "community": 212
+      "community": 213
     },
     {
       "label": "printJSON()",
@@ -35321,7 +35433,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L230",
       "id": "check_legacy_script_usage_printjson",
-      "community": 212
+      "community": 213
     },
     {
       "label": "printText()",
@@ -35329,7 +35441,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L237",
       "id": "check_legacy_script_usage_printtext",
-      "community": 212
+      "community": 213
     },
     {
       "label": "quality-report.ts",
@@ -35337,7 +35449,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "parseArgs()",
@@ -35345,7 +35457,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 403
+      "community": 404
     },
     {
       "label": "printHelp()",
@@ -35353,7 +35465,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 403
+      "community": 404
     },
     {
       "label": "main()",
@@ -35361,7 +35473,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 403
+      "community": 404
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35369,7 +35481,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L1",
       "id": "scripts_check_magic_numbers_ts",
-      "community": 141
+      "community": 142
     },
     {
       "label": "isCoreModule()",
@@ -35377,7 +35489,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L73",
       "id": "check_magic_numbers_iscoremodule",
-      "community": 141
+      "community": 142
     },
     {
       "label": "isExcluded()",
@@ -35385,7 +35497,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L77",
       "id": "check_magic_numbers_isexcluded",
-      "community": 141
+      "community": 142
     },
     {
       "label": "findMagicNumbers()",
@@ -35393,7 +35505,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L82",
       "id": "check_magic_numbers_findmagicnumbers",
-      "community": 141
+      "community": 142
     },
     {
       "label": "getAllTsFiles()",
@@ -35401,7 +35513,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L130",
       "id": "check_magic_numbers_getalltsfiles",
-      "community": 141
+      "community": 142
     },
     {
       "label": "countMagicNumbers()",
@@ -35409,7 +35521,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L161",
       "id": "check_magic_numbers_countmagicnumbers",
-      "community": 141
+      "community": 142
     },
     {
       "label": "printResultsJSON()",
@@ -35417,7 +35529,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L195",
       "id": "check_magic_numbers_printresultsjson",
-      "community": 141
+      "community": 142
     },
     {
       "label": "printResultsCSV()",
@@ -35425,7 +35537,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L214",
       "id": "check_magic_numbers_printresultscsv",
-      "community": 141
+      "community": 142
     },
     {
       "label": "printResultsText()",
@@ -35433,7 +35545,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L222",
       "id": "check_magic_numbers_printresultstext",
-      "community": 141
+      "community": 142
     },
     {
       "label": "main()",
@@ -35441,7 +35553,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L233",
       "id": "check_magic_numbers_main",
-      "community": 141
+      "community": 142
     },
     {
       "label": "prepack-bundle-core.js",
@@ -35449,7 +35561,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 645
+      "community": 647
     },
     {
       "label": "shouldInclude()",
@@ -35457,7 +35569,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 645
+      "community": 647
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35465,7 +35577,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 472
+      "community": 473
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35473,7 +35585,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 472
+      "community": 473
     },
     {
       "label": "readTarString()",
@@ -35481,7 +35593,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 472
+      "community": 473
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35489,7 +35601,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_candidates_ts",
-      "community": 243
+      "community": 244
     },
     {
       "label": "parseArgs()",
@@ -35497,7 +35609,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L23",
       "id": "generate_search_quality_candidates_parseargs",
-      "community": 243
+      "community": 244
     },
     {
       "label": "printHelp()",
@@ -35505,7 +35617,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L63",
       "id": "generate_search_quality_candidates_printhelp",
-      "community": 243
+      "community": 244
     },
     {
       "label": "buildMemoryIdToBenchmarkIdMap()",
@@ -35513,7 +35625,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L83",
       "id": "generate_search_quality_candidates_buildmemoryidtobenchmarkidmap",
-      "community": 243
+      "community": 244
     },
     {
       "label": "hashString()",
@@ -35521,7 +35633,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L91",
       "id": "generate_search_quality_candidates_hashstring",
-      "community": 243
+      "community": 244
     },
     {
       "label": "sampleDeterministicNegatives()",
@@ -35529,7 +35641,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L100",
       "id": "generate_search_quality_candidates_sampledeterministicnegatives",
-      "community": 243
+      "community": 244
     },
     {
       "label": "main()",
@@ -35537,7 +35649,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L123",
       "id": "generate_search_quality_candidates_main",
-      "community": 243
+      "community": 244
     },
     {
       "label": "fix-migration.js",
@@ -35545,7 +35657,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 646
+      "community": 648
     },
     {
       "label": "fixMigration()",
@@ -35553,7 +35665,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 646
+      "community": 648
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35561,7 +35673,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 949
+      "community": 951
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35569,7 +35681,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_ts",
-      "community": 244
+      "community": 245
     },
     {
       "label": "mean()",
@@ -35577,7 +35689,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L44",
       "id": "compare_weight_profiles_mean",
-      "community": 244
+      "community": 245
     },
     {
       "label": "pairedPermutationPValue()",
@@ -35585,7 +35697,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L51",
       "id": "compare_weight_profiles_pairedpermutationpvalue",
-      "community": 244
+      "community": 245
     },
     {
       "label": "runProfile()",
@@ -35593,7 +35705,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L75",
       "id": "compare_weight_profiles_runprofile",
-      "community": 244
+      "community": 245
     },
     {
       "label": "assertRankingProfileFilesExist()",
@@ -35601,7 +35713,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L149",
       "id": "compare_weight_profiles_assertrankingprofilefilesexist",
-      "community": 244
+      "community": 245
     },
     {
       "label": "parseArgs()",
@@ -35609,7 +35721,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L158",
       "id": "compare_weight_profiles_parseargs",
-      "community": 244
+      "community": 245
     },
     {
       "label": "main()",
@@ -35617,7 +35729,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L173",
       "id": "compare_weight_profiles_main",
-      "community": 244
+      "community": 245
     },
     {
       "label": "verify-search-quality-benchmark-review.ts",
@@ -35625,7 +35737,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "parseArgs()",
@@ -35633,7 +35745,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 404
+      "community": 405
     },
     {
       "label": "printHelp()",
@@ -35641,7 +35753,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 404
+      "community": 405
     },
     {
       "label": "main()",
@@ -35649,7 +35761,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 404
+      "community": 405
     },
     {
       "label": "check-path-traversal.ts",
@@ -35657,7 +35769,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L1",
       "id": "scripts_check_path_traversal_ts",
-      "community": 178
+      "community": 180
     },
     {
       "label": "parseArgs()",
@@ -35665,7 +35777,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L59",
       "id": "check_path_traversal_parseargs",
-      "community": 178
+      "community": 180
     },
     {
       "label": "printHelp()",
@@ -35673,7 +35785,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L90",
       "id": "check_path_traversal_printhelp",
-      "community": 178
+      "community": 180
     },
     {
       "label": "shouldExclude()",
@@ -35681,7 +35793,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L113",
       "id": "check_path_traversal_shouldexclude",
-      "community": 178
+      "community": 180
     },
     {
       "label": "findFiles()",
@@ -35689,7 +35801,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L131",
       "id": "check_path_traversal_findfiles",
-      "community": 178
+      "community": 180
     },
     {
       "label": "checkFile()",
@@ -35697,7 +35809,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L163",
       "id": "check_path_traversal_checkfile",
-      "community": 178
+      "community": 180
     },
     {
       "label": "checkAllFiles()",
@@ -35705,7 +35817,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L285",
       "id": "check_path_traversal_checkallfiles",
-      "community": 178
+      "community": 180
     },
     {
       "label": "printResults()",
@@ -35713,7 +35825,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L318",
       "id": "check_path_traversal_printresults",
-      "community": 178
+      "community": 180
     },
     {
       "label": "main()",
@@ -35721,7 +35833,7 @@
       "source_file": "scripts/check-path-traversal.ts",
       "source_location": "L347",
       "id": "check_path_traversal_main",
-      "community": 178
+      "community": 180
     },
     {
       "label": "auto-setup.js",
@@ -35849,7 +35961,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "parseArgs()",
@@ -35857,7 +35969,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 330
+      "community": 331
     },
     {
       "label": "printHelp()",
@@ -35865,7 +35977,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 330
+      "community": 331
     },
     {
       "label": "printThresholds()",
@@ -35873,7 +35985,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 330
+      "community": 331
     },
     {
       "label": "main()",
@@ -35881,7 +35993,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 330
+      "community": 331
     },
     {
       "label": "simple-update.js",
@@ -35889,7 +36001,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 647
+      "community": 649
     },
     {
       "label": "updateEmbeddings()",
@@ -35897,7 +36009,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 647
+      "community": 649
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -35905,7 +36017,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L1",
       "id": "scripts_export_search_quality_benchmark_ts",
-      "community": 126
+      "community": 127
     },
     {
       "label": "parseArgs()",
@@ -35913,7 +36025,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L21",
       "id": "export_search_quality_benchmark_parseargs",
-      "community": 126
+      "community": 127
     },
     {
       "label": "printHelp()",
@@ -35921,7 +36033,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L51",
       "id": "export_search_quality_benchmark_printhelp",
-      "community": 126
+      "community": 127
     },
     {
       "label": "loadJsonArrayLength()",
@@ -35929,7 +36041,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L74",
       "id": "export_search_quality_benchmark_loadjsonarraylength",
-      "community": 126
+      "community": 127
     },
     {
       "label": "deriveBenchmarkVersion()",
@@ -35937,7 +36049,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L83",
       "id": "export_search_quality_benchmark_derivebenchmarkversion",
-      "community": 126
+      "community": 127
     },
     {
       "label": "createManifest()",
@@ -35945,7 +36057,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L89",
       "id": "export_search_quality_benchmark_createmanifest",
-      "community": 126
+      "community": 127
     },
     {
       "label": "loadSourceMemories()",
@@ -35953,7 +36065,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L108",
       "id": "export_search_quality_benchmark_loadsourcememories",
-      "community": 126
+      "community": 127
     },
     {
       "label": "writeCorpus()",
@@ -35961,7 +36073,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L117",
       "id": "export_search_quality_benchmark_writecorpus",
-      "community": 126
+      "community": 127
     },
     {
       "label": "writeManifest()",
@@ -35969,7 +36081,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L126",
       "id": "export_search_quality_benchmark_writemanifest",
-      "community": 126
+      "community": 127
     },
     {
       "label": "main()",
@@ -35977,7 +36089,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L131",
       "id": "export_search_quality_benchmark_main",
-      "community": 126
+      "community": 127
     },
     {
       "label": "printDatabaseHint()",
@@ -35985,7 +36097,7 @@
       "source_file": "scripts/export-search-quality-benchmark.ts",
       "source_location": "L187",
       "id": "export_search_quality_benchmark_printdatabasehint",
-      "community": 126
+      "community": 127
     },
     {
       "label": "check-pii-masking.ts",
@@ -35993,7 +36105,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L1",
       "id": "scripts_check_pii_masking_ts",
-      "community": 179
+      "community": 181
     },
     {
       "label": "parseArgs()",
@@ -36001,7 +36113,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L56",
       "id": "check_pii_masking_parseargs",
-      "community": 179
+      "community": 181
     },
     {
       "label": "printHelp()",
@@ -36009,7 +36121,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L87",
       "id": "check_pii_masking_printhelp",
-      "community": 179
+      "community": 181
     },
     {
       "label": "shouldExclude()",
@@ -36017,7 +36129,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L110",
       "id": "check_pii_masking_shouldexclude",
-      "community": 179
+      "community": 181
     },
     {
       "label": "findFiles()",
@@ -36025,7 +36137,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L128",
       "id": "check_pii_masking_findfiles",
-      "community": 179
+      "community": 181
     },
     {
       "label": "checkFile()",
@@ -36033,7 +36145,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L160",
       "id": "check_pii_masking_checkfile",
-      "community": 179
+      "community": 181
     },
     {
       "label": "checkAllFiles()",
@@ -36041,7 +36153,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L287",
       "id": "check_pii_masking_checkallfiles",
-      "community": 179
+      "community": 181
     },
     {
       "label": "printResults()",
@@ -36049,7 +36161,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L320",
       "id": "check_pii_masking_printresults",
-      "community": 179
+      "community": 181
     },
     {
       "label": "main()",
@@ -36057,7 +36169,7 @@
       "source_file": "scripts/check-pii-masking.ts",
       "source_location": "L349",
       "id": "check_pii_masking_main",
-      "community": 179
+      "community": 181
     },
     {
       "label": "simple-migrate-wrapper.ts",
@@ -36065,7 +36177,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 648
+      "community": 650
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36073,7 +36185,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 648
+      "community": 650
     },
     {
       "label": "test-docker.js",
@@ -36081,7 +36193,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 649
+      "community": 651
     },
     {
       "label": "testDockerServer()",
@@ -36089,7 +36201,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 649
+      "community": 651
     },
     {
       "label": "pack-with-restore.js",
@@ -36097,7 +36209,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 950
+      "community": 952
     },
     {
       "label": "run-migration.js",
@@ -36105,7 +36217,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 650
+      "community": 652
     },
     {
       "label": "runMigration()",
@@ -36113,7 +36225,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 650
+      "community": 652
     },
     {
       "label": "safe-migration.js",
@@ -36121,7 +36233,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 651
+      "community": 653
     },
     {
       "label": "safeMigration()",
@@ -36129,7 +36241,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 651
+      "community": 653
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36137,7 +36249,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L1",
       "id": "scripts_generate_ground_truth_ts",
-      "community": 245
+      "community": 246
     },
     {
       "label": "parseArgs()",
@@ -36145,7 +36257,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L53",
       "id": "generate_ground_truth_parseargs",
-      "community": 245
+      "community": 246
     },
     {
       "label": "printHelp()",
@@ -36153,7 +36265,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L92",
       "id": "generate_ground_truth_printhelp",
-      "community": 245
+      "community": 246
     },
     {
       "label": "getMemoryIds()",
@@ -36161,7 +36273,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L129",
       "id": "generate_ground_truth_getmemoryids",
-      "community": 245
+      "community": 246
     },
     {
       "label": "extractKeywordsFromMemories()",
@@ -36169,7 +36281,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L143",
       "id": "generate_ground_truth_extractkeywordsfrommemories",
-      "community": 245
+      "community": 246
     },
     {
       "label": "generateGroundTruthFromSearch()",
@@ -36177,7 +36289,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L186",
       "id": "generate_ground_truth_generategroundtruthfromsearch",
-      "community": 245
+      "community": 246
     },
     {
       "label": "main()",
@@ -36185,7 +36297,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L226",
       "id": "generate_ground_truth_main",
-      "community": 245
+      "community": 246
     },
     {
       "label": "save-work-memory.ts",
@@ -36193,7 +36305,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 652
+      "community": 654
     },
     {
       "label": "saveWorkMemory()",
@@ -36201,7 +36313,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 652
+      "community": 654
     },
     {
       "label": "check-file-sizes.ts",
@@ -36209,7 +36321,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L1",
       "id": "scripts_check_file_sizes_ts",
-      "community": 127
+      "community": 128
     },
     {
       "label": "parseArgs()",
@@ -36217,7 +36329,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L59",
       "id": "check_file_sizes_parseargs",
-      "community": 127
+      "community": 128
     },
     {
       "label": "printHelp()",
@@ -36225,7 +36337,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L95",
       "id": "check_file_sizes_printhelp",
-      "community": 127
+      "community": 128
     },
     {
       "label": "countLines()",
@@ -36233,7 +36345,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L124",
       "id": "check_file_sizes_countlines",
-      "community": 127
+      "community": 128
     },
     {
       "label": "validateFileSize()",
@@ -36241,7 +36353,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L147",
       "id": "check_file_sizes_validatefilesize",
-      "community": 127
+      "community": 128
     },
     {
       "label": "matchesPattern()",
@@ -36249,7 +36361,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L170",
       "id": "check_file_sizes_matchespattern",
-      "community": 127
+      "community": 128
     },
     {
       "label": "shouldExclude()",
@@ -36257,7 +36369,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L197",
       "id": "check_file_sizes_shouldexclude",
-      "community": 127
+      "community": 128
     },
     {
       "label": "findFiles()",
@@ -36265,7 +36377,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L213",
       "id": "check_file_sizes_findfiles",
-      "community": 127
+      "community": 128
     },
     {
       "label": "calculateStats()",
@@ -36273,7 +36385,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L254",
       "id": "check_file_sizes_calculatestats",
-      "community": 127
+      "community": 128
     },
     {
       "label": "printResults()",
@@ -36281,7 +36393,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L290",
       "id": "check_file_sizes_printresults",
-      "community": 127
+      "community": 128
     },
     {
       "label": "main()",
@@ -36289,7 +36401,7 @@
       "source_file": "scripts/check-file-sizes.ts",
       "source_location": "L338",
       "id": "check_file_sizes_main",
-      "community": 127
+      "community": 128
     },
     {
       "label": "find-external-api-calls.ts",
@@ -36297,7 +36409,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L1",
       "id": "scripts_find_external_api_calls_ts",
-      "community": 180
+      "community": 182
     },
     {
       "label": "isCoreModule()",
@@ -36305,7 +36417,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L64",
       "id": "find_external_api_calls_iscoremodule",
-      "community": 180
+      "community": 182
     },
     {
       "label": "findExternalAPICalls()",
@@ -36313,7 +36425,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L68",
       "id": "find_external_api_calls_findexternalapicalls",
-      "community": 180
+      "community": 182
     },
     {
       "label": "getAllTsFiles()",
@@ -36321,7 +36433,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L124",
       "id": "find_external_api_calls_getalltsfiles",
-      "community": 180
+      "community": 182
     },
     {
       "label": "countExternalAPICalls()",
@@ -36329,7 +36441,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L154",
       "id": "find_external_api_calls_countexternalapicalls",
-      "community": 180
+      "community": 182
     },
     {
       "label": "printResultsJSON()",
@@ -36337,7 +36449,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L186",
       "id": "find_external_api_calls_printresultsjson",
-      "community": 180
+      "community": 182
     },
     {
       "label": "printResultsCSV()",
@@ -36345,7 +36457,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L195",
       "id": "find_external_api_calls_printresultscsv",
-      "community": 180
+      "community": 182
     },
     {
       "label": "printResultsText()",
@@ -36353,7 +36465,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L203",
       "id": "find_external_api_calls_printresultstext",
-      "community": 180
+      "community": 182
     },
     {
       "label": "main()",
@@ -36361,7 +36473,7 @@
       "source_file": "scripts/find-external-api-calls.ts",
       "source_location": "L214",
       "id": "find_external_api_calls_main",
-      "community": 180
+      "community": 182
     },
     {
       "label": "quality-feedback-reappearance-report.spec.ts",
@@ -36369,7 +36481,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36377,7 +36489,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 653
+      "community": 655
     },
     {
       "label": "main()",
@@ -36385,7 +36497,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 653
+      "community": 655
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36393,7 +36505,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "parseArgs()",
@@ -36401,7 +36513,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 405
+      "community": 406
     },
     {
       "label": "printHelp()",
@@ -36409,7 +36521,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 405
+      "community": 406
     },
     {
       "label": "main()",
@@ -36417,7 +36529,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 405
+      "community": 406
     },
     {
       "label": "verify-bin.js",
@@ -36425,7 +36537,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 952
+      "community": 954
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36433,7 +36545,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "getTriggerInfo()",
@@ -36441,7 +36553,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 331
+      "community": 332
     },
     {
       "label": "fixTriggers()",
@@ -36449,7 +36561,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 331
+      "community": 332
     },
     {
       "label": "checkMigrationVersion()",
@@ -36457,7 +36569,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 331
+      "community": 332
     },
     {
       "label": "main()",
@@ -36465,7 +36577,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 331
+      "community": 332
     },
     {
       "label": "simple-migrate.js",
@@ -36473,7 +36585,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 654
+      "community": 656
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36481,7 +36593,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 654
+      "community": 656
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36489,7 +36601,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 655
+      "community": 657
     },
     {
       "label": "fixVectorDimensions()",
@@ -36497,7 +36609,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 655
+      "community": 657
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36505,7 +36617,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36513,7 +36625,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 406
+      "community": 407
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36521,7 +36633,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 406
+      "community": 407
     },
     {
       "label": "main()",
@@ -36529,7 +36641,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 406
+      "community": 407
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36537,7 +36649,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "loadVecExtension()",
@@ -36545,7 +36657,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 473
+      "community": 474
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36553,7 +36665,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 473
+      "community": 474
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36561,7 +36673,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 656
+      "community": 658
     },
     {
       "label": "runUpdateMigration()",
@@ -36569,7 +36681,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 656
+      "community": 658
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36577,7 +36689,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "reappearanceRate()",
@@ -36585,7 +36697,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 474
+      "community": 475
     },
     {
       "label": "main()",
@@ -36593,7 +36705,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 474
+      "community": 475
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36601,7 +36713,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 657
+      "community": 659
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36609,7 +36721,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 657
+      "community": 659
     },
     {
       "label": "generate-relation-report.ts",
@@ -36617,7 +36729,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L1",
       "id": "scripts_generate_relation_report_ts",
-      "community": 213
+      "community": 214
     },
     {
       "label": "parseArgs()",
@@ -36625,7 +36737,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L35",
       "id": "generate_relation_report_parseargs",
-      "community": 213
+      "community": 214
     },
     {
       "label": "loadTestDataset()",
@@ -36633,7 +36745,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L69",
       "id": "generate_relation_report_loadtestdataset",
-      "community": 213
+      "community": 214
     },
     {
       "label": "createBaseSchema()",
@@ -36641,7 +36753,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L102",
       "id": "generate_relation_report_createbaseschema",
-      "community": 213
+      "community": 214
     },
     {
       "label": "createTestMemory()",
@@ -36649,7 +36761,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L132",
       "id": "generate_relation_report_createtestmemory",
-      "community": 213
+      "community": 214
     },
     {
       "label": "extractRelations()",
@@ -36657,7 +36769,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L147",
       "id": "generate_relation_report_extractrelations",
-      "community": 213
+      "community": 214
     },
     {
       "label": "generateMarkdownReport()",
@@ -36665,7 +36777,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L224",
       "id": "generate_relation_report_generatemarkdownreport",
-      "community": 213
+      "community": 214
     },
     {
       "label": "main()",
@@ -36673,7 +36785,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L355",
       "id": "generate_relation_report_main",
-      "community": 213
+      "community": 214
     },
     {
       "label": "check-sql-injection.ts",
@@ -36681,7 +36793,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L1",
       "id": "scripts_check_sql_injection_ts",
-      "community": 142
+      "community": 143
     },
     {
       "label": "parseArgs()",
@@ -36689,7 +36801,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L56",
       "id": "check_sql_injection_parseargs",
-      "community": 142
+      "community": 143
     },
     {
       "label": "printHelp()",
@@ -36697,7 +36809,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L87",
       "id": "check_sql_injection_printhelp",
-      "community": 142
+      "community": 143
     },
     {
       "label": "matchesPattern()",
@@ -36705,7 +36817,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L110",
       "id": "check_sql_injection_matchespattern",
-      "community": 142
+      "community": 143
     },
     {
       "label": "shouldExclude()",
@@ -36713,7 +36825,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L129",
       "id": "check_sql_injection_shouldexclude",
-      "community": 142
+      "community": 143
     },
     {
       "label": "findFiles()",
@@ -36721,7 +36833,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L141",
       "id": "check_sql_injection_findfiles",
-      "community": 142
+      "community": 143
     },
     {
       "label": "findSqlInjectionPatterns()",
@@ -36729,7 +36841,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L179",
       "id": "check_sql_injection_findsqlinjectionpatterns",
-      "community": 142
+      "community": 143
     },
     {
       "label": "checkSqlInjection()",
@@ -36737,7 +36849,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L453",
       "id": "check_sql_injection_checksqlinjection",
-      "community": 142
+      "community": 143
     },
     {
       "label": "printResults()",
@@ -36745,7 +36857,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L483",
       "id": "check_sql_injection_printresults",
-      "community": 142
+      "community": 143
     },
     {
       "label": "main()",
@@ -36753,7 +36865,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L542",
       "id": "check_sql_injection_main",
-      "community": 142
+      "community": 143
     },
     {
       "label": "quality-benchmark-category-report.spec.ts",
@@ -36761,7 +36873,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "sampleReport()",
@@ -36769,7 +36881,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 658
+      "community": 660
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -36777,7 +36889,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 953
+      "community": 955
     },
     {
       "label": "debug-embeddings.js",
@@ -36785,7 +36897,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 659
+      "community": 661
     },
     {
       "label": "debugEmbeddings()",
@@ -36793,7 +36905,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 659
+      "community": 661
     },
     {
       "label": "check-db-integrity.js",
@@ -36801,7 +36913,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 407
+      "community": 408
     },
     {
       "label": "log()",
@@ -36809,7 +36921,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 407
+      "community": 408
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -36817,7 +36929,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 407
+      "community": 408
     },
     {
       "label": "main()",
@@ -36825,7 +36937,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 407
+      "community": 408
     },
     {
       "label": "mcp-http-client.js",
@@ -36833,7 +36945,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L1",
       "id": "scripts_mcp_http_client_js",
-      "community": 246
+      "community": 247
     },
     {
       "label": "callHttpTool()",
@@ -36841,7 +36953,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L15",
       "id": "mcp_http_client_callhttptool",
-      "community": 246
+      "community": 247
     },
     {
       "label": "getHttpTools()",
@@ -36849,7 +36961,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L38",
       "id": "mcp_http_client_gethttptools",
-      "community": 246
+      "community": 247
     },
     {
       "label": "sendResponse()",
@@ -36857,7 +36969,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L61",
       "id": "mcp_http_client_sendresponse",
-      "community": 246
+      "community": 247
     },
     {
       "label": "handleRequest()",
@@ -36865,7 +36977,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L77",
       "id": "mcp_http_client_handlerequest",
-      "community": 246
+      "community": 247
     },
     {
       "label": "checkServerHealth()",
@@ -36873,7 +36985,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L143",
       "id": "mcp_http_client_checkserverhealth",
-      "community": 246
+      "community": 247
     },
     {
       "label": "main()",
@@ -36881,7 +36993,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L158",
       "id": "mcp_http_client_main",
-      "community": 246
+      "community": 247
     },
     {
       "label": "weekly-relation-validation.ts",
@@ -36889,7 +37001,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L1",
       "id": "scripts_weekly_relation_validation_ts",
-      "community": 214
+      "community": 215
     },
     {
       "label": "parseArgs()",
@@ -36897,7 +37009,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L32",
       "id": "weekly_relation_validation_parseargs",
-      "community": 214
+      "community": 215
     },
     {
       "label": "loadTestDataset()",
@@ -36905,7 +37017,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L61",
       "id": "weekly_relation_validation_loadtestdataset",
-      "community": 214
+      "community": 215
     },
     {
       "label": "createBaseSchema()",
@@ -36913,7 +37025,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L86",
       "id": "weekly_relation_validation_createbaseschema",
-      "community": 214
+      "community": 215
     },
     {
       "label": "createTestMemory()",
@@ -36921,7 +37033,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L116",
       "id": "weekly_relation_validation_createtestmemory",
-      "community": 214
+      "community": 215
     },
     {
       "label": "extractRelations()",
@@ -36929,7 +37041,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L131",
       "id": "weekly_relation_validation_extractrelations",
-      "community": 214
+      "community": 215
     },
     {
       "label": "generateMarkdownReport()",
@@ -36937,7 +37049,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L208",
       "id": "weekly_relation_validation_generatemarkdownreport",
-      "community": 214
+      "community": 215
     },
     {
       "label": "main()",
@@ -36945,7 +37057,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L296",
       "id": "weekly_relation_validation_main",
-      "community": 214
+      "community": 215
     },
     {
       "label": "migrate-embedding-data.js",
@@ -37065,7 +37177,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 660
+      "community": 662
     },
     {
       "label": "backupEmbeddings()",
@@ -37073,7 +37185,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 660
+      "community": 662
     },
     {
       "label": "count-any-types.ts",
@@ -37081,7 +37193,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L1",
       "id": "scripts_count_any_types_ts",
-      "community": 143
+      "community": 144
     },
     {
       "label": "parseArgs()",
@@ -37089,7 +37201,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L56",
       "id": "count_any_types_parseargs",
-      "community": 143
+      "community": 144
     },
     {
       "label": "printHelp()",
@@ -37097,7 +37209,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L92",
       "id": "count_any_types_printhelp",
-      "community": 143
+      "community": 144
     },
     {
       "label": "matchesPattern()",
@@ -37105,7 +37217,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L118",
       "id": "count_any_types_matchespattern",
-      "community": 143
+      "community": 144
     },
     {
       "label": "shouldExclude()",
@@ -37113,7 +37225,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L137",
       "id": "count_any_types_shouldexclude",
-      "community": 143
+      "community": 144
     },
     {
       "label": "findFiles()",
@@ -37121,7 +37233,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L149",
       "id": "count_any_types_findfiles",
-      "community": 143
+      "community": 144
     },
     {
       "label": "findAnyTypes()",
@@ -37129,7 +37241,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L186",
       "id": "count_any_types_findanytypes",
-      "community": 143
+      "community": 144
     },
     {
       "label": "countAnyTypes()",
@@ -37137,7 +37249,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L251",
       "id": "count_any_types_countanytypes",
-      "community": 143
+      "community": 144
     },
     {
       "label": "printResults()",
@@ -37145,7 +37257,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L278",
       "id": "count_any_types_printresults",
-      "community": 143
+      "community": 144
     },
     {
       "label": "main()",
@@ -37153,7 +37265,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L318",
       "id": "count_any_types_main",
-      "community": 143
+      "community": 144
     },
     {
       "label": "count-console-logs.ts",
@@ -37289,7 +37401,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37297,7 +37409,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37305,7 +37417,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37313,7 +37425,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37321,7 +37433,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "jsonEmbedding()",
@@ -37329,7 +37441,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 661
+      "community": 663
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37337,7 +37449,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37345,7 +37457,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37353,7 +37465,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37361,7 +37473,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 662
+      "community": 664
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37369,7 +37481,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 662
+      "community": 664
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37377,7 +37489,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37385,7 +37497,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "jsonEmbedding()",
@@ -37393,7 +37505,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 663
+      "community": 665
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37401,7 +37513,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "main()",
@@ -37409,7 +37521,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 664
+      "community": 666
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37417,7 +37529,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37425,7 +37537,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 665
+      "community": 667
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37433,7 +37545,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "createBackup()",
@@ -37441,7 +37553,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 475
+      "community": 476
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37449,7 +37561,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 475
+      "community": 476
     },
     {
       "label": "restore-legacy.ps1",
@@ -37457,7 +37569,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 962
+      "community": 964
     },
     {
       "label": "check-retry-usage.ts",
@@ -37465,7 +37577,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_retry_usage_ts",
-      "community": 215
+      "community": 216
     },
     {
       "label": "getAllTsFiles()",
@@ -37473,7 +37585,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L53",
       "id": "check_retry_usage_getalltsfiles",
-      "community": 215
+      "community": 216
     },
     {
       "label": "checkRetryUsage()",
@@ -37481,7 +37593,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L84",
       "id": "check_retry_usage_checkretryusage",
-      "community": 215
+      "community": 216
     },
     {
       "label": "checkAllFiles()",
@@ -37489,7 +37601,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L130",
       "id": "check_retry_usage_checkallfiles",
-      "community": 215
+      "community": 216
     },
     {
       "label": "printResultsJSON()",
@@ -37497,7 +37609,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L147",
       "id": "check_retry_usage_printresultsjson",
-      "community": 215
+      "community": 216
     },
     {
       "label": "printResultsCSV()",
@@ -37505,7 +37617,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L156",
       "id": "check_retry_usage_printresultscsv",
-      "community": 215
+      "community": 216
     },
     {
       "label": "printResultsText()",
@@ -37513,7 +37625,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L164",
       "id": "check_retry_usage_printresultstext",
-      "community": 215
+      "community": 216
     },
     {
       "label": "main()",
@@ -37521,7 +37633,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L185",
       "id": "check_retry_usage_main",
-      "community": 215
+      "community": 216
     },
     {
       "label": "analyze-simple-throws.ts",
@@ -37529,7 +37641,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_simple_throws_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "isTestFile()",
@@ -37537,7 +37649,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L29",
       "id": "analyze_simple_throws_istestfile",
-      "community": 281
+      "community": 282
     },
     {
       "label": "shouldExcludeDir()",
@@ -37545,7 +37657,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L38",
       "id": "analyze_simple_throws_shouldexcludedir",
-      "community": 281
+      "community": 282
     },
     {
       "label": "findThrows()",
@@ -37553,7 +37665,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L45",
       "id": "analyze_simple_throws_findthrows",
-      "community": 281
+      "community": 282
     },
     {
       "label": "scanDirectory()",
@@ -37561,7 +37673,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L102",
       "id": "analyze_simple_throws_scandirectory",
-      "community": 281
+      "community": 282
     },
     {
       "label": "main()",
@@ -37569,7 +37681,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L126",
       "id": "analyze_simple_throws_main",
-      "community": 281
+      "community": 282
     },
     {
       "label": "analyze-benchmark-test-data.ts",
@@ -37577,7 +37689,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37585,7 +37697,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 666
+      "community": 668
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37593,7 +37705,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_no_console_violations_ts",
-      "community": 128
+      "community": 129
     },
     {
       "label": "parseArgs()",
@@ -37601,7 +37713,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L96",
       "id": "check_no_console_violations_parseargs",
-      "community": 128
+      "community": 129
     },
     {
       "label": "printHelp()",
@@ -37609,7 +37721,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L134",
       "id": "check_no_console_violations_printhelp",
-      "community": 128
+      "community": 129
     },
     {
       "label": "runESLint()",
@@ -37617,7 +37729,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L161",
       "id": "check_no_console_violations_runeslint",
-      "community": 128
+      "community": 129
     },
     {
       "label": "extractNoConsoleViolations()",
@@ -37625,7 +37737,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L221",
       "id": "check_no_console_violations_extractnoconsoleviolations",
-      "community": 128
+      "community": 129
     },
     {
       "label": "createSnapshot()",
@@ -37633,7 +37745,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L243",
       "id": "check_no_console_violations_createsnapshot",
-      "community": 128
+      "community": 129
     },
     {
       "label": "saveSnapshot()",
@@ -37641,7 +37753,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L262",
       "id": "check_no_console_violations_savesnapshot",
-      "community": 128
+      "community": 129
     },
     {
       "label": "loadSnapshot()",
@@ -37649,7 +37761,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L281",
       "id": "check_no_console_violations_loadsnapshot",
-      "community": 128
+      "community": 129
     },
     {
       "label": "compareSnapshots()",
@@ -37657,7 +37769,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L301",
       "id": "check_no_console_violations_comparesnapshots",
-      "community": 128
+      "community": 129
     },
     {
       "label": "printResults()",
@@ -37665,7 +37777,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L335",
       "id": "check_no_console_violations_printresults",
-      "community": 128
+      "community": 129
     },
     {
       "label": "main()",
@@ -37673,7 +37785,7 @@
       "source_file": "scripts/archive/check-no-console-violations.ts",
       "source_location": "L398",
       "id": "check_no_console_violations_main",
-      "community": 128
+      "community": 129
     },
     {
       "label": "fix-vec-table-dimensions.ts",
@@ -37681,7 +37793,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37689,7 +37801,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 667
+      "community": 669
     },
     {
       "label": "sources.ts",
@@ -37697,7 +37809,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "splitJsonlLines()",
@@ -37705,7 +37817,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L13",
       "id": "sources_splitjsonllines",
-      "community": 282
+      "community": 283
     },
     {
       "label": "runDocker()",
@@ -37713,7 +37825,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L22",
       "id": "sources_rundocker",
-      "community": 282
+      "community": 283
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -37721,7 +37833,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L42",
       "id": "sources_resolvedockerlogsref",
-      "community": 282
+      "community": 283
     },
     {
       "label": "readDockerLogs()",
@@ -37729,7 +37841,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L89",
       "id": "sources_readdockerlogs",
-      "community": 282
+      "community": 283
     },
     {
       "label": "readJsonlFiles()",
@@ -37737,7 +37849,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L118",
       "id": "sources_readjsonlfiles",
-      "community": 282
+      "community": 283
     },
     {
       "label": "types.ts",
@@ -37745,7 +37857,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "issue-body.ts",
@@ -37753,7 +37865,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "startMarker()",
@@ -37761,7 +37873,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 408
+      "community": 409
     },
     {
       "label": "renderManagedIssueBody()",
@@ -37769,7 +37881,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 408
+      "community": 409
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -37777,7 +37889,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 408
+      "community": 409
     },
     {
       "label": "fingerprint.ts",
@@ -37785,7 +37897,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "normalizeMessage()",
@@ -37793,7 +37905,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 476
+      "community": 477
     },
     {
       "label": "createFingerprint()",
@@ -37801,7 +37913,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 476
+      "community": 477
     },
     {
       "label": "sanitizer.ts",
@@ -37809,7 +37921,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "limitUtf8Bytes()",
@@ -37817,7 +37929,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 477
+      "community": 478
     },
     {
       "label": "sanitizeExcerpt()",
@@ -37825,7 +37937,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 477
+      "community": 478
     },
     {
       "label": "parsers.ts",
@@ -37833,7 +37945,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "inferLevel()",
@@ -37841,7 +37953,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 409
+      "community": 410
     },
     {
       "label": "parseAppLogLine()",
@@ -37849,7 +37961,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 409
+      "community": 410
     },
     {
       "label": "parseJsonlRecord()",
@@ -37857,7 +37969,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 409
+      "community": 410
     },
     {
       "label": "index.ts",
@@ -37865,7 +37977,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -37873,7 +37985,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 410
+      "community": 411
     },
     {
       "label": "createMonitorRuntime()",
@@ -37881,7 +37993,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 410
+      "community": 411
     },
     {
       "label": "runForever()",
@@ -37889,7 +38001,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 410
+      "community": 411
     },
     {
       "label": "promotion.ts",
@@ -37897,7 +38009,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -37905,7 +38017,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 668
+      "community": 670
     },
     {
       "label": "state-store.ts",
@@ -37913,7 +38025,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_state_store_ts",
-      "community": 283
+      "community": 284
     },
     {
       "label": "emptyState()",
@@ -37921,7 +38033,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L5",
       "id": "state_store_emptystate",
-      "community": 283
+      "community": 284
     },
     {
       "label": "loadState()",
@@ -37929,7 +38041,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L9",
       "id": "state_store_loadstate",
-      "community": 283
+      "community": 284
     },
     {
       "label": "saveState()",
@@ -37937,7 +38049,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L20",
       "id": "state_store_savestate",
-      "community": 283
+      "community": 284
     },
     {
       "label": "upsertOccurrence()",
@@ -37945,7 +38057,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L27",
       "id": "state_store_upsertoccurrence",
-      "community": 283
+      "community": 284
     },
     {
       "label": "appendOccurrence()",
@@ -37953,7 +38065,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L55",
       "id": "state_store_appendoccurrence",
-      "community": 283
+      "community": 284
     },
     {
       "label": "monitor.ts",
@@ -37961,7 +38073,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "recordMonitorError()",
@@ -37969,7 +38081,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L20",
       "id": "monitor_recordmonitorerror",
-      "community": 332
+      "community": 333
     },
     {
       "label": "withFingerprint()",
@@ -37977,7 +38089,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L29",
       "id": "monitor_withfingerprint",
-      "community": 332
+      "community": 333
     },
     {
       "label": "syncFingerprint()",
@@ -37985,7 +38097,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_syncfingerprint",
-      "community": 332
+      "community": 333
     },
     {
       "label": "runMonitorCycle()",
@@ -37993,7 +38105,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L103",
       "id": "monitor_runmonitorcycle",
-      "community": 332
+      "community": 333
     },
     {
       "label": "github-client.ts",
@@ -38001,7 +38113,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_github_client_ts",
-      "community": 216
+      "community": 217
     },
     {
       "label": "GitHubIssueClient",
@@ -38009,7 +38121,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L13",
       "id": "github_client_githubissueclient",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".constructor()",
@@ -38017,7 +38129,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L17",
       "id": "github_client_githubissueclient_constructor",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".findOpenIssueByFingerprint()",
@@ -38025,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L21",
       "id": "github_client_githubissueclient_findopenissuebyfingerprint",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".getIssue()",
@@ -38033,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L33",
       "id": "github_client_githubissueclient_getissue",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".createIssue()",
@@ -38041,7 +38153,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L37",
       "id": "github_client_githubissueclient_createissue",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".updateIssue()",
@@ -38049,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L44",
       "id": "github_client_githubissueclient_updateissue",
-      "community": 216
+      "community": 217
     },
     {
       "label": ".request()",
@@ -38057,7 +38169,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L51",
       "id": "github_client_githubissueclient_request",
-      "community": 216
+      "community": 217
     },
     {
       "label": "detectors.ts",
@@ -38065,7 +38177,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_detectors_ts",
-      "community": 284
+      "community": 285
     },
     {
       "label": "nowIso()",
@@ -38073,7 +38185,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L6",
       "id": "detectors_nowiso",
-      "community": 284
+      "community": 285
     },
     {
       "label": "truncateTitle()",
@@ -38081,7 +38193,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L10",
       "id": "detectors_truncatetitle",
-      "community": 284
+      "community": 285
     },
     {
       "label": "detectAppLogEvent()",
@@ -38089,7 +38201,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L14",
       "id": "detectors_detectapplogevent",
-      "community": 284
+      "community": 285
     },
     {
       "label": "detectRuntimeAnomaly()",
@@ -38097,7 +38209,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L62",
       "id": "detectors_detectruntimeanomaly",
-      "community": 284
+      "community": 285
     },
     {
       "label": "detectDockerAnomaly()",
@@ -38105,7 +38217,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L85",
       "id": "detectors_detectdockeranomaly",
-      "community": 284
+      "community": 285
     },
     {
       "label": "config.ts",
@@ -38113,7 +38225,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_config_ts",
-      "community": 247
+      "community": 248
     },
     {
       "label": "defaultLogsRoot()",
@@ -38121,7 +38233,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L5",
       "id": "config_defaultlogsroot",
-      "community": 247
+      "community": 248
     },
     {
       "label": "optionalString()",
@@ -38129,7 +38241,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L7",
       "id": "config_optionalstring",
-      "community": 247
+      "community": 248
     },
     {
       "label": "numberFromEnv()",
@@ -38137,7 +38249,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L12",
       "id": "config_numberfromenv",
-      "community": 247
+      "community": 248
     },
     {
       "label": "booleanFromEnv()",
@@ -38145,7 +38257,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L19",
       "id": "config_booleanfromenv",
-      "community": 247
+      "community": 248
     },
     {
       "label": "labelsFromEnv()",
@@ -38153,7 +38265,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L27",
       "id": "config_labelsfromenv",
-      "community": 247
+      "community": 248
     },
     {
       "label": "loadMonitorConfig()",
@@ -38161,7 +38273,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L32",
       "id": "config_loadmonitorconfig",
-      "community": 247
+      "community": 248
     },
     {
       "label": "promotion.spec.ts",
@@ -38169,7 +38281,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "issue-body.spec.ts",
@@ -38177,7 +38289,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "github-client.spec.ts",
@@ -38185,7 +38297,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "config.spec.ts",
@@ -38193,7 +38305,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "detectors.spec.ts",
@@ -38201,7 +38313,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "sources.spec.ts",
@@ -38209,7 +38321,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "parsers.spec.ts",
@@ -38217,7 +38329,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "monitor.spec.ts",
@@ -38225,7 +38337,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "config()",
@@ -38233,7 +38345,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 669
+      "community": 671
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38241,7 +38353,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "state-store.spec.ts",
@@ -38249,7 +38361,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38257,7 +38369,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38265,7 +38377,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "index.ts",
@@ -38273,7 +38385,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "main()",
@@ -38281,7 +38393,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 411
+      "community": 412
     },
     {
       "label": "index.ts",
@@ -38289,7 +38401,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "runExample()",
@@ -38297,7 +38409,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 411
+      "community": 412
     },
     {
       "label": "index.spec.ts",
@@ -38305,7 +38417,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "memento-admin-fetch.js",
@@ -38313,7 +38425,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L1",
       "id": "static_js_memento_admin_fetch_js",
-      "community": 285
+      "community": 286
     },
     {
       "label": "getDashboardAuth()",
@@ -38321,7 +38433,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L8",
       "id": "memento_admin_fetch_getdashboardauth",
-      "community": 285
+      "community": 286
     },
     {
       "label": "waitForSession()",
@@ -38329,7 +38441,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L12",
       "id": "memento_admin_fetch_waitforsession",
-      "community": 285
+      "community": 286
     },
     {
       "label": "buildRequestOptions()",
@@ -38337,7 +38449,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L20",
       "id": "memento_admin_fetch_buildrequestoptions",
-      "community": 285
+      "community": 286
     },
     {
       "label": "performFetch()",
@@ -38345,7 +38457,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L28",
       "id": "memento_admin_fetch_performfetch",
-      "community": 285
+      "community": 286
     },
     {
       "label": "mementoAdminFetch()",
@@ -38353,7 +38465,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L51",
       "id": "memento_admin_fetch_mementoadminfetch",
-      "community": 285
+      "community": 286
     },
     {
       "label": "dashboard-auth.js",
@@ -39409,7 +39521,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 333
+      "community": 334
     },
     {
       "label": "getTabButtons()",
@@ -39417,7 +39529,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 333
+      "community": 334
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -39425,7 +39537,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 333
+      "community": 334
     },
     {
       "label": "setRovingTabindex()",
@@ -39433,7 +39545,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 333
+      "community": 334
     },
     {
       "label": "activateTab()",
@@ -39441,7 +39553,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 333
+      "community": 334
     }
   ],
   "links": [
@@ -42716,6 +42828,18 @@
       "source_location": "L45",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_ts",
+      "_tgt": "cli_stripglobalargvforagentdetection",
+      "source": "packages_memento_server_src_cli_ts",
+      "target": "cli_stripglobalargvforagentdetection",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli.ts",
+      "source_location": "L59",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_ts",
       "_tgt": "cli_parseglobalflags",
       "source": "packages_memento_server_src_cli_ts",
       "target": "cli_parseglobalflags",
@@ -42725,7 +42849,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L61",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_ts",
       "_tgt": "cli_findsubcommandwithindex",
@@ -42737,7 +42861,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L77",
+      "source_location": "L91",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_ts",
       "_tgt": "cli_subcommandargvfrom",
@@ -42749,7 +42873,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L92",
+      "source_location": "L106",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_ts",
       "_tgt": "cli_parsecli",
@@ -42761,7 +42885,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L136",
+      "source_location": "L150",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_ts",
       "_tgt": "cli_main",
@@ -42773,7 +42897,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L227",
+      "source_location": "L252",
       "weight": 1.0,
       "_src": "cli_main",
       "_tgt": "cli_writestdout",
@@ -42785,7 +42909,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L138",
+      "source_location": "L155",
       "weight": 1.0,
       "_src": "cli_main",
       "_tgt": "cli_writestderr",
@@ -42797,7 +42921,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L101",
+      "source_location": "L151",
+      "weight": 1.0,
+      "_src": "cli_main",
+      "_tgt": "cli_stripglobalargvforagentdetection",
+      "source": "cli_stripglobalargvforagentdetection",
+      "target": "cli_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli.ts",
+      "source_location": "L115",
       "weight": 1.0,
       "_src": "cli_parsecli",
       "_tgt": "cli_parseglobalflags",
@@ -42809,7 +42945,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L103",
+      "source_location": "L117",
       "weight": 1.0,
       "_src": "cli_parsecli",
       "_tgt": "cli_findsubcommandwithindex",
@@ -42821,7 +42957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli.ts",
-      "source_location": "L173",
+      "source_location": "L198",
       "weight": 1.0,
       "_src": "cli_main",
       "_tgt": "cli_subcommandargvfrom",
@@ -46300,6 +46436,18 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_spec_ts",
+      "_tgt": "agent_ask_spec_argv",
+      "source": "packages_memento_server_src_cli_agent_ask_spec_ts",
+      "target": "agent_ask_spec_argv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "weight": 1.0,
@@ -46343,6 +46491,246 @@
       "_tgt": "cli_ac5_ac6_spec_runcli",
       "source": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
       "target": "cli_ac5_ac6_spec_runcli",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L35",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_stripglobalcliargs",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_stripglobalcliargs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L65",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_parseagentaskinvocation",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_parseagentaskinvocation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L136",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_resolvedbpath",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_resolvedbpath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L153",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_jsonfailure",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_jsonfailure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L165",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_writeout",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_writeout",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L171",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_writeerr",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_writeerr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L177",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_debugerr",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_debugerr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L183",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_promptapprove",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_promptapprove",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L208",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_runagentaskmain",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L456",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_agentaskhelptext",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_agentaskhelptext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L66",
+      "weight": 1.0,
+      "_src": "agent_ask_parseagentaskinvocation",
+      "_tgt": "agent_ask_stripglobalcliargs",
+      "source": "agent_ask_stripglobalcliargs",
+      "target": "agent_ask_parseagentaskinvocation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L212",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_parseagentaskinvocation",
+      "source": "agent_ask_parseagentaskinvocation",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L263",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_resolvedbpath",
+      "source": "agent_ask_resolvedbpath",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L220",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_jsonfailure",
+      "source": "agent_ask_jsonfailure",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L220",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_writeout",
+      "source": "agent_ask_writeout",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L179",
+      "weight": 1.0,
+      "_src": "agent_ask_debugerr",
+      "_tgt": "agent_ask_writeerr",
+      "source": "agent_ask_writeerr",
+      "target": "agent_ask_debugerr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L214",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_writeerr",
+      "source": "agent_ask_writeerr",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L280",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_debugerr",
+      "source": "agent_ask_debugerr",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L371",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_promptapprove",
+      "source": "agent_ask_promptapprove",
+      "target": "agent_ask_runagentaskmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L214",
+      "weight": 1.0,
+      "_src": "agent_ask_runagentaskmain",
+      "_tgt": "agent_ask_agentaskhelptext",
+      "source": "agent_ask_runagentaskmain",
+      "target": "agent_ask_agentaskhelptext",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -57,7 +57,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L1",
       "id": "coverage_prettify_js",
-      "community": 105
+      "community": 106
     },
     {
       "label": "k()",
@@ -65,7 +65,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_k",
-      "community": 105
+      "community": 106
     },
     {
       "label": "a()",
@@ -73,7 +73,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_a",
-      "community": 105
+      "community": 106
     },
     {
       "label": "B()",
@@ -81,7 +81,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_b",
-      "community": 105
+      "community": 106
     },
     {
       "label": "o()",
@@ -89,7 +89,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_o",
-      "community": 105
+      "community": 106
     },
     {
       "label": "g()",
@@ -97,7 +97,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_g",
-      "community": 105
+      "community": 106
     },
     {
       "label": "i()",
@@ -105,7 +105,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_i",
-      "community": 105
+      "community": 106
     },
     {
       "label": "Q()",
@@ -113,7 +113,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_q",
-      "community": 105
+      "community": 106
     },
     {
       "label": "D()",
@@ -121,7 +121,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_d",
-      "community": 105
+      "community": 106
     },
     {
       "label": "c()",
@@ -129,7 +129,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_c",
-      "community": 105
+      "community": 106
     },
     {
       "label": "y()",
@@ -137,7 +137,7 @@
       "source_file": "coverage/prettify.js",
       "source_location": "L2",
       "id": "prettify_y",
-      "community": 105
+      "community": 106
     },
     {
       "label": "sorter.js",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_performance_examples_ts",
-      "community": 106
+      "community": 107
     },
     {
       "label": "batchProcessingExample()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L25",
       "id": "performance_examples_batchprocessingexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "parallelSearchExample()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L54",
       "id": "performance_examples_parallelsearchexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "cachingExample()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L87",
       "id": "performance_examples_cachingexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "streamingSearchExample()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L118",
       "id": "performance_examples_streamingsearchexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "compressedSearchExample()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L152",
       "id": "performance_examples_compressedsearchexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "benchmarkExample()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L183",
       "id": "performance_examples_benchmarkexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "memoryOptimizationExample()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L209",
       "id": "performance_examples_memoryoptimizationexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "realTimeMonitoringExample()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L285",
       "id": "performance_examples_realtimemonitoringexample",
-      "community": 106
+      "community": 107
     },
     {
       "label": "processPageData()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L367",
       "id": "performance_examples_processpagedata",
-      "community": 106
+      "community": 107
     },
     {
       "label": "runPerformanceExamples()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L373",
       "id": "performance_examples_runperformanceexamples",
-      "community": 106
+      "community": 107
     },
     {
       "label": "advanced-usage.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_ts",
-      "community": 94
+      "community": 95
     },
     {
       "label": "parseCliOptions()",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L76",
       "id": "telemetry_cli_parseclioptions",
-      "community": 94
+      "community": 95
     },
     {
       "label": "executeTelemetry()",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L142",
       "id": "telemetry_cli_executetelemetry",
-      "community": 94
+      "community": 95
     },
     {
       "label": "fmt()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L205",
       "id": "telemetry_cli_fmt",
-      "community": 94
+      "community": 95
     },
     {
       "label": "fmtPct()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L210",
       "id": "telemetry_cli_fmtpct",
-      "community": 94
+      "community": 95
     },
     {
       "label": "fmtMs()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L215",
       "id": "telemetry_cli_fmtms",
-      "community": 94
+      "community": 95
     },
     {
       "label": "pad()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L220",
       "id": "telemetry_cli_pad",
-      "community": 94
+      "community": 95
     },
     {
       "label": "formatSearchQuality()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L227",
       "id": "telemetry_cli_formatsearchquality",
-      "community": 94
+      "community": 95
     },
     {
       "label": "formatMemoryQuality()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L242",
       "id": "telemetry_cli_formatmemoryquality",
-      "community": 94
+      "community": 95
     },
     {
       "label": "formatSystemMetrics()",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L266",
       "id": "telemetry_cli_formatsystemmetrics",
-      "community": 94
+      "community": 95
     },
     {
       "label": "printHelp()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L287",
       "id": "telemetry_cli_printhelp",
-      "community": 94
+      "community": 95
     },
     {
       "label": "main()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.ts",
       "source_location": "L304",
       "id": "telemetry_cli_main",
-      "community": 94
+      "community": 95
     },
     {
       "label": "cli.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_ts",
-      "community": 107
+      "community": 108
     },
     {
       "label": "setTestDependencies()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L75",
       "id": "http_server_settestdependencies",
-      "community": 107
+      "community": 108
     },
     {
       "label": "writeRuntimeDiagnosticsEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L92",
       "id": "http_server_writeruntimediagnosticsevent",
-      "community": 107
+      "community": 108
     },
     {
       "label": "resolveStaticRoot()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L116",
       "id": "http_server_resolvestaticroot",
-      "community": 107
+      "community": 108
     },
     {
       "label": "isProtectedMcpProgrammaticPath()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L209",
       "id": "http_server_isprotectedmcpprogrammaticpath",
-      "community": 107
+      "community": 108
     },
     {
       "label": "getHttpAuthTrustModelNotice()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L213",
       "id": "http_server_gethttpauthtrustmodelnotice",
-      "community": 107
+      "community": 108
     },
     {
       "label": "getHttpAuthMissingAdminKeyWarning()",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L217",
       "id": "http_server_gethttpauthmissingadminkeywarning",
-      "community": 107
+      "community": 108
     },
     {
       "label": "initializeServer()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L252",
       "id": "http_server_initializeserver",
-      "community": 107
+      "community": 108
     },
     {
       "label": "cleanup()",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L371",
       "id": "http_server_cleanup",
-      "community": 107
+      "community": 108
     },
     {
       "label": "registerCleanupHandlers()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L443",
       "id": "http_server_registercleanuphandlers",
-      "community": 107
+      "community": 108
     },
     {
       "label": "startServer()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L625",
       "id": "http_server_startserver",
-      "community": 107
+      "community": 108
     },
     {
       "label": "context.ts",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_response_ts",
-      "community": 108
+      "community": 109
     },
     {
       "label": "EmbeddingMapBuildError",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L55",
       "id": "admin_embedding_map_response_embeddingmapbuilderror",
-      "community": 108
+      "community": 109
     },
     {
       "label": ".constructor()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L56",
       "id": "admin_embedding_map_response_embeddingmapbuilderror_constructor",
-      "community": 108
+      "community": 109
     },
     {
       "label": "clearEmbeddingMapCacheForTests()",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L66",
       "id": "admin_embedding_map_response_clearembeddingmapcachefortests",
-      "community": 108
+      "community": 109
     },
     {
       "label": "getCacheKey()",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L75",
       "id": "admin_embedding_map_response_getcachekey",
-      "community": 108
+      "community": 109
     },
     {
       "label": "distSq()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L79",
       "id": "admin_embedding_map_response_distsq",
-      "community": 108
+      "community": 109
     },
     {
       "label": "hash32()",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L89",
       "id": "admin_embedding_map_response_hash32",
-      "community": 108
+      "community": 109
     },
     {
       "label": "mulberry32()",
@@ -4241,7 +4241,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L99",
       "id": "admin_embedding_map_response_mulberry32",
-      "community": 108
+      "community": 109
     },
     {
       "label": "kMeans()",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L112",
       "id": "admin_embedding_map_response_kmeans",
-      "community": 108
+      "community": 109
     },
     {
       "label": "parseTags()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L198",
       "id": "admin_embedding_map_response_parsetags",
-      "community": 108
+      "community": 109
     },
     {
       "label": "buildEmbeddingMapResponse()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L207",
       "id": "admin_embedding_map_response_buildembeddingmapresponse",
-      "community": 108
+      "community": 109
     },
     {
       "label": "agent-ask.spec.ts",
@@ -4279,7 +4279,7 @@
       "label": "argv()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
-      "source_location": "L4",
+      "source_location": "L9",
       "id": "agent_ask_spec_argv",
       "community": 510
     },
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_ts",
-      "community": 109
+      "community": 90
     },
     {
       "label": "stripGlobalCliArgs()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L35",
       "id": "agent_ask_stripglobalcliargs",
-      "community": 109
+      "community": 90
     },
     {
       "label": "parseAgentAskInvocation()",
@@ -4345,71 +4345,87 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L65",
       "id": "agent_ask_parseagentaskinvocation",
-      "community": 109
+      "community": 90
+    },
+    {
+      "label": "validateAgentAskFlagArgv()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L157",
+      "id": "agent_ask_validateagentaskflagargv",
+      "community": 90
+    },
+    {
+      "label": "validateAgentAskRawTypes()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L187",
+      "id": "agent_ask_validateagentaskrawtypes",
+      "community": 90
     },
     {
       "label": "resolveDbPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L136",
+      "source_location": "L207",
       "id": "agent_ask_resolvedbpath",
-      "community": 109
+      "community": 90
     },
     {
       "label": "jsonFailure()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L153",
+      "source_location": "L224",
       "id": "agent_ask_jsonfailure",
-      "community": 109
+      "community": 90
     },
     {
       "label": "writeOut()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L165",
+      "source_location": "L236",
       "id": "agent_ask_writeout",
-      "community": 109
+      "community": 90
     },
     {
       "label": "writeErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L171",
+      "source_location": "L242",
       "id": "agent_ask_writeerr",
-      "community": 109
+      "community": 90
     },
     {
       "label": "debugErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L177",
+      "source_location": "L248",
       "id": "agent_ask_debugerr",
-      "community": 109
+      "community": 90
     },
     {
       "label": "promptApprove()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L183",
+      "source_location": "L254",
       "id": "agent_ask_promptapprove",
-      "community": 109
+      "community": 90
     },
     {
       "label": "runAgentAskMain()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L208",
+      "source_location": "L279",
       "id": "agent_ask_runagentaskmain",
-      "community": 109
+      "community": 90
     },
     {
       "label": "agentAskHelpText()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L456",
+      "source_location": "L527",
       "id": "agent_ask_agentaskhelptext",
-      "community": 109
+      "community": 90
     },
     {
       "label": "option-map.ts",
@@ -6089,7 +6105,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_workers_consolidation_score_worker_ts",
-      "community": 95
+      "community": 96
     },
     {
       "label": "ConsolidationScoreWorker",
@@ -6097,7 +6113,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L63",
       "id": "consolidation_score_worker_consolidationscoreworker",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".constructor()",
@@ -6105,7 +6121,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L67",
       "id": "consolidation_score_worker_consolidationscoreworker_constructor",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".runIncrementalRecalculation()",
@@ -6113,7 +6129,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L92",
       "id": "consolidation_score_worker_consolidationscoreworker_runincrementalrecalculation",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".runFullSweep()",
@@ -6121,7 +6137,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L217",
       "id": "consolidation_score_worker_consolidationscoreworker_runfullsweep",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".fetchRecentRecords()",
@@ -6129,7 +6145,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L345",
       "id": "consolidation_score_worker_consolidationscoreworker_fetchrecentrecords",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".fetchAllRecords()",
@@ -6137,7 +6153,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L387",
       "id": "consolidation_score_worker_consolidationscoreworker_fetchallrecords",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".processChunk()",
@@ -6145,7 +6161,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L423",
       "id": "consolidation_score_worker_consolidationscoreworker_processchunk",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".getCurrentScore()",
@@ -6153,7 +6169,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L535",
       "id": "consolidation_score_worker_consolidationscoreworker_getcurrentscore",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".chunkArray()",
@@ -6161,7 +6177,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L546",
       "id": "consolidation_score_worker_consolidationscoreworker_chunkarray",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".delay()",
@@ -6169,7 +6185,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L557",
       "id": "consolidation_score_worker_consolidationscoreworker_delay",
-      "community": 95
+      "community": 96
     },
     {
       "label": ".log()",
@@ -6177,7 +6193,7 @@
       "source_file": "packages/memento-core/src/workers/consolidation-score-worker.ts",
       "source_location": "L564",
       "id": "consolidation_score_worker_consolidationscoreworker_log",
-      "community": 95
+      "community": 96
     },
     {
       "label": "mcp-logger.ts",
@@ -7505,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_ts",
-      "community": 96
+      "community": 97
     },
     {
       "label": "WalCheckpointScheduler",
@@ -7513,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L124",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".constructor()",
@@ -7521,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L130",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_constructor",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".start()",
@@ -7529,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L141",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_start",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".stop()",
@@ -7537,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L172",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_stop",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".checkpointNow()",
@@ -7545,7 +7561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L201",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_checkpointnow",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".checkpoint()",
@@ -7553,7 +7569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L213",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_checkpoint",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".scheduleCheckpoint()",
@@ -7561,7 +7577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L358",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_schedulecheckpoint",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".sleep()",
@@ -7569,7 +7585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L378",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_sleep",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".executeCheckpoint()",
@@ -7577,7 +7593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L390",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_executecheckpoint",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".getWalFileSize()",
@@ -7585,7 +7601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L435",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_getwalfilesize",
-      "community": 96
+      "community": 97
     },
     {
       "label": ".writeDiagnosticsEvent()",
@@ -7593,7 +7609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.ts",
       "source_location": "L448",
       "id": "wal_checkpoint_scheduler_walcheckpointscheduler_writediagnosticsevent",
-      "community": 96
+      "community": 97
     },
     {
       "label": "wal-checkpoint-scheduler.spec.ts",
@@ -7617,7 +7633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_migration_monitor_service_ts",
-      "community": 97
+      "community": 98
     },
     {
       "label": "MigrationMonitorService",
@@ -7625,7 +7641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L13",
       "id": "migration_monitor_service_migrationmonitorservice",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".publish()",
@@ -7633,7 +7649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L19",
       "id": "migration_monitor_service_migrationmonitorservice_publish",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".subscribe()",
@@ -7641,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L27",
       "id": "migration_monitor_service_migrationmonitorservice_subscribe",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".subscribeAll()",
@@ -7649,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L44",
       "id": "migration_monitor_service_migrationmonitorservice_subscribeall",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".getLatest()",
@@ -7657,7 +7673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L54",
       "id": "migration_monitor_service_migrationmonitorservice_getlatest",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".getStatus()",
@@ -7665,7 +7681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L59",
       "id": "migration_monitor_service_migrationmonitorservice_getstatus",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".listActiveRuns()",
@@ -7673,7 +7689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L63",
       "id": "migration_monitor_service_migrationmonitorservice_listactiveruns",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".clear()",
@@ -7681,7 +7697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L69",
       "id": "migration_monitor_service_migrationmonitorservice_clear",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".channel()",
@@ -7689,7 +7705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L74",
       "id": "migration_monitor_service_migrationmonitorservice_channel",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".cloneEvent()",
@@ -7697,7 +7713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L78",
       "id": "migration_monitor_service_migrationmonitorservice_cloneevent",
-      "community": 97
+      "community": 98
     },
     {
       "label": ".cloneProgress()",
@@ -7705,7 +7721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/migration-monitor-service.ts",
       "source_location": "L87",
       "id": "migration_monitor_service_migrationmonitorservice_cloneprogress",
-      "community": 97
+      "community": 98
     },
     {
       "label": "database-lock-monitor.spec.ts",
@@ -10697,7 +10713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_ts",
-      "community": 98
+      "community": 99
     },
     {
       "label": "RelationEngineSchemaMigration",
@@ -10705,7 +10721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L29",
       "id": "005_relation_engine_schema_relationengineschemamigration",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".loadSQLFile()",
@@ -10713,7 +10729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L37",
       "id": "005_relation_engine_schema_relationengineschemamigration_loadsqlfile",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".executeSQL()",
@@ -10721,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L46",
       "id": "005_relation_engine_schema_relationengineschemamigration_executesql",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".tableExists()",
@@ -10729,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L71",
       "id": "005_relation_engine_schema_relationengineschemamigration_tableexists",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".indexExists()",
@@ -10737,7 +10753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L82",
       "id": "005_relation_engine_schema_relationengineschemamigration_indexexists",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".columnExists()",
@@ -10745,7 +10761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L93",
       "id": "005_relation_engine_schema_relationengineschemamigration_columnexists",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".mapRelationType()",
@@ -10753,7 +10769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L101",
       "id": "005_relation_engine_schema_relationengineschemamigration_maprelationtype",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".validateBefore()",
@@ -10761,7 +10777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L114",
       "id": "005_relation_engine_schema_relationengineschemamigration_validatebefore",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".up()",
@@ -10769,7 +10785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L145",
       "id": "005_relation_engine_schema_relationengineschemamigration_up",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".down()",
@@ -10777,7 +10793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L214",
       "id": "005_relation_engine_schema_relationengineschemamigration_down",
-      "community": 98
+      "community": 99
     },
     {
       "label": ".validateAfter()",
@@ -10785,7 +10801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L241",
       "id": "005_relation_engine_schema_relationengineschemamigration_validateafter",
-      "community": 98
+      "community": 99
     },
     {
       "label": "019-backfill-kg-triple-from-memory-item.spec.ts",
@@ -11817,7 +11833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_sqlite_core_memory_adapter_ts",
-      "community": 99
+      "community": 100
     },
     {
       "label": "SqliteCoreMemoryPreparedStatement",
@@ -11825,7 +11841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L15",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".constructor()",
@@ -11833,7 +11849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L18",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_constructor",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".all()",
@@ -11841,7 +11857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L25",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_all",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".get()",
@@ -11849,7 +11865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L36",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_get",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".run()",
@@ -11857,7 +11873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L47",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_run",
-      "community": 99
+      "community": 100
     },
     {
       "label": "SqliteCoreMemoryAdapter",
@@ -11865,7 +11881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L64",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".constructor()",
@@ -11873,7 +11889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L67",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_constructor",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".prepare()",
@@ -11881,7 +11897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L74",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_prepare",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".exec()",
@@ -11889,7 +11905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L86",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_exec",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".close()",
@@ -11897,7 +11913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L98",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_close",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".isOpen()",
@@ -11905,7 +11921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L110",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_isopen",
-      "community": 99
+      "community": 100
     },
     {
       "label": "sqlite-core-memory-adapter.spec.ts",
@@ -14393,7 +14409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 90
+      "community": 91
     },
     {
       "label": "buildExactMatchQuery()",
@@ -14401,7 +14417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L46",
       "id": "procedural_memory_extractor_buildexactmatchquery",
-      "community": 90
+      "community": 91
     },
     {
       "label": "runFallbackSearchAnd()",
@@ -14409,7 +14425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L67",
       "id": "procedural_memory_extractor_runfallbacksearchand",
-      "community": 90
+      "community": 91
     },
     {
       "label": "runFallbackSearchOr()",
@@ -14417,7 +14433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L90",
       "id": "procedural_memory_extractor_runfallbacksearchor",
-      "community": 90
+      "community": 91
     },
     {
       "label": "extractWorkflowName()",
@@ -14425,7 +14441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L120",
       "id": "procedural_memory_extractor_extractworkflowname",
-      "community": 90
+      "community": 91
     },
     {
       "label": "extractSkillName()",
@@ -14433,7 +14449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L237",
       "id": "procedural_memory_extractor_extractskillname",
-      "community": 90
+      "community": 91
     },
     {
       "label": "extractSteps()",
@@ -14441,7 +14457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L316",
       "id": "procedural_memory_extractor_extractsteps",
-      "community": 90
+      "community": 91
     },
     {
       "label": "generateTriggerConditions()",
@@ -14449,7 +14465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L401",
       "id": "procedural_memory_extractor_generatetriggerconditions",
-      "community": 90
+      "community": 91
     },
     {
       "label": "extractProceduralMemory()",
@@ -14457,7 +14473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L509",
       "id": "procedural_memory_extractor_extractproceduralmemory",
-      "community": 90
+      "community": 91
     },
     {
       "label": "calculateSimilarity()",
@@ -14465,7 +14481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L541",
       "id": "procedural_memory_extractor_calculatesimilarity",
-      "community": 90
+      "community": 91
     },
     {
       "label": "determineMergeStrategy()",
@@ -14473,7 +14489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L622",
       "id": "procedural_memory_extractor_determinemergestrategy",
-      "community": 90
+      "community": 91
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -14481,7 +14497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L704",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 90
+      "community": 91
     },
     {
       "label": ".extract()",
@@ -14489,7 +14505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L705",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 90
+      "community": 91
     },
     {
       "label": "sql-security-validator.ts",
@@ -17873,7 +17889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_ts",
-      "community": 91
+      "community": 92
     },
     {
       "label": "AnchorManager",
@@ -17881,7 +17897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L17",
       "id": "anchor_manager_anchormanager",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".constructor()",
@@ -17889,7 +17905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L35",
       "id": "anchor_manager_anchormanager_constructor",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".setErrorLoggingService()",
@@ -17897,7 +17913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L51",
       "id": "anchor_manager_anchormanager_seterrorloggingservice",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".setDatabase()",
@@ -17905,7 +17921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L58",
       "id": "anchor_manager_anchormanager_setdatabase",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".setAnchor()",
@@ -17913,7 +17929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L87",
       "id": "anchor_manager_anchormanager_setanchor",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".getAnchor()",
@@ -17921,7 +17937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L194",
       "id": "anchor_manager_anchormanager_getanchor",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".clearAnchor()",
@@ -17929,7 +17945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L282",
       "id": "anchor_manager_anchormanager_clearanchor",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".getSlotConfig()",
@@ -17937,7 +17953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L327",
       "id": "anchor_manager_anchormanager_getslotconfig",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".getSearchService()",
@@ -17945,7 +17961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L335",
       "id": "anchor_manager_anchormanager_getsearchservice",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".getCacheService()",
@@ -17953,7 +17969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L343",
       "id": "anchor_manager_anchormanager_getcacheservice",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".restoreCacheFromDB()",
@@ -17961,7 +17977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L351",
       "id": "anchor_manager_anchormanager_restorecachefromdb",
-      "community": 91
+      "community": 92
     },
     {
       "label": ".searchLocal()",
@@ -17969,7 +17985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L363",
       "id": "anchor_manager_anchormanager_searchlocal",
-      "community": 91
+      "community": 92
     },
     {
       "label": "fallback-search-service.ts",
@@ -20913,7 +20929,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_ts",
-      "community": 100
+      "community": 101
     },
     {
       "label": "SpacedRepetitionAlgorithm",
@@ -20921,7 +20937,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L29",
       "id": "spaced_repetition_spacedrepetitionalgorithm",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".constructor()",
@@ -20929,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L33",
       "id": "spaced_repetition_spacedrepetitionalgorithm_constructor",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".calculateNextInterval()",
@@ -20937,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L47",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculatenextinterval",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".calculateRecallProbability()",
@@ -20945,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L66",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculaterecallprobability",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".needsReview()",
@@ -20953,7 +20969,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L77",
       "id": "spaced_repetition_spacedrepetitionalgorithm_needsreview",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".createReviewSchedule()",
@@ -20961,7 +20977,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L90",
       "id": "spaced_repetition_spacedrepetitionalgorithm_createreviewschedule",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -20969,7 +20985,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L116",
       "id": "spaced_repetition_spacedrepetitionalgorithm_createbatchreviewschedules",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".calculateReviewPriority()",
@@ -20977,7 +20993,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L148",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculatereviewpriority",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -20985,7 +21001,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L160",
       "id": "spaced_repetition_spacedrepetitionalgorithm_analyzereviewperformance",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -20993,7 +21009,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L210",
       "id": "spaced_repetition_spacedrepetitionalgorithm_recommendoptimalinterval",
-      "community": 100
+      "community": 101
     },
     {
       "label": ".getDaysSince()",
@@ -21001,7 +21017,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L238",
       "id": "spaced_repetition_spacedrepetitionalgorithm_getdayssince",
-      "community": 100
+      "community": 101
     },
     {
       "label": "spaced-repetition-refactored.ts",
@@ -21129,7 +21145,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_forgetting_algorithm_ts",
-      "community": 92
+      "community": 93
     },
     {
       "label": "ForgettingAlgorithm",
@@ -21137,7 +21153,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L30",
       "id": "forgetting_algorithm_forgettingalgorithm",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".constructor()",
@@ -21145,7 +21161,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L33",
       "id": "forgetting_algorithm_forgettingalgorithm_constructor",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".calculateForgetScore()",
@@ -21153,7 +21169,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L48",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateforgetscore",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".shouldForget()",
@@ -21161,7 +21177,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L64",
       "id": "forgetting_algorithm_forgettingalgorithm_shouldforget",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".generateForgetReason()",
@@ -21169,7 +21185,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L72",
       "id": "forgetting_algorithm_forgettingalgorithm_generateforgetreason",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".calculateFeatures()",
@@ -21177,7 +21193,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L102",
       "id": "forgetting_algorithm_forgettingalgorithm_calculatefeatures",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".calculateRecency()",
@@ -21185,7 +21201,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L142",
       "id": "forgetting_algorithm_forgettingalgorithm_calculaterecency",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".calculateUsage()",
@@ -21193,7 +21209,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L153",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateusage",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".calculateAccessScore()",
@@ -21201,7 +21217,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L177",
       "id": "forgetting_algorithm_forgettingalgorithm_calculateaccessscore",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".getAgeInDays()",
@@ -21209,7 +21225,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L187",
       "id": "forgetting_algorithm_forgettingalgorithm_getageindays",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".getHalfLife()",
@@ -21217,7 +21233,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L197",
       "id": "forgetting_algorithm_forgettingalgorithm_gethalflife",
-      "community": 92
+      "community": 93
     },
     {
       "label": ".analyzeForgetCandidates()",
@@ -21225,7 +21241,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/forgetting-algorithm.ts",
       "source_location": "L211",
       "id": "forgetting_algorithm_forgettingalgorithm_analyzeforgetcandidates",
-      "community": 92
+      "community": 93
     },
     {
       "label": "forgetting-algorithm.spec.ts",
@@ -21585,7 +21601,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_ts",
-      "community": 93
+      "community": 94
     },
     {
       "label": "DefaultIntervalStrategy",
@@ -21593,7 +21609,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L17",
       "id": "interval_calculation_service_defaultintervalstrategy",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".constructor()",
@@ -21601,7 +21617,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L18",
       "id": "interval_calculation_service_defaultintervalstrategy_constructor",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".calculateInterval()",
@@ -21609,7 +21625,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L20",
       "id": "interval_calculation_service_defaultintervalstrategy_calculateinterval",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".calculateConfidence()",
@@ -21617,7 +21633,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L42",
       "id": "interval_calculation_service_defaultintervalstrategy_calculateconfidence",
-      "community": 93
+      "community": 94
     },
     {
       "label": "ConservativeIntervalStrategy",
@@ -21625,7 +21641,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L57",
       "id": "interval_calculation_service_conservativeintervalstrategy",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".constructor()",
@@ -21633,7 +21649,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L58",
       "id": "interval_calculation_service_conservativeintervalstrategy_constructor",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".calculateInterval()",
@@ -21641,7 +21657,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L60",
       "id": "interval_calculation_service_conservativeintervalstrategy_calculateinterval",
-      "community": 93
+      "community": 94
     },
     {
       "label": "AdaptiveIntervalStrategy",
@@ -21649,7 +21665,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L88",
       "id": "interval_calculation_service_adaptiveintervalstrategy",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".constructor()",
@@ -21657,7 +21673,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L89",
       "id": "interval_calculation_service_adaptiveintervalstrategy_constructor",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".calculateInterval()",
@@ -21665,7 +21681,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L94",
       "id": "interval_calculation_service_adaptiveintervalstrategy_calculateinterval",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".calculatePerformanceAdjustment()",
@@ -21673,7 +21689,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L112",
       "id": "interval_calculation_service_adaptiveintervalstrategy_calculateperformanceadjustment",
-      "community": 93
+      "community": 94
     },
     {
       "label": ".updatePerformanceHistory()",
@@ -21681,7 +21697,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.ts",
       "source_location": "L123",
       "id": "interval_calculation_service_adaptiveintervalstrategy_updateperformancehistory",
-      "community": 93
+      "community": 94
     },
     {
       "label": "review-scheduling.service.ts",
@@ -22305,7 +22321,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_recall_probability_service_ts",
-      "community": 101
+      "community": 102
     },
     {
       "label": "DefaultRecallProbabilityCalculator",
@@ -22313,7 +22329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L12",
       "id": "recall_probability_service_defaultrecallprobabilitycalculator",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".calculateRecallProbability()",
@@ -22321,7 +22337,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L13",
       "id": "recall_probability_service_defaultrecallprobabilitycalculator_calculaterecallprobability",
-      "community": 101
+      "community": 102
     },
     {
       "label": "EnhancedRecallProbabilityCalculator",
@@ -22329,7 +22345,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L28",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".constructor()",
@@ -22337,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L29",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_constructor",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".calculateRecallProbability()",
@@ -22345,7 +22361,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L34",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_calculaterecallprobability",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".updateLearningEfficiency()",
@@ -22353,7 +22369,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L46",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_updatelearningefficiency",
-      "community": 101
+      "community": 102
     },
     {
       "label": "AdaptiveRecallProbabilityCalculator",
@@ -22361,7 +22377,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L58",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".calculateRecallProbability()",
@@ -22369,7 +22385,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L61",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_calculaterecallprobability",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".calculatePersonalizedProbability()",
@@ -22377,7 +22393,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L81",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_calculatepersonalizedprobability",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".updateForgettingCurve()",
@@ -22385,7 +22401,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L98",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_updateforgettingcurve",
-      "community": 101
+      "community": 102
     },
     {
       "label": ".estimateForgettingCurve()",
@@ -22393,7 +22409,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L104",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_estimateforgettingcurve",
-      "community": 101
+      "community": 102
     },
     {
       "label": "index.ts",
@@ -23649,7 +23665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_convert_episodic_to_semantic_tool_ts",
-      "community": 102
+      "community": 103
     },
     {
       "label": "ConvertEpisodicToSemanticTool",
@@ -23657,7 +23673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L46",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".constructor()",
@@ -23665,7 +23681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L47",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_constructor",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".handle()",
@@ -23673,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L86",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handle",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".resolveMemories()",
@@ -23681,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L158",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_resolvememories",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".fetchAlreadyConverted()",
@@ -23689,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L171",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchalreadyconverted",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".fetchSingleMemory()",
@@ -23697,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L186",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchsinglememory",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".convertSingleMemory()",
@@ -23705,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L231",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_convertsinglememory",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".handleConversionError()",
@@ -23713,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L252",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handleconversionerror",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".handleConversionSuccess()",
@@ -23721,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L298",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handleconversionsuccess",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".handleNoTriples()",
@@ -23729,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L380",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handlenotriples",
-      "community": 102
+      "community": 103
     },
     {
       "label": ".fetchBatchMemories()",
@@ -23737,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L431",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchbatchmemories",
-      "community": 102
+      "community": 103
     },
     {
       "label": "pin-tool.ts",
@@ -23745,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_pin_tool_ts",
-      "community": 103
+      "community": 104
     },
     {
       "label": "PinTool",
@@ -23753,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L23",
       "id": "pin_tool_pintool",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".constructor()",
@@ -23761,7 +23777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L24",
       "id": "pin_tool_pintool_constructor",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".handle()",
@@ -23769,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L63",
       "id": "pin_tool_pintool_handle",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".handleSinglePin()",
@@ -23777,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L84",
       "id": "pin_tool_pintool_handlesinglepin",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".handleBatchPin()",
@@ -23785,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L144",
       "id": "pin_tool_pintool_handlebatchpin",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".getMemoryById()",
@@ -23793,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L192",
       "id": "pin_tool_pintool_getmemorybyid",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".getMemoriesByIds()",
@@ -23801,7 +23817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L203",
       "id": "pin_tool_pintool_getmemoriesbyids",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".logPinAction()",
@@ -23809,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L217",
       "id": "pin_tool_pintool_logpinaction",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".handleDatabaseLock()",
@@ -23817,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L241",
       "id": "pin_tool_pintool_handledatabaselock",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".getPinnedMemories()",
@@ -23825,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L256",
       "id": "pin_tool_pintool_getpinnedmemories",
-      "community": 103
+      "community": 104
     },
     {
       "label": ".getPinStats()",
@@ -23833,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L273",
       "id": "pin_tool_pintool_getpinstats",
-      "community": 103
+      "community": 104
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -25345,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_ts",
-      "community": 104
+      "community": 105
     },
     {
       "label": "parseSqliteInstant()",
@@ -25353,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L12",
       "id": "memory_review_candidate_selection_scoring_parsesqliteinstant",
-      "community": 104
+      "community": 105
     },
     {
       "label": "resolveStaleAnchor()",
@@ -25361,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L30",
       "id": "memory_review_candidate_selection_scoring_resolvestaleanchor",
-      "community": 104
+      "community": 105
     },
     {
       "label": "computeStaleDays()",
@@ -25369,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L45",
       "id": "memory_review_candidate_selection_scoring_computestaledays",
-      "community": 104
+      "community": 105
     },
     {
       "label": "computeStaleRatio()",
@@ -25377,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L50",
       "id": "memory_review_candidate_selection_scoring_computestaleratio",
-      "community": 104
+      "community": 105
     },
     {
       "label": "computePriority()",
@@ -25385,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L55",
       "id": "memory_review_candidate_selection_scoring_computepriority",
-      "community": 104
+      "community": 105
     },
     {
       "label": "isTruthyFlag()",
@@ -25393,7 +25409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L59",
       "id": "memory_review_candidate_selection_scoring_istruthyflag",
-      "community": 104
+      "community": 105
     },
     {
       "label": "isNonEmptyDeletedAt()",
@@ -25401,7 +25417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L63",
       "id": "memory_review_candidate_selection_scoring_isnonemptydeletedat",
-      "community": 104
+      "community": 105
     },
     {
       "label": "isMemoryRowActive()",
@@ -25409,7 +25425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L68",
       "id": "memory_review_candidate_selection_scoring_ismemoryrowactive",
-      "community": 104
+      "community": 105
     },
     {
       "label": "passesEligibility()",
@@ -25417,7 +25433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L75",
       "id": "memory_review_candidate_selection_scoring_passeseligibility",
-      "community": 104
+      "community": 105
     },
     {
       "label": "buildScoreBreakdown()",
@@ -25425,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L89",
       "id": "memory_review_candidate_selection_scoring_buildscorebreakdown",
-      "community": 104
+      "community": 105
     },
     {
       "label": "buildReason()",
@@ -25433,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L106",
       "id": "memory_review_candidate_selection_scoring_buildreason",
-      "community": 104
+      "community": 105
     },
     {
       "label": "memory-review-candidate-persistence-service.ts",
@@ -46437,7 +46453,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
-      "source_location": "L4",
+      "source_location": "L9",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_spec_ts",
       "_tgt": "agent_ask_spec_argv",
@@ -46521,7 +46537,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L136",
+      "source_location": "L157",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_validateagentaskflagargv",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_validateagentaskflagargv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L187",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_validateagentaskrawtypes",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_validateagentaskrawtypes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L207",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46533,7 +46573,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L153",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
@@ -46545,7 +46585,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L165",
+      "source_location": "L236",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
@@ -46557,7 +46597,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L171",
+      "source_location": "L242",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
@@ -46569,7 +46609,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L177",
+      "source_location": "L248",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
@@ -46581,7 +46621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L183",
+      "source_location": "L254",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapprove",
@@ -46593,7 +46633,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L208",
+      "source_location": "L279",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
@@ -46605,7 +46645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L456",
+      "source_location": "L527",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -46629,7 +46669,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L212",
+      "source_location": "L106",
+      "weight": 1.0,
+      "_src": "agent_ask_parseagentaskinvocation",
+      "_tgt": "agent_ask_validateagentaskflagargv",
+      "source": "agent_ask_parseagentaskinvocation",
+      "target": "agent_ask_validateagentaskflagargv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L112",
+      "weight": 1.0,
+      "_src": "agent_ask_parseagentaskinvocation",
+      "_tgt": "agent_ask_validateagentaskrawtypes",
+      "source": "agent_ask_parseagentaskinvocation",
+      "target": "agent_ask_validateagentaskrawtypes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L283",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46641,7 +46705,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L263",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46653,7 +46717,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L220",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46665,7 +46729,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L220",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46677,7 +46741,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L179",
+      "source_location": "L250",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -46689,7 +46753,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L214",
+      "source_location": "L285",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -46701,7 +46765,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L280",
+      "source_location": "L351",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -46713,7 +46777,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L371",
+      "source_location": "L442",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_promptapprove",
@@ -46725,7 +46789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L214",
+      "source_location": "L285",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4326,15 +4326,15 @@
     {
       "label": "agent-ask.ts",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
-      "id": "packages_memento_server_src_cli_agent_ask_ts",
+      "id": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "community": 90
     },
     {
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L35",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
@@ -4342,7 +4342,7 @@
     {
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L65",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
@@ -4350,7 +4350,7 @@
     {
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L157",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
@@ -4358,7 +4358,7 @@
     {
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L187",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
@@ -4366,7 +4366,7 @@
     {
       "label": "resolveDbPath()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L207",
       "id": "agent_ask_resolvedbpath",
       "community": 90
@@ -4374,7 +4374,7 @@
     {
       "label": "jsonFailure()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L224",
       "id": "agent_ask_jsonfailure",
       "community": 90
@@ -4382,7 +4382,7 @@
     {
       "label": "writeOut()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L236",
       "id": "agent_ask_writeout",
       "community": 90
@@ -4390,7 +4390,7 @@
     {
       "label": "writeErr()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L242",
       "id": "agent_ask_writeerr",
       "community": 90
@@ -4398,7 +4398,7 @@
     {
       "label": "debugErr()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L248",
       "id": "agent_ask_debugerr",
       "community": 90
@@ -4406,7 +4406,7 @@
     {
       "label": "promptApprove()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L254",
       "id": "agent_ask_promptapprove",
       "community": 90
@@ -4414,16 +4414,16 @@
     {
       "label": "runAgentAskMain()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L279",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L292",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
     {
       "label": "agentAskHelpText()",
       "file_type": "code",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L527",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L541",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -22910,15 +22910,15 @@
     {
       "label": "tool-context-remember-persistence-adapter.ts",
       "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
-      "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
+      "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
       "community": 316
     },
     {
       "label": "parseRememberSuccess()",
       "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
       "community": 316
@@ -22926,7 +22926,7 @@
     {
       "label": "ToolContextRememberPersistenceAdapter",
       "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
       "community": 316
@@ -22934,7 +22934,7 @@
     {
       "label": ".constructor()",
       "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
       "community": 316
@@ -22942,7 +22942,7 @@
     {
       "label": ".persistApproved()",
       "file_type": "code",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
       "community": 316
@@ -46512,151 +46512,151 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L35",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_stripglobalcliargs",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L65",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_parseagentaskinvocation",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L157",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_validateagentaskflagargv",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L187",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_validateagentaskrawtypes",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L207",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_resolvedbpath",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L224",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_jsonfailure",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L236",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_writeout",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L242",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_writeerr",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L248",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_debugerr",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L254",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapprove",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_promptapprove",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L279",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L292",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_runagentaskmain",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L527",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L541",
       "weight": 1.0,
-      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
-      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_agentaskhelptext",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L66",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
@@ -46668,7 +46668,7 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L106",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
@@ -46680,7 +46680,7 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L112",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
@@ -46692,8 +46692,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L283",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L296",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46704,8 +46704,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L334",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L347",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46716,8 +46716,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L291",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L304",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46728,8 +46728,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L291",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L304",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46740,7 +46740,7 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L250",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
@@ -46752,8 +46752,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L285",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L298",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -46764,8 +46764,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L351",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L362",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -46776,8 +46776,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L442",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L450",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_promptapprove",
@@ -46788,8 +46788,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L285",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L298",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -80304,31 +80304,31 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "weight": 1.0,
-      "_src": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
       "_tgt": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "source": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
       "target": "tool_context_remember_persistence_adapter_parseremembersuccess",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "weight": 1.0,
-      "_src": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
+      "_src": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
       "_tgt": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "source": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
+      "source": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
       "target": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L79",
       "weight": 1.0,
       "_src": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
@@ -80340,7 +80340,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "weight": 1.0,
       "_src": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
@@ -80352,7 +80352,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
+      "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "weight": 1.0,
       "_src": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",

--- a/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts
@@ -69,7 +69,7 @@ export class ToolContextRememberPersistenceAdapter implements IPersistencePort {
       }
 
       const mapped = mapKnowledgeCandidateToRememberParams(candidate, ctx);
-      if (!mapped.ok) {
+      if (mapped.ok === false) {
         items.push({ candidateId: candidate.id, status: 'error', errorMessage: mapped.errorMessage });
         continue;
       }
@@ -77,7 +77,7 @@ export class ToolContextRememberPersistenceAdapter implements IPersistencePort {
       try {
         const result = await this.rememberTool.handle(mapped.params, this.toolContext);
         const parsed = parseRememberSuccess(result);
-        if (!parsed.ok) {
+        if (parsed.ok === false) {
           items.push({ candidateId: candidate.id, status: 'error', errorMessage: parsed.errorMessage });
           continue;
         }

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -142,6 +142,19 @@ export {
 export type { SleepConsolidationRunResult } from './shared/types/consolidation.types.js';
 export type { SleepConsolidationServiceDeps } from './domains/consolidation/index.js';
 
+// 개인 지식 Agent (in-process CLI·예시 앱용)
+export {
+  PersonalKnowledgeAgentService,
+  DeterministicMockLlmAdapter,
+  ToolContextKnowledgeContextAdapter,
+  ToolContextRememberPersistenceAdapter,
+} from './domains/personal-agent/index.js';
+export type {
+  PersonalKnowledgeAgentDeps,
+  KnowledgeCandidate,
+  PersonalKnowledgePersistItemResult,
+} from './domains/personal-agent/index.js';
+
 // 타입·인터페이스 re-export (서버/앱에서 사용)
 export type { ToolContext, ToolResult, ToolDefinition } from './tools/types.js';
 export type { TelemetryPeriod, EventType } from './domains/telemetry/types/telemetry.types.js';

--- a/packages/memento-server/src/cli.ts
+++ b/packages/memento-server/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Memento CLI for AI
- * 명세: REQ-CLI-1, REQ-OPT-1~3, REQ-CFG-1, REQ-IO-4, AC8. 서브커맨드: recall, remember, forget, memory_injection
+ * 명세: REQ-CLI-1, REQ-OPT-1~3, REQ-CFG-1, REQ-IO-4, AC8. 서브커맨드: recall, remember, forget, memory_injection, agent ask
  */
 
 function writeStdout(message: string): Promise<void> {
@@ -40,6 +40,20 @@ import {
 } from './cli/option-map.js';
 
 const TOOL_SUBCOMMANDS = new Set(['recall', 'remember', 'forget', 'memory_injection']);
+
+/** agent 분기용: argv[2..]에서 글로벌 옵션 쌍 제거 (agent-ask.ts와 동일 규칙). */
+function stripGlobalArgvForAgentDetection(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--db-path' || arg === '--env-file' || arg === '--config-dir') {
+      if (argv[i + 1]) i++;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
 
 /** 전체 argv에서 글로벌 플래그를 수집 (--db-path 등은 서브커맨드 뒤에 와도 인식). */
 function parseGlobalFlags(argv: string[]): { dbPath?: string; envFile?: string; configDir?: string } {
@@ -134,6 +148,16 @@ const commandToken = preOptions.commandToken;
 const showHelp = preOptions.help || (!commandToken && !subcommand);
 
 export async function main(): Promise<number> {
+  const agentTokens = stripGlobalArgvForAgentDetection(process.argv);
+  if (agentTokens[0] === 'agent') {
+    const { runAgentAskMain, agentAskHelpText } = await import('./cli/agent-ask.js');
+    if (preOptions.help && agentTokens[1] !== 'ask') {
+      await writeStderr(agentAskHelpText());
+      return 0;
+    }
+    return runAgentAskMain(preOptions, process.argv);
+  }
+
   if (showHelp) {
     await writeStderr('memento – Memento CLI for AI\n');
     await writeStderr('Usage: memento [options] <command> [command-args]\n\n');
@@ -141,7 +165,8 @@ export async function main(): Promise<number> {
     await writeStderr('  recall              관련 기억을 검색합니다 (하이브리드 검색)\n');
     await writeStderr('  remember            기억을 저장합니다\n');
     await writeStderr('  forget              기억을 삭제합니다 (소프트/하드)\n');
-    await writeStderr('  memory_injection    관련 기억을 요약하여 프롬프트에 주입\n\n');
+    await writeStderr('  memory_injection    관련 기억을 요약하여 프롬프트에 주입\n');
+    await writeStderr('  agent ask           개인 지식 Agent 한 턴 (in-process, #236)\n\n');
     await writeStderr('Global options (서브커맨드 앞·뒤 모두 가능):\n');
     await writeStderr('  --db-path <path>    (deprecated) DB 파일 경로\n');
     await writeStderr('  --env-file <path>   (deprecated) .env 파일 경로\n');

--- a/packages/memento-server/src/cli/agent-ask.spec.ts
+++ b/packages/memento-server/src/cli/agent-ask.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { parseAgentAskInvocation, stripGlobalCliArgs } from './agent-ask.js';
+
+function argv(...parts: string[]): string[] {
+  return ['node', '/virtual/cli.js', ...parts];
+}
+
+describe('stripGlobalCliArgs', () => {
+  it('글로벌 옵션 쌍을 제거하고 나머지 순서를 유지한다', () => {
+    const a = argv(
+      '--config-dir',
+      '/tmp/cfg',
+      'agent',
+      'ask',
+      'hello',
+      '--json',
+    );
+    expect(stripGlobalCliArgs(a)).toEqual(['agent', 'ask', 'hello', '--json']);
+  });
+});
+
+describe('parseAgentAskInvocation', () => {
+  it('agent ask <msg> --json --no-save', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'hello world', '--json', '--no-save'),
+    );
+    expect(p.kind).toBe('run');
+    if (p.kind === 'run') {
+      expect(p.userMessage).toBe('hello world');
+      expect(p.json).toBe(true);
+      expect(p.noSave).toBe(true);
+      expect(p.jsonImplicitNoSave).toBe(false);
+    }
+  });
+
+  it('--json 단독이면 jsonImplicitNoSave', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'ask', 'x', '--json'));
+    expect(p.kind).toBe('run');
+    if (p.kind === 'run') {
+      expect(p.jsonImplicitNoSave).toBe(true);
+    }
+  });
+
+  it('메시지 없으면 usage', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'ask'));
+    expect(p.kind).toBe('usage');
+  });
+
+  it('플래그가 메시지 자리면 usage', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'ask', '--json'));
+    expect(p.kind).toBe('usage');
+  });
+
+  it('ask --help 은 help', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'ask', '--help'));
+    expect(p.kind).toBe('help');
+  });
+
+  it('--llm openai 는 usage', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'm', '--llm', 'openai'),
+    );
+    expect(p.kind).toBe('usage');
+  });
+
+  it('알 수 없는 agent 서브커맨드', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'foo'));
+    expect(p.kind).toBe('usage');
+    if (p.kind === 'usage') {
+      expect(p.message).toContain('foo');
+    }
+  });
+});

--- a/packages/memento-server/src/cli/agent-ask.spec.ts
+++ b/packages/memento-server/src/cli/agent-ask.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseAgentAskInvocation, stripGlobalCliArgs } from './agent-ask.js';
+import {
+  parseAgentAskInvocation,
+  stripGlobalCliArgs,
+  validateAgentAskFlagArgv,
+  validateAgentAskRawTypes,
+} from './agent-ask.js';
 
 function argv(...parts: string[]): string[] {
   return ['node', '/virtual/cli.js', ...parts];
@@ -69,5 +74,60 @@ describe('parseAgentAskInvocation', () => {
     if (p.kind === 'usage') {
       expect(p.message).toContain('foo');
     }
+  });
+
+  it('알 수 없는 옵션은 usage (exit 1 경로)', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'hi', '--json', '--bogus', 'nope'),
+    );
+    expect(p.kind).toBe('usage');
+    if (p.kind === 'usage') {
+      expect(p.message).toContain('bogus');
+    }
+  });
+
+  it('--token-budget 값 없으면 usage', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'hi', '--token-budget', '--json'),
+    );
+    expect(p.kind).toBe('usage');
+  });
+
+  it('--json 뒤에 남는 토큰이 있으면 usage', () => {
+    const p = parseAgentAskInvocation(argv('agent', 'ask', 'hi', '--json', 'orphan'));
+    expect(p.kind).toBe('usage');
+  });
+
+  it('--token-bduget 처럼 오타는 알 수 없는 옵션', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'hi', '--token-bduget', '100'),
+    );
+    expect(p.kind).toBe('usage');
+    if (p.kind === 'usage') {
+      expect(p.message).toMatch(/token-bduget|알 수 없는/);
+    }
+  });
+});
+
+describe('validateAgentAskFlagArgv', () => {
+  it('허용 플래그만 통과', () => {
+    expect(
+      validateAgentAskFlagArgv([
+        '--json',
+        '--no-save',
+        '--project-id',
+        'p1',
+        '--token-budget',
+        '500',
+        '--llm',
+        'mock',
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe('validateAgentAskRawTypes', () => {
+  it('--json 에 잘못된 값 타입 거절', () => {
+    expect(validateAgentAskRawTypes({ json: 'yes' })).not.toBeNull();
   });
 });

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -255,8 +255,14 @@ async function promptApprove(
   candidate: KnowledgeCandidate,
   index: number,
   total: number,
-): Promise<'y' | 'n' | 's' | 'q'> {
+  interruptRef: { interrupted: boolean },
+): Promise<'y' | 'n' | 's' | 'q' | 'interrupt'> {
   const rl = createInterface({ input: stdinStream, output: stderrStream });
+  const onRlSigInt = (): void => {
+    interruptRef.interrupted = true;
+    rl.close();
+  };
+  rl.on('SIGINT', onRlSigInt);
   try {
     const header =
       `\n[${index + 1}/${total}] (${candidate.category}, importance=${candidate.importance})\n` +
@@ -264,7 +270,13 @@ async function promptApprove(
       `  reason: ${candidate.reason}\n` +
       `  suggested type: ${candidate.suggestedMemoryType}, tags: ${JSON.stringify(candidate.tags)}\n` +
       `  Save? (y)es / (n)o / (s)kip rest / (q)uit & save approved > `;
-    const line = await rl.question(header);
+    let line: string;
+    try {
+      line = await rl.question(header);
+    } catch {
+      if (interruptRef.interrupted) return 'interrupt';
+      return 'n';
+    }
     const t = String(line).trim().toLowerCase();
     if (t === '' || t === 'n') return 'n';
     if (t === 'y' || t === 'yes') return 'y';
@@ -272,6 +284,7 @@ async function promptApprove(
     if (t === 'q' || t === 'quit') return 'q';
     return 'n';
   } finally {
+    rl.removeListener('SIGINT', onRlSigInt);
     rl.close();
   }
 }
@@ -322,18 +335,17 @@ export async function runAgentAskMain(
     return 1;
   }
 
-  let interrupted = false;
-  const onSigInt = (): void => {
-    interrupted = true;
+  const interruptRef = { interrupted: false };
+  const onProcessSigInt = (): void => {
+    interruptRef.interrupted = true;
   };
-  process.once('SIGINT', onSigInt);
-
+  process.on('SIGINT', onProcessSigInt);
+  try {
   const sessionId = randomUUID();
   let dbPath: string;
   try {
     dbPath = resolveDbPath(preOptions);
   } catch (e) {
-    process.removeListener('SIGINT', onSigInt);
     const msg = e instanceof Error ? e.message : String(e);
     if (json) {
       await writeOut(jsonFailure('INVALID_OPTION', 'usage', msg));
@@ -347,7 +359,6 @@ export async function runAgentAskMain(
   try {
     core = await createMementoCore({ dbPath });
   } catch (e) {
-    process.removeListener('SIGINT', onSigInt);
     debugErr(e);
     const msg = e instanceof Error ? e.message : String(e);
     if (json) {
@@ -375,7 +386,6 @@ export async function runAgentAskMain(
       ownerId: undefined,
     });
   } catch (e) {
-    process.removeListener('SIGINT', onSigInt);
     debugErr(e);
     const msg = e instanceof Error ? e.message : String(e);
     if (json) {
@@ -388,8 +398,7 @@ export async function runAgentAskMain(
     return 3;
   }
 
-  if (interrupted) {
-    process.removeListener('SIGINT', onSigInt);
+  if (interruptRef.interrupted) {
     await writeErr('중단되어 저장하지 않습니다.\n');
     await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
     closeDatabase(db);
@@ -431,15 +440,20 @@ export async function runAgentAskMain(
   if (!skipPersist && stdinTty && runResult.candidates.length > 0) {
     const approved: string[] = [];
     for (let i = 0; i < runResult.candidates.length; i++) {
-      if (interrupted) {
-        process.removeListener('SIGINT', onSigInt);
+      if (interruptRef.interrupted) {
         await writeErr('중단되어 저장하지 않습니다.\n');
         await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
         closeDatabase(db);
         return 130;
       }
       const c = runResult.candidates[i];
-      const ans = await promptApprove(c, i, runResult.candidates.length);
+      const ans = await promptApprove(c, i, runResult.candidates.length, interruptRef);
+      if (ans === 'interrupt') {
+        await writeErr('중단되어 저장하지 않습니다.\n');
+        await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+        closeDatabase(db);
+        return 130;
+      }
       if (ans === 'y') {
         approved.push(c.id);
       } else if (ans === 's' || ans === 'q') {
@@ -463,7 +477,6 @@ export async function runAgentAskMain(
           errorCount: pr.errorCount,
         };
       } catch (e) {
-        process.removeListener('SIGINT', onSigInt);
         debugErr(e);
         const msg = e instanceof Error ? e.message : String(e);
         if (json) {
@@ -481,8 +494,6 @@ export async function runAgentAskMain(
       }
     }
   }
-
-  process.removeListener('SIGINT', onSigInt);
 
   const successObj = {
     ...basePayload,
@@ -513,6 +524,9 @@ export async function runAgentAskMain(
     return 4;
   }
   return 0;
+  } finally {
+    process.removeListener('SIGINT', onProcessSigInt);
+  }
   } finally {
     if (json) {
       if (prevCliQuiet === undefined) {

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline/promises';
-import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
+import { stdin as stdinStream, stderr as stderrStream } from 'node:process';
 
 import {
   closeDatabase,
@@ -103,7 +103,17 @@ export function parseAgentAskInvocation(argv: string[]): ParsedAgentAsk {
     return { kind: 'help' };
   }
 
+  const flagErr = validateAgentAskFlagArgv(flagArgv);
+  if (flagErr) {
+    return { kind: 'usage', message: flagErr };
+  }
+
   const raw = parseArgvToParams(flagArgv);
+  const typeErr = validateAgentAskRawTypes(raw);
+  if (typeErr) {
+    return { kind: 'usage', message: typeErr };
+  }
+
   const json = raw.json === true;
   const noSave = raw.no_save === true;
 
@@ -131,6 +141,67 @@ export function parseAgentAskInvocation(argv: string[]): ParsedAgentAsk {
     noSave,
     jsonImplicitNoSave: json && !noSave,
   };
+}
+
+/** `agent ask` 가 허용하는 `--` 옵션만 통과(알 수 없는 플래그·남는 인자 거절). */
+const AGENT_ASK_ALLOWED_FLAGS = new Set([
+  'json',
+  'no_save',
+  'project_id',
+  'token_budget',
+  'llm',
+]);
+
+const AGENT_ASK_VALUE_FLAGS = new Set(['project_id', 'token_budget', 'llm']);
+
+export function validateAgentAskFlagArgv(flagArgv: string[]): string | null {
+  for (let i = 0; i < flagArgv.length; ) {
+    const arg = flagArgv[i];
+    if (arg === '-h' || arg === '--help') {
+      i += 1;
+      continue;
+    }
+    if (!arg.startsWith('-')) {
+      return `알 수 없는 인자: ${arg}`;
+    }
+    if (!arg.startsWith('--') || arg.length <= 2) {
+      return `알 수 없는 옵션: ${arg}`;
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    if (!AGENT_ASK_ALLOWED_FLAGS.has(key)) {
+      return `알 수 없는 옵션: --${arg.slice(2)}`;
+    }
+    if (AGENT_ASK_VALUE_FLAGS.has(key)) {
+      const next = flagArgv[i + 1];
+      if (next === undefined || next.startsWith('-')) {
+        return `옵션 --${key.replace(/_/g, '-')} 에는 값이 필요합니다.`;
+      }
+      i += 2;
+      continue;
+    }
+    i += 1;
+  }
+  return null;
+}
+
+export function validateAgentAskRawTypes(raw: Record<string, unknown>): string | null {
+  if ('json' in raw && raw.json !== true) {
+    return 'agent ask: --json 은 값 없이 쓰는 플래그입니다.';
+  }
+  if ('no_save' in raw && raw.no_save !== true) {
+    return 'agent ask: --no-save 는 값 없이 쓰는 플래그입니다.';
+  }
+  if ('project_id' in raw) {
+    if (typeof raw.project_id !== 'string' || !String(raw.project_id).trim()) {
+      return 'agent ask: --project-id 는 비어 있지 않은 문자열이어야 합니다.';
+    }
+  }
+  if ('token_budget' in raw) {
+    if (typeof raw.token_budget !== 'number' || !Number.isFinite(raw.token_budget)) {
+      return 'agent ask: --token-budget 는 유한한 숫자여야 합니다.';
+    }
+  }
+  return null;
 }
 
 function resolveDbPath(pre: PreCliOptions): string {
@@ -185,7 +256,7 @@ async function promptApprove(
   index: number,
   total: number,
 ): Promise<'y' | 'n' | 's' | 'q'> {
-  const rl = createInterface({ input: stdinStream, output: stdoutStream });
+  const rl = createInterface({ input: stdinStream, output: stderrStream });
   try {
     const header =
       `\n[${index + 1}/${total}] (${candidate.category}, importance=${candidate.importance})\n` +

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -1,0 +1,469 @@
+/**
+ * `memento agent ask` — in-process 개인 지식 Agent 한 턴 (#236).
+ * 설계: docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createInterface } from 'node:readline/promises';
+import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
+
+import {
+  closeDatabase,
+  createMementoCore,
+  createToolContext,
+  mementoConfig,
+  PersonalKnowledgeAgentService,
+  DeterministicMockLlmAdapter,
+  ToolContextKnowledgeContextAdapter,
+  ToolContextRememberPersistenceAdapter,
+} from '@memento/core';
+import type { KnowledgeCandidate, PersonalKnowledgePersistItemResult } from '@memento/core';
+
+import { parseArgvToParams } from './option-map.js';
+
+const PROCESS_ID = 'cli/agent-ask';
+const JSON_INTERACTION_INFO =
+  '[info] --json은 인터랙션을 비활성화합니다(저장 생략).\n';
+
+export type PreCliOptions = {
+  dbPath?: string;
+  envFile?: string;
+  configDir?: string;
+};
+
+/** argv[2..]에서 글로벌 CLI 쌍 제거 (cli.ts와 동일 3종). */
+export function stripGlobalCliArgs(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--db-path' || arg === '--env-file' || arg === '--config-dir') {
+      if (argv[i + 1]) i++;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+export type ParsedAgentAsk =
+  | { kind: 'help' }
+  | { kind: 'usage'; message: string }
+  | {
+      kind: 'run';
+      userMessage: string;
+      projectId?: string;
+      tokenBudget?: number;
+      json: boolean;
+      noSave: boolean;
+      /** `--json`만 있고 `--no-save`는 없을 때 true — stderr 안내 한 줄 출력 */
+      jsonImplicitNoSave: boolean;
+    };
+
+/**
+ * `memento … agent ask …` 패턴 파싱. `ask` 직후 첫 토큰이 userMessage(플래그 아님).
+ */
+export function parseAgentAskInvocation(argv: string[]): ParsedAgentAsk {
+  const rest = stripGlobalCliArgs(argv);
+  if (rest.length === 0) {
+    return { kind: 'usage', message: 'agent ask: 인자가 없습니다.' };
+  }
+  if (rest[0] !== 'agent') {
+    return { kind: 'usage', message: 'internal: not an agent command' };
+  }
+  const sub = rest[1];
+  if (sub === undefined || sub === '--help' || sub === '-h') {
+    return { kind: 'help' };
+  }
+  if (sub !== 'ask') {
+    return {
+      kind: 'usage',
+      message: `알 수 없는 agent 서브커맨드: ${sub}. 사용: memento agent ask <message> [options]`,
+    };
+  }
+  const tail = rest.slice(2);
+  if (tail.length === 0) {
+    return { kind: 'usage', message: 'agent ask: 사용자 메시지가 필요합니다.' };
+  }
+  if (tail[0] === '--help' || tail[0] === '-h') {
+    return { kind: 'help' };
+  }
+  if (tail[0].startsWith('-')) {
+    return {
+      kind: 'usage',
+      message: 'agent ask: 사용자 메시지는 ask 바로 다음에 와야 합니다(플래그 아님).',
+    };
+  }
+  const userMessage = tail[0];
+  if (!String(userMessage).trim()) {
+    return { kind: 'usage', message: 'agent ask: 사용자 메시지가 비어 있습니다.' };
+  }
+
+  const flagArgv = tail.slice(1);
+  if (flagArgv.includes('--help') || flagArgv.includes('-h')) {
+    return { kind: 'help' };
+  }
+
+  const raw = parseArgvToParams(flagArgv);
+  const json = raw.json === true;
+  const noSave = raw.no_save === true;
+
+  if (raw.llm !== undefined) {
+    if (raw.llm !== 'mock') {
+      return {
+        kind: 'usage',
+        message: 'agent ask: --llm 값은 현재 mock만 지원합니다.',
+      };
+    }
+  }
+  if (raw.llm === true) {
+    return { kind: 'usage', message: 'agent ask: --llm 에는 mock 을 지정하세요.' };
+  }
+
+  const projectId = typeof raw.project_id === 'string' ? raw.project_id : undefined;
+  const tokenBudget = typeof raw.token_budget === 'number' ? raw.token_budget : undefined;
+
+  return {
+    kind: 'run',
+    userMessage,
+    projectId,
+    tokenBudget,
+    json,
+    noSave,
+    jsonImplicitNoSave: json && !noSave,
+  };
+}
+
+function resolveDbPath(pre: PreCliOptions): string {
+  const fromCli = pre.dbPath?.trim();
+  if (fromCli) return fromCli;
+  const fromEnv = process.env.DB_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  return mementoConfig.dbPath;
+}
+
+type ErrorCode =
+  | 'MISSING_QUERY'
+  | 'INVALID_OPTION'
+  | 'BOOTSTRAP_FAILED'
+  | 'AGENT_RUN_FAILED'
+  | 'PERSIST_FAILED'
+  | 'INTERRUPTED'
+  | 'NON_INTERACTIVE';
+
+function jsonFailure(
+  code: ErrorCode,
+  stage: 'usage' | 'bootstrap' | 'run' | 'persist',
+  message: string,
+  details: Record<string, unknown> = {},
+): string {
+  return `${JSON.stringify({
+    ok: false,
+    error: { code, stage, message, details },
+  })}\n`;
+}
+
+function writeOut(s: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(s, (e) => (e ? reject(e) : resolve()));
+  });
+}
+
+function writeErr(s: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.stderr.write(s, (e) => (e ? reject(e) : resolve()));
+  });
+}
+
+function debugErr(err: unknown): void {
+  if (process.env.MEMENTO_DEBUG === '1' && err instanceof Error && err.stack) {
+    void writeErr(err.stack + '\n');
+  }
+}
+
+async function promptApprove(
+  candidate: KnowledgeCandidate,
+  index: number,
+  total: number,
+): Promise<'y' | 'n' | 's' | 'q'> {
+  const rl = createInterface({ input: stdinStream, output: stdoutStream });
+  try {
+    const header =
+      `\n[${index + 1}/${total}] (${candidate.category}, importance=${candidate.importance})\n` +
+      `  ${candidate.content}\n` +
+      `  reason: ${candidate.reason}\n` +
+      `  suggested type: ${candidate.suggestedMemoryType}, tags: ${JSON.stringify(candidate.tags)}\n` +
+      `  Save? (y)es / (n)o / (s)kip rest / (q)uit & save approved > `;
+    const line = await rl.question(header);
+    const t = String(line).trim().toLowerCase();
+    if (t === '' || t === 'n') return 'n';
+    if (t === 'y' || t === 'yes') return 'y';
+    if (t === 's' || t === 'skip') return 's';
+    if (t === 'q' || t === 'quit') return 'q';
+    return 'n';
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runAgentAskMain(
+  preOptions: PreCliOptions,
+  argv: string[],
+): Promise<number> {
+  const parsed = parseAgentAskInvocation(argv);
+  if (parsed.kind === 'help') {
+    await writeErr(agentAskHelpText());
+    return 0;
+  }
+  if (parsed.kind === 'usage') {
+    const useJson = argv.includes('--json');
+    if (useJson) {
+      await writeOut(jsonFailure('INVALID_OPTION', 'usage', parsed.message));
+    } else {
+      await writeErr(parsed.message + '\n');
+    }
+    return 1;
+  }
+
+  const {
+    userMessage,
+    projectId,
+    tokenBudget,
+    json,
+    noSave,
+    jsonImplicitNoSave,
+  } = parsed;
+
+  const prevCliQuiet = process.env.MEMENTO_CLI_QUIET;
+  if (json) {
+    process.env.MEMENTO_CLI_QUIET = '1';
+  }
+  try {
+  const stdinTty = Boolean(stdinStream.isTTY);
+  const skipPersist = noSave || json;
+
+  if (!stdinTty && !json && !noSave) {
+    const msg = '비대화형 환경에서는 --json 또는 --no-save 가 필요합니다.';
+    if (argv.includes('--json')) {
+      await writeOut(jsonFailure('NON_INTERACTIVE', 'usage', msg));
+    } else {
+      await writeErr(msg + '\n');
+    }
+    return 1;
+  }
+
+  let interrupted = false;
+  const onSigInt = (): void => {
+    interrupted = true;
+  };
+  process.once('SIGINT', onSigInt);
+
+  const sessionId = randomUUID();
+  let dbPath: string;
+  try {
+    dbPath = resolveDbPath(preOptions);
+  } catch (e) {
+    process.removeListener('SIGINT', onSigInt);
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      await writeOut(jsonFailure('INVALID_OPTION', 'usage', msg));
+    } else {
+      await writeErr(msg + '\n');
+    }
+    return 1;
+  }
+
+  let core: Awaited<ReturnType<typeof createMementoCore>> | undefined;
+  try {
+    core = await createMementoCore({ dbPath });
+  } catch (e) {
+    process.removeListener('SIGINT', onSigInt);
+    debugErr(e);
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      await writeOut(jsonFailure('BOOTSTRAP_FAILED', 'bootstrap', msg));
+    } else {
+      await writeErr(msg + '\n');
+    }
+    return 2;
+  }
+
+  const { db, services } = core;
+  const toolContext = createToolContext(db, services);
+  const llm = new DeterministicMockLlmAdapter();
+  const context = new ToolContextKnowledgeContextAdapter(toolContext);
+  const persistence = new ToolContextRememberPersistenceAdapter(toolContext);
+  const service = new PersonalKnowledgeAgentService({ llm, context, persistence });
+
+  let runResult: Awaited<ReturnType<PersonalKnowledgeAgentService['runOneTurn']>>;
+  try {
+    runResult = await service.runOneTurn({
+      userMessage,
+      projectId,
+      tokenBudget,
+      sessionId,
+      ownerId: undefined,
+    });
+  } catch (e) {
+    process.removeListener('SIGINT', onSigInt);
+    debugErr(e);
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      await writeOut(jsonFailure('AGENT_RUN_FAILED', 'run', msg));
+    } else {
+      await writeErr(msg + '\n');
+    }
+    await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+    closeDatabase(db);
+    return 3;
+  }
+
+  if (interrupted) {
+    process.removeListener('SIGINT', onSigInt);
+    await writeErr('중단되어 저장하지 않습니다.\n');
+    await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+    closeDatabase(db);
+    return 130;
+  }
+
+  const basePayload = {
+    ok: true as const,
+    sessionId,
+    input: {
+      userMessage,
+      projectId,
+      tokenBudget,
+    },
+    knowledgeContext: {
+      itemCount: runResult.knowledgeContext.itemCount,
+      tokenEstimate: runResult.knowledgeContext.tokenEstimate,
+      summary: runResult.knowledgeContext.summary,
+    },
+    llm: {
+      response: runResult.llmResponse,
+      metadata: runResult.llmMetadata ?? null,
+    },
+    candidates: runResult.candidates,
+  };
+
+  let persistenceBlock: {
+    attempted: boolean;
+    items: PersonalKnowledgePersistItemResult[];
+    persistedCount: number;
+    errorCount: number;
+  } = {
+    attempted: false,
+    items: [],
+    persistedCount: 0,
+    errorCount: 0,
+  };
+
+  if (!skipPersist && stdinTty && runResult.candidates.length > 0) {
+    const approved: string[] = [];
+    for (let i = 0; i < runResult.candidates.length; i++) {
+      if (interrupted) {
+        process.removeListener('SIGINT', onSigInt);
+        await writeErr('중단되어 저장하지 않습니다.\n');
+        await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+        closeDatabase(db);
+        return 130;
+      }
+      const c = runResult.candidates[i];
+      const ans = await promptApprove(c, i, runResult.candidates.length);
+      if (ans === 'y') {
+        approved.push(c.id);
+      } else if (ans === 's' || ans === 'q') {
+        break;
+      }
+    }
+
+    if (approved.length > 0) {
+      try {
+        const pr = await service.persistApprovedCandidates({
+          candidates: runResult.candidates,
+          approvedCandidateIds: approved,
+          projectId,
+          sessionId,
+          processId: PROCESS_ID,
+        });
+        persistenceBlock = {
+          attempted: true,
+          items: pr.items,
+          persistedCount: pr.persistedCount,
+          errorCount: pr.errorCount,
+        };
+      } catch (e) {
+        process.removeListener('SIGINT', onSigInt);
+        debugErr(e);
+        const msg = e instanceof Error ? e.message : String(e);
+        if (json) {
+          await writeOut(
+            jsonFailure('PERSIST_FAILED', 'persist', msg, {
+              partial: persistenceBlock,
+            }),
+          );
+        } else {
+          await writeErr(msg + '\n');
+        }
+        await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+        closeDatabase(db);
+        return 4;
+      }
+    }
+  }
+
+  process.removeListener('SIGINT', onSigInt);
+
+  const successObj = {
+    ...basePayload,
+    persistence: persistenceBlock,
+  };
+
+  if (json) {
+    await writeOut(JSON.stringify(successObj) + '\n');
+    if (jsonImplicitNoSave) {
+      await writeErr(JSON_INTERACTION_INFO);
+    }
+  } else {
+    await writeErr(
+      `LLM: ${runResult.llmResponse}\n` +
+        `컨텍스트: ${runResult.knowledgeContext.summary}\n` +
+        `후보 ${runResult.candidates.length}건\n`,
+    );
+    if (skipPersist) {
+      await writeErr('(저장 생략: --json 또는 --no-save)\n');
+    }
+    await writeOut(JSON.stringify(successObj) + '\n');
+  }
+
+  await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+  closeDatabase(db);
+
+  if (persistenceBlock.attempted && persistenceBlock.errorCount > 0) {
+    return 4;
+  }
+  return 0;
+  } finally {
+    if (json) {
+      if (prevCliQuiet === undefined) {
+        delete process.env.MEMENTO_CLI_QUIET;
+      } else {
+        process.env.MEMENTO_CLI_QUIET = prevCliQuiet;
+      }
+    }
+  }
+}
+
+export function agentAskHelpText(): string {
+  return (
+    'memento agent ask — 개인 지식 Agent 한 턴 (in-process)\n\n' +
+    'Usage: memento [global-options] agent ask <message> [options]\n\n' +
+    '  <message>   ask 바로 다음에 오는 한 덩어리 문자열(필수)\n\n' +
+    'Options:\n' +
+    '  --project-id <id>     project_id 전달\n' +
+    '  --token-budget <n>    memory_injection 추정 예산\n' +
+    '  --json                stdout에 JSON 한 줄 (--json 단독 시 저장 생략)\n' +
+    '  --no-save             승인·저장 단계 생략\n' +
+    '  --llm mock            LLM 어댑터(현재 mock만)\n\n' +
+    'Global options: --config-dir, --db-path (in-process DB 경로), --env-file\n'
+  );
+}

--- a/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
+++ b/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
@@ -151,6 +151,28 @@ describe('CLI AC5/AC6', () => {
     }
   }, 30_000);
 
+  it('issue #236: agent ask 알 수 없는 옵션 + --json → exit 1, stdout에 JSON 오류', async () => {
+    const dbPath = path.join(os.tmpdir(), `memento-cli-agent236-bad-${Date.now()}.db`);
+    const { stdout, stderr, code } = await runCli([
+      '--db-path', dbPath,
+      'agent',
+      'ask',
+      'hello',
+      '--json',
+      '--not-a-real-flag',
+    ]);
+    expect(code).toBe(1);
+    const obj = JSON.parse(stdout.trim()) as { ok: boolean; error?: { code: string } };
+    expect(obj.ok).toBe(false);
+    expect(obj.error?.code).toBe('INVALID_OPTION');
+    expect(stderr).toBe('');
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {
+      // ignore
+    }
+  }, 15_000);
+
   it('AC6/AC9: 서버 미실행 시 exit 1 및 서버 실행 안내 메시지 출력', async () => {
     const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-cli-ac6-cwd-'));
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-cli-home-'));

--- a/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
+++ b/packages/memento-server/src/cli/cli-ac5-ac6.spec.ts
@@ -121,7 +121,35 @@ describe('CLI AC5/AC6', () => {
     expect(output).toContain('remember');
     expect(output).toContain('forget');
     expect(output).toContain('memory_injection');
+    expect(output).toContain('agent ask');
   });
+
+  it('issue #236: agent ask --json --no-save prints JSON only on stdout', async () => {
+    const dbPath = path.join(os.tmpdir(), `memento-cli-agent236-${Date.now()}.db`);
+    const { stdout, stderr, code } = await runCli([
+      '--db-path', dbPath,
+      'agent',
+      'ask',
+      '앞으로는 커밋 메시지는 영어로 쓰자',
+      '--json',
+      '--no-save',
+    ]);
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+    const obj = JSON.parse(stdout.trim()) as {
+      ok: boolean;
+      llm: { response: string };
+      persistence: { attempted: boolean };
+    };
+    expect(obj.ok).toBe(true);
+    expect(obj.llm.response.length).toBeGreaterThan(0);
+    expect(obj.persistence.attempted).toBe(false);
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {
+      // ignore
+    }
+  }, 30_000);
 
   it('AC6/AC9: 서버 미실행 시 exit 1 및 서버 실행 안내 메시지 출력', async () => {
     const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-cli-ac6-cwd-'));


### PR DESCRIPTION
## 요약

로컬에서 **HTTP 없이** `createMementoCore` + Personal Knowledge Agent 경로를 쓰는 **`memento agent ask`** CLI를 추가합니다. 설계는 `docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md`, 구현 계획은 `docs/superpowers/plans/2026-05-14-issue-236-agent-ask-cli.md`를 따릅니다.

## 변경 사항

- **CLI**: `packages/memento-server` — `agent ask` 서브커맨드(lazy load), 인자 파싱·TTY/JSON 동작·exit 코드 정책 반영.
- **코어 공개 API**: `packages/memento-core/src/index.ts`에서 에이전트·mock LLM·툴 컨텍스트 어댑터 타입 re-export.
- **테스트**: `agent-ask.spec.ts`(파서 등), `cli-ac5-ac6.spec.ts`에 `--json --no-save` 통합 검증 추가.
- **품질**: `--json`일 때 stderr가 로그로 오염되지 않도록 `MEMENTO_CLI_QUIET`를 일시 설정(설계대로 machine-readable 출력 보장).
- **graphify**: 코드 변경에 맞춰 `graphify-out/` 갱신.

## 테스트

- `npm run lint`
- `npm test`
- `npm run type-check -w memento-server`

## 관련 이슈

- Closes https://github.com/jee1/memento/issues/236
- Related to https://github.com/jee1/memento/issues/82 (부모 추적 이슈)

## 지식 복리 (선택)

JSON 모드에서 코어 초기화 로그가 `stderr`를 깨뜨리는 함정은 **`MEMENTO_CLI_QUIET`** 로 막았습니다. 운영/스크립트에서 동일 패턴이 필요하면 동일 플래그를 참고하면 됩니다.
