### PR TITLE
feat(cli): agent ask 이슈 #237 E2E·훅·한국어 MVP 가이드

### DIFF
--- a/docs/guides/ko/personal-knowledge-agent-mvp.md
+++ b/docs/guides/ko/personal-knowledge-agent-mvp.md
@@ -1,0 +1,61 @@
+# 개인 지식 Agent MVP — CLI 사용 가이드 (한국어)
+
+이 문서는 **로컬 SQLite DB**와 **`memento agent ask`** 서브커맨드만으로, 질문 → 컨텍스트 주입 → mock LLM 응답 → 지식 후보 → 터미널 승인 → `remember` 저장까지의 **MVP 한 턴**을 실행하는 방법을 설명합니다.  
+(MCP/HTTP 서버·실제 LLM provider·대시보드는 범위 밖입니다. 관련 이슈: [#82](https://github.com/jee1/memento/issues/82), [#236](https://github.com/jee1/memento/issues/236), [#237](https://github.com/jee1/memento/issues/237).)
+
+## 전제 조건
+
+- 저장소 루트에서 `npm install` 및 `npm run build` 완료.
+- CLI 진입점: `node packages/memento-server/dist/cli.js` (또는 배포본의 `memento`가 PATH에 있는 경우 `memento`).
+- **로컬 DB 파일**을 쓰려면 `--db-path <파일>`을 지정합니다. (기본 `recall` / `remember` 도구 CLI는 서버 모드 전제가 많으니, 이 가이드는 **에이전트 ask 경로**에 맞춥니다.)
+
+## 1. DB 준비 및 시드
+
+```bash
+DB=./tmp-memento-agent.db
+node packages/memento-server/dist/cli.js --db-path "$DB" remember "프로젝트 A 전용 결정 문서" \
+  --type semantic --project-id my-app
+```
+
+`--project-id`가 같은 기억끼리 `memory_injection` / Agent 컨텍스트에서 묶입니다 (프로젝트 스코프 메모리, 이슈 #81).
+
+## 2. 한 턴 실행 (TTY, 승인 저장)
+
+```bash
+node packages/memento-server/dist/cli.js --db-path "$DB" agent ask \
+  "앞으로는 커밋 메시지는 영어로 쓰고 싶어" \
+  --project-id my-app \
+  --llm mock
+```
+
+- stderr에 LLM 요약·후보 목록이 표시되고, stdout **마지막 한 줄**은 JSON 결과입니다.
+- 각 후보마다 `(y)es / (n)o / (s)kip rest / (q)uit & save approved` 프롬프트가 뜹니다.  
+  - `y`: 해당 후보를 승인해 `remember`에 반영합니다.  
+  - 빈 줄 또는 `n`: 거절(저장 안 함).  
+  - `s` / `q`: 남은 질문을 건너뛰고, 지금까지 `y`로 승인한 항목만 저장합니다.
+
+## 3. 스크립트·CI용 (`--json` / `--no-save`)
+
+- `--json --no-save`: stdout에 **JSON 한 줄만** (저장 단계 생략, 인터랙션 없음).
+- `--json`만 주면 설계상 **저장 생략**과 동일하며, stderr에 한 줄 안내가 붙을 수 있습니다.
+
+```bash
+node packages/memento-server/dist/cli.js --db-path "$DB" agent ask "짧은 질문" \
+  --project-id my-app --llm mock --json --no-save
+```
+
+## 4. 비TTY 환경에서의 제약
+
+표준 입력이 TTY가 아니면 **저장·승인 루프**를 쓰려면 반드시 `--json` 또는 `--no-save`가 필요합니다. 그렇지 않으면 exit `1`입니다.  
+자동화에서 **승인 저장까지** 검증하려면 Vitest 등 in-process 테스트에서 `runAgentAskMain`의 **런타임 훅**(`stdinIsTTY` / `promptApprove`)을 사용합니다(구현: `packages/memento-server/src/cli/agent-ask.ts`, 예시: `agent-ask-issue237.e2e.spec.ts`).
+
+## 5. 제외·후속 범위
+
+- 실제 OpenAI/Gemini 등 provider 연결: [#238](https://github.com/jee1/memento/issues/238) 트랙.
+- HTTP MCP로 Agent 위임: [#390](https://github.com/jee1/memento/issues/390) 등.
+- 대시보드·자동 리뷰 문서: 이 MVP 가이드 범위 밖.
+
+## 6. 관련 문서
+
+- CLI 설계(옵션·JSON 스키마·exit code): `docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md`
+- 기존 CLI·클라이언트 개요: `docs/guides/ko/user-manual.md`

--- a/docs/guides/ko/user-manual.md
+++ b/docs/guides/ko/user-manual.md
@@ -123,6 +123,8 @@ await client.remember({
 
 CLI(`memento` 등)를 사용하는 경우:
 
+개인 지식 Agent 한 턴(`memento agent ask`, mock LLM, 프로젝트 범위·승인 저장)은 [개인 지식 Agent MVP (한국어)](./personal-knowledge-agent-mvp.md)를 참고하세요.
+
 ```bash
 memento remember "React Hook 사용법" --type semantic --tags "react,hooks,programming"
 ```

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - /home/jee1lee/git/memento  (2026-05-14)
+# Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 981 files · ~1,577,389 words
+- 982 files · ~1,578,398 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4946 nodes · 6135 edges · 978 communities detected
+- 4951 nodes · 6139 edges · 979 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -988,6 +988,7 @@
 - [[_COMMUNITY_Community 975|Community 975]]
 - [[_COMMUNITY_Community 976|Community 976]]
 - [[_COMMUNITY_Community 977|Community 977]]
+- [[_COMMUNITY_Community 978|Community 978]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -1367,8 +1368,8 @@ Cohesion: 0.23
 Nodes (1): EmbeddingMigration
 
 ### Community 90 - "Community 90"
-Cohesion: 0.31
-Nodes (12): agentAskHelpText(), debugErr(), jsonFailure(), parseAgentAskInvocation(), promptApprove(), resolveDbPath(), runAgentAskMain(), stripGlobalCliArgs() (+4 more)
+Cohesion: 0.29
+Nodes (11): agentAskHelpText(), debugErr(), jsonFailure(), parseAgentAskInvocation(), resolveDbPath(), runAgentAskMain(), stripGlobalCliArgs(), validateAgentAskFlagArgv() (+3 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.27
@@ -2187,8 +2188,8 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 295 - "Community 295"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): seedTwoProjectMemories(), stopBatchSchedulerSingleton()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.4
@@ -2215,28 +2216,28 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 302 - "Community 302"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 303 - "Community 303"
 Cohesion: 0.5
 Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (2): getStopWords(), isStopWord()
 
 ### Community 307 - "Community 307"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): getStopWords(), isStopWord()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.4
@@ -2247,120 +2248,120 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 310 - "Community 310"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 311 - "Community 311"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 312 - "Community 312"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 313 - "Community 313"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 321 - "Community 321"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 322 - "Community 322"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 324 - "Community 324"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 326 - "Community 326"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): TokenBucketRateLimiter
 
 ### Community 327 - "Community 327"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 328 - "Community 328"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 338 - "Community 338"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 339 - "Community 339"
 Cohesion: 0.5
@@ -2372,23 +2373,23 @@ Nodes (0):
 
 ### Community 341 - "Community 341"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 342 - "Community 342"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): BraveSearchProvider
 
 ### Community 343 - "Community 343"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (1): DatabaseOptimizeTool
-
 ### Community 345 - "Community 345"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): DatabaseOptimizeTool
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
@@ -2412,171 +2413,171 @@ Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
-Nodes (1): RelationValidatorExecutor
+Nodes (0): 
 
 ### Community 352 - "Community 352"
+Cohesion: 0.5
+Nodes (1): RelationValidatorExecutor
+
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (1): QualityMeasurementBatchJob
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (1): SleepConsolidationBatchJob
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (1): TelemetryCleanupBatchJob
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 359 - "Community 359"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
-Nodes (1): SearchResultCombiner
+Nodes (1): RestoreAnchorsTool
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
+Cohesion: 0.5
+Nodes (1): SearchResultCombiner
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (2): computeProcessAttributeFit(), toSet()
+Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): computeProcessAttributeFit(), toSet()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.5
-Nodes (1): ForgettingStatsTool
+Nodes (0): 
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
-Nodes (1): GetTelemetrySummaryTool
+Nodes (1): ForgettingStatsTool
 
 ### Community 370 - "Community 370"
+Cohesion: 0.5
+Nodes (1): GetTelemetrySummaryTool
+
+### Community 371 - "Community 371"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.5
 Nodes (1): MemoryInjectionPrompt
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (1): GetMemoryNeighborsTool
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (1): ProceduralRollbackTool
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (1): CleanupMemoryTool
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (1): ProceduralDiffTool
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (1): GetIntrospectionSummaryTool
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (1): RememberProcedureTool
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 379 - "Community 379"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 381 - "Community 381"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 389 - "Community 389"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 393 - "Community 393"
 Cohesion: 0.5
@@ -2588,15 +2589,15 @@ Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
@@ -2611,20 +2612,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 401 - "Community 401"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 402 - "Community 402"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 403 - "Community 403"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 404 - "Community 404"
+### Community 402 - "Community 402"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 403 - "Community 403"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 404 - "Community 404"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 405 - "Community 405"
 Cohesion: 0.83
@@ -2636,59 +2637,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 408 - "Community 408"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 409 - "Community 409"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 410 - "Community 410"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 414 - "Community 414"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 415 - "Community 415"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 418 - "Community 418"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 419 - "Community 419"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
@@ -2699,24 +2700,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 423 - "Community 423"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 424 - "Community 424"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 425 - "Community 425"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 426 - "Community 426"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
@@ -2724,31 +2725,31 @@ Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 433 - "Community 433"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 434 - "Community 434"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -2759,12 +2760,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 438 - "Community 438"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 439 - "Community 439"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
@@ -2779,16 +2780,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 443 - "Community 443"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 444 - "Community 444"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
@@ -2808,11 +2809,11 @@ Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Nodes (0): 
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
@@ -2828,19 +2829,19 @@ Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 456 - "Community 456"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 457 - "Community 457"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 458 - "Community 458"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
@@ -2867,28 +2868,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 465 - "Community 465"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 466 - "Community 466"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 467 - "Community 467"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 468 - "Community 468"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 469 - "Community 469"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 470 - "Community 470"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 471 - "Community 471"
 Cohesion: 0.67
@@ -2899,32 +2900,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 473 - "Community 473"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 474 - "Community 474"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 475 - "Community 475"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 476 - "Community 476"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
@@ -4918,1006 +4919,1010 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 978 - "Community 978"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 479`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 480`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 481`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 482`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 483`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 484`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 485`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 486`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 487`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 488`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 489`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 490`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 491`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 492`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 493`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 494`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 495`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 496`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 497`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 498`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 499`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 500`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 501`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 502`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 503`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 504`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 505`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 506`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 510`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 511`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 512`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 513`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 514`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 515`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 516`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 517`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 518`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 519`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 520`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 521`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 522`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 523`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 524`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 525`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 526`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 527`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 528`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 529`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 530`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 531`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 532`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 533`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 534`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 535`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 536`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 537`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 538`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 539`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 541`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 554`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 555`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 556`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 557`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 558`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 559`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 560`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 561`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 562`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 563`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 564`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 565`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 566`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 567`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 568`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 569`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 570`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 571`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 572`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 573`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 574`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 575`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 576`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 577`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 578`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 579`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 580`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 581`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 582`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 583`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 584`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 585`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 586`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 587`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 589`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 590`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 591`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 592`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 593`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 594`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 595`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 596`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 598`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 599`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 603`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 604`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 606`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 607`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 608`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 609`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 610`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 611`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 612`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 613`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 614`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 615`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 616`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 617`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 618`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 619`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 620`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 621`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 622`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 623`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 624`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 625`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 626`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 627`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 628`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 629`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 630`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 631`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 632`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 633`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 634`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 635`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 636`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 637`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 638`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 639`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 640`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 641`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 642`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 643`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 644`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 645`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 646`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 648`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 649`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 650`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 651`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 652`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 653`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 654`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 655`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 656`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 657`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 658`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 659`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 660`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 661`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 662`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 663`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 664`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 665`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 666`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 667`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 668`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 669`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 670`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 671`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 672`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 673`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 674`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `types.ts`
+- **Thin community `Community 675`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 676`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `index.ts`
+- **Thin community `Community 677`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 678`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `transport.ts`
+- **Thin community `Community 684`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `index.ts`
+- **Thin community `Community 685`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 698`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 712`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `context.ts`
+- **Thin community `Community 714`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `index.ts`
+- **Thin community `Community 719`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `types.ts`
+- **Thin community `Community 722`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 723`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 724`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 725`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 726`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 727`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 728`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 729`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 730`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 731`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 732`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 733`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `index.ts`
+- **Thin community `Community 734`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 735`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 736`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `types.ts`
+- **Thin community `Community 744`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 751`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 752`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 762`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 779`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 780`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 781`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 782`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 783`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 784`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 785`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 786`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 787`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 788`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 789`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `error-types.ts`
+- **Thin community `Community 790`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 791`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 792`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `search.types.ts`
+- **Thin community `Community 793`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 795`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `constants.ts`
+- **Thin community `Community 796`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 797`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 804`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 805`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 807`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 808`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 832`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 833`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `index.ts`
+- **Thin community `Community 835`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `database-types.ts`
+- **Thin community `Community 837`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `index.ts`
+- **Thin community `Community 857`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 858`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `index.ts`
+- **Thin community `Community 860`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 863`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 864`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `context-port.ts`
+- **Thin community `Community 865`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 866`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 869`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 870`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 871`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 872`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 873`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 874`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 875`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 876`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 877`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 878`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 880`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 890`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 891`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `index.ts`
+- **Thin community `Community 901`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 903`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 913`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `types.ts`
+- **Thin community `Community 923`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `types.ts`
+- **Thin community `Community 938`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 940`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 942`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 943`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 944`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 951`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 952`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 954`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 955`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 964`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `types.ts`
+- **Thin community `Community 965`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 978`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 413
+      "community": 414
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 413
+      "community": 414
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 479
+      "community": 480
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 414
+      "community": 415
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 414
+      "community": 415
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 480
+      "community": 481
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 481
+      "community": 482
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 415
+      "community": 416
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 415
+      "community": 416
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 482
+      "community": 483
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "mock-transport.ts",
@@ -817,7 +817,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createRateLimitedLogger()",
@@ -825,7 +825,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 335
+      "community": 336
     },
     {
       "label": "levelFromEnv()",
@@ -833,7 +833,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 335
+      "community": 336
     },
     {
       "label": "consoleSink()",
@@ -841,7 +841,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 335
+      "community": 336
     },
     {
       "label": "logger.spec.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "start-http-server.ts",
@@ -985,7 +985,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "startTestHttpServer()",
@@ -993,7 +993,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 336
+      "community": 337
     },
     {
       "label": "findFreePort()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 336
+      "community": 337
     },
     {
       "label": "waitForHealth()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 336
+      "community": 337
     },
     {
       "label": "http-server-runner.js",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 698
+      "community": 699
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 483
+      "community": 484
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 483
+      "community": 484
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 484
+      "community": 485
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 485
+      "community": 486
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 486
+      "community": 487
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "getRepoRoot()",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 337
+      "community": 338
     },
     {
       "label": "collectEnvKeys()",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 337
+      "community": 338
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 337
+      "community": 338
     },
     {
       "label": "server-info.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "createMockResponse()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 416
+      "community": 417
     },
     {
       "label": "sendOptions()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 416
+      "community": 417
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 487
+      "community": 488
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "readRepoFile()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 417
+      "community": 418
     },
     {
       "label": "sectionBetween()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 417
+      "community": 418
     },
     {
       "label": "http-server.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 488
+      "community": 489
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 338
+      "community": 339
     },
     {
       "label": "postJsonRpc()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 338
+      "community": 339
     },
     {
       "label": "openSse()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 338
+      "community": 339
     },
     {
       "label": "index.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 489
+      "community": 490
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "createMockResponse()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 418
+      "community": 419
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 418
+      "community": 419
     },
     {
       "label": "server-state.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "sse-server-impl.ts",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "startSseServer()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 339
+      "community": 340
     },
     {
       "label": "stopSseServer()",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 339
+      "community": 340
     },
     {
       "label": "cleanupSseServer()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 339
+      "community": 340
     },
     {
       "label": "http-server.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "batch-run-history.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 419
+      "community": 420
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 419
+      "community": 420
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 490
+      "community": 491
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 491
+      "community": 492
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 492
+      "community": 493
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3489,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "readCookie()",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 340
+      "community": 341
     },
     {
       "label": "writeUnauthorized()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 340
+      "community": 341
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 340
+      "community": 341
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 493
+      "community": 494
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 494
+      "community": 495
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 495
+      "community": 496
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 496
+      "community": 497
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 497
+      "community": 498
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 498
+      "community": 499
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 499
+      "community": 500
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 500
+      "community": 501
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 420
+      "community": 421
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 420
+      "community": 421
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "parseParams()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 421
+      "community": 422
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 421
+      "community": 422
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 501
+      "community": 502
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 502
+      "community": 503
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 503
+      "community": 504
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "parseCleanupParams()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 422
+      "community": 423
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 422
+      "community": 423
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,47 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 510
+      "community": 511
+    },
+    {
+      "label": "agent-ask-issue237.e2e.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "community": 295
+    },
+    {
+      "label": "stopBatchSchedulerSingleton()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L22",
+      "id": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
+      "community": 295
+    },
+    {
+      "label": "argvAgentAsk()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L30",
+      "id": "agent_ask_issue237_e2e_spec_argvagentask",
+      "community": 295
+    },
+    {
+      "label": "captureStdoutWrite()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L38",
+      "id": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
+      "community": 295
+    },
+    {
+      "label": "seedTwoProjectMemories()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L52",
+      "id": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
+      "community": 295
     },
     {
       "label": "env-loader.ts",
@@ -4289,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "resolveEnvPath()",
@@ -4297,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 423
+      "community": 424
     },
     {
       "label": "loadEnv()",
@@ -4305,7 +4345,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 423
+      "community": 424
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4313,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "runCli()",
@@ -4321,109 +4361,109 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 511
+      "community": 512
     },
     {
       "label": "agent-ask.ts",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
-      "id": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "id": "packages_memento_server_src_cli_agent_ask_ts",
       "community": 90
     },
     {
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L35",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L36",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
     },
     {
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L65",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L66",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
     },
     {
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L157",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L158",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
     },
     {
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L187",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L188",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
     },
     {
       "label": "resolveDbPath()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L207",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L208",
       "id": "agent_ask_resolvedbpath",
       "community": 90
     },
     {
       "label": "jsonFailure()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L224",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L225",
       "id": "agent_ask_jsonfailure",
       "community": 90
     },
     {
       "label": "writeOut()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L236",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L237",
       "id": "agent_ask_writeout",
       "community": 90
     },
     {
       "label": "writeErr()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L242",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L243",
       "id": "agent_ask_writeerr",
       "community": 90
     },
     {
       "label": "debugErr()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L248",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L249",
       "id": "agent_ask_debugerr",
       "community": 90
     },
     {
-      "label": "promptApprove()",
+      "label": "promptApproveInteractive()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L254",
-      "id": "agent_ask_promptapprove",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L258",
+      "id": "agent_ask_promptapproveinteractive",
       "community": 90
     },
     {
       "label": "runAgentAskMain()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L292",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L311",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
     {
       "label": "agentAskHelpText()",
       "file_type": "code",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L541",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L562",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -4481,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4489,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4497,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 424
+      "community": 425
     },
     {
       "label": "runQualityMeasurement()",
@@ -4505,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 424
+      "community": 425
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4513,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "testSimpleAlerts()",
@@ -4521,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4529,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "testBasicFunctionality()",
@@ -4537,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 513
+      "community": 514
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4545,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4553,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 514
+      "community": 515
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4561,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "compareServices()",
@@ -4569,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 425
+      "community": 426
     },
     {
       "label": "testServerSynchronization()",
@@ -4577,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 425
+      "community": 426
     },
     {
       "label": "test-error-logging.ts",
@@ -4585,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "testErrorLogging()",
@@ -4593,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 515
+      "community": 516
     },
     {
       "label": "debug-http-v2.ts",
@@ -4601,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "testFetch()",
@@ -4609,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 516
+      "community": 517
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4617,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "initializeTestDatabase()",
@@ -4625,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 517
+      "community": 518
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4633,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4641,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4649,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "testReflexionE2E()",
@@ -4657,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 518
+      "community": 519
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4665,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "testAlertsDirect()",
@@ -4673,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 519
+      "community": 520
     },
     {
       "label": "test-client.ts",
@@ -4681,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "assert()",
@@ -4689,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 426
+      "community": 427
     },
     {
       "label": "testMementoClient()",
@@ -4697,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 426
+      "community": 427
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4705,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4777,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4785,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4793,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4801,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4809,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4817,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4825,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4833,7 +4873,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "createBaseSchema()",
@@ -4841,7 +4881,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 427
+      "community": 428
     },
     {
       "label": "createTestMemory()",
@@ -4849,7 +4889,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 427
+      "community": 428
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4857,7 +4897,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4865,7 +4905,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 428
+      "community": 429
     },
     {
       "label": "findNodeForAnchor()",
@@ -4873,7 +4913,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 428
+      "community": 429
     },
     {
       "label": "vitest.config.ts",
@@ -4881,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4889,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "brave-search-provider.ts",
@@ -4897,7 +4937,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "BraveSearchProvider",
@@ -4905,7 +4945,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 341
+      "community": 342
     },
     {
       "label": ".constructor()",
@@ -4913,7 +4953,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 341
+      "community": 342
     },
     {
       "label": ".search()",
@@ -4921,7 +4961,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 341
+      "community": 342
     },
     {
       "label": "noop-search-provider.ts",
@@ -4929,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "NoopSearchProvider",
@@ -4937,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 429
+      "community": 430
     },
     {
       "label": ".search()",
@@ -4945,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 429
+      "community": 430
     },
     {
       "label": "search-factory.ts",
@@ -4953,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "createSearchProvider()",
@@ -4961,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 523
+      "community": 524
     },
     {
       "label": "search-provider.ts",
@@ -4969,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "llm-provider.ts",
@@ -4977,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "claude-provider.spec.ts",
@@ -4985,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "types.ts",
@@ -4993,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "loadAgentConfig()",
@@ -5001,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 524
+      "community": 525
     },
     {
       "label": "system-prompt.ts",
@@ -5009,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "vitest.config.ts",
@@ -5017,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "utils.spec.ts",
@@ -5025,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "buildMemory()",
@@ -5033,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 525
+      "community": 526
     },
     {
       "label": "context-injector.ts",
@@ -5857,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "logger.ts",
@@ -5865,7 +5905,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "shouldLog()",
@@ -5873,7 +5913,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 430
+      "community": 431
     },
     {
       "label": "log()",
@@ -5881,7 +5921,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 430
+      "community": 431
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5889,7 +5929,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "constructor()",
@@ -5897,7 +5937,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L231",
       "id": "bootstrap_spec_constructor",
-      "community": 342
+      "community": 343
     },
     {
       "label": "loadBootstrap()",
@@ -5905,7 +5945,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L254",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 342
+      "community": 343
     },
     {
       "label": "installTimeoutSpy()",
@@ -5913,7 +5953,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L258",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 342
+      "community": 343
     },
     {
       "label": "index.ts",
@@ -5921,7 +5961,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "createMementoCore()",
@@ -5929,7 +5969,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 431
+      "community": 432
     },
     {
       "label": "closeDatabase()",
@@ -5937,7 +5977,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 431
+      "community": 432
     },
     {
       "label": "bootstrap.ts",
@@ -5945,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "initializeServices()",
@@ -5953,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 526
+      "community": 527
     },
     {
       "label": "context.ts",
@@ -5961,7 +6001,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createServerContext()",
@@ -5969,7 +6009,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L15",
       "id": "context_createservercontext",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createToolContext()",
@@ -5977,7 +6017,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L24",
       "id": "context_createtoolcontext",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -5985,7 +6025,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L37",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 343
+      "community": 344
     },
     {
       "label": "write-and-meta.ts",
@@ -5993,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6001,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 527
+      "community": 528
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6009,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6017,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 528
+      "community": 529
     },
     {
       "label": "anchor-stack.ts",
@@ -6025,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createAnchorStack()",
@@ -6033,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 529
+      "community": 530
     },
     {
       "label": "failure-reflexion.ts",
@@ -6041,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6049,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 530
+      "community": 531
     },
     {
       "label": "search-and-embedding.ts",
@@ -6057,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6065,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 531
+      "community": 532
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6073,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6081,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 532
+      "community": 533
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6089,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6097,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 533
+      "community": 534
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6905,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createInput()",
@@ -6913,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 534
+      "community": 535
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -6921,7 +6961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "extract()",
@@ -6929,7 +6969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 295
+      "community": 296
     },
     {
       "label": "waitForEventProcessing()",
@@ -6937,7 +6977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createProceduralMemory()",
@@ -6945,7 +6985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 295
+      "community": 296
     },
     {
       "label": "createFailureEvent()",
@@ -6953,7 +6993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 295
+      "community": 296
     },
     {
       "label": "relation-graph-factory.ts",
@@ -6961,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createRelationGraph()",
@@ -6969,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 535
+      "community": 536
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7057,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7137,7 +7177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -7145,7 +7185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 344
+      "community": 345
     },
     {
       "label": ".constructor()",
@@ -7153,7 +7193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 344
+      "community": 345
     },
     {
       "label": ".handle()",
@@ -7161,7 +7201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 344
+      "community": 345
     },
     {
       "label": "migration-history-service.ts",
@@ -7481,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "createBaseSchema()",
@@ -7489,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 432
+      "community": 433
     },
     {
       "label": "measureTime()",
@@ -7497,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 432
+      "community": 433
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7505,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createBaseSchema()",
@@ -7513,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 536
+      "community": 537
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7617,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7625,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 537
+      "community": 538
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7729,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "openLockTestDatabase()",
@@ -7737,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 538
+      "community": 539
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7745,7 +7785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -7753,7 +7793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createPlan()",
@@ -7761,7 +7801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createResult()",
@@ -7769,7 +7809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 345
+      "community": 346
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -7777,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createProgress()",
@@ -7785,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 539
+      "community": 540
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7793,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7801,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7809,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7817,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 540
+      "community": 541
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7825,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7833,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7841,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 541
+      "community": 542
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7849,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "addMissingColumn()",
@@ -7857,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 433
+      "community": 434
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7865,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 433
+      "community": 434
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7873,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -7969,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "init.ts",
@@ -8089,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createDbPath()",
@@ -8097,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 542
+      "community": 543
     },
     {
       "label": "migrate.spec.ts",
@@ -8105,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "migrate.ts",
@@ -8113,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "isDuplicateColumnError()",
@@ -8121,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 434
+      "community": 435
     },
     {
       "label": "migrateDatabase()",
@@ -8129,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 434
+      "community": 435
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8137,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "migration-runner.ts",
@@ -8217,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createBaseSchema()",
@@ -8225,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 543
+      "community": 544
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8233,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "migration-detector.ts",
@@ -8425,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8433,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "backup-manager.ts",
@@ -8513,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "dependency-validator.ts",
@@ -8617,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "schema-version-manager.ts",
@@ -8705,7 +8745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "createMemoryItemTable()",
@@ -8713,7 +8753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 346
+      "community": 347
     },
     {
       "label": "columnExists()",
@@ -8721,7 +8761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 346
+      "community": 347
     },
     {
       "label": "indexExists()",
@@ -8729,7 +8769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 346
+      "community": 347
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -9097,7 +9137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createMemoryItemTable()",
@@ -9105,7 +9145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9113,7 +9153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 296
+      "community": 297
     },
     {
       "label": "columnExists()",
@@ -9121,7 +9161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "indexExists()",
@@ -9129,7 +9169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 296
+      "community": 297
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -9209,7 +9249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "createMemoryItemTable()",
@@ -9217,7 +9257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 297
+      "community": 298
     },
     {
       "label": "createSchemaVersionTable()",
@@ -9225,7 +9265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 297
+      "community": 298
     },
     {
       "label": "columnExists()",
@@ -9233,7 +9273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 297
+      "community": 298
     },
     {
       "label": "indexExists()",
@@ -9241,7 +9281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 297
+      "community": 298
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -9473,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createBaseSchema()",
@@ -9481,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 544
+      "community": 545
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9665,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createBaseSchema()",
@@ -9673,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 545
+      "community": 546
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -9969,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -9977,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 546
+      "community": 547
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -9985,7 +10025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "createMemoryItemTable()",
@@ -9993,7 +10033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 298
+      "community": 299
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10001,7 +10041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 298
+      "community": 299
     },
     {
       "label": "columnExists()",
@@ -10009,7 +10049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 298
+      "community": 299
     },
     {
       "label": "indexExists()",
@@ -10017,7 +10057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 298
+      "community": 299
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -10345,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "createMemoryItemTable()",
@@ -10353,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 435
+      "community": 436
     },
     {
       "label": "tableExists()",
@@ -10361,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 435
+      "community": 436
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10601,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "createMemoryItemTable()",
@@ -10609,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 436
+      "community": 437
     },
     {
       "label": "tableExists()",
@@ -10617,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 436
+      "community": 437
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10697,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createBaseSchema()",
@@ -10705,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 547
+      "community": 548
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10809,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createSchemaWith018()",
@@ -10817,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 548
+      "community": 549
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10825,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -10833,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 549
+      "community": 550
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -10841,7 +10881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -10849,7 +10889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 347
+      "community": 348
     },
     {
       "label": "createMemoryLinkTable()",
@@ -10857,7 +10897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 347
+      "community": 348
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10865,7 +10905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 347
+      "community": 348
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -11057,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "createMemoryItemTable()",
@@ -11065,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 299
+      "community": 300
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11073,7 +11113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 299
+      "community": 300
     },
     {
       "label": "columnExists()",
@@ -11081,7 +11121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 299
+      "community": 300
     },
     {
       "label": "indexExists()",
@@ -11089,7 +11129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 299
+      "community": 300
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -11169,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "createMemoryItemTable()",
@@ -11177,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 300
+      "community": 301
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11185,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 300
+      "community": 301
     },
     {
       "label": "columnExists()",
@@ -11193,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 300
+      "community": 301
     },
     {
       "label": "indexExists()",
@@ -11201,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 300
+      "community": 301
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -11457,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -11465,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11593,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -11601,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11609,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "createBaseSchema()",
@@ -11617,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 437
+      "community": 438
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11625,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 437
+      "community": 438
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11705,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createBaseSchema()",
@@ -11713,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 552
+      "community": 553
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11721,7 +11761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -11729,7 +11769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 348
+      "community": 349
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11737,7 +11777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 348
+      "community": 349
     },
     {
       "label": "getIndexNames()",
@@ -11745,7 +11785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 348
+      "community": 349
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -11753,7 +11793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "createSchemaWith019()",
@@ -11761,7 +11801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 349
+      "community": 350
     },
     {
       "label": "tableExists()",
@@ -11769,7 +11809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 349
+      "community": 350
     },
     {
       "label": "columnExists()",
@@ -11777,7 +11817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 349
+      "community": 350
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -11929,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12361,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "cache-service.ts",
@@ -12689,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "batch-scheduler.ts",
@@ -13073,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -13081,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 350
+      "community": 351
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -13089,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 350
+      "community": 351
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -13097,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 350
+      "community": 351
     },
     {
       "label": "health-checker.ts",
@@ -13153,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13161,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 553
+      "community": 554
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13169,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13177,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 554
+      "community": 555
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13185,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "readInsertedUpdated()",
@@ -13193,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 438
+      "community": 439
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13201,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 438
+      "community": 439
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13209,7 +13249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_relation_validator_executor_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "RelationValidatorExecutor",
@@ -13217,7 +13257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L31",
       "id": "relation_validator_executor_relationvalidatorexecutor",
-      "community": 351
+      "community": 352
     },
     {
       "label": ".constructor()",
@@ -13225,7 +13265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L34",
       "id": "relation_validator_executor_relationvalidatorexecutor_constructor",
-      "community": 351
+      "community": 352
     },
     {
       "label": ".execute()",
@@ -13233,7 +13273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/relation-validator-executor.ts",
       "source_location": "L49",
       "id": "relation_validator_executor_relationvalidatorexecutor_execute",
-      "community": 351
+      "community": 352
     },
     {
       "label": "batch-scheduler-types.ts",
@@ -13241,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13249,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13257,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 555
+      "community": 556
     },
     {
       "label": "retry-manager.ts",
@@ -13713,7 +13753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -13721,7 +13761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -13729,7 +13769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -13737,7 +13777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L113",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 301
+      "community": 302
     },
     {
       "label": "runLogRotation()",
@@ -13745,7 +13785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L168",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 301
+      "community": 302
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -13753,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13761,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13769,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 439
+      "community": 440
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13777,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 439
+      "community": 440
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13785,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13793,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 440
+      "community": 441
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13801,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 440
+      "community": 441
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13809,7 +13849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -13817,7 +13857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L16",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 352
+      "community": 353
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -13825,7 +13865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L46",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 352
+      "community": 353
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -13833,7 +13873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L83",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 352
+      "community": 353
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -13841,7 +13881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -13849,7 +13889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 302
+      "community": 303
     },
     {
       "label": "runMemoryCleanup()",
@@ -13857,7 +13897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 302
+      "community": 303
     },
     {
       "label": "runMonitoring()",
@@ -13865,7 +13905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 302
+      "community": 303
     },
     {
       "label": "runHealthCheck()",
@@ -13873,7 +13913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 302
+      "community": 303
     },
     {
       "label": "file-logger.spec.ts",
@@ -13881,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13953,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "retry-manager.spec.ts",
@@ -13961,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "shouldRetry()",
@@ -13969,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 556
+      "community": 557
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -13977,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "baseResult()",
@@ -13985,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 557
+      "community": 558
     },
     {
       "label": "job-queue.spec.ts",
@@ -13993,7 +14033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "job()",
@@ -14001,7 +14041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 303
+      "community": 304
     },
     {
       "label": "job1()",
@@ -14009,7 +14049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 303
+      "community": 304
     },
     {
       "label": "job2()",
@@ -14017,7 +14057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 303
+      "community": 304
     },
     {
       "label": "job3()",
@@ -14025,7 +14065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 303
+      "community": 304
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -14033,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14041,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "initializeTestDatabase()",
@@ -14049,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 558
+      "community": 559
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14145,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14153,7 +14193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -14161,7 +14201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".constructor()",
@@ -14169,7 +14209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".execute()",
@@ -14177,7 +14217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 353
+      "community": 354
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -14185,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14193,7 +14233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -14201,7 +14241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".constructor()",
@@ -14209,7 +14249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".execute()",
@@ -14217,7 +14257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 354
+      "community": 355
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -14225,7 +14265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -14233,7 +14273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".constructor()",
@@ -14241,7 +14281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".execute()",
@@ -14249,7 +14289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 355
+      "community": 356
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -14257,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "generateId()",
@@ -14265,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 441
+      "community": 442
     },
     {
       "label": "initializeTestDatabase()",
@@ -14273,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 441
+      "community": 442
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14281,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "createQualityTables()",
@@ -14289,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 559
+      "community": 560
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14297,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "generateId()",
@@ -14305,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 442
+      "community": 443
     },
     {
       "label": "initializeTestDatabase()",
@@ -14313,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 442
+      "community": 443
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14321,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "stopwords.spec.ts",
@@ -14329,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "type-guards.ts",
@@ -14513,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "validateTableName()",
@@ -14521,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 443
+      "community": 444
     },
     {
       "label": "getVectorTableName()",
@@ -14529,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 443
+      "community": 444
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14537,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14545,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 560
+      "community": 561
     },
     {
       "label": "environment-check.ts",
@@ -14553,7 +14593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "isTestEnvironment()",
@@ -14561,7 +14601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 356
+      "community": 357
     },
     {
       "label": "isValidationDisabled()",
@@ -14569,7 +14609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 356
+      "community": 357
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -14577,7 +14617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 356
+      "community": 357
     },
     {
       "label": "db-path.spec.ts",
@@ -14585,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14593,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14601,7 +14641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -14609,7 +14649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 304
+      "community": 305
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -14617,7 +14657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 304
+      "community": 305
     },
     {
       "label": "extractKeyTokens()",
@@ -14625,7 +14665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 304
+      "community": 305
     },
     {
       "label": "getSearchQueryExamples()",
@@ -14633,7 +14673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 304
+      "community": 305
     },
     {
       "label": "relation-type-converter.ts",
@@ -14641,7 +14681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "toDbRelationType()",
@@ -14649,7 +14689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 305
+      "community": 306
     },
     {
       "label": "fromDbRelationType()",
@@ -14657,7 +14697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 305
+      "community": 306
     },
     {
       "label": "isValidDbRelationType()",
@@ -14665,7 +14705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 305
+      "community": 306
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -14673,7 +14713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 305
+      "community": 306
     },
     {
       "label": "db-path.ts",
@@ -14681,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14689,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 561
+      "community": 562
     },
     {
       "label": "error-handling.spec.ts",
@@ -14697,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "operation()",
@@ -14705,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 562
+      "community": 563
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14889,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "relation-visualizer.ts",
@@ -15289,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "issue()",
@@ -15297,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 444
+      "community": 445
     },
     {
       "label": "validateConfiguration()",
@@ -15305,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 444
+      "community": 445
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15313,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "cache-key-generator.ts",
@@ -15369,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "transactionFn()",
@@ -15377,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 445
+      "community": 446
     },
     {
       "label": "outerTransaction()",
@@ -15385,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 445
+      "community": 446
     },
     {
       "label": "write-coalescing.ts",
@@ -15473,7 +15513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "validateReflectionNote()",
@@ -15481,7 +15521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 357
+      "community": 358
     },
     {
       "label": "validateReflectionNotes()",
@@ -15489,7 +15529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 357
+      "community": 358
     },
     {
       "label": "formatValidationErrors()",
@@ -15497,7 +15537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 357
+      "community": 358
     },
     {
       "label": "environment-check.spec.ts",
@@ -15505,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "path-validator.ts",
@@ -15569,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15577,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 563
+      "community": 564
     },
     {
       "label": "error-handling.ts",
@@ -15585,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "withErrorHandling()",
@@ -15593,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 564
+      "community": 565
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15601,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15609,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15809,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15817,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 565
+      "community": 566
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15825,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "createValidReflectionNote()",
@@ -15833,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 446
+      "community": 447
     },
     {
       "label": "createLargeNote()",
@@ -15841,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 446
+      "community": 447
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15849,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "initializeTestDatabase()",
@@ -15857,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 566
+      "community": 567
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15865,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15873,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 567
+      "community": 568
     },
     {
       "label": "logging-helpers.ts",
@@ -15969,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "pii-masker.ts",
@@ -16041,7 +16081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "getStopWords()",
@@ -16049,7 +16089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 306
+      "community": 307
     },
     {
       "label": "getEnglishStopWords()",
@@ -16057,7 +16097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 306
+      "community": 307
     },
     {
       "label": "getKoreanStopWords()",
@@ -16065,7 +16105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 306
+      "community": 307
     },
     {
       "label": "isStopWord()",
@@ -16073,7 +16113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 306
+      "community": 307
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -16081,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16089,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "path-validator.spec.ts",
@@ -16097,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16105,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16113,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16121,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16129,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16137,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16145,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16153,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "initializeTestDatabase()",
@@ -16161,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 568
+      "community": 569
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16169,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16177,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "benchmark.types.ts",
@@ -16185,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "assertMacroCategory()",
@@ -16193,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 569
+      "community": 570
     },
     {
       "label": "migration.types.ts",
@@ -16201,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16209,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "consolidation.types.ts",
@@ -16217,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "vector-search.types.ts",
@@ -16225,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16233,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "procedural-versioning.ts",
@@ -16241,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "triple-extraction.ts",
@@ -16249,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "feedback.types.ts",
@@ -16257,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "embedding.types.ts",
@@ -16265,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "relation-graph.ts",
@@ -16273,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "failure-event.ts",
@@ -16281,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "index.ts",
@@ -16289,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "isMemoryItemType()",
@@ -16297,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 447
+      "community": 448
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16305,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 447
+      "community": 448
     },
     {
       "label": "error-types.ts",
@@ -16313,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "ranking.types.ts",
@@ -16321,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "alerts.types.ts",
@@ -16329,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "relation.ts",
@@ -16337,7 +16377,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "isApplicableRelationType()",
@@ -16345,7 +16385,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L151",
       "id": "relation_isapplicablerelationtype",
-      "community": 358
+      "community": 359
     },
     {
       "label": "getRelationCategory()",
@@ -16353,7 +16393,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L161",
       "id": "relation_getrelationcategory",
-      "community": 358
+      "community": 359
     },
     {
       "label": "getRelationBoost()",
@@ -16361,7 +16401,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L168",
       "id": "relation_getrelationboost",
-      "community": 358
+      "community": 359
     },
     {
       "label": "search.types.ts",
@@ -16369,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "index.spec.ts",
@@ -16377,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16385,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "constants.ts",
@@ -16393,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "environment.ts",
@@ -16537,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "retry-options-loader.ts",
@@ -16593,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "validateConfig()",
@@ -16601,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 570
+      "community": 571
     },
     {
       "label": "config-loader-utils.ts",
@@ -16673,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "constants.spec.ts",
@@ -16681,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "config-validation.spec.ts",
@@ -16689,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16697,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16705,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16713,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "relation-constants.ts",
@@ -16721,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "introspection-constants.ts",
@@ -16729,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16737,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "http-bind-policy.ts",
@@ -16817,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16825,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "cache.interface.ts",
@@ -16833,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16841,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "error-logging.interface.ts",
@@ -16849,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16857,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16865,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "database.interface.ts",
@@ -16873,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16881,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16889,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17073,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "getMockMementoConfig()",
@@ -17081,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 448
+      "community": 449
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -17089,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 448
+      "community": 449
     },
     {
       "label": "initialize.spec.ts",
@@ -17097,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "openai-client.spec.ts",
@@ -17105,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17113,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17121,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17129,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17137,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17145,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17153,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17161,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17169,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "search-local-tool.ts",
@@ -17177,7 +17217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "SearchLocalTool",
@@ -17185,7 +17225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".constructor()",
@@ -17193,7 +17233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".handle()",
@@ -17201,7 +17241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 359
+      "community": 360
     },
     {
       "label": "get-anchor-tool.ts",
@@ -17209,7 +17249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "GetAnchorTool",
@@ -17217,7 +17257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".constructor()",
@@ -17225,7 +17265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".handle()",
@@ -17233,7 +17273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 360
+      "community": 361
     },
     {
       "label": "set-anchor-tool.ts",
@@ -17241,7 +17281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "SetAnchorTool",
@@ -17249,7 +17289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".constructor()",
@@ -17257,7 +17297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".handle()",
@@ -17265,7 +17305,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 361
+      "community": 362
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -17273,7 +17313,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "ClearAnchorTool",
@@ -17281,7 +17321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".constructor()",
@@ -17289,7 +17329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".handle()",
@@ -17297,7 +17337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 362
+      "community": 363
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -17305,7 +17345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 363
+      "community": 364
     },
     {
       "label": "RestoreAnchorsTool",
@@ -17313,7 +17353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".constructor()",
@@ -17321,7 +17361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".handle()",
@@ -17329,7 +17369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 363
+      "community": 364
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -17337,7 +17377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "initializeTestDatabase()",
@@ -17345,7 +17385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17353,7 +17393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17361,7 +17401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 307
+      "community": 308
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17369,7 +17409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 307
+      "community": 308
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -17377,7 +17417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "initializeTestDatabase()",
@@ -17385,7 +17425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17393,7 +17433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17401,7 +17441,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 308
+      "community": 309
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17409,7 +17449,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 308
+      "community": 309
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -17417,7 +17457,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "initializeTestDatabase()",
@@ -17425,7 +17465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 309
+      "community": 310
     },
     {
       "label": "createMockEmbeddingService()",
@@ -17433,7 +17473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 309
+      "community": 310
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -17441,7 +17481,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 309
+      "community": 310
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -17449,7 +17489,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 309
+      "community": 310
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -17457,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "initializeTestDatabase()",
@@ -17465,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 571
+      "community": 572
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17473,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "initializeTestDatabase()",
@@ -17481,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 572
+      "community": 573
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17489,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17497,7 +17537,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "QueryFilterStrategy",
@@ -17505,7 +17545,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".constructor()",
@@ -17513,7 +17553,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".filter()",
@@ -17521,7 +17561,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".execute()",
@@ -17529,7 +17569,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 310
+      "community": 311
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -17537,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17545,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "local-search-service.ts",
@@ -17617,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17625,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17753,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17761,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17769,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 573
+      "community": 574
     },
     {
       "label": "embedding-types.ts",
@@ -17777,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17785,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -17793,7 +17833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 311
+      "community": 312
     },
     {
       "label": "NHopSearchStrategy",
@@ -17801,7 +17841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".constructor()",
@@ -17809,7 +17849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".search()",
@@ -17817,7 +17857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 311
+      "community": 312
     },
     {
       "label": ".execute()",
@@ -17825,7 +17865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 311
+      "community": 312
     },
     {
       "label": "query-filter-service.ts",
@@ -17993,7 +18033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "FallbackSearchService",
@@ -18001,7 +18041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".setDatabase()",
@@ -18009,7 +18049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -18017,7 +18057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 312
+      "community": 313
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -18025,7 +18065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 312
+      "community": 313
     },
     {
       "label": "index.ts",
@@ -18033,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "fallback-strategy.ts",
@@ -18041,7 +18081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "FallbackStrategy",
@@ -18049,7 +18089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".constructor()",
@@ -18057,7 +18097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".fallback()",
@@ -18065,7 +18105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".execute()",
@@ -18073,7 +18113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 313
+      "community": 314
     },
     {
       "label": "anchor-search-service.ts",
@@ -18217,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18465,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18473,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18481,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "vector-search.factory.ts",
@@ -18609,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18617,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 574
+      "community": 575
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18625,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "search-result-combiner.ts",
@@ -18633,7 +18673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 364
+      "community": 365
     },
     {
       "label": "SearchResultCombiner",
@@ -18641,7 +18681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L19",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".combine()",
@@ -18649,7 +18689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L31",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".generateHybridReason()",
@@ -18657,7 +18697,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L103",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 364
+      "community": 365
     },
     {
       "label": "search-engine.ts",
@@ -18809,7 +18849,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 365
+      "community": 366
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -18817,7 +18857,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 365
+      "community": 366
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -18825,7 +18865,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 365
+      "community": 366
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -18833,7 +18873,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 365
+      "community": 366
     },
     {
       "label": "search-ranking.ts",
@@ -19697,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19705,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 575
+      "community": 576
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19825,7 +19865,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 366
+      "community": 367
     },
     {
       "label": "normalize()",
@@ -19833,7 +19873,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 366
+      "community": 367
     },
     {
       "label": "toSet()",
@@ -19841,7 +19881,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 366
+      "community": 367
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -19849,7 +19889,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 366
+      "community": 367
     },
     {
       "label": "procedural-memory-matcher.spec.ts",
@@ -19857,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19865,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19873,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "initializeTestDatabase()",
@@ -19881,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 449
+      "community": 450
     },
     {
       "label": "createValidReflectionNote()",
@@ -19889,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 449
+      "community": 450
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -19969,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -19977,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "search-engine.spec.ts",
@@ -19985,7 +20025,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 367
+      "community": 368
     },
     {
       "label": "createCountingSearchDb()",
@@ -19993,7 +20033,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 367
+      "community": 368
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -20001,7 +20041,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 367
+      "community": 368
     },
     {
       "label": "createSearchRows()",
@@ -20009,7 +20049,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 367
+      "community": 368
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -20017,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "vector-search.repository.ts",
@@ -20209,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20217,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "vector-search.service.ts",
@@ -20313,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20321,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 576
+      "community": 577
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20385,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "createMockRepository()",
@@ -20393,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 577
+      "community": 578
     },
     {
       "label": "vector-index-manager.ts",
@@ -20657,7 +20697,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "selectScore()",
@@ -20665,7 +20705,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 314
+      "community": 315
     },
     {
       "label": "computeNormalizationRange()",
@@ -20673,7 +20713,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 314
+      "community": 315
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -20681,7 +20721,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".normalize()",
@@ -20689,7 +20729,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 314
+      "community": 315
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -20697,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "createMockRepositories()",
@@ -20705,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20713,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20721,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "createMockIndexRepository()",
@@ -20729,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 579
+      "community": 580
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20905,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20913,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20921,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "spaced-repetition.ts",
@@ -21249,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21257,7 +21297,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 368
+      "community": 369
     },
     {
       "label": "ForgettingStatsTool",
@@ -21265,7 +21305,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".constructor()",
@@ -21273,7 +21313,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".handle()",
@@ -21281,7 +21321,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 368
+      "community": 369
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -21289,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21425,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21433,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22313,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "recall-probability.service.ts",
@@ -22417,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "telemetry.types.ts",
@@ -22425,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22433,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "openTelemetryDb()",
@@ -22441,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 580
+      "community": 581
     },
     {
       "label": "telemetry-repository.ts",
@@ -22601,7 +22641,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "makeSearchQuality()",
@@ -22609,7 +22649,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 315
+      "community": 316
     },
     {
       "label": "makeMemoryQuality()",
@@ -22617,7 +22657,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 315
+      "community": 316
     },
     {
       "label": "makeConsolidationQuality()",
@@ -22625,7 +22665,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 315
+      "community": 316
     },
     {
       "label": "makeContext()",
@@ -22633,7 +22673,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 315
+      "community": 316
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -22641,7 +22681,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 369
+      "community": 370
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -22649,7 +22689,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".constructor()",
@@ -22657,7 +22697,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".handle()",
@@ -22665,7 +22705,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 369
+      "community": 370
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -22673,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "telemetry-service.ts",
@@ -22801,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22809,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22817,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22825,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22833,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 581
+      "community": 582
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22841,7 +22881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 370
+      "community": 371
     },
     {
       "label": "baseTags()",
@@ -22849,7 +22889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 370
+      "community": 371
     },
     {
       "label": "pushUnique()",
@@ -22857,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 370
+      "community": 371
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -22865,7 +22905,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 370
+      "community": 371
     },
     {
       "label": "llm-port.ts",
@@ -22873,7 +22913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "persistence-port.ts",
@@ -22881,7 +22921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "context-port.ts",
@@ -22889,7 +22929,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "agent-types.ts",
@@ -22897,7 +22937,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -22905,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -22913,7 +22953,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "parseRememberSuccess()",
@@ -22921,7 +22961,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 316
+      "community": 317
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -22929,7 +22969,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".constructor()",
@@ -22937,7 +22977,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 316
+      "community": 317
     },
     {
       "label": ".persistApproved()",
@@ -22945,7 +22985,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 316
+      "community": 317
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -22953,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 317
+      "community": 318
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -22961,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".constructor()",
@@ -22969,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".buildContext()",
@@ -22977,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".proposeCandidates()",
@@ -22985,7 +23025,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 317
+      "community": 318
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -22993,7 +23033,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 318
+      "community": 319
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -23001,7 +23041,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".constructor()",
@@ -23009,7 +23049,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".complete()",
@@ -23017,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".createRequestId()",
@@ -23025,7 +23065,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 318
+      "community": 319
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -23033,7 +23073,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23041,7 +23081,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "baseCandidate()",
@@ -23049,7 +23089,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 582
+      "community": 583
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23057,7 +23097,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 319
+      "community": 320
     },
     {
       "label": "normalizeOwnerId()",
@@ -23065,7 +23105,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 319
+      "community": 320
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -23073,7 +23113,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 319
+      "community": 320
     },
     {
       "label": "assertUnreachable()",
@@ -23081,7 +23121,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 319
+      "community": 320
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -23089,7 +23129,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 319
+      "community": 320
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -23097,7 +23137,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "makeDeps()",
@@ -23105,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 583
+      "community": 584
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23113,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 320
+      "community": 321
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -23121,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 320
+      "community": 321
     },
     {
       "label": ".constructor()",
@@ -23129,7 +23169,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 320
+      "community": 321
     },
     {
       "label": ".runOneTurn()",
@@ -23137,7 +23177,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 320
+      "community": 321
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -23145,7 +23185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 320
+      "community": 321
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -23153,7 +23193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23161,7 +23201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 584
+      "community": 585
     },
     {
       "label": "core-memory-repository.ts",
@@ -23169,7 +23209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23177,7 +23217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23185,7 +23225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23193,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23201,7 +23241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "feedback-repository.ts",
@@ -23209,7 +23249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23217,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 450
+      "community": 451
     },
     {
       "label": "FeedbackRepository",
@@ -23225,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 450
+      "community": 451
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23233,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23241,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 875
+      "community": 876
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23249,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 876
+      "community": 877
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23257,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 877
+      "community": 878
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23265,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 878
+      "community": 879
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23273,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "createKgTripleTable()",
@@ -23281,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 585
+      "community": 586
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23289,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23297,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 586
+      "community": 587
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23305,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23313,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23321,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 879
+      "community": 880
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23329,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23337,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 588
+      "community": 589
     },
     {
       "label": "remember-tool.ts",
@@ -23425,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "validateRecallQuery()",
@@ -23433,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 451
+      "community": 452
     },
     {
       "label": "validateRecallFilters()",
@@ -23441,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 451
+      "community": 452
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23449,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23457,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 589
+      "community": 590
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23465,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 371
+      "community": 372
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23473,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".constructor()",
@@ -23481,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".handle()",
@@ -23489,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 371
+      "community": 372
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23497,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 372
+      "community": 373
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23505,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".constructor()",
@@ -23513,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".handle()",
@@ -23521,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 372
+      "community": 373
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23529,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23537,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".constructor()",
@@ -23545,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".handle()",
@@ -23553,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 373
+      "community": 374
     },
     {
       "label": "feedback-tool.ts",
@@ -23609,7 +23649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "CleanupMemoryTool",
@@ -23617,7 +23657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23625,7 +23665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -23633,7 +23673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 374
+      "community": 375
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23641,7 +23681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23649,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 452
+      "community": 453
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23657,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 452
+      "community": 453
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -23857,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "ProceduralDiffTool",
@@ -23865,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23873,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23881,7 +23921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "unpin-tool.ts",
@@ -24001,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -24009,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -24017,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -24025,7 +24065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -24033,7 +24073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "RememberProcedureTool",
@@ -24041,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -24049,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -24057,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 377
+      "community": 378
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -24065,7 +24105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -24073,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 321
+      "community": 322
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -24081,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 321
+      "community": 322
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -24089,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 321
+      "community": 322
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -24097,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 321
+      "community": 322
     },
     {
       "label": "recall-tool-results.ts",
@@ -24105,7 +24145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24113,7 +24153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 590
+      "community": 591
     },
     {
       "label": "recall-tool.ts",
@@ -24249,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 880
+      "community": 881
     },
     {
       "label": "forget-tool.ts",
@@ -24393,7 +24433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createSchema()",
@@ -24401,7 +24441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 591
+      "community": 592
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24409,7 +24449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 881
+      "community": 882
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24417,7 +24457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "initializeTestDatabase()",
@@ -24425,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 453
+      "community": 454
     },
     {
       "label": "createValidReflectionNote()",
@@ -24433,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 453
+      "community": 454
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24441,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 882
+      "community": 883
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24449,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createSchema()",
@@ -24457,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 592
+      "community": 593
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24465,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "generateId()",
@@ -24473,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 378
+      "community": 379
     },
     {
       "label": "initializeTestDatabase()",
@@ -24481,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 378
+      "community": 379
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24489,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 378
+      "community": 379
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24497,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 883
+      "community": 884
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24505,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 884
+      "community": 885
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24513,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "initializeTestDatabase()",
@@ -24521,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 593
+      "community": 594
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24529,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "parseData()",
@@ -24537,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 594
+      "community": 595
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24545,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 885
+      "community": 886
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24553,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "initializeTestDatabase()",
@@ -24561,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 454
+      "community": 455
     },
     {
       "label": "createValidReflectionNote()",
@@ -24569,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 454
+      "community": 455
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24577,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 886
+      "community": 887
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24585,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 887
+      "community": 888
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24593,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 888
+      "community": 889
     },
     {
       "label": "meta-memory-service.ts",
@@ -24721,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "fieldDiff()",
@@ -24729,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 379
+      "community": 380
     },
     {
       "label": "parseStepsJson()",
@@ -24737,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 379
+      "community": 380
     },
     {
       "label": "computeProceduralDiff()",
@@ -24745,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 379
+      "community": 380
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24753,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -24761,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".constructor()",
@@ -24769,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".notFound()",
@@ -24777,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".notActionable()",
@@ -24785,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 322
+      "community": 323
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -24793,7 +24833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24801,7 +24841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 380
+      "community": 381
     },
     {
       "label": "parsePositiveInt()",
@@ -24809,7 +24849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 380
+      "community": 381
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24817,7 +24857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 380
+      "community": 381
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -24825,7 +24865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "createBaseSchema()",
@@ -24833,7 +24873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 595
+      "community": 596
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -24913,7 +24953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "baseRow()",
@@ -24921,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 596
+      "community": 597
     },
     {
       "label": "procedural-versioning.ts",
@@ -24929,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "getVersionChain()",
@@ -24937,7 +24977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 381
+      "community": 382
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -24945,7 +24985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 381
+      "community": 382
     },
     {
       "label": "getNextVersionNumber()",
@@ -24953,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 381
+      "community": 382
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -24961,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -24969,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 455
+      "community": 456
     },
     {
       "label": ".runScan()",
@@ -24977,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 455
+      "community": 456
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -24985,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "generateMemoryId()",
@@ -24993,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 456
+      "community": 457
     },
     {
       "label": "rollbackToVersion()",
@@ -25001,7 +25041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 456
+      "community": 457
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25073,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "selectionWindowLimit()",
@@ -25081,7 +25121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 457
+      "community": 458
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25089,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 457
+      "community": 458
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25097,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 323
+      "community": 324
     },
     {
       "label": "IntrospectionScanCache",
@@ -25105,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".set()",
@@ -25113,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".get()",
@@ -25121,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".clear()",
@@ -25129,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 323
+      "community": 324
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -25137,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 889
+      "community": 890
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25145,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25153,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 597
+      "community": 598
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25161,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "openDb()",
@@ -25169,7 +25209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 598
+      "community": 599
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25761,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "createBaseSchema()",
@@ -25769,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 599
+      "community": 600
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26033,7 +26073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 890
+      "community": 891
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26041,7 +26081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26049,7 +26089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 458
+      "community": 459
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26057,7 +26097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 458
+      "community": 459
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26065,7 +26105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 891
+      "community": 892
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26073,7 +26113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 892
+      "community": 893
     },
     {
       "label": "core-memory-service.ts",
@@ -26233,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "createBaseSchema()",
@@ -26241,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 600
+      "community": 601
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26249,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26257,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 601
+      "community": 602
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26337,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 893
+      "community": 894
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26345,7 +26385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 894
+      "community": 895
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26353,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "createSchema()",
@@ -26361,7 +26401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 602
+      "community": 603
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26369,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 895
+      "community": 896
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26377,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createSchema()",
@@ -26385,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 603
+      "community": 604
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26393,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 896
+      "community": 897
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26401,7 +26441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createBaseSchema()",
@@ -26409,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 604
+      "community": 605
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26417,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 897
+      "community": 898
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26425,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createSchema()",
@@ -26433,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26441,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 898
+      "community": 899
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26449,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 899
+      "community": 900
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26569,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 900
+      "community": 901
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26833,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 901
+      "community": 902
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26841,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26849,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26857,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 902
+      "community": 903
     },
     {
       "label": "consolidation-repository.ts",
@@ -27089,7 +27129,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "row()",
@@ -27097,7 +27137,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 607
+      "community": 608
     },
     {
       "label": "summarization-service.ts",
@@ -27153,7 +27193,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 324
+      "community": 325
     },
     {
       "label": "insertEpisodic()",
@@ -27161,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 324
+      "community": 325
     },
     {
       "label": "insertEmbedding()",
@@ -27169,7 +27209,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 324
+      "community": 325
     },
     {
       "label": "FailingRepo",
@@ -27177,7 +27217,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".insertSemanticMemory()",
@@ -27185,7 +27225,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 324
+      "community": 325
     },
     {
       "label": "clustering-service.spec.ts",
@@ -27193,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "ep()",
@@ -27201,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 608
+      "community": 609
     },
     {
       "label": "relation-graph.port.ts",
@@ -27209,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 903
+      "community": 904
     },
     {
       "label": "get-relations-tool.ts",
@@ -27217,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "GetRelationsTool",
@@ -27225,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 382
+      "community": 383
     },
     {
       "label": ".constructor()",
@@ -27233,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 382
+      "community": 383
     },
     {
       "label": ".handle()",
@@ -27241,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 382
+      "community": 383
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27249,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27257,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 609
+      "community": 610
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27265,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27273,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".constructor()",
@@ -27281,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".handle()",
@@ -27289,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 383
+      "community": 384
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27297,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "RemoveRelationTool",
@@ -27305,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".constructor()",
@@ -27313,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".handle()",
@@ -27321,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 384
+      "community": 385
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27329,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "ExtractRelationsTool",
@@ -27337,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".constructor()",
@@ -27345,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".handle()",
@@ -27353,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 385
+      "community": 386
     },
     {
       "label": "add-relation-tool.ts",
@@ -27361,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "AddRelationTool",
@@ -27369,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27377,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".handle()",
@@ -27385,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 386
+      "community": 387
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27441,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createBaseSchema()",
@@ -27449,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createTestMemory()",
@@ -27457,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 459
+      "community": 460
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27465,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createBaseSchema()",
@@ -27473,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createTestMemory()",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 460
+      "community": 461
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createBaseSchema()",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createTestMemory()",
@@ -27505,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 461
+      "community": 462
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27513,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 904
+      "community": 905
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27521,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createBaseSchema()",
@@ -27529,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createTestMemory()",
@@ -27537,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27545,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "RelationRetryManager",
@@ -27553,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -27561,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".retry()",
@@ -27569,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 387
+      "community": 388
     },
     {
       "label": "relation-errors.ts",
@@ -28321,7 +28361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "loadTestDataset()",
@@ -28329,7 +28369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createBaseSchema()",
@@ -28337,7 +28377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 388
+      "community": 389
     },
     {
       "label": "createTestMemory()",
@@ -28345,7 +28385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 388
+      "community": 389
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28353,7 +28393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 905
+      "community": 906
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28361,7 +28401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createBaseSchema()",
@@ -28369,7 +28409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createTestMemory()",
@@ -28377,7 +28417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 463
+      "community": 464
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28385,7 +28425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "createTestMemory()",
@@ -28393,7 +28433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 610
+      "community": 611
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28401,7 +28441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createBaseSchema()",
@@ -28409,7 +28449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createTestMemory()",
@@ -28417,7 +28457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createBulkMemories()",
@@ -28425,7 +28465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 389
+      "community": 390
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28433,7 +28473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "createTestMemory()",
@@ -28441,7 +28481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 611
+      "community": 612
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28505,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 906
+      "community": 907
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28513,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 907
+      "community": 908
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28521,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "getMockMementoConfig()",
@@ -28529,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 464
+      "community": 465
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28537,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 464
+      "community": 465
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28545,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 908
+      "community": 909
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28553,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 909
+      "community": 910
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28561,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 910
+      "community": 911
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28569,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 911
+      "community": 912
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28577,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 325
+      "community": 326
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -28585,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 325
+      "community": 326
     },
     {
       "label": ".constructor()",
@@ -28593,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 325
+      "community": 326
     },
     {
       "label": ".consume()",
@@ -28601,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 325
+      "community": 326
     },
     {
       "label": ".refill()",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 325
+      "community": 326
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -28617,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28625,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 390
+      "community": 391
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28633,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28641,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 390
+      "community": 391
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -28889,7 +28929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "extract()",
@@ -28897,7 +28937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 612
+      "community": 613
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -28905,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "tripleDedupeKey()",
@@ -28913,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 465
+      "community": 466
     },
     {
       "label": "mergeTripleLists()",
@@ -28921,7 +28961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 465
+      "community": 466
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -28929,7 +28969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 912
+      "community": 913
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -28937,7 +28977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 326
+      "community": 327
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -28945,7 +28985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 326
+      "community": 327
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -28953,7 +28993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L38",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 326
+      "community": 327
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -28961,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L71",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 326
+      "community": 327
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -28969,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L105",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 326
+      "community": 327
     },
     {
       "label": "triple-extraction-service.ts",
@@ -29113,7 +29153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 913
+      "community": 914
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29121,7 +29161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 914
+      "community": 915
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29129,7 +29169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 915
+      "community": 916
     },
     {
       "label": "triple-extractor.ts",
@@ -29273,7 +29313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "TripleNormalizer",
@@ -29281,7 +29321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 391
+      "community": 392
     },
     {
       "label": ".constructor()",
@@ -29289,7 +29329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 391
+      "community": 392
     },
     {
       "label": ".normalize()",
@@ -29297,7 +29337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 391
+      "community": 392
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29305,7 +29345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 916
+      "community": 917
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29313,7 +29353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29321,7 +29361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 392
+      "community": 393
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29329,7 +29369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 392
+      "community": 393
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29337,7 +29377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 392
+      "community": 393
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29345,7 +29385,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 917
+      "community": 918
     },
     {
       "label": "triple-parser.ts",
@@ -29353,7 +29393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "TripleParser",
@@ -29361,7 +29401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 327
+      "community": 328
     },
     {
       "label": ".parse()",
@@ -29369,7 +29409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 327
+      "community": 328
     },
     {
       "label": ".extractJSON()",
@@ -29377,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 327
+      "community": 328
     },
     {
       "label": ".isValidTriple()",
@@ -29385,7 +29425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 327
+      "community": 328
     },
     {
       "label": "triple-text-chunker.ts",
@@ -29393,7 +29433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29401,7 +29441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 613
+      "community": 614
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29409,7 +29449,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29417,7 +29457,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 614
+      "community": 615
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29505,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 918
+      "community": 919
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29513,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 919
+      "community": 920
     },
     {
       "label": "interfaces.spec.ts",
@@ -29521,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 920
+      "community": 921
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29529,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 921
+      "community": 922
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29537,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 922
+      "community": 923
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29545,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29553,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 615
+      "community": 616
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29561,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29569,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 616
+      "community": 617
     },
     {
       "label": "types.ts",
@@ -29577,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 923
+      "community": 924
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29585,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "checkOllamaModel()",
@@ -29593,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 393
+      "community": 394
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29601,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 393
+      "community": 394
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29609,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 393
+      "community": 394
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29617,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29625,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 617
+      "community": 618
     },
     {
       "label": "provider-selection.ts",
@@ -29633,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29641,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 466
+      "community": 467
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29649,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 466
+      "community": 467
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29657,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29665,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 618
+      "community": 619
     },
     {
       "label": "llm-response-parse.ts",
@@ -29673,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -29681,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 328
+      "community": 329
     },
     {
       "label": "trimToValidJsonObject()",
@@ -29689,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 328
+      "community": 329
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -29697,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 328
+      "community": 329
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -29705,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 328
+      "community": 329
     },
     {
       "label": "embedding-provider-factory.ts",
@@ -29945,7 +29985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "createMockService()",
@@ -29953,7 +29993,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 394
+      "community": 395
     },
     {
       "label": "resolver()",
@@ -29961,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 394
+      "community": 395
     },
     {
       "label": "priority()",
@@ -29969,7 +30009,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 394
+      "community": 395
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -29977,7 +30017,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 924
+      "community": 925
     },
     {
       "label": "embedding-service.ts",
@@ -31089,7 +31129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 925
+      "community": 926
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31097,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 926
+      "community": 927
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31105,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "createSchema()",
@@ -31113,7 +31153,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 467
+      "community": 468
     },
     {
       "label": "seedMemoryItem()",
@@ -31121,7 +31161,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 467
+      "community": 468
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31129,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 927
+      "community": 928
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31137,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 928
+      "community": 929
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31145,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 929
+      "community": 930
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31153,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31161,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".constructor()",
@@ -31169,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".handle()",
@@ -31177,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 395
+      "community": 396
     },
     {
       "label": "performance-alerts.ts",
@@ -31233,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "PerformanceStatsTool",
@@ -31241,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 396
+      "community": 397
     },
     {
       "label": ".constructor()",
@@ -31249,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 396
+      "community": 397
     },
     {
       "label": ".handle()",
@@ -31257,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 396
+      "community": 397
     },
     {
       "label": "resolve-error.ts",
@@ -31265,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "executeResolveError()",
@@ -31273,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 619
+      "community": 620
     },
     {
       "label": "error-stats.ts",
@@ -31281,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "executeErrorStats()",
@@ -31289,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 620
+      "community": 621
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31297,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 930
+      "community": 931
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 931
+      "community": 932
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "createBaseSchema()",
@@ -31321,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 621
+      "community": 622
     },
     {
       "label": "error-stats.spec.ts",
@@ -31329,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 932
+      "community": 933
     },
     {
       "label": "performance-monitor.ts",
@@ -32241,7 +32281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 933
+      "community": 934
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32249,7 +32289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 934
+      "community": 935
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32257,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 935
+      "community": 936
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32265,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 936
+      "community": 937
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32273,7 +32313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "toBytes()",
@@ -32281,7 +32321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 329
+      "community": 330
     },
     {
       "label": "createMetrics()",
@@ -32289,7 +32329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 329
+      "community": 330
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -32297,7 +32337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 329
+      "community": 330
     },
     {
       "label": "makeMonitor()",
@@ -32305,7 +32345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 329
+      "community": 330
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -32313,7 +32353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "restoreEnvValue()",
@@ -32321,7 +32361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 622
+      "community": 623
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32329,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32337,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32345,7 +32385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32353,7 +32393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "quality-recorder.ts",
@@ -32425,7 +32465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32433,7 +32473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 623
+      "community": 624
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32513,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32521,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 624
+      "community": 625
     },
     {
       "label": "quality-reporter.ts",
@@ -32609,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32617,7 +32657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32625,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32633,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32641,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 937
+      "community": 938
     },
     {
       "label": "quality-assurance-service.ts",
@@ -32921,7 +32961,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32929,7 +32969,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32937,7 +32977,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32945,7 +32985,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -33137,7 +33177,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 938
+      "community": 939
     },
     {
       "label": "base-tool.ts",
@@ -33433,7 +33473,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33441,7 +33481,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 625
+      "community": 626
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33449,7 +33489,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "measureRecall()",
@@ -33457,7 +33497,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 626
+      "community": 627
     },
     {
       "label": "test-embedding.ts",
@@ -33465,7 +33505,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33473,7 +33513,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 627
+      "community": 628
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33481,7 +33521,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "compareToolResults()",
@@ -33489,7 +33529,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 468
+      "community": 469
     },
     {
       "label": "testToolConsistency()",
@@ -33497,7 +33537,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 468
+      "community": 469
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33505,7 +33545,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "createQualityTables()",
@@ -33513,7 +33553,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 469
+      "community": 470
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33521,7 +33561,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 469
+      "community": 470
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33529,7 +33569,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "PerformanceBenchmark",
@@ -33537,7 +33577,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 330
+      "community": 331
     },
     {
       "label": ".measureOperation()",
@@ -33545,7 +33585,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 330
+      "community": 331
     },
     {
       "label": ".getResults()",
@@ -33553,7 +33593,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 330
+      "community": 331
     },
     {
       "label": ".getSummary()",
@@ -33561,7 +33601,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 330
+      "community": 331
     },
     {
       "label": "test-search.ts",
@@ -33569,7 +33609,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "testSearchFunctionality()",
@@ -33577,7 +33617,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 628
+      "community": 629
     },
     {
       "label": "test-forgetting.ts",
@@ -33585,7 +33625,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33593,7 +33633,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 629
+      "community": 630
     },
     {
       "label": "mock-database.spec.ts",
@@ -33601,7 +33641,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 939
+      "community": 940
     },
     {
       "label": "test-m1-completion.ts",
@@ -33609,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "testM1Completion()",
@@ -33617,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 630
+      "community": 631
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33625,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33633,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 631
+      "community": 632
     },
     {
       "label": "vitest.setup.ts",
@@ -33641,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 940
+      "community": 941
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "parseItems()",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 632
+      "community": 633
     },
     {
       "label": "test-memory-resource.ts",
@@ -33665,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "setupResourceHandlers()",
@@ -33673,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 470
+      "community": 471
     },
     {
       "label": "createTestMemories()",
@@ -33681,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 470
+      "community": 471
     },
     {
       "label": "test-regression.ts",
@@ -33689,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testRegression()",
@@ -33697,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 633
+      "community": 634
     },
     {
       "label": "test-anchor-system.ts",
@@ -33761,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 941
+      "community": 942
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33833,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33841,7 +33881,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 634
+      "community": 635
     },
     {
       "label": "visualize-recency.ts",
@@ -33905,7 +33945,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 942
+      "community": 943
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -33969,7 +34009,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "constructor()",
@@ -33977,7 +34017,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 635
+      "community": 636
     },
     {
       "label": "mock-database.ts",
@@ -34209,7 +34249,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 943
+      "community": 944
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34217,7 +34257,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "telemetryDb()",
@@ -34225,7 +34265,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 400
+      "community": 401
     },
     {
       "label": "percentile95()",
@@ -34233,7 +34273,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 400
+      "community": 401
     },
     {
       "label": "run()",
@@ -34241,7 +34281,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 400
+      "community": 401
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34249,7 +34289,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "createTestMemories()",
@@ -34257,7 +34297,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34265,7 +34305,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34273,7 +34313,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34281,7 +34321,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 944
+      "community": 945
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34289,7 +34329,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "seedCluster()",
@@ -34297,7 +34337,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 638
+      "community": 639
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34305,7 +34345,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "readSource()",
@@ -34313,7 +34353,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 471
+      "community": 472
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34321,7 +34361,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 471
+      "community": 472
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34329,7 +34369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34337,7 +34377,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 401
+      "community": 402
     },
     {
       "label": "normalizeTags()",
@@ -34345,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 401
+      "community": 402
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34353,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 401
+      "community": 402
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34361,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "writeFixtureDir()",
@@ -34369,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 639
+      "community": 640
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34465,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 945
+      "community": 946
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34529,7 +34569,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "normalizeMemoryType()",
@@ -34537,7 +34577,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34545,7 +34585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 402
+      "community": 403
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34553,7 +34593,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 402
+      "community": 403
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34561,7 +34601,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 946
+      "community": 947
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34569,7 +34609,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 947
+      "community": 948
     },
     {
       "label": "test-database.ts",
@@ -34601,7 +34641,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "mergeCandidateIds()",
@@ -34609,7 +34649,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 640
+      "community": 641
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34617,7 +34657,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34625,7 +34665,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 472
+      "community": 473
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34633,7 +34673,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 472
+      "community": 473
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34641,7 +34681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 948
+      "community": 949
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34649,7 +34689,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 949
+      "community": 950
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34849,7 +34889,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 950
+      "community": 951
     },
     {
       "label": "query-counter.ts",
@@ -34857,7 +34897,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "extractQueryType()",
@@ -34865,7 +34905,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 403
+      "community": 404
     },
     {
       "label": "isExcluded()",
@@ -34873,7 +34913,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 403
+      "community": 404
     },
     {
       "label": "createQueryCounter()",
@@ -34881,7 +34921,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 403
+      "community": 404
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35249,7 +35289,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 641
+      "community": 642
     },
     {
       "label": "copyDir()",
@@ -35257,7 +35297,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 641
+      "community": 642
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35265,7 +35305,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "readRootPackageJson()",
@@ -35273,7 +35313,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 642
+      "community": 643
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35281,7 +35321,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "readJson()",
@@ -35289,7 +35329,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 643
+      "community": 644
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35297,7 +35337,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "readWorkflow()",
@@ -35305,7 +35345,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 644
+      "community": 645
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35369,7 +35409,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "readStaticFile()",
@@ -35377,7 +35417,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 645
+      "community": 646
     },
     {
       "label": "smoke.spec.ts",
@@ -35385,7 +35425,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "extractFencedBlocks()",
@@ -35393,7 +35433,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 646
+      "community": 647
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35465,7 +35505,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "parseArgs()",
@@ -35473,7 +35513,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 404
+      "community": 405
     },
     {
       "label": "printHelp()",
@@ -35481,7 +35521,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 404
+      "community": 405
     },
     {
       "label": "main()",
@@ -35489,7 +35529,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 404
+      "community": 405
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35577,7 +35617,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 647
+      "community": 648
     },
     {
       "label": "shouldInclude()",
@@ -35585,7 +35625,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 647
+      "community": 648
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35593,7 +35633,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 473
+      "community": 474
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35601,7 +35641,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 473
+      "community": 474
     },
     {
       "label": "readTarString()",
@@ -35609,7 +35649,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 473
+      "community": 474
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35673,7 +35713,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 648
+      "community": 649
     },
     {
       "label": "fixMigration()",
@@ -35681,7 +35721,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 648
+      "community": 649
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35689,7 +35729,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 951
+      "community": 952
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35753,7 +35793,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "parseArgs()",
@@ -35761,7 +35801,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 405
+      "community": 406
     },
     {
       "label": "printHelp()",
@@ -35769,7 +35809,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 405
+      "community": 406
     },
     {
       "label": "main()",
@@ -35777,7 +35817,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 405
+      "community": 406
     },
     {
       "label": "check-path-traversal.ts",
@@ -35977,7 +36017,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "parseArgs()",
@@ -35985,7 +36025,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 331
+      "community": 332
     },
     {
       "label": "printHelp()",
@@ -35993,7 +36033,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 331
+      "community": 332
     },
     {
       "label": "printThresholds()",
@@ -36001,7 +36041,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 331
+      "community": 332
     },
     {
       "label": "main()",
@@ -36009,7 +36049,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 331
+      "community": 332
     },
     {
       "label": "simple-update.js",
@@ -36017,7 +36057,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 649
+      "community": 650
     },
     {
       "label": "updateEmbeddings()",
@@ -36025,7 +36065,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 649
+      "community": 650
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36193,7 +36233,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36201,7 +36241,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 650
+      "community": 651
     },
     {
       "label": "test-docker.js",
@@ -36209,7 +36249,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 651
+      "community": 652
     },
     {
       "label": "testDockerServer()",
@@ -36217,7 +36257,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 651
+      "community": 652
     },
     {
       "label": "pack-with-restore.js",
@@ -36225,7 +36265,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 952
+      "community": 953
     },
     {
       "label": "run-migration.js",
@@ -36233,7 +36273,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 652
+      "community": 653
     },
     {
       "label": "runMigration()",
@@ -36241,7 +36281,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 652
+      "community": 653
     },
     {
       "label": "safe-migration.js",
@@ -36249,7 +36289,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "safeMigration()",
@@ -36257,7 +36297,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 653
+      "community": 654
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36321,7 +36361,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "saveWorkMemory()",
@@ -36329,7 +36369,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 654
+      "community": 655
     },
     {
       "label": "check-file-sizes.ts",
@@ -36497,7 +36537,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 953
+      "community": 954
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36505,7 +36545,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "main()",
@@ -36513,7 +36553,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 655
+      "community": 656
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36521,7 +36561,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "parseArgs()",
@@ -36529,7 +36569,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 406
+      "community": 407
     },
     {
       "label": "printHelp()",
@@ -36537,7 +36577,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 406
+      "community": 407
     },
     {
       "label": "main()",
@@ -36545,7 +36585,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 406
+      "community": 407
     },
     {
       "label": "verify-bin.js",
@@ -36553,7 +36593,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 954
+      "community": 955
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36561,7 +36601,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "getTriggerInfo()",
@@ -36569,7 +36609,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 332
+      "community": 333
     },
     {
       "label": "fixTriggers()",
@@ -36577,7 +36617,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 332
+      "community": 333
     },
     {
       "label": "checkMigrationVersion()",
@@ -36585,7 +36625,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 332
+      "community": 333
     },
     {
       "label": "main()",
@@ -36593,7 +36633,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 332
+      "community": 333
     },
     {
       "label": "simple-migrate.js",
@@ -36601,7 +36641,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 656
+      "community": 657
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36609,7 +36649,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 656
+      "community": 657
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36617,7 +36657,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 657
+      "community": 658
     },
     {
       "label": "fixVectorDimensions()",
@@ -36625,7 +36665,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 657
+      "community": 658
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36633,7 +36673,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36641,7 +36681,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 407
+      "community": 408
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36649,7 +36689,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 407
+      "community": 408
     },
     {
       "label": "main()",
@@ -36657,7 +36697,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 407
+      "community": 408
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36665,7 +36705,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "loadVecExtension()",
@@ -36673,7 +36713,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 474
+      "community": 475
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36681,7 +36721,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 474
+      "community": 475
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36689,7 +36729,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "runUpdateMigration()",
@@ -36697,7 +36737,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 658
+      "community": 659
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36705,7 +36745,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "reappearanceRate()",
@@ -36713,7 +36753,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 475
+      "community": 476
     },
     {
       "label": "main()",
@@ -36721,7 +36761,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 475
+      "community": 476
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36729,7 +36769,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 659
+      "community": 660
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36737,7 +36777,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 659
+      "community": 660
     },
     {
       "label": "generate-relation-report.ts",
@@ -36889,7 +36929,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "sampleReport()",
@@ -36897,7 +36937,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 660
+      "community": 661
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -36905,7 +36945,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 955
+      "community": 956
     },
     {
       "label": "debug-embeddings.js",
@@ -36913,7 +36953,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 661
+      "community": 662
     },
     {
       "label": "debugEmbeddings()",
@@ -36921,7 +36961,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 661
+      "community": 662
     },
     {
       "label": "check-db-integrity.js",
@@ -36929,7 +36969,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 408
+      "community": 409
     },
     {
       "label": "log()",
@@ -36937,7 +36977,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 408
+      "community": 409
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -36945,7 +36985,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 408
+      "community": 409
     },
     {
       "label": "main()",
@@ -36953,7 +36993,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 408
+      "community": 409
     },
     {
       "label": "mcp-http-client.js",
@@ -37193,7 +37233,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 662
+      "community": 663
     },
     {
       "label": "backupEmbeddings()",
@@ -37201,7 +37241,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 662
+      "community": 663
     },
     {
       "label": "count-any-types.ts",
@@ -37417,7 +37457,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 956
+      "community": 957
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37425,7 +37465,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 957
+      "community": 958
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37433,7 +37473,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 958
+      "community": 959
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37441,7 +37481,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 959
+      "community": 960
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37449,7 +37489,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "jsonEmbedding()",
@@ -37457,7 +37497,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 663
+      "community": 664
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37465,7 +37505,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 960
+      "community": 961
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37473,7 +37513,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 961
+      "community": 962
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37481,7 +37521,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 962
+      "community": 963
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37489,7 +37529,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37497,7 +37537,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 664
+      "community": 665
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37505,7 +37545,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 963
+      "community": 964
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37513,7 +37553,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "jsonEmbedding()",
@@ -37521,7 +37561,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 665
+      "community": 666
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37529,7 +37569,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "main()",
@@ -37537,7 +37577,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 666
+      "community": 667
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37545,7 +37585,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37553,7 +37593,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 667
+      "community": 668
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37561,7 +37601,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "createBackup()",
@@ -37569,7 +37609,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 476
+      "community": 477
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37577,7 +37617,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 476
+      "community": 477
     },
     {
       "label": "restore-legacy.ps1",
@@ -37585,7 +37625,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 964
+      "community": 965
     },
     {
       "label": "check-retry-usage.ts",
@@ -37705,7 +37745,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37713,7 +37753,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 668
+      "community": 669
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37809,7 +37849,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37817,7 +37857,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 669
+      "community": 670
     },
     {
       "label": "sources.ts",
@@ -37873,7 +37913,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 965
+      "community": 966
     },
     {
       "label": "issue-body.ts",
@@ -37881,7 +37921,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "startMarker()",
@@ -37889,7 +37929,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 409
+      "community": 410
     },
     {
       "label": "renderManagedIssueBody()",
@@ -37897,7 +37937,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 409
+      "community": 410
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -37905,7 +37945,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 409
+      "community": 410
     },
     {
       "label": "fingerprint.ts",
@@ -37913,7 +37953,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "normalizeMessage()",
@@ -37921,7 +37961,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 477
+      "community": 478
     },
     {
       "label": "createFingerprint()",
@@ -37929,7 +37969,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 477
+      "community": 478
     },
     {
       "label": "sanitizer.ts",
@@ -37937,7 +37977,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "limitUtf8Bytes()",
@@ -37945,7 +37985,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 478
+      "community": 479
     },
     {
       "label": "sanitizeExcerpt()",
@@ -37953,7 +37993,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 478
+      "community": 479
     },
     {
       "label": "parsers.ts",
@@ -37961,7 +38001,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "inferLevel()",
@@ -37969,7 +38009,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 410
+      "community": 411
     },
     {
       "label": "parseAppLogLine()",
@@ -37977,7 +38017,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 410
+      "community": 411
     },
     {
       "label": "parseJsonlRecord()",
@@ -37985,7 +38025,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 410
+      "community": 411
     },
     {
       "label": "index.ts",
@@ -37993,7 +38033,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -38001,7 +38041,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 411
+      "community": 412
     },
     {
       "label": "createMonitorRuntime()",
@@ -38009,7 +38049,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 411
+      "community": 412
     },
     {
       "label": "runForever()",
@@ -38017,7 +38057,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 411
+      "community": 412
     },
     {
       "label": "promotion.ts",
@@ -38025,7 +38065,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38033,7 +38073,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 670
+      "community": 671
     },
     {
       "label": "state-store.ts",
@@ -38089,7 +38129,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "recordMonitorError()",
@@ -38097,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L20",
       "id": "monitor_recordmonitorerror",
-      "community": 333
+      "community": 334
     },
     {
       "label": "withFingerprint()",
@@ -38105,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L29",
       "id": "monitor_withfingerprint",
-      "community": 333
+      "community": 334
     },
     {
       "label": "syncFingerprint()",
@@ -38113,7 +38153,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_syncfingerprint",
-      "community": 333
+      "community": 334
     },
     {
       "label": "runMonitorCycle()",
@@ -38121,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L103",
       "id": "monitor_runmonitorcycle",
-      "community": 333
+      "community": 334
     },
     {
       "label": "github-client.ts",
@@ -38297,7 +38337,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 966
+      "community": 967
     },
     {
       "label": "issue-body.spec.ts",
@@ -38305,7 +38345,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 967
+      "community": 968
     },
     {
       "label": "github-client.spec.ts",
@@ -38313,7 +38353,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 968
+      "community": 969
     },
     {
       "label": "config.spec.ts",
@@ -38321,7 +38361,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 969
+      "community": 970
     },
     {
       "label": "detectors.spec.ts",
@@ -38329,7 +38369,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 970
+      "community": 971
     },
     {
       "label": "sources.spec.ts",
@@ -38337,7 +38377,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 971
+      "community": 972
     },
     {
       "label": "parsers.spec.ts",
@@ -38345,7 +38385,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 972
+      "community": 973
     },
     {
       "label": "monitor.spec.ts",
@@ -38353,7 +38393,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "config()",
@@ -38361,7 +38401,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 671
+      "community": 672
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38369,7 +38409,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 973
+      "community": 974
     },
     {
       "label": "state-store.spec.ts",
@@ -38377,7 +38417,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 974
+      "community": 975
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38385,7 +38425,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 975
+      "community": 976
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38393,7 +38433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 976
+      "community": 977
     },
     {
       "label": "index.ts",
@@ -38401,7 +38441,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "main()",
@@ -38409,7 +38449,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 412
+      "community": 413
     },
     {
       "label": "index.ts",
@@ -38417,7 +38457,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "runExample()",
@@ -38425,7 +38465,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 412
+      "community": 413
     },
     {
       "label": "index.spec.ts",
@@ -38433,7 +38473,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 977
+      "community": 978
     },
     {
       "label": "memento-admin-fetch.js",
@@ -39537,7 +39577,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 334
+      "community": 335
     },
     {
       "label": "getTabButtons()",
@@ -39545,7 +39585,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 334
+      "community": 335
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -39553,7 +39593,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 334
+      "community": 335
     },
     {
       "label": "setRovingTabindex()",
@@ -39561,7 +39601,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 334
+      "community": 335
     },
     {
       "label": "activateTab()",
@@ -39569,7 +39609,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 334
+      "community": 335
     }
   ],
   "links": [
@@ -46464,6 +46504,66 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "_tgt": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
+      "source": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "target": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L30",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "_tgt": "agent_ask_issue237_e2e_spec_argvagentask",
+      "source": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "target": "agent_ask_issue237_e2e_spec_argvagentask",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "_tgt": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
+      "source": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "target": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L52",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "_tgt": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
+      "source": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
+      "target": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
+      "source_location": "L76",
+      "weight": 1.0,
+      "_src": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
+      "_tgt": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
+      "source": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
+      "target": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "weight": 1.0,
@@ -46512,152 +46612,152 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L35",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L36",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_stripglobalcliargs",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L65",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L66",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_parseagentaskinvocation",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L157",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L158",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_validateagentaskflagargv",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L187",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L188",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_validateagentaskrawtypes",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L207",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L208",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_resolvedbpath",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L224",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L225",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_jsonfailure",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L236",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L237",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_writeout",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L242",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L243",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_writeerr",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L248",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L249",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_debugerr",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L254",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L258",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
-      "_tgt": "agent_ask_promptapprove",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
-      "target": "agent_ask_promptapprove",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
+      "_tgt": "agent_ask_promptapproveinteractive",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
+      "target": "agent_ask_promptapproveinteractive",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L292",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L311",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_runagentaskmain",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L541",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L562",
       "weight": 1.0,
-      "_src": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
-      "source": "home_jee1lee_git_memento_packages_memento_server_src_cli_agent_ask_ts",
+      "source": "packages_memento_server_src_cli_agent_ask_ts",
       "target": "agent_ask_agentaskhelptext",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L66",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L67",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46668,8 +46768,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L106",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L107",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46680,8 +46780,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L112",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46692,8 +46792,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L296",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L316",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46704,8 +46804,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L347",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L368",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46716,8 +46816,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L304",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L324",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46728,8 +46828,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L304",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L324",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46740,8 +46840,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L250",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L251",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -46752,8 +46852,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L298",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L318",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -46764,8 +46864,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L362",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L383",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -46776,20 +46876,8 @@
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L450",
-      "weight": 1.0,
-      "_src": "agent_ask_runagentaskmain",
-      "_tgt": "agent_ask_promptapprove",
-      "source": "agent_ask_promptapprove",
-      "target": "agent_ask_runagentaskmain",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "/home/jee1lee/git/memento/packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L298",
+      "source_file": "packages/memento-server/src/cli/agent-ask.ts",
+      "source_location": "L318",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",

--- a/packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts
+++ b/packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * 이슈 #237: mock LLM 한 턴 + project scope 주입 + 승인/거절 persistence.
+ * 비TTY 환경에서도 `AgentAskRuntimeHooks`로 동일 코드 경로를 검증한다.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  createMementoCore,
+  createToolContext,
+  executeTool,
+  getBatchScheduler,
+  resetBatchScheduler,
+} from '@memento/core';
+
+import { runAgentAskMain } from './agent-ask.js';
+
+async function stopBatchSchedulerSingleton(): Promise<void> {
+  const bs = getBatchScheduler();
+  if (bs.getStatus().isRunning) {
+    await bs.stop();
+  }
+  resetBatchScheduler();
+}
+
+function argvAgentAsk(
+  dbPath: string,
+  userMessage: string,
+  extraFlags: string[] = [],
+): string[] {
+  return ['node', 'memento', '--db-path', dbPath, 'agent', 'ask', userMessage, '--llm', 'mock', ...extraFlags];
+}
+
+function captureStdoutWrite(): { chunks: string[]; restore: () => void } {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk, ...args): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    const cb = args.find((a) => typeof a === 'function') as ((err?: Error) => void) | undefined;
+    if (cb) queueMicrotask(() => cb());
+    return true;
+  });
+  return {
+    chunks,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+async function seedTwoProjectMemories(dbPath: string): Promise<void> {
+  const core = await createMementoCore({ dbPath });
+  try {
+    const toolContext = createToolContext(core.db, core.services);
+    await executeTool(
+      'remember',
+      {
+        content: 'proj237 aloha-seed 고유 내용',
+        type: 'semantic',
+        project_id: 'proj-237',
+      },
+      toolContext,
+    );
+    await executeTool(
+      'remember',
+      {
+        content: 'otherproj-secret-다른-내용',
+        type: 'semantic',
+        project_id: 'other-proj',
+      },
+      toolContext,
+    );
+  } finally {
+    await core.services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+    await stopBatchSchedulerSingleton();
+    await new Promise((r) => setTimeout(r, 150));
+    closeDatabase(core.db);
+  }
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await stopBatchSchedulerSingleton();
+});
+
+describe('agent ask #237 hooks E2E', () => {
+  it('project scope: --project-id 가 run에 전달되고 컨텍스트가 비어 있지 않다', async () => {
+    const dbPath = path.join(os.tmpdir(), `memento-i237-ctx-${Date.now()}.db`);
+    await seedTwoProjectMemories(dbPath);
+    const { chunks, restore } = captureStdoutWrite();
+    try {
+      const userMessage =
+        'proj237 aloha-seed 고유 내용을 참고해서 요약해 줘. 그리고 앞으로는 커밋 메시지는 영어로 쓰자';
+      const code = await runAgentAskMain(
+        { dbPath },
+        argvAgentAsk(dbPath, userMessage, ['--project-id', 'proj-237', '--no-save']),
+        { stdinIsTTY: true },
+      );
+      expect(code).toBe(0);
+      const tail = chunks.join('').trim();
+      const obj = JSON.parse(tail) as {
+        input: { projectId?: string };
+        knowledgeContext: { summary: string; itemCount: number };
+      };
+      expect(obj.input.projectId).toBe('proj-237');
+      expect(obj.knowledgeContext.itemCount).toBeGreaterThan(0);
+      expect(obj.knowledgeContext.summary.length).toBeGreaterThan(0);
+    } finally {
+      restore();
+      try {
+        fs.unlinkSync(dbPath);
+      } catch {
+        // ignore
+      }
+    }
+  }, 60_000);
+
+  it('후보 승인 시 persistence 시도·저장 성공', async () => {
+    const dbPath = path.join(os.tmpdir(), `memento-i237-y-${Date.now()}.db`);
+    await seedTwoProjectMemories(dbPath);
+    const { chunks, restore } = captureStdoutWrite();
+    try {
+      const userMessage = '앞으로는 커밋 메시지는 영어로 쓰자';
+      const code = await runAgentAskMain(
+        { dbPath },
+        argvAgentAsk(dbPath, userMessage, ['--project-id', 'proj-237']),
+        {
+          stdinIsTTY: true,
+          promptApprove: async () => 'y',
+        },
+      );
+      expect(code).toBe(0);
+      const obj = JSON.parse(chunks.join('').trim()) as {
+        persistence: { attempted: boolean; persistedCount: number; items: { status: string }[] };
+      };
+      expect(obj.persistence.attempted).toBe(true);
+      expect(obj.persistence.persistedCount).toBeGreaterThanOrEqual(1);
+      expect(obj.persistence.items.some((i) => i.status === 'persisted')).toBe(true);
+    } finally {
+      restore();
+      try {
+        fs.unlinkSync(dbPath);
+      } catch {
+        // ignore
+      }
+    }
+  }, 60_000);
+
+  it('후보 거절 시 persistence 미시도', async () => {
+    const dbPath = path.join(os.tmpdir(), `memento-i237-n-${Date.now()}.db`);
+    await seedTwoProjectMemories(dbPath);
+    const { chunks, restore } = captureStdoutWrite();
+    try {
+      const userMessage = '앞으로는 커밋 메시지는 영어로 쓰자';
+      const code = await runAgentAskMain(
+        { dbPath },
+        argvAgentAsk(dbPath, userMessage, ['--project-id', 'proj-237']),
+        {
+          stdinIsTTY: true,
+          promptApprove: async () => 'n',
+        },
+      );
+      expect(code).toBe(0);
+      const obj = JSON.parse(chunks.join('').trim()) as {
+        persistence: { attempted: boolean; persistedCount: number; items: unknown[] };
+      };
+      expect(obj.persistence.attempted).toBe(false);
+      expect(obj.persistence.persistedCount).toBe(0);
+      expect(obj.persistence.items).toEqual([]);
+    } finally {
+      restore();
+      try {
+        fs.unlinkSync(dbPath);
+      } catch {
+        // ignore
+      }
+    }
+  }, 60_000);
+});

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -1,6 +1,7 @@
 /**
  * `memento agent ask` — in-process 개인 지식 Agent 한 턴 (#236).
  * 설계: docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md
+ * 테스트 훅: `AgentAskRuntimeHooks` (#237, Vitest에서 stdin/승인 주입).
  */
 
 import { randomUUID } from 'node:crypto';
@@ -251,12 +252,15 @@ function debugErr(err: unknown): void {
   }
 }
 
-async function promptApprove(
+export type AgentAskApproveAnswer = 'y' | 'n' | 's' | 'q' | 'interrupt';
+
+/** 기본 readline 승인 프롬프트. 테스트에서는 `AgentAskRuntimeHooks.promptApprove`로 대체 가능 (#237). */
+export async function promptApproveInteractive(
   candidate: KnowledgeCandidate,
   index: number,
   total: number,
   interruptRef: { interrupted: boolean },
-): Promise<'y' | 'n' | 's' | 'q' | 'interrupt'> {
+): Promise<AgentAskApproveAnswer> {
   const rl = createInterface({ input: stdinStream, output: stderrStream });
   const onRlSigInt = (): void => {
     interruptRef.interrupted = true;
@@ -289,9 +293,25 @@ async function promptApprove(
   }
 }
 
+export type AgentAskPromptApprove = (
+  candidate: KnowledgeCandidate,
+  index: number,
+  total: number,
+  interruptRef: { interrupted: boolean },
+) => Promise<AgentAskApproveAnswer>;
+
+/** in-process 테스트 전용: 제품 CLI 경로는 `cli.ts`가 훅 없이 호출한다 (#237). */
+export interface AgentAskRuntimeHooks {
+  /** 미지정 시 `process.stdin.isTTY` */
+  stdinIsTTY?: boolean;
+  /** 미지정 시 `promptApproveInteractive` */
+  promptApprove?: AgentAskPromptApprove;
+}
+
 export async function runAgentAskMain(
   preOptions: PreCliOptions,
   argv: string[],
+  hooks?: AgentAskRuntimeHooks,
 ): Promise<number> {
   const parsed = parseAgentAskInvocation(argv);
   if (parsed.kind === 'help') {
@@ -322,7 +342,8 @@ export async function runAgentAskMain(
     process.env.MEMENTO_CLI_QUIET = '1';
   }
   try {
-  const stdinTty = Boolean(stdinStream.isTTY);
+  const stdinTty = hooks?.stdinIsTTY ?? Boolean(stdinStream.isTTY);
+  const promptFn = hooks?.promptApprove ?? promptApproveInteractive;
   const skipPersist = noSave || json;
 
   if (!stdinTty && !json && !noSave) {
@@ -447,7 +468,7 @@ export async function runAgentAskMain(
         return 130;
       }
       const c = runResult.candidates[i];
-      const ans = await promptApprove(c, i, runResult.candidates.length, interruptRef);
+      const ans = await promptFn(c, i, runResult.candidates.length, interruptRef);
       if (ans === 'interrupt') {
         await writeErr('중단되어 저장하지 않습니다.\n');
         await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});


### PR DESCRIPTION
## Summary
- `memento agent ask`에 `AgentAskRuntimeHooks`(선택)을 추가해 Vitest 등에서 `stdinIsTTY`·`promptApprove`를 주입해 승인/거절 경로를 동일 코드로 검증할 수 있게 했습니다. 기본 동작(실제 TTY + readline)은 변경 없습니다.
- 이슈 #237 시나리오 Vitest(`agent-ask-issue237.e2e.spec.ts`): project_id 전달·컨텍스트 비어 있지 않음, 후보 승인 시 persistence, 전부 거절 시 미시도. `BatchScheduler` 싱글톤 정리로 동일 워커에서 연속 부트스트랩이 가능하도록 했습니다.
- 한국어 MVP 가이드 `docs/guides/ko/personal-knowledge-agent-mvp.md` 및 `user-manual.md` 링크, graphify 산출물 갱신.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test`

Closes #237

Made with [Cursor](https://cursor.com)