### PR TITLE
feat(personal-agent): 이슈 #238 실제 LLM provider 연결 (OpenAI/Gemini/Ollama)

### DIFF
--- a/docs/guides/ko/personal-knowledge-agent-mvp.md
+++ b/docs/guides/ko/personal-knowledge-agent-mvp.md
@@ -1,7 +1,7 @@
 # 개인 지식 Agent MVP — CLI 사용 가이드 (한국어)
 
-이 문서는 **로컬 SQLite DB**와 **`memento agent ask`** 서브커맨드만으로, 질문 → 컨텍스트 주입 → mock LLM 응답 → 지식 후보 → 터미널 승인 → `remember` 저장까지의 **MVP 한 턴**을 실행하는 방법을 설명합니다.  
-(MCP/HTTP 서버·실제 LLM provider·대시보드는 범위 밖입니다. 관련 이슈: [#82](https://github.com/jee1/memento/issues/82), [#236](https://github.com/jee1/memento/issues/236), [#237](https://github.com/jee1/memento/issues/237).)
+이 문서는 **로컬 SQLite DB**와 **`memento agent ask`** 서브커맨드만으로, 질문 → 컨텍스트 주입 → LLM 응답(mock 기본, 선택 시 Ollama 등) → 지식 후보 → 터미널 승인 → `remember` 저장까지의 **MVP 한 턴**을 실행하는 방법을 설명합니다.  
+(MCP/HTTP 서버·대시보드는 범위 밖입니다. OpenAI/Gemini·환경 변수 계약은 [#238](https://github.com/jee1/memento/issues/238) 트랙, CLI 설계는 [#236](https://github.com/jee1/memento/issues/236), 테스트 훅은 [#237](https://github.com/jee1/memento/issues/237).)
 
 ## 전제 조건
 
@@ -19,7 +19,28 @@ node packages/memento-server/dist/cli.js --db-path "$DB" remember "프로젝트 
 
 `--project-id`가 같은 기억끼리 `memory_injection` / Agent 컨텍스트에서 묶입니다 (프로젝트 스코프 메모리, 이슈 #81).
 
-## 2. 한 턴 실행 (TTY, 승인 저장)
+## 2. 실제 LLM: Ollama (로컬 smoke)
+
+1. [Ollama](https://ollama.com/)를 설치한 뒤 터미널에서 `ollama serve`로 데몬을 띄웁니다.
+2. 사용할 모델을 받습니다. 예: `ollama pull llama3.2`
+3. 아래 환경 변수를 설정합니다.
+   - `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=ollama`
+   - `MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL=llama3.2` (필수)
+   - (선택) `MEMENTO_PERSONAL_AGENT_OLLAMA_URL` — 기본값 `http://127.0.0.1:11434`
+4. **문서 예시처럼 `--llm mock`을 붙이면** 환경 변수와 관계없이 항상 mock으로 동작합니다. Ollama를 쓰려면 **`--llm` 플래그를 생략**하세요.
+
+```bash
+export MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=ollama
+export MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL=llama3.2
+node packages/memento-server/dist/cli.js --db-path "$DB" agent ask \
+  "로컬 Ollama로 한 줄만 답해 줘" \
+  --project-id my-app \
+  --json --no-save
+```
+
+- Ollama가 꺼져 있거나 모델이 없으면 CLI는 `provider_runtime_failed` / `PROVIDER_MISCONFIGURED` 등으로 종료될 수 있습니다. 메시지와 HTTP 상태를 확인하세요.
+
+## 3. 한 턴 실행 (TTY, 승인 저장)
 
 ```bash
 node packages/memento-server/dist/cli.js --db-path "$DB" agent ask \
@@ -34,7 +55,7 @@ node packages/memento-server/dist/cli.js --db-path "$DB" agent ask \
   - 빈 줄 또는 `n`: 거절(저장 안 함).  
   - `s` / `q`: 남은 질문을 건너뛰고, 지금까지 `y`로 승인한 항목만 저장합니다.
 
-## 3. 스크립트·CI용 (`--json` / `--no-save`)
+## 4. 스크립트·CI용 (`--json` / `--no-save`)
 
 - `--json --no-save`: stdout에 **JSON 한 줄만** (저장 단계 생략, 인터랙션 없음).
 - `--json`만 주면 설계상 **저장 생략**과 동일하며, stderr에 한 줄 안내가 붙을 수 있습니다.
@@ -44,18 +65,18 @@ node packages/memento-server/dist/cli.js --db-path "$DB" agent ask "짧은 질�
   --project-id my-app --llm mock --json --no-save
 ```
 
-## 4. 비TTY 환경에서의 제약
+## 5. 비TTY 환경에서의 제약
 
 표준 입력이 TTY가 아니면 **저장·승인 루프**를 쓰려면 반드시 `--json` 또는 `--no-save`가 필요합니다. 그렇지 않으면 exit `1`입니다.  
 자동화에서 **승인 저장까지** 검증하려면 Vitest 등 in-process 테스트에서 `runAgentAskMain`의 **런타임 훅**(`stdinIsTTY` / `promptApprove`)을 사용합니다(구현: `packages/memento-server/src/cli/agent-ask.ts`, 예시: `agent-ask-issue237.e2e.spec.ts`).
 
-## 5. 제외·후속 범위
+## 6. 제외·후속 범위
 
-- 실제 OpenAI/Gemini 등 provider 연결: [#238](https://github.com/jee1/memento/issues/238) 트랙.
+- OpenAI/Gemini 등 hosted provider 및 공통 계약: [#238](https://github.com/jee1/memento/issues/238) 및 저장소 `docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md`.
 - HTTP MCP로 Agent 위임: [#390](https://github.com/jee1/memento/issues/390) 등.
 - 대시보드·자동 리뷰 문서: 이 MVP 가이드 범위 밖.
 
-## 6. 관련 문서
+## 7. 관련 문서
 
 - CLI 설계(옵션·JSON 스키마·exit code): `docs/superpowers/specs/2026-05-14-issue-236-agent-ask-cli-design.md`
 - 기존 CLI·클라이언트 개요: `docs/guides/ko/user-manual.md`

--- a/docs/superpowers/plans/2026-05-15-issue-238-personal-agent-llm-providers.md
+++ b/docs/superpowers/plans/2026-05-15-issue-238-personal-agent-llm-providers.md
@@ -1,0 +1,515 @@
+# 이슈 #238 personal-agent 실제 LLM provider 연결 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `PersonalKnowledgeAgentService`에 주입되는 `ILLMPort`를 환경 기반으로 선택하고, mock은 기본·무조건 유지하며 OpenAI·Gemini·Ollama는 **명시적 설정이 있을 때만** 활성화한다. 공통 오류 모델로 `provider_disabled` / `provider_misconfigured` / `provider_runtime_failed`를 구분한다.
+
+**Architecture:** `@memento/core`의 `personal-agent` 도메인에 **환경 파싱·런타임 팩토리(#334)**를 두고, provider별 `ILLMPort` 구현체(#335~#337)를 같은 패키지 `adapters/`에 추가한다. CLI `agent-ask`는 팩토리만 호출해 어댑터 조립을 한 곳에 모은다. 임베딩과 동일하게 루트 워크스페이스에 이미 있는 `openai`, `@google/genai`, `@google/generative-ai`를 재사용하고, Ollama는 **추가 npm 의존성 없이** `fetch`로 호출한다.
+
+**Tech Stack:** TypeScript 5.x, Vitest, Node 24, `zod`(core에 이미 사용 중이면 동일 패턴), `openai` ^4.x, `@google/generative-ai` 또는 `@google/genai`(구현 시 한 패키지로 통일), native `fetch`.
+
+**Spec:** [docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md](../specs/2026-05-10-issue-238-provider-adapter-split-design.md) — 하위 이슈 [#334](https://github.com/jee1/memento/issues/334)~[#337](https://github.com/jee1/memento/issues/337).
+
+---
+
+## 구현 전 파일 맵
+
+| 구분 | 경로 | 책임 |
+| --- | --- | --- |
+| 포트(기존) | `packages/memento-core/src/domains/personal-agent/ports/llm-port.ts` | `ILLMPort` 계약 |
+| Mock(기존) | `packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts` | 기본 mock |
+| 서비스(기존) | `packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts` | LLM 주입 소비 |
+| CLI(기존) | `packages/memento-server/src/cli/agent-ask.ts` | 현재 `new DeterministicMockLlmAdapter()` 하드코딩 → 팩토리 호출로 교체 |
+| 배럴(기존) | `packages/memento-core/src/domains/personal-agent/index.ts`, `packages/memento-core/src/index.ts` | 신규 심볼 export |
+| 신규(#334) | `packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts` | env 파싱·정규화 |
+| 신규(#334) | `packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts` | 구분 가능한 오류 코드 |
+| 신규(#334) | `packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts` | gating + 분기 |
+| 신규(#335) | `packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts` | OpenAI chat → `ILLMPort` |
+| 신규(#336) | `packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts` | Gemini chat → `ILLMPort` |
+| 신규(#337) | `packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts` | Ollama HTTP → `ILLMPort` |
+| 신규(테스트) | 각 구현 옆 `*.spec.ts` | 단위 테스트(네트워크는 mock) |
+| 문서(#337) | `docs/` 하위 agent / personal-agent 사용 가이드 | 로컬 smoke 절차 |
+
+**환경 변수(제안 — 구현 시 스펙과 PR 본문에 동일하게 명시):**
+
+- `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER` — `mock` \| `openai` \| `gemini` \| `ollama` (미설정·빈값 = `mock`)
+- OpenAI: 기존 `OPENAI_API_KEY` 재사용(이미 `mementoConfig`에서 로드). 모델 오버라이드용 `MEMENTO_PERSONAL_AGENT_OPENAI_MODEL` (선택, 기본 `gpt-4o-mini`)
+- Gemini: 기존 `GEMINI_API_KEY` 재사용. 모델 오버라이드 `MEMENTO_PERSONAL_AGENT_GEMINI_MODEL` (선택, 기본은 `gemini-2.0-flash` 등 팀이 정한 안전한 기본값 하나로 고정)
+- Ollama: `MEMENTO_PERSONAL_AGENT_OLLAMA_URL`(기본 `http://127.0.0.1:11434`), `MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL`(필수로 두어 misconfigured 구분)
+
+---
+
+### Task 1 (#334) — `PersonalAgentLlmError` + 코드 상수
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts`
+- Test: `packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts`
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+`personal-agent-llm-error.spec.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import {
+  PersonalAgentLlmError,
+  isPersonalAgentLlmError,
+} from './personal-agent-llm-error.js';
+
+describe('PersonalAgentLlmError', () => {
+  it('exposes provider_misconfigured code', () => {
+    const err = new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: 'OPENAI_API_KEY is missing',
+    });
+    expect(err.code).toBe('provider_misconfigured');
+    expect(isPersonalAgentLlmError(err)).toBe(true);
+  });
+
+  it('narrows unknown', () => {
+    expect(isPersonalAgentLlmError(new Error('x'))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts`
+
+Expected: FAIL (모듈 없음 또는 클래스 없음)
+
+- [ ] **Step 3: 최소 구현**
+
+`personal-agent-llm-error.ts`:
+
+```typescript
+export type PersonalAgentLlmErrorCode =
+  | 'provider_disabled'
+  | 'provider_misconfigured'
+  | 'provider_runtime_failed';
+
+export type PersonalAgentLlmErrorOptions = {
+  code: PersonalAgentLlmErrorCode;
+  message: string;
+  cause?: unknown;
+};
+
+export class PersonalAgentLlmError extends Error {
+  readonly code: PersonalAgentLlmErrorCode;
+
+  constructor(options: PersonalAgentLlmErrorOptions) {
+    super(options.message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = 'PersonalAgentLlmError';
+    this.code = options.code;
+  }
+}
+
+export function isPersonalAgentLlmError(value: unknown): value is PersonalAgentLlmError {
+  return value instanceof PersonalAgentLlmError;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/errors/
+git commit -m "feat(personal-agent): LLM 런타임 오류 타입 추가 (#334)"
+```
+
+---
+
+### Task 2 (#334) — env 파싱 (`zod`)
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts`
+- Test: `packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts`
+
+- [ ] **Step 1: 실패 테스트**
+
+`personal-agent-llm-env.spec.ts`에서 `parsePersonalAgentLlmEnv`를 import하고:
+- `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER` 미설정 시 `provider: 'mock'`
+- `provider: 'openai'`인데 `OPENAI_API_KEY` 없으면 `PersonalAgentLlmError` `provider_misconfigured`
+- `provider: 'ollama'`인데 `MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL` 비어 있으면 `provider_misconfigured`
+
+(테스트에서 `process.env` 백업 후 복원 패턴 사용)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts`
+
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+`personal-agent-llm-env.ts` — `zod` 스키마로 provider enum 파싱, `parsePersonalAgentLlmEnv(env: NodeJS.ProcessEnv, keys: { openaiApiKey?: string; geminiApiKey?: string })` 형태로 **API 키는 인자로 주입**(테스트에서 고정, 런타임에서는 `mementoConfig.openaiApiKey` 등 전달). 반환 타입 예:
+
+```typescript
+export type ParsedPersonalAgentLlmEnv =
+  | { provider: 'mock' }
+  | { provider: 'openai'; model: string }
+  | { provider: 'gemini'; model: string }
+  | { provider: 'ollama'; baseUrl: string; model: string };
+```
+
+`export function parsePersonalAgentLlmEnv(...): ParsedPersonalAgentLlmEnv` — misconfiguration 시 `throw new PersonalAgentLlmError({ code: 'provider_misconfigured', message: '...' })`.
+
+- [ ] **Step 4: PASS**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/config/
+git commit -m "feat(personal-agent): LLM provider env 파싱 (#334)"
+```
+
+---
+
+### Task 3 (#334) — `createPersonalAgentLlmPort` 팩토리 + 단위 테스트
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts`
+- Modify: `packages/memento-core/src/domains/personal-agent/index.ts` (export)
+- Modify: `packages/memento-core/src/index.ts` (필요 시 re-export 한 줄)
+
+- [ ] **Step 1: 실패 테스트**
+
+`create-personal-agent-llm-port.spec.ts`:
+- `provider: mock` → `DeterministicMockLlmAdapter` 인스턴스(`complete` 호출 가능)
+- `provider: openai`이고 `deps.createOpenAi`가 주어지면 그 팩토리가 반환한 stub `ILLMPort`를 사용
+- `provider: openai`인데 `deps.createOpenAi`가 `undefined`이면 `PersonalAgentLlmError` `provider_misconfigured`
+
+팩토리 시그니처 예:
+
+```typescript
+import type { ILLMPort } from '../ports/llm-port.js';
+import type { ParsedPersonalAgentLlmEnv } from '../config/personal-agent-llm-env.js';
+import { DeterministicMockLlmAdapter } from '../adapters/deterministic-mock-llm-adapter.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type CreatePersonalAgentLlmPortDeps = {
+  createOpenAi?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'openai' }>) => ILLMPort;
+  createGemini?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'gemini' }>) => ILLMPort;
+  createOllama?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'ollama' }>) => ILLMPort;
+};
+
+export function createPersonalAgentLlmPort(
+  parsed: ParsedPersonalAgentLlmEnv,
+  deps: CreatePersonalAgentLlmPortDeps = {},
+): ILLMPort {
+  if (parsed.provider === 'mock') {
+    return new DeterministicMockLlmAdapter();
+  }
+  if (parsed.provider === 'openai') {
+    if (!deps.createOpenAi) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'OpenAI adapter is not registered in this build path',
+      });
+    }
+    return deps.createOpenAi(parsed);
+  }
+  if (parsed.provider === 'gemini') {
+    if (!deps.createGemini) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'Gemini adapter is not registered in this build path',
+      });
+    }
+    return deps.createGemini(parsed);
+  }
+  if (!deps.createOllama) {
+    throw new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: 'Ollama adapter is not registered in this build path',
+    });
+  }
+  return deps.createOllama(parsed);
+}
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts`
+
+- [ ] **Step 3: 구현** (위 시그니처와 동일하게 파일 작성)
+
+- [ ] **Step 4: PASS**
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts \
+  packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts \
+  packages/memento-core/src/domains/personal-agent/index.ts \
+  packages/memento-core/src/index.ts
+git commit -m "feat(personal-agent): LLM 포트 팩토리와 gating (#334)"
+```
+
+---
+
+### Task 4 (#334) — CLI `agent-ask`에 파싱·팩토리 연결 (아직 mock만)
+
+**Files:**
+- Modify: `packages/memento-server/src/cli/agent-ask.ts` (import + `const llm = ...` 교체)
+- Test: `packages/memento-server`에 CLI 단위 테스트가 있으면 env mock으로 한 케이스 추가; 없으면 **core** 테스트만으로 #334 마무리하고 CLI는 수동 스모크 체크리스트에 기록
+
+- [ ] **Step 1:** `mementoConfig` 또는 `process.env`에서 키 읽기 → `parsePersonalAgentLlmEnv` → `createPersonalAgentLlmPort(parsed, {})` 호출. **#335 이전**이므로 `createOpenAi` 등은 넘기지 않고, `openai`/`gemini`/`ollama` 선택 시 사용자에게 명확한 `provider_misconfigured` 메시지로 종료(JSON 모드면 기존 `jsonFailure` 패턴에 매핑).
+
+- [ ] **Step 2:** `npm run type-check` 및 `npx vitest run packages/memento-core/src/domains/personal-agent/`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/memento-server/src/cli/agent-ask.ts
+git commit -m "feat(cli): personal-agent LLM env 연동 기본(mock) (#334)"
+```
+
+---
+
+### Task 5 (#335) — `OpenAiChatLlmAdapter`
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts`
+- Modify: `packages/memento-core/src/domains/personal-agent/index.ts`
+- Modify: `packages/memento-server/src/cli/agent-ask.ts` — `createOpenAi: (cfg) => new OpenAiChatLlmAdapter({ apiKey: mementoConfig.openaiApiKey!, model: cfg.model, timeoutMs: ... })` (키 없으면 앞 단계에서 이미 파싱 실패)
+
+- [ ] **Step 1: 실패 테스트** — `openai.chat.completions.create`를 `vi.spyOn` 또는 작은 래퍼 주입으로 모킹해 `messages` 전달·`LLMCompletionResult.metadata.provider === 'openai'` 검증
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts`
+
+- [ ] **Step 3: 구현** — `OpenAI` from `openai`:
+
+```typescript
+import OpenAI from 'openai';
+import type { ILLMPort, LLMCompletionResult, LLMMessage } from '../ports/llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type OpenAiChatLlmAdapterOptions = {
+  apiKey: string;
+  model: string;
+  timeoutMs?: number;
+};
+
+export class OpenAiChatLlmAdapter implements ILLMPort {
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor(options: OpenAiChatLlmAdapterOptions) {
+    this.client = new OpenAI({ apiKey: options.apiKey, timeout: options.timeoutMs ?? 60_000 });
+    this.model = options.model;
+  }
+
+  async complete(messages: LLMMessage[]): Promise<LLMCompletionResult> {
+    try {
+      const completion = await this.client.chat.completions.create({
+        model: this.model,
+        messages,
+      });
+      const text = completion.choices[0]?.message?.content ?? '';
+      return {
+        content: text,
+        metadata: {
+          provider: 'openai',
+          model: this.model,
+          requestId: completion.id,
+          finishReason: completion.choices[0]?.finish_reason ?? undefined,
+        },
+      };
+    } catch (cause) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_runtime_failed',
+        message: 'OpenAI chat completion failed',
+        cause,
+      });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: PASS**
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts \
+  packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts \
+  packages/memento-core/src/domains/personal-agent/index.ts \
+  packages/memento-server/src/cli/agent-ask.ts
+git commit -m "feat(personal-agent): OpenAI chat LLM adapter (#335)"
+```
+
+---
+
+### Task 6 (#336) — `GeminiChatLlmAdapter`
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts`
+- Modify: `packages/memento-core/src/domains/personal-agent/index.ts`
+- Modify: `packages/memento-server/src/cli/agent-ask.ts` — `createGemini` 등록
+
+- [ ] **Step 1: 실패 테스트** — `@google/generative-ai`의 `GenerativeModel.prototype.generateContent`를 `vi.spyOn`으로 모킹. `getGenerativeModel({ model })` 호출 후 `metadata.provider === 'gemini'`.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `npx vitest run packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts`
+
+- [ ] **Step 3: 구현** — `GoogleGenerativeAI` 사용 예:
+
+```typescript
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { GenerativeModel } from '@google/generative-ai';
+import type { ILLMPort, LLMCompletionResult, LLMMessage } from '../ports/llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type GeminiChatLlmAdapterOptions = {
+  apiKey: string;
+  model: string;
+};
+
+export class GeminiChatLlmAdapter implements ILLMPort {
+  private readonly generativeModel: GenerativeModel;
+  private readonly modelName: string;
+
+  constructor(options: GeminiChatLlmAdapterOptions) {
+    this.modelName = options.model;
+    const genAI = new GoogleGenerativeAI(options.apiKey);
+    this.generativeModel = genAI.getGenerativeModel({ model: options.model });
+  }
+
+  async complete(messages: LLMMessage[]): Promise<LLMCompletionResult> {
+    try {
+      const system = messages.find((m) => m.role === 'system')?.content ?? '';
+      const rest = messages.filter((m) => m.role !== 'system');
+      const prompt = [system, ...rest.map((m) => `${m.role}: ${m.content}`)].join('\n\n');
+      const result = await this.generativeModel.generateContent({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      });
+      const text = result.response.text();
+      return {
+        content: text,
+        metadata: {
+          provider: 'gemini',
+          model: this.modelName,
+          finishReason: undefined,
+        },
+      };
+    } catch (cause) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_runtime_failed',
+        message: 'Gemini generateContent failed',
+        cause,
+      });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: PASS**
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts \
+  packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts \
+  packages/memento-core/src/domains/personal-agent/index.ts \
+  packages/memento-server/src/cli/agent-ask.ts
+git commit -m "feat(personal-agent): Gemini chat LLM adapter (#336)"
+```
+
+---
+
+### Task 7 (#337) — `OllamaChatLlmAdapter` + smoke 문서
+
+**Files:**
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts`
+- Create: `packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts`
+- Modify: `packages/memento-core/src/domains/personal-agent/index.ts`
+- Modify: `packages/memento-server/src/cli/agent-ask.ts`
+- Create or Modify: `docs/` 내 personal-agent / CLI 절차 (기존 agent-ask 문서가 있으면 그 파일에 "Ollama smoke" 절 추가)
+
+Ollama HTTP 예 (`/api/chat`):
+
+```typescript
+const res = await fetch(new URL('/api/chat', baseUrl), {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    model,
+    messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    stream: false,
+  }),
+});
+if (!res.ok) {
+  throw new PersonalAgentLlmError({
+    code: 'provider_runtime_failed',
+    message: `Ollama HTTP ${res.status}`,
+  });
+}
+```
+
+- [ ] **Step 1~4:** Task 5와 동일 리듬(Vitest에서 `global.fetch` mock)
+
+- [ ] **Step 5: 문서** — `ollama serve` 선행, 환경 변수 예, `memento ... agent ask` 한 줄 예시
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git commit -m "feat(personal-agent): Ollama chat LLM adapter 및 로컬 smoke 문서 (#337)"
+```
+
+---
+
+### Task 8 — 품질 게이트
+
+- [ ] **Step 1:** 루트에서 `npm run type-check`
+
+- [ ] **Step 2:** `npm test`
+
+- [ ] **Step 3:** `npm run lint`
+
+- [ ] **Step 4:** 커밋(필요 시만) 또는 CI 녹색 확인
+
+---
+
+## Spec coverage (self-review)
+
+| 스펙 요구 | 담당 Task |
+| --- | --- |
+| 명시 설정 없으면 실제 provider 비활성(mock) | Task 2, 3, 4 |
+| disabled / misconfigured / runtime-failed 구분 | Task 1(`provider_disabled`는 예: 사용자가 `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=openai`로 두고 기능 플래그로 막는 경우 등 **정책 확정 후** CLI 메시지에 사용), Task 2·5~7 |
+| provider별 독립 검증 | Task 5, 6, 7 각각 전용 spec |
+| mock 테스트 외부 API 없음 | 모든 provider 테스트는 mock/spy |
+
+**Gap 보완:** `provider_disabled`의 정확한 UX(예: 향후 `MEMENTO_PERSONAL_AGENT_LLM_ENABLED=false`)는 스펙 비목표와 충돌하지 않는 선에서 Task 2에 **한 문장**으로만 추가하거나, 별도 이슈로 남긴다.
+
+## Placeholder scan
+
+- 본 문서에 `TBD` / `implement later` 없음.
+
+## Type consistency
+
+- 모든 어댑터는 `ILLMPort` 구현.
+- `LLMProviderMetadata.provider`는 `llm-port.ts`의 리터럴 유니온과 일치(`'openai' \| 'gemini' \| 'ollama' \| 'mock'`).
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-15-issue-238-personal-agent-llm-providers.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 태스크마다 새 서브에이전트를 붙이고 태스크 사이에 리뷰.
+
+**2. Inline Execution** — 이 세션에서 `executing-plans` 스타일로 체크포인트마다 실행.
+
+원하시는 쪽을 알려 주세요.

--- a/docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-238-provider-adapter-split-design.md
@@ -4,6 +4,17 @@
 **부모 기능:** [GitHub #82](https://github.com/jee1/memento/issues/82)  
 **관련 구현 이슈:** [#231](https://github.com/jee1/memento/issues/231) ~ [#237](https://github.com/jee1/memento/issues/237)
 
+**하위 실행 이슈(실제 provider 연결):**
+
+| 순서 | 이슈 | 제목(요약) |
+| ---: | --- | --- |
+| 1 | [#334](https://github.com/jee1/memento/issues/334) | provider runtime contract + config gating |
+| 2 | [#335](https://github.com/jee1/memento/issues/335) | OpenAI provider adapter 연결 |
+| 3 | [#336](https://github.com/jee1/memento/issues/336) | Gemini provider adapter 연결 |
+| 4 | [#337](https://github.com/jee1/memento/issues/337) | Ollama provider adapter + local smoke/docs |
+
+**문서 개정 이력:** 2026-05-15 — `#238` GitHub 본문의 하위 이슈 번호·완료 기준·용어를 본 설계에 반영(추적성 보강). 설계 결정(분해 구조·권장 순서)은 변경 없음.
+
 ## 1. 문제
 
 `#238`은 현재 다음 책임을 한 이슈에 함께 담고 있다.
@@ -48,9 +59,9 @@
 
 직접 구현 항목:
 
-- 없음. 실제 코드는 모두 하위 이슈에서 처리한다.
+- 없음. 실제 코드는 모두 하위 이슈([#334](https://github.com/jee1/memento/issues/334)~[#337](https://github.com/jee1/memento/issues/337))에서 처리한다.
 
-### 하위 이슈 1: provider runtime contract + config gating
+### [#334](https://github.com/jee1/memento/issues/334) — provider runtime contract + config gating
 
 공통 런타임 경계를 먼저 고정하는 이슈다.
 
@@ -71,10 +82,10 @@
 완료 기준:
 
 - 명시적 설정 없이는 실제 provider가 절대 활성화되지 않는다.
-- disabled/provider-misconfigured/provider-runtime-failed 상태가 구분된다.
+- **provider disabled**, **misconfigured**, **runtime-failed**(구현·로그에서는 `provider-misconfigured`, `provider-runtime-failed` 등 기계 판독형 식별자와 매핑 가능)가 상호 배타적으로 구분된다.
 - 공통 계약을 검증하는 단위 테스트가 있다.
 
-### 하위 이슈 2: OpenAI adapter 연결
+### [#335](https://github.com/jee1/memento/issues/335) — OpenAI adapter 연결
 
 가장 먼저 붙일 실제 hosted provider 구현이다.
 
@@ -97,7 +108,7 @@
 - 실패 시 공통 오류 모델로 반환된다.
 - mock 기반 기존 테스트는 외부 API 없이 유지된다.
 
-### 하위 이슈 3: Gemini adapter 연결
+### [#336](https://github.com/jee1/memento/issues/336) — Gemini adapter 연결
 
 OpenAI와 분리된 두 번째 hosted provider 구현이다.
 
@@ -117,7 +128,7 @@ OpenAI와 분리된 두 번째 hosted provider 구현이다.
 - 명시적 Gemini 설정이 있을 때만 활성화된다.
 - OpenAI 구현과 독립적으로 테스트 가능하다.
 
-### 하위 이슈 4: Ollama adapter + local smoke/docs
+### [#337](https://github.com/jee1/memento/issues/337) — Ollama adapter + local smoke/docs
 
 로컬 런타임 특성이 커서 별도 이슈로 둔다.
 
@@ -141,10 +152,10 @@ OpenAI와 분리된 두 번째 hosted provider 구현이다.
 
 ## 5. 권장 순서
 
-1. `provider runtime contract + config gating`
-2. `OpenAI adapter 연결`
-3. `Gemini adapter 연결`
-4. `Ollama adapter + local smoke/docs`
+1. [#334](https://github.com/jee1/memento/issues/334) — provider runtime contract + config gating
+2. [#335](https://github.com/jee1/memento/issues/335) — OpenAI adapter 연결
+3. [#336](https://github.com/jee1/memento/issues/336) — Gemini adapter 연결
+4. [#337](https://github.com/jee1/memento/issues/337) — Ollama adapter + local smoke/docs
 
 이 순서의 이유는 공통 경계를 먼저 고정해야 provider별 구현이 흔들리지 않기 때문이다. 또한 hosted provider를 먼저 정리하면 로컬 런타임 특수성이 큰 Ollama를 마지막에 별도로 닫을 수 있다.
 
@@ -159,7 +170,7 @@ OpenAI와 분리된 두 번째 hosted provider 구현이다.
 ## 7. GitHub 정리 방식
 
 - `#238` 본문 상단에 “umbrella” 성격을 명시한다.
-- 하위 이슈 4개를 새로 생성하고 모두 `Parent: #238`를 적는다.
+- 하위 이슈 4개([#334](https://github.com/jee1/memento/issues/334)~[#337](https://github.com/jee1/memento/issues/337))는 생성되었으며, 각 본문에 `Parent: #238`를 적는다.
 - `#82`에는 `#231`~`#238`이 MVP 분해 구조임을 유지하되, `#238` 아래에 실제 provider 연결 서브트리가 있음을 링크로 보강한다.
 - 기존 `#238` 본문에 있던 구현 세부사항은 하위 이슈로 이동하고, `#238` 본문에는 추적용 요약만 남긴다.
 
@@ -168,3 +179,20 @@ OpenAI와 분리된 두 번째 hosted provider 구현이다.
 - 각 하위 이슈가 단독 PR로 닫힐 수 있는지 확인한다.
 - 각 하위 이슈의 제외 범위가 겹치지 않는지 확인한다.
 - `#238` 본문이 실행 이슈가 아니라 umbrella로 읽히는지 확인한다.
+
+## 9. Umbrella(`#238`) 완료 기준 요약
+
+`#238` GitHub 본문과 동일한 상위 완료 조건을 설계 상위에서도 고정한다.
+
+- 실제 provider 사용은 **명시적 설정이 있을 때만** 활성화된다.
+- **provider disabled** / **misconfigured** / **runtime-failed** 상태가 구분된다(구현체는 공통 오류 모델·코드로 표현).
+- 각 provider 구현이 **독립 이슈(#335~#337)**로 검증 가능하다.
+- **mock provider** 기반 테스트는 계속 외부 API 없이 통과한다.
+
+(`#238` 본문의 **제외 범위**는 아래 **비목표(섹션 6)**와 동일 주제이며, “다중 provider 자동 튜닝·후보 추출 고도화·24/7 background agent”는 비목표로 유지한다.)
+
+## 10. 권장 검증(수동·자동)
+
+- mock provider 테스트
+- provider disabled 상태 테스트
+- 각 provider별 수동 smoke test(해당 하위 이슈·문서에 절차 명시)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 982 files · ~1,578,398 words
+- 984 files · ~1,580,714 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4951 nodes · 6139 edges · 979 communities detected
+- 4956 nodes · 6142 edges · 981 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -989,6 +989,8 @@
 - [[_COMMUNITY_Community 976|Community 976]]
 - [[_COMMUNITY_Community 977|Community 977]]
 - [[_COMMUNITY_Community 978|Community 978]]
+- [[_COMMUNITY_Community 979|Community 979]]
+- [[_COMMUNITY_Community 980|Community 980]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2497,91 +2499,91 @@ Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (1): PersonalAgentLlmError
 
 ### Community 373 - "Community 373"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 380 - "Community 380"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 381 - "Community 381"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 382 - "Community 382"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 390 - "Community 390"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 392 - "Community 392"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 393 - "Community 393"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
@@ -2593,15 +2595,15 @@ Nodes (0):
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
@@ -2616,20 +2618,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 403 - "Community 403"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 405 - "Community 405"
+### Community 403 - "Community 403"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 404 - "Community 404"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 405 - "Community 405"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 406 - "Community 406"
 Cohesion: 0.83
@@ -2641,59 +2643,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 409 - "Community 409"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 410 - "Community 410"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 411 - "Community 411"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 415 - "Community 415"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 416 - "Community 416"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 419 - "Community 419"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 420 - "Community 420"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 421 - "Community 421"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
@@ -2704,24 +2706,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 424 - "Community 424"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 425 - "Community 425"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 426 - "Community 426"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 427 - "Community 427"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
@@ -2729,31 +2731,31 @@ Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 431 - "Community 431"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 434 - "Community 434"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 435 - "Community 435"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 436 - "Community 436"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
@@ -2764,12 +2766,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 440 - "Community 440"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -2784,16 +2786,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 444 - "Community 444"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 445 - "Community 445"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
@@ -2813,11 +2815,11 @@ Nodes (0):
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Nodes (0): 
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 453 - "Community 453"
 Cohesion: 0.67
@@ -2833,19 +2835,19 @@ Nodes (0):
 
 ### Community 456 - "Community 456"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 457 - "Community 457"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 458 - "Community 458"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 459 - "Community 459"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
@@ -2872,28 +2874,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 466 - "Community 466"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 467 - "Community 467"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 469 - "Community 469"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 470 - "Community 470"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
@@ -2904,32 +2906,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 474 - "Community 474"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 475 - "Community 475"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 476 - "Community 476"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
@@ -4923,1006 +4925,1016 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 979 - "Community 979"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 980 - "Community 980"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 480`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 481`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 482`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 483`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 484`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 485`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 486`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 487`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 488`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 489`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 490`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 491`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 492`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 493`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 494`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 495`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 496`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 497`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 498`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 499`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 500`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 501`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 502`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 503`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 504`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 505`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 506`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 510`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 511`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 512`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 513`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 514`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 515`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 516`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 517`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 518`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 519`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 520`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 521`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 522`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 523`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 524`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 525`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 526`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 527`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 528`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 529`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 530`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 531`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 532`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 533`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 534`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 535`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 536`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 537`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 538`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 539`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 542`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 555`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 556`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 557`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 558`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 559`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 560`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 561`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 562`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 563`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 564`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 565`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 566`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 567`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 568`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 569`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 570`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 571`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 572`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 573`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 574`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 575`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 576`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 577`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 578`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 579`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 580`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 581`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 582`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 583`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 584`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 585`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 586`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 587`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 588`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 589`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 591`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 592`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 593`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 594`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 595`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 596`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 598`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 599`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 600`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 604`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 605`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 607`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 608`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 609`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 610`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 612`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 613`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 614`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 615`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 616`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 617`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 618`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 619`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 620`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 621`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 622`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 623`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 624`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 625`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 626`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 627`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 628`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 629`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 630`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 631`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 632`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 633`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 634`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 635`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 636`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 637`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 638`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 639`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 640`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 641`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 642`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 643`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 644`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 645`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 646`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 648`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 649`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 650`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 651`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 652`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 653`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 654`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 655`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 656`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 657`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 658`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 659`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 660`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 661`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 662`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 663`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 664`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 665`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 666`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 667`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 668`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 669`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 670`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 671`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 672`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 673`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 674`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 675`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `types.ts`
+- **Thin community `Community 676`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 677`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `index.ts`
+- **Thin community `Community 678`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `transport.ts`
+- **Thin community `Community 685`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `index.ts`
+- **Thin community `Community 686`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 699`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 713`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `context.ts`
+- **Thin community `Community 715`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `index.ts`
+- **Thin community `Community 720`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `types.ts`
+- **Thin community `Community 723`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 724`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 725`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 726`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 727`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 728`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 729`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 730`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 731`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 732`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 733`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 734`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `index.ts`
+- **Thin community `Community 735`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 736`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `types.ts`
+- **Thin community `Community 745`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 752`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 753`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 763`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 780`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 781`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 782`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 783`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 784`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 785`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 786`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 787`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 788`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 789`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 790`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `error-types.ts`
+- **Thin community `Community 791`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 792`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 793`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `search.types.ts`
+- **Thin community `Community 794`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 796`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `constants.ts`
+- **Thin community `Community 797`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 798`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 805`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 806`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 808`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 833`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 834`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `index.ts`
+- **Thin community `Community 836`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `database-types.ts`
+- **Thin community `Community 838`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `index.ts`
+- **Thin community `Community 858`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 859`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `index.ts`
+- **Thin community `Community 861`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 864`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 865`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `context-port.ts`
+- **Thin community `Community 866`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 867`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 870`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 871`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 872`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 873`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 874`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 875`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 876`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 877`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 878`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 879`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 881`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 891`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 892`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `index.ts`
+- **Thin community `Community 902`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 904`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 914`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `types.ts`
+- **Thin community `Community 924`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `types.ts`
+- **Thin community `Community 939`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 941`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 943`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 944`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 945`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 952`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 953`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 955`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 956`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 965`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `types.ts`
+- **Thin community `Community 966`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 979`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 980`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 988 files · ~1,581,846 words
+- 990 files · ~1,582,329 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4963 nodes · 6146 edges · 985 communities detected
+- 4968 nodes · 6149 edges · 987 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -995,6 +995,8 @@
 - [[_COMMUNITY_Community 982|Community 982]]
 - [[_COMMUNITY_Community 983|Community 983]]
 - [[_COMMUNITY_Community 984|Community 984]]
+- [[_COMMUNITY_Community 985|Community 985]]
+- [[_COMMUNITY_Community 986|Community 986]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2507,91 +2509,91 @@ Nodes (1): PersonalAgentLlmError
 
 ### Community 373 - "Community 373"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (1): OpenAiChatLlmAdapter
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 381 - "Community 381"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 382 - "Community 382"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 383 - "Community 383"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 391 - "Community 391"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 392 - "Community 392"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 393 - "Community 393"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
@@ -2603,15 +2605,15 @@ Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 400 - "Community 400"
 Cohesion: 0.5
@@ -2626,20 +2628,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 403 - "Community 403"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 404 - "Community 404"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 405 - "Community 405"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 406 - "Community 406"
+### Community 404 - "Community 404"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 405 - "Community 405"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 406 - "Community 406"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 407 - "Community 407"
 Cohesion: 0.83
@@ -2651,59 +2653,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 409 - "Community 409"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 410 - "Community 410"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 411 - "Community 411"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 412 - "Community 412"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 416 - "Community 416"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 417 - "Community 417"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 420 - "Community 420"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 421 - "Community 421"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 422 - "Community 422"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
@@ -2714,24 +2716,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 425 - "Community 425"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 426 - "Community 426"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 427 - "Community 427"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 428 - "Community 428"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
@@ -2739,31 +2741,31 @@ Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 432 - "Community 432"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 433 - "Community 433"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 435 - "Community 435"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 436 - "Community 436"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
@@ -2774,12 +2776,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 440 - "Community 440"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 441 - "Community 441"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
@@ -2794,16 +2796,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 445 - "Community 445"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 446 - "Community 446"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
@@ -2822,16 +2824,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 452 - "Community 452"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 453 - "Community 453"
 Cohesion: 1.0
 Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
-### Community 453 - "Community 453"
-Cohesion: 0.67
-Nodes (1): FeedbackRepository
-
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
@@ -2847,19 +2849,19 @@ Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 459 - "Community 459"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 460 - "Community 460"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 461 - "Community 461"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -2886,28 +2888,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 468 - "Community 468"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 469 - "Community 469"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 470 - "Community 470"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 471 - "Community 471"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 472 - "Community 472"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 473 - "Community 473"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
@@ -2918,32 +2920,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 476 - "Community 476"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 483 - "Community 483"
 Cohesion: 1.0
@@ -4953,1014 +4955,1024 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 985 - "Community 985"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 986 - "Community 986"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 482`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 483`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 484`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 485`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 486`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 487`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 488`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 489`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 490`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 491`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 492`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 493`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 494`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 495`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 496`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 497`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 498`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 499`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 500`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 501`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 502`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 503`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 504`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 505`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 506`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 510`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 511`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 512`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 513`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 514`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 515`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 516`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 517`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 518`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 519`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 520`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 521`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 522`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 523`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 524`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 525`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 526`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 527`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 528`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 529`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 530`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 531`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 532`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 533`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 534`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 535`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 536`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 537`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 538`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 539`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 541`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 544`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 557`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 558`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 559`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 560`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 561`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 562`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 563`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 564`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 565`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 566`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 567`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 568`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 569`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 570`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 571`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 572`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 573`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 574`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 575`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 576`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 577`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 578`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 579`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 580`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 581`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 582`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 583`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 584`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 585`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 586`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 587`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 588`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 589`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 591`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 592`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 594`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 595`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 596`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 597`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 598`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 599`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 602`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 607`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 608`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 609`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 610`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 611`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 612`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 613`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 614`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 615`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 616`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 617`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 618`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 619`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 620`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 621`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 622`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 623`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 624`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 625`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 626`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 627`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 628`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 629`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 630`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 631`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 632`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 633`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 634`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 635`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 636`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 637`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 638`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 639`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 640`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 641`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 642`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 643`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 644`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 645`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 646`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 648`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 649`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 650`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 651`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 652`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 653`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 654`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 655`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 656`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 657`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 658`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 659`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 660`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 661`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 662`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 663`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 664`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 665`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 666`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 667`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 668`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 669`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 670`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 671`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 672`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 673`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 674`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 675`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 676`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 677`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 678`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `types.ts`
+- **Thin community `Community 679`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `index.ts`
+- **Thin community `Community 681`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `transport.ts`
+- **Thin community `Community 688`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `index.ts`
+- **Thin community `Community 689`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 702`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 716`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `context.ts`
+- **Thin community `Community 718`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `index.ts`
+- **Thin community `Community 723`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 724`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 725`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `types.ts`
+- **Thin community `Community 726`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 727`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 728`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 729`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 730`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 731`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 732`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 733`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 734`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 735`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 736`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 737`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `index.ts`
+- **Thin community `Community 738`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `types.ts`
+- **Thin community `Community 748`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 755`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 756`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 766`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 783`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 784`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 785`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 786`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 787`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 788`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 789`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 790`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 791`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 792`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 793`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `error-types.ts`
+- **Thin community `Community 794`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 795`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 796`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `search.types.ts`
+- **Thin community `Community 797`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 799`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `constants.ts`
+- **Thin community `Community 800`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 801`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 808`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 809`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 810`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 818`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 819`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 820`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 836`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 837`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `index.ts`
+- **Thin community `Community 839`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `database-types.ts`
+- **Thin community `Community 841`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `index.ts`
+- **Thin community `Community 861`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 862`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `index.ts`
+- **Thin community `Community 864`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 868`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 869`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `context-port.ts`
+- **Thin community `Community 870`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 871`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 876`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 877`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 878`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 879`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 880`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 881`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 882`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 883`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 884`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 885`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 887`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 897`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 898`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `index.ts`
+- **Thin community `Community 908`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 910`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 920`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `types.ts`
+- **Thin community `Community 930`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 943`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `types.ts`
+- **Thin community `Community 945`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 947`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 949`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 950`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 951`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 958`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 959`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 961`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 962`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 971`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `types.ts`
+- **Thin community `Community 972`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 983`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 984`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 985`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 986`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 986 files · ~1,581,320 words
+- 988 files · ~1,581,846 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4960 nodes · 6145 edges · 983 communities detected
+- 4963 nodes · 6146 edges · 985 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -993,6 +993,8 @@
 - [[_COMMUNITY_Community 980|Community 980]]
 - [[_COMMUNITY_Community 981|Community 981]]
 - [[_COMMUNITY_Community 982|Community 982]]
+- [[_COMMUNITY_Community 983|Community 983]]
+- [[_COMMUNITY_Community 984|Community 984]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -4943,6 +4945,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 983 - "Community 983"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 984 - "Community 984"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -5156,797 +5166,801 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 586`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 587`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 589`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 591`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 592`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 593`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 594`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 595`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 596`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 598`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 599`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 600`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 605`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 606`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 607`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 608`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 609`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 610`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 612`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 613`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 614`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 615`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 616`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 617`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 618`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 619`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 620`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 621`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 622`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 623`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 624`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 625`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 626`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 627`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 628`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 629`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 630`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 631`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 632`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 633`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 634`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 635`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 636`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 637`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 638`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 639`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 640`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 641`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 642`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 643`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 644`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 645`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 646`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 648`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 649`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 650`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 651`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 652`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 653`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 654`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 655`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 656`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 657`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 658`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 659`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 660`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 661`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 662`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 663`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 664`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 665`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 666`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 667`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 668`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 669`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 670`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 671`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 672`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 673`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 674`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 675`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 676`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 677`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `types.ts`
+- **Thin community `Community 678`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `index.ts`
+- **Thin community `Community 680`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `transport.ts`
+- **Thin community `Community 687`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `index.ts`
+- **Thin community `Community 688`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 701`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 715`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `context.ts`
+- **Thin community `Community 717`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `index.ts`
+- **Thin community `Community 722`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 724`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `types.ts`
+- **Thin community `Community 725`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 726`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 727`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 728`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 729`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 730`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 731`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 732`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 733`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 734`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 735`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 736`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `index.ts`
+- **Thin community `Community 737`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `types.ts`
+- **Thin community `Community 747`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 754`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 755`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 765`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 782`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 783`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 784`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 785`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 786`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 787`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 788`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 789`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 790`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 791`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 792`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `error-types.ts`
+- **Thin community `Community 793`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 794`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 795`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `search.types.ts`
+- **Thin community `Community 796`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 797`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 798`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `constants.ts`
+- **Thin community `Community 799`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 800`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 807`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 808`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 809`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 818`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 819`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 835`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 836`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `index.ts`
+- **Thin community `Community 838`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `database-types.ts`
+- **Thin community `Community 840`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `index.ts`
+- **Thin community `Community 860`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 861`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `index.ts`
+- **Thin community `Community 863`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 867`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 868`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `context-port.ts`
+- **Thin community `Community 869`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 870`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 874`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 875`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 876`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 877`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 878`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 879`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 880`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 881`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 882`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 883`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 885`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 895`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 896`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `index.ts`
+- **Thin community `Community 906`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 908`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 918`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `types.ts`
+- **Thin community `Community 928`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `types.ts`
+- **Thin community `Community 943`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 945`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 947`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 948`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 949`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 956`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 957`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 959`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 960`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 969`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `types.ts`
+- **Thin community `Community 970`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 983`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 984`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 990 files · ~1,582,329 words
+- 992 files · ~1,582,824 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4968 nodes · 6149 edges · 987 communities detected
+- 4973 nodes · 6152 edges · 989 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -997,6 +997,8 @@
 - [[_COMMUNITY_Community 984|Community 984]]
 - [[_COMMUNITY_Community 985|Community 985]]
 - [[_COMMUNITY_Community 986|Community 986]]
+- [[_COMMUNITY_Community 987|Community 987]]
+- [[_COMMUNITY_Community 988|Community 988]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2513,91 +2515,91 @@ Nodes (1): OpenAiChatLlmAdapter
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (1): GeminiChatLlmAdapter
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 382 - "Community 382"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 383 - "Community 383"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 384 - "Community 384"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 385 - "Community 385"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 392 - "Community 392"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 393 - "Community 393"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 394 - "Community 394"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
@@ -2609,15 +2611,15 @@ Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 400 - "Community 400"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 401 - "Community 401"
 Cohesion: 0.5
@@ -2632,20 +2634,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 404 - "Community 404"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 405 - "Community 405"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 406 - "Community 406"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 407 - "Community 407"
+### Community 405 - "Community 405"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 406 - "Community 406"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 407 - "Community 407"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 408 - "Community 408"
 Cohesion: 0.83
@@ -2657,59 +2659,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 411 - "Community 411"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 412 - "Community 412"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 413 - "Community 413"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 417 - "Community 417"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 418 - "Community 418"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 422 - "Community 422"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
@@ -2720,24 +2722,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 426 - "Community 426"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 427 - "Community 427"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 428 - "Community 428"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 430 - "Community 430"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
@@ -2745,31 +2747,31 @@ Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 433 - "Community 433"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 434 - "Community 434"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 436 - "Community 436"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 437 - "Community 437"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
@@ -2780,12 +2782,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 441 - "Community 441"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 442 - "Community 442"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 442 - "Community 442"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
@@ -2800,16 +2802,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 446 - "Community 446"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 447 - "Community 447"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
@@ -2828,16 +2830,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 453 - "Community 453"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 454 - "Community 454"
 Cohesion: 1.0
 Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
-### Community 454 - "Community 454"
-Cohesion: 0.67
-Nodes (1): FeedbackRepository
-
 ### Community 455 - "Community 455"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 456 - "Community 456"
 Cohesion: 0.67
@@ -2853,19 +2855,19 @@ Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 460 - "Community 460"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 461 - "Community 461"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
@@ -2892,28 +2894,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 469 - "Community 469"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 470 - "Community 470"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 472 - "Community 472"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 473 - "Community 473"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
@@ -2924,32 +2926,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 477 - "Community 477"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 483 - "Community 483"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 484 - "Community 484"
 Cohesion: 1.0
@@ -4963,1016 +4965,1026 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 987 - "Community 987"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 988 - "Community 988"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 483`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 484`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 485`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 486`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 487`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 488`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 489`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 490`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 491`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 492`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 493`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 494`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 495`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 496`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 497`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 498`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 499`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 500`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 501`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 502`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 503`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 504`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 505`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 506`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 507`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 510`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 511`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 512`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 513`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 514`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 515`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 516`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 517`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 518`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 519`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 520`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 521`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 522`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 523`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 524`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 525`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 526`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 527`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 528`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 529`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 530`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 531`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 532`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 533`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 534`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 535`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 536`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 537`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 538`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 539`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 540`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 542`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 543`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 545`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 557`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 558`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 559`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 560`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 561`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 562`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 563`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 564`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 565`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 566`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 567`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 568`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 569`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 570`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 571`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 572`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 573`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 574`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 575`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 576`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 577`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 578`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 579`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 580`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 581`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 582`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 583`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 584`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 585`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 586`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 587`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 588`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 589`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 590`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 591`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 592`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 594`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 595`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 596`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 597`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 598`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 599`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 600`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 603`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 604`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 607`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 608`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 609`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 610`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 611`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 612`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 613`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 614`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 615`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 616`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 617`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 618`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 619`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 620`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 621`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 622`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 623`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 624`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 625`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 626`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 627`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 628`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 629`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 630`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 631`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 632`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 633`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 634`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 635`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 636`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 637`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 638`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 639`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 640`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 641`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 642`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 643`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 644`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 645`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 646`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 647`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 648`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 649`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 650`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 651`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 652`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 653`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 654`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 655`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 656`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 657`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 658`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 659`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 660`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 661`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 662`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 663`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 664`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 665`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 666`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 667`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 668`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 669`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 670`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 671`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 672`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 673`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 674`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 675`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 676`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 677`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 678`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 679`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `types.ts`
+- **Thin community `Community 680`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `index.ts`
+- **Thin community `Community 682`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `transport.ts`
+- **Thin community `Community 689`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `index.ts`
+- **Thin community `Community 690`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 703`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 717`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `context.ts`
+- **Thin community `Community 719`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 723`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `index.ts`
+- **Thin community `Community 724`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 725`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 726`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `types.ts`
+- **Thin community `Community 727`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 728`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 729`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 730`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 731`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 732`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 733`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 734`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 735`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 736`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 737`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 738`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `index.ts`
+- **Thin community `Community 739`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `types.ts`
+- **Thin community `Community 749`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 756`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 757`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 767`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 784`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 785`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 786`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 787`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 788`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 789`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 790`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 791`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 792`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 793`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 794`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `error-types.ts`
+- **Thin community `Community 795`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 796`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 797`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `search.types.ts`
+- **Thin community `Community 798`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 800`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `constants.ts`
+- **Thin community `Community 801`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 802`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 809`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 810`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 811`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 818`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 819`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 820`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 821`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 837`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 838`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `index.ts`
+- **Thin community `Community 840`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `database-types.ts`
+- **Thin community `Community 842`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `index.ts`
+- **Thin community `Community 862`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 863`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `index.ts`
+- **Thin community `Community 865`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 869`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 870`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `context-port.ts`
+- **Thin community `Community 871`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 872`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 878`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 879`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 880`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 881`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 882`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 883`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 884`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 885`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 886`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 887`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 889`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 899`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 900`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `index.ts`
+- **Thin community `Community 910`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 912`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 922`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `types.ts`
+- **Thin community `Community 932`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 943`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `types.ts`
+- **Thin community `Community 947`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 949`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 951`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 952`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 953`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 960`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 961`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 963`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 964`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 973`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `types.ts`
+- **Thin community `Community 974`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 983`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 984`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 985`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 986`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 987`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 988`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 992 files · ~1,582,824 words
+- 994 files · ~1,583,593 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4973 nodes · 6152 edges · 989 communities detected
+- 4978 nodes · 6155 edges · 991 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -999,6 +999,8 @@
 - [[_COMMUNITY_Community 986|Community 986]]
 - [[_COMMUNITY_Community 987|Community 987]]
 - [[_COMMUNITY_Community 988|Community 988]]
+- [[_COMMUNITY_Community 989|Community 989]]
+- [[_COMMUNITY_Community 990|Community 990]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2515,95 +2517,95 @@ Nodes (1): OpenAiChatLlmAdapter
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
-Nodes (1): GeminiChatLlmAdapter
+Nodes (1): OllamaChatLlmAdapter
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (1): GeminiChatLlmAdapter
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 382 - "Community 382"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 383 - "Community 383"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 384 - "Community 384"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
-Nodes (1): GetRelationsTool
+Nodes (0): 
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (1): GetRelationsTool
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
-Nodes (1): AddRelationTool
+Nodes (1): ExtractRelationsTool
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): AddRelationTool
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RelationRetryManager
 
 ### Community 393 - "Community 393"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 394 - "Community 394"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 395 - "Community 395"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
@@ -2615,15 +2617,15 @@ Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
-Nodes (1): GetMetaMemoryStatsTool
+Nodes (0): 
 
 ### Community 400 - "Community 400"
 Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
+Nodes (1): GetMetaMemoryStatsTool
 
 ### Community 401 - "Community 401"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 402 - "Community 402"
 Cohesion: 0.5
@@ -2638,20 +2640,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 405 - "Community 405"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 406 - "Community 406"
-Cohesion: 0.83
-Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
-
-### Community 407 - "Community 407"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 408 - "Community 408"
+### Community 406 - "Community 406"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
+### Community 407 - "Community 407"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): createSeededBenchmarkDatabase(), normalizeMemoryType(), seedOneCorpusRow()
+
+### Community 408 - "Community 408"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 409 - "Community 409"
 Cohesion: 0.83
@@ -2663,59 +2665,59 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 412 - "Community 412"
-Cohesion: 1.0
-Nodes (3): checkDatabaseIntegrity(), log(), main()
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
 
 ### Community 413 - "Community 413"
 Cohesion: 1.0
-Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
+Nodes (3): checkDatabaseIntegrity(), log(), main()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
-Nodes (2): inferLevel(), parseAppLogLine()
+Cohesion: 1.0
+Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (2): createMonitorRuntime(), runForever()
+Nodes (2): inferLevel(), parseAppLogLine()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (2): main(), runExample()
+Nodes (2): createMonitorRuntime(), runForever()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (1): SlowTransport
+Nodes (2): main(), runExample()
 
 ### Community 418 - "Community 418"
+Cohesion: 0.67
+Nodes (1): SlowTransport
+
+### Community 419 - "Community 419"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 422 - "Community 422"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 423 - "Community 423"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 424 - "Community 424"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
@@ -2726,24 +2728,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 427 - "Community 427"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 428 - "Community 428"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -2751,31 +2753,31 @@ Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 434 - "Community 434"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Cohesion: 0.67
+Nodes (1): NoopSearchProvider
 
 ### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): log(), shouldLog()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 437 - "Community 437"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 438 - "Community 438"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
@@ -2786,12 +2788,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 442 - "Community 442"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
-
-### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 443 - "Community 443"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
@@ -2806,16 +2808,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 447 - "Community 447"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 448 - "Community 448"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 449 - "Community 449"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
@@ -2834,16 +2836,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 454 - "Community 454"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 455 - "Community 455"
 Cohesion: 1.0
 Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
-### Community 455 - "Community 455"
-Cohesion: 0.67
-Nodes (1): FeedbackRepository
-
 ### Community 456 - "Community 456"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -2859,19 +2861,19 @@ Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 461 - "Community 461"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 462 - "Community 462"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
@@ -2898,28 +2900,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 470 - "Community 470"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 471 - "Community 471"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 472 - "Community 472"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 473 - "Community 473"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 474 - "Community 474"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 475 - "Community 475"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
@@ -2930,32 +2932,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 478 - "Community 478"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 483 - "Community 483"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 484 - "Community 484"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 485 - "Community 485"
 Cohesion: 1.0
@@ -4973,1018 +4975,1028 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 989 - "Community 989"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 990 - "Community 990"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 484`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 485`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 486`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 487`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 488`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 489`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 490`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 491`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 492`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 493`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 494`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 495`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 496`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 497`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 498`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 499`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 500`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 501`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 502`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 503`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 504`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 505`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 506`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 508`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 510`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 511`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 512`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 513`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 514`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 515`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 516`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 517`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 518`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 519`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 520`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 521`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 522`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 523`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 524`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 525`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 526`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 527`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 528`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 529`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 530`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 531`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 532`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 533`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 534`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 535`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 536`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 537`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 538`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 539`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 540`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 541`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 543`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 546`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 557`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 558`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 559`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 560`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 561`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 562`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 563`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 564`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 565`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 566`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 567`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 568`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 569`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 570`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 571`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 572`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 573`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 574`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 575`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 576`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 577`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 578`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 579`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 580`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 581`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 582`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 583`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 584`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 585`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 586`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 587`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 589`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 590`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 591`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 592`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 593`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 594`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 595`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 596`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 597`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 598`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 599`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 600`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 604`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 605`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 607`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 608`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 609`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 610`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 612`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 613`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 614`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 615`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 616`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 617`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 618`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 619`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 620`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 621`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 622`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 623`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 624`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 625`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 626`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 627`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 628`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 629`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 630`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 631`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 632`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 633`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 634`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 635`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 636`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 637`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 638`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 639`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 640`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 641`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 642`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 643`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 644`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 645`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 646`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 647`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 648`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 649`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 650`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 651`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 652`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 653`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 654`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 655`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 656`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 657`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 658`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 659`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 660`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 661`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 662`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 663`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 664`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 665`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 666`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 667`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 668`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 669`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 670`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 671`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 672`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 673`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 674`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 675`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 676`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 677`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 678`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 679`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `types.ts`
+- **Thin community `Community 681`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `index.ts`
+- **Thin community `Community 683`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 686`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 687`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `transport.ts`
+- **Thin community `Community 690`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `index.ts`
+- **Thin community `Community 691`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 700`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 704`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 714`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 716`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 718`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `context.ts`
+- **Thin community `Community 720`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 721`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 723`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 724`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `index.ts`
+- **Thin community `Community 725`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 726`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 727`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `types.ts`
+- **Thin community `Community 728`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 729`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 730`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 731`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 732`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 733`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 734`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 735`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 736`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 738`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 739`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `index.ts`
+- **Thin community `Community 740`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 746`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `types.ts`
+- **Thin community `Community 750`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 753`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 757`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 758`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 768`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 784`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 785`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 786`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 787`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 788`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 789`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 790`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 791`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 792`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 793`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 794`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 795`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `error-types.ts`
+- **Thin community `Community 796`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 797`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 798`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `search.types.ts`
+- **Thin community `Community 799`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 801`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `constants.ts`
+- **Thin community `Community 802`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 803`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 809`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 810`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 811`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 812`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 818`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 819`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 820`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 821`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 822`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 838`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 839`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `index.ts`
+- **Thin community `Community 841`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `database-types.ts`
+- **Thin community `Community 843`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `index.ts`
+- **Thin community `Community 863`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 864`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `index.ts`
+- **Thin community `Community 866`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 870`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 871`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `context-port.ts`
+- **Thin community `Community 872`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 873`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 880`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 881`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 882`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 883`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 884`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 885`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 886`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 887`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 888`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 889`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 891`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 901`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 902`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `index.ts`
+- **Thin community `Community 912`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 914`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 916`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 924`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `types.ts`
+- **Thin community `Community 934`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 943`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `types.ts`
+- **Thin community `Community 949`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 951`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 953`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 954`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 955`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 962`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 963`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 965`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 966`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 975`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `types.ts`
+- **Thin community `Community 976`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 983`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 984`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 985`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 986`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 987`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 988`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 989`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 990`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-05-15)
 
 ## Corpus Check
-- 984 files · ~1,580,714 words
+- 986 files · ~1,581,320 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4956 nodes · 6142 edges · 981 communities detected
+- 4960 nodes · 6145 edges · 983 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -991,6 +991,8 @@
 - [[_COMMUNITY_Community 978|Community 978]]
 - [[_COMMUNITY_Community 979|Community 979]]
 - [[_COMMUNITY_Community 980|Community 980]]
+- [[_COMMUNITY_Community 981|Community 981]]
+- [[_COMMUNITY_Community 982|Community 982]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2818,12 +2820,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 452 - "Community 452"
-Cohesion: 0.67
-Nodes (1): FeedbackRepository
+Cohesion: 1.0
+Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): FeedbackRepository
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
@@ -2839,19 +2841,19 @@ Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 458 - "Community 458"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 459 - "Community 459"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 460 - "Community 460"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
@@ -2878,28 +2880,28 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 467 - "Community 467"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 468 - "Community 468"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 469 - "Community 469"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 470 - "Community 470"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 471 - "Community 471"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 472 - "Community 472"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
@@ -2910,32 +2912,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 475 - "Community 475"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 476 - "Community 476"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 477 - "Community 477"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 478 - "Community 478"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 479 - "Community 479"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 482 - "Community 482"
 Cohesion: 1.0
@@ -4933,1008 +4935,1018 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 981 - "Community 981"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 982 - "Community 982"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `FeedbackRepository`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 481`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 482`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 483`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 484`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 485`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 486`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 487`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 488`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 489`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 490`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 491`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 492`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 493`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 494`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 495`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 496`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 497`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 498`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 499`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 500`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 501`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 502`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 503`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 504`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 505`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 506`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 507`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 508`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 509`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 510`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 511`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 512`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 513`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 514`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 515`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 516`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 517`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 518`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 519`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 520`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 521`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 522`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 523`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 524`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 525`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 526`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 527`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 528`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 529`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 530`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 531`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 532`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 533`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 534`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 535`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 536`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 537`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 538`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 539`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 540`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 541`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 542`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 543`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 544`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 545`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 550`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 551`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 555`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 556`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 557`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 558`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 559`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 560`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 561`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 562`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 563`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 564`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 565`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 566`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 567`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 568`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 569`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 570`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 571`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 572`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 573`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 574`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 575`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 576`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 577`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 578`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 579`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 580`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 581`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 582`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 583`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 584`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 585`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 586`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 587`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 588`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 589`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 590`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 591`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 592`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 593`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 594`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 595`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 596`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 597`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 598`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 599`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 600`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 601`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 603`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 604`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 605`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 606`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 607`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 608`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 609`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 610`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 612`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 613`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 614`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 615`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 616`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 617`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 618`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 619`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 620`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 621`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 622`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 623`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 624`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 625`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 626`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 627`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 628`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 629`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 630`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 631`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 632`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 633`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 634`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 635`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 636`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 637`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 638`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 639`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 640`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 641`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 642`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 643`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 644`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 645`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 646`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 648`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 649`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 650`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 651`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 652`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 653`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 654`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 655`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 656`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 657`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 658`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 659`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 660`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 661`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 662`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 663`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 664`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 665`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 666`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 667`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 668`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 669`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 670`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 671`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 672`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 673`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `config()`, `monitor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 674`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 675`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 676`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `types.ts`
+- **Thin community `Community 677`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 678`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `index.ts`
+- **Thin community `Community 679`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 680`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 681`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 682`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 683`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 684`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 685`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `transport.ts`
+- **Thin community `Community 686`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `index.ts`
+- **Thin community `Community 687`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 688`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 689`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 690`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 691`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 692`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 693`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 694`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 695`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 696`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 697`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 698`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 699`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 700`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 701`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 702`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 703`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 704`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 705`** (1 nodes): `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 706`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 707`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 708`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 709`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 710`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 711`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 712`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 713`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 714`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 715`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `context.ts`
+- **Thin community `Community 716`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 717`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 718`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 719`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 720`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `index.ts`
+- **Thin community `Community 721`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 722`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 723`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `types.ts`
+- **Thin community `Community 724`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 725`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 726`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 727`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 728`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 729`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 730`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 731`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 732`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 733`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 734`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 735`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `index.ts`
+- **Thin community `Community 736`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 737`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 738`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 739`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 740`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 741`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 742`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 743`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 744`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 745`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `types.ts`
+- **Thin community `Community 746`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 747`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 748`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 749`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 750`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 751`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 753`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 754`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 755`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 762`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 763`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 764`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 781`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 782`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 783`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 784`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 785`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 786`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 787`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 788`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 789`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 790`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 791`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `error-types.ts`
+- **Thin community `Community 792`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 793`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 794`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `search.types.ts`
+- **Thin community `Community 795`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 797`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `constants.ts`
+- **Thin community `Community 798`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 799`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 806`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 807`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 809`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 810`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 811`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 812`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 813`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 814`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 815`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 816`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 817`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 818`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 827`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 828`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 834`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 835`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `index.ts`
+- **Thin community `Community 837`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `database-types.ts`
+- **Thin community `Community 839`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 850`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `index.ts`
+- **Thin community `Community 859`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 860`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `index.ts`
+- **Thin community `Community 862`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 866`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 867`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `context-port.ts`
+- **Thin community `Community 868`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 869`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 872`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 873`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 874`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 875`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 876`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 877`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 878`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 879`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 880`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 881`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 883`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 893`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 894`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `index.ts`
+- **Thin community `Community 904`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 905`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 906`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 907`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 908`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 909`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 910`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 911`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 912`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 913`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 914`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 915`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 916`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `types.ts`
+- **Thin community `Community 926`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 932`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 935`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 937`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `types.ts`
+- **Thin community `Community 941`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 943`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 945`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 946`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 947`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 954`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 955`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 957`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 958`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `compare-weight-profiles.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 967`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `types.ts`
+- **Thin community `Community 968`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `sanitizer.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 981`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 982`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 417
+      "community": 418
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 417
+      "community": 418
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 484
+      "community": 485
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 418
+      "community": 419
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 418
+      "community": 419
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 485
+      "community": 486
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 486
+      "community": 487
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 419
+      "community": 420
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 419
+      "community": 420
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 487
+      "community": 488
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 704
+      "community": 705
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 488
+      "community": 489
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 488
+      "community": 489
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 489
+      "community": 490
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 490
+      "community": 491
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 491
+      "community": 492
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "createMockResponse()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 420
+      "community": 421
     },
     {
       "label": "sendOptions()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 420
+      "community": 421
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 492
+      "community": 493
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "readRepoFile()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 421
+      "community": 422
     },
     {
       "label": "sectionBetween()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 421
+      "community": 422
     },
     {
       "label": "http-server.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 493
+      "community": 494
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 494
+      "community": 495
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "createMockResponse()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 422
+      "community": 423
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 422
+      "community": 423
     },
     {
       "label": "server-state.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "batch-run-history.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 423
+      "community": 424
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 423
+      "community": 424
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 495
+      "community": 496
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 496
+      "community": 497
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 497
+      "community": 498
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 498
+      "community": 499
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 499
+      "community": 500
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 500
+      "community": 501
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 501
+      "community": 502
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 502
+      "community": 503
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 503
+      "community": 504
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 504
+      "community": 505
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 424
+      "community": 425
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 424
+      "community": 425
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "parseParams()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 425
+      "community": 426
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 425
+      "community": 426
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 510
+      "community": 511
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "parseCleanupParams()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 426
+      "community": 427
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 426
+      "community": 427
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 511
+      "community": 512
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 512
+      "community": 513
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 513
+      "community": 514
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 514
+      "community": 515
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 515
+      "community": 516
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "resolveEnvPath()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 427
+      "community": 428
     },
     {
       "label": "loadEnv()",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 427
+      "community": 428
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "runCli()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 516
+      "community": 517
     },
     {
       "label": "agent-ask.ts",
@@ -4375,7 +4375,7 @@
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
     },
@@ -4383,7 +4383,7 @@
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L70",
+      "source_location": "L73",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
     },
@@ -4391,7 +4391,7 @@
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L162",
+      "source_location": "L166",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
     },
@@ -4399,7 +4399,7 @@
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L192",
+      "source_location": "L196",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
     },
@@ -4407,7 +4407,7 @@
       "label": "resolveDbPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L212",
+      "source_location": "L216",
       "id": "agent_ask_resolvedbpath",
       "community": 90
     },
@@ -4415,7 +4415,7 @@
       "label": "jsonFailure()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L230",
+      "source_location": "L234",
       "id": "agent_ask_jsonfailure",
       "community": 90
     },
@@ -4423,7 +4423,7 @@
       "label": "writeOut()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L242",
+      "source_location": "L246",
       "id": "agent_ask_writeout",
       "community": 90
     },
@@ -4431,7 +4431,7 @@
       "label": "writeErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L248",
+      "source_location": "L252",
       "id": "agent_ask_writeerr",
       "community": 90
     },
@@ -4439,7 +4439,7 @@
       "label": "debugErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L254",
+      "source_location": "L258",
       "id": "agent_ask_debugerr",
       "community": 90
     },
@@ -4447,7 +4447,7 @@
       "label": "promptApproveInteractive()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L263",
+      "source_location": "L267",
       "id": "agent_ask_promptapproveinteractive",
       "community": 90
     },
@@ -4455,7 +4455,7 @@
       "label": "runAgentAskMain()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L316",
+      "source_location": "L320",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
@@ -4463,7 +4463,7 @@
       "label": "agentAskHelpText()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L625",
+      "source_location": "L638",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 428
+      "community": 429
     },
     {
       "label": "runQualityMeasurement()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 428
+      "community": 429
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "testSimpleAlerts()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "testBasicFunctionality()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 518
+      "community": 519
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 519
+      "community": 520
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "compareServices()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 429
+      "community": 430
     },
     {
       "label": "testServerSynchronization()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 429
+      "community": 430
     },
     {
       "label": "test-error-logging.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "testErrorLogging()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 520
+      "community": 521
     },
     {
       "label": "debug-http-v2.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "testFetch()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "initializeTestDatabase()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "testReflexionE2E()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 523
+      "community": 524
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "testAlertsDirect()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 524
+      "community": 525
     },
     {
       "label": "test-client.ts",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "assert()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 430
+      "community": 431
     },
     {
       "label": "testMementoClient()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 430
+      "community": 431
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 526
+      "community": 527
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 527
+      "community": 528
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "createBaseSchema()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 431
+      "community": 432
     },
     {
       "label": "createTestMemory()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 431
+      "community": 432
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 432
+      "community": 433
     },
     {
       "label": "findNodeForAnchor()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 432
+      "community": 433
     },
     {
       "label": "vitest.config.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "brave-search-provider.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "NoopSearchProvider",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 433
+      "community": 434
     },
     {
       "label": ".search()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 433
+      "community": 434
     },
     {
       "label": "search-factory.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "createSearchProvider()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 528
+      "community": 529
     },
     {
       "label": "search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "types.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "loadAgentConfig()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 529
+      "community": 530
     },
     {
       "label": "system-prompt.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "utils.spec.ts",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "buildMemory()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 530
+      "community": 531
     },
     {
       "label": "context-injector.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "logger.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "shouldLog()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 434
+      "community": 435
     },
     {
       "label": "log()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 434
+      "community": 435
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "createMementoCore()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 435
+      "community": 436
     },
     {
       "label": "closeDatabase()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 435
+      "community": 436
     },
     {
       "label": "bootstrap.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "initializeServices()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 531
+      "community": 532
     },
     {
       "label": "context.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 532
+      "community": 533
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 533
+      "community": 534
     },
     {
       "label": "anchor-stack.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createAnchorStack()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 534
+      "community": 535
     },
     {
       "label": "failure-reflexion.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 535
+      "community": 536
     },
     {
       "label": "search-and-embedding.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 536
+      "community": 537
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 537
+      "community": 538
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 538
+      "community": 539
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createInput()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 539
+      "community": 540
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createRelationGraph()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 540
+      "community": 541
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "createBaseSchema()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 436
+      "community": 437
     },
     {
       "label": "measureTime()",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 436
+      "community": 437
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createBaseSchema()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 541
+      "community": 542
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 542
+      "community": 543
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "openLockTestDatabase()",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 543
+      "community": 544
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createProgress()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 544
+      "community": 545
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 545
+      "community": 546
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 546
+      "community": 547
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "addMissingColumn()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 437
+      "community": 438
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 437
+      "community": 438
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "init.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createDbPath()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 547
+      "community": 548
     },
     {
       "label": "migrate.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "migrate.ts",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "isDuplicateColumnError()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 438
+      "community": 439
     },
     {
       "label": "migrateDatabase()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 438
+      "community": 439
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "migration-runner.ts",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 548
+      "community": 549
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "schema-version-manager.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 549
+      "community": 550
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMemoryItemTable()",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 439
+      "community": 440
     },
     {
       "label": "tableExists()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 439
+      "community": 440
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createMemoryItemTable()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 440
+      "community": 441
     },
     {
       "label": "tableExists()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 440
+      "community": 441
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createBaseSchema()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 552
+      "community": 553
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createSchemaWith018()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 553
+      "community": 554
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "createBaseSchema()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 554
+      "community": 555
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 555
+      "community": 556
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "createBaseSchema()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 556
+      "community": 557
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "createBaseSchema()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 441
+      "community": 442
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 441
+      "community": 442
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "createBaseSchema()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 557
+      "community": 558
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "batch-scheduler.ts",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 558
+      "community": 559
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 559
+      "community": 560
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "readInsertedUpdated()",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 442
+      "community": 443
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 442
+      "community": 443
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 560
+      "community": 561
     },
     {
       "label": "retry-manager.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 444
+      "community": 445
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 444
+      "community": 445
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "shouldRetry()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 561
+      "community": 562
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "baseResult()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 562
+      "community": 563
     },
     {
       "label": "job-queue.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "initializeTestDatabase()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 563
+      "community": 564
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "generateId()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 445
+      "community": 446
     },
     {
       "label": "initializeTestDatabase()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 445
+      "community": 446
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "createQualityTables()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 564
+      "community": 565
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "generateId()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 446
+      "community": 447
     },
     {
       "label": "initializeTestDatabase()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 446
+      "community": 447
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "type-guards.ts",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "validateTableName()",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 447
+      "community": 448
     },
     {
       "label": "getVectorTableName()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 447
+      "community": 448
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 565
+      "community": 566
     },
     {
       "label": "environment-check.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 566
+      "community": 567
     },
     {
       "label": "error-handling.spec.ts",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "operation()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 567
+      "community": 568
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "relation-visualizer.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "issue()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 448
+      "community": 449
     },
     {
       "label": "validateConfiguration()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 448
+      "community": 449
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "cache-key-generator.ts",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "transactionFn()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 449
+      "community": 450
     },
     {
       "label": "outerTransaction()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 449
+      "community": 450
     },
     {
       "label": "write-coalescing.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "path-validator.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 568
+      "community": 569
     },
     {
       "label": "error-handling.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "withErrorHandling()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 569
+      "community": 570
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 570
+      "community": 571
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "createValidReflectionNote()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 450
+      "community": 451
     },
     {
       "label": "createLargeNote()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 450
+      "community": 451
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "initializeTestDatabase()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 571
+      "community": 572
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 572
+      "community": 573
     },
     {
       "label": "logging-helpers.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "initializeTestDatabase()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 573
+      "community": 574
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "benchmark.types.ts",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "assertMacroCategory()",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 574
+      "community": 575
     },
     {
       "label": "migration.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "index.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "isMemoryItemType()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 451
+      "community": 452
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 451
+      "community": 452
     },
     {
       "label": "error-types.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "retry-options-loader.ts",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "validateConfig()",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 575
+      "community": 576
     },
     {
       "label": "config-loader-utils.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "getMockMementoConfig()",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 452
+      "community": 453
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 452
+      "community": 453
     },
     {
       "label": "initialize.spec.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "search-local-tool.ts",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "initializeTestDatabase()",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 576
+      "community": 577
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "initializeTestDatabase()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 577
+      "community": 578
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 578
+      "community": 579
     },
     {
       "label": "embedding-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "vector-search.factory.ts",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 579
+      "community": 580
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "search-result-combiner.ts",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 580
+      "community": 581
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19913,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "initializeTestDatabase()",
@@ -19921,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 453
+      "community": 454
     },
     {
       "label": "createValidReflectionNote()",
@@ -19929,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 453
+      "community": 454
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "vector-search.service.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 581
+      "community": 582
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createMockRepository()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 582
+      "community": 583
     },
     {
       "label": "vector-index-manager.ts",
@@ -20737,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "createMockRepositories()",
@@ -20745,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 583
+      "community": 584
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20761,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "createMockIndexRepository()",
@@ -20769,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 584
+      "community": 585
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22473,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "openTelemetryDb()",
@@ -22481,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 585
+      "community": 586
     },
     {
       "label": "telemetry-repository.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 586
+      "community": 587
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "llm-port.ts",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "persistence-port.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "context-port.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "agent-types.ts",
@@ -22977,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -22985,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "readProviderToken()",
@@ -22993,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 454
+      "community": 455
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -23001,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 454
+      "community": 455
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 875
+      "community": 876
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23097,7 +23097,39 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 876
+      "community": 877
+    },
+    {
+      "label": "ollama-chat-llm-adapter.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
+      "community": 374
+    },
+    {
+      "label": "OllamaChatLlmAdapter",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "id": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "community": 374
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L20",
+      "id": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
+      "community": 374
+    },
+    {
+      "label": ".complete()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L27",
+      "id": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
+      "community": 374
     },
     {
       "label": "gemini-chat-llm-adapter.ts",
@@ -23105,7 +23137,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "GeminiChatLlmAdapter",
@@ -23113,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23121,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".complete()",
@@ -23129,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L21",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
-      "community": 374
+      "community": 375
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -23217,7 +23249,15 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 877
+      "community": 878
+    },
+    {
+      "label": "ollama-chat-llm-adapter.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
+      "community": 879
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -23225,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23233,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "baseCandidate()",
@@ -23241,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 587
+      "community": 588
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23289,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -23297,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "makeDeps()",
@@ -23305,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 588
+      "community": 589
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23353,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -23361,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 589
+      "community": 590
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -23369,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23377,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 590
+      "community": 591
     },
     {
       "label": "core-memory-repository.ts",
@@ -23385,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23393,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23401,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23409,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23417,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "feedback-repository.ts",
@@ -23425,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23433,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 455
+      "community": 456
     },
     {
       "label": "FeedbackRepository",
@@ -23441,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 455
+      "community": 456
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23449,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23457,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23465,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23473,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23481,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23489,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createKgTripleTable()",
@@ -23497,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 591
+      "community": 592
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23505,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23513,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23521,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23529,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 593
+      "community": 594
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23537,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23545,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23553,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 594
+      "community": 595
     },
     {
       "label": "remember-tool.ts",
@@ -23641,7 +23681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "validateRecallQuery()",
@@ -23649,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 456
+      "community": 457
     },
     {
       "label": "validateRecallFilters()",
@@ -23657,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 456
+      "community": 457
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23665,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23673,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 595
+      "community": 596
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23681,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23689,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23697,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23705,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23713,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23721,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -23729,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -23737,7 +23777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23745,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23753,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -23761,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -23769,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 377
+      "community": 378
     },
     {
       "label": "feedback-tool.ts",
@@ -23825,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "CleanupMemoryTool",
@@ -23833,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".constructor()",
@@ -23841,7 +23881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".handle()",
@@ -23849,7 +23889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 378
+      "community": 379
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23857,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23865,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 457
+      "community": 458
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23873,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 457
+      "community": 458
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -24073,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "ProceduralDiffTool",
@@ -24081,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".constructor()",
@@ -24089,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".handle()",
@@ -24097,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 379
+      "community": 380
     },
     {
       "label": "unpin-tool.ts",
@@ -24217,7 +24257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -24225,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 380
+      "community": 381
     },
     {
       "label": ".constructor()",
@@ -24233,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 380
+      "community": 381
     },
     {
       "label": ".handle()",
@@ -24241,7 +24281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 380
+      "community": 381
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -24249,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "RememberProcedureTool",
@@ -24257,7 +24297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 381
+      "community": 382
     },
     {
       "label": ".constructor()",
@@ -24265,7 +24305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 381
+      "community": 382
     },
     {
       "label": ".handle()",
@@ -24273,7 +24313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 381
+      "community": 382
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -24321,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24329,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 596
+      "community": 597
     },
     {
       "label": "recall-tool.ts",
@@ -24465,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "forget-tool.ts",
@@ -24609,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "createSchema()",
@@ -24617,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 597
+      "community": 598
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24625,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24633,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "initializeTestDatabase()",
@@ -24641,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createValidReflectionNote()",
@@ -24649,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 458
+      "community": 459
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24657,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24665,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "createSchema()",
@@ -24673,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 598
+      "community": 599
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24681,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "generateId()",
@@ -24689,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 382
+      "community": 383
     },
     {
       "label": "initializeTestDatabase()",
@@ -24697,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 382
+      "community": 383
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24705,7 +24745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 382
+      "community": 383
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24713,7 +24753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24721,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24729,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "initializeTestDatabase()",
@@ -24737,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 599
+      "community": 600
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24745,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "parseData()",
@@ -24753,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 600
+      "community": 601
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24761,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24769,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "initializeTestDatabase()",
@@ -24777,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 459
+      "community": 460
     },
     {
       "label": "createValidReflectionNote()",
@@ -24785,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 459
+      "community": 460
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24793,7 +24833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24801,7 +24841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24809,7 +24849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "meta-memory-service.ts",
@@ -24937,7 +24977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "fieldDiff()",
@@ -24945,7 +24985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 383
+      "community": 384
     },
     {
       "label": "parseStepsJson()",
@@ -24953,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 383
+      "community": 384
     },
     {
       "label": "computeProceduralDiff()",
@@ -24961,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 383
+      "community": 384
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -25009,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "parseImportanceThreshold()",
@@ -25017,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 384
+      "community": 385
     },
     {
       "label": "parsePositiveInt()",
@@ -25025,7 +25065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 384
+      "community": 385
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -25033,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 384
+      "community": 385
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -25041,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "createBaseSchema()",
@@ -25049,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 601
+      "community": 602
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -25129,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "baseRow()",
@@ -25137,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 602
+      "community": 603
     },
     {
       "label": "procedural-versioning.ts",
@@ -25145,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "getVersionChain()",
@@ -25153,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 385
+      "community": 386
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -25161,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 385
+      "community": 386
     },
     {
       "label": "getNextVersionNumber()",
@@ -25169,7 +25209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 385
+      "community": 386
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -25177,7 +25217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -25185,7 +25225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".runScan()",
@@ -25193,7 +25233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 460
+      "community": 461
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -25201,7 +25241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "generateMemoryId()",
@@ -25209,7 +25249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 461
+      "community": 462
     },
     {
       "label": "rollbackToVersion()",
@@ -25217,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 461
+      "community": 462
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25289,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "selectionWindowLimit()",
@@ -25297,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 462
+      "community": 463
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25305,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 462
+      "community": 463
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25353,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25361,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25369,7 +25409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 603
+      "community": 604
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25377,7 +25417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "openDb()",
@@ -25385,7 +25425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 604
+      "community": 605
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25977,7 +26017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createBaseSchema()",
@@ -25985,7 +26025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26249,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26257,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26265,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 463
+      "community": 464
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26273,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 463
+      "community": 464
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26281,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26289,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "core-memory-service.ts",
@@ -26449,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createBaseSchema()",
@@ -26457,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26465,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26473,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 607
+      "community": 608
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26553,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26561,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26569,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "createSchema()",
@@ -26577,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26585,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26593,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "createSchema()",
@@ -26601,7 +26641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 609
+      "community": 610
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26609,7 +26649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26617,7 +26657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "createBaseSchema()",
@@ -26625,7 +26665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 610
+      "community": 611
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26633,7 +26673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26641,7 +26681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "createSchema()",
@@ -26649,7 +26689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 611
+      "community": 612
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26657,7 +26697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26665,7 +26705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26785,7 +26825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -27049,7 +27089,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -27057,7 +27097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -27065,7 +27105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 612
+      "community": 613
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -27073,7 +27113,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "consolidation-repository.ts",
@@ -27305,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "row()",
@@ -27313,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 613
+      "community": 614
     },
     {
       "label": "summarization-service.ts",
@@ -27409,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "ep()",
@@ -27417,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 614
+      "community": 615
     },
     {
       "label": "relation-graph.port.ts",
@@ -27425,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "get-relations-tool.ts",
@@ -27433,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "GetRelationsTool",
@@ -27441,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27449,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".handle()",
@@ -27457,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 386
+      "community": 387
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27465,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27473,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 615
+      "community": 616
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".handle()",
@@ -27505,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 387
+      "community": 388
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27513,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "RemoveRelationTool",
@@ -27521,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".constructor()",
@@ -27529,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".handle()",
@@ -27537,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 388
+      "community": 389
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27545,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "ExtractRelationsTool",
@@ -27553,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".constructor()",
@@ -27561,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".handle()",
@@ -27569,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 389
+      "community": 390
     },
     {
       "label": "add-relation-tool.ts",
@@ -27577,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "AddRelationTool",
@@ -27585,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".constructor()",
@@ -27593,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".handle()",
@@ -27601,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 390
+      "community": 391
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27657,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createBaseSchema()",
@@ -27665,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createTestMemory()",
@@ -27673,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 464
+      "community": 465
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27681,7 +27721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createBaseSchema()",
@@ -27689,7 +27729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createTestMemory()",
@@ -27697,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27705,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createBaseSchema()",
@@ -27713,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createTestMemory()",
@@ -27721,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 466
+      "community": 467
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27729,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27737,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "createBaseSchema()",
@@ -27745,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 467
+      "community": 468
     },
     {
       "label": "createTestMemory()",
@@ -27753,7 +27793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 467
+      "community": 468
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27761,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "RelationRetryManager",
@@ -27769,7 +27809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 391
+      "community": 392
     },
     {
       "label": ".constructor()",
@@ -27777,7 +27817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 391
+      "community": 392
     },
     {
       "label": ".retry()",
@@ -27785,7 +27825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 391
+      "community": 392
     },
     {
       "label": "relation-errors.ts",
@@ -28537,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "loadTestDataset()",
@@ -28545,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createBaseSchema()",
@@ -28553,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createTestMemory()",
@@ -28561,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 392
+      "community": 393
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28569,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28577,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "createBaseSchema()",
@@ -28585,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 468
+      "community": 469
     },
     {
       "label": "createTestMemory()",
@@ -28593,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 468
+      "community": 469
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28601,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "createTestMemory()",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 616
+      "community": 617
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28617,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "createBaseSchema()",
@@ -28625,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 393
+      "community": 394
     },
     {
       "label": "createTestMemory()",
@@ -28633,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 393
+      "community": 394
     },
     {
       "label": "createBulkMemories()",
@@ -28641,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 393
+      "community": 394
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28649,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "createTestMemory()",
@@ -28657,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 617
+      "community": 618
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28721,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28729,7 +28769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28737,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "getMockMementoConfig()",
@@ -28745,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 469
+      "community": 470
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28753,7 +28793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 469
+      "community": 470
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28761,7 +28801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28769,7 +28809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28777,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28785,7 +28825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28833,7 +28873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28841,7 +28881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 394
+      "community": 395
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28849,7 +28889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 394
+      "community": 395
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28857,7 +28897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 394
+      "community": 395
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -29105,7 +29145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "extract()",
@@ -29113,7 +29153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 618
+      "community": 619
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -29121,7 +29161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "tripleDedupeKey()",
@@ -29129,7 +29169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 470
+      "community": 471
     },
     {
       "label": "mergeTripleLists()",
@@ -29137,7 +29177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 470
+      "community": 471
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -29145,7 +29185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29329,7 +29369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29337,7 +29377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29345,7 +29385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "triple-extractor.ts",
@@ -29489,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "TripleNormalizer",
@@ -29497,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".constructor()",
@@ -29505,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".normalize()",
@@ -29513,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 395
+      "community": 396
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29521,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29529,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29537,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 396
+      "community": 397
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29545,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 396
+      "community": 397
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29553,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 396
+      "community": 397
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29561,7 +29601,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "triple-parser.ts",
@@ -29609,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29617,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 619
+      "community": 620
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29625,7 +29665,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29633,7 +29673,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 620
+      "community": 621
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29721,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29729,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "interfaces.spec.ts",
@@ -29737,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29745,7 +29785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29753,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29761,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29769,7 +29809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 621
+      "community": 622
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29777,7 +29817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29785,7 +29825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 622
+      "community": 623
     },
     {
       "label": "types.ts",
@@ -29793,7 +29833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29801,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "checkOllamaModel()",
@@ -29809,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 397
+      "community": 398
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29817,7 +29857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 397
+      "community": 398
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29825,7 +29865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 397
+      "community": 398
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29833,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29841,7 +29881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 623
+      "community": 624
     },
     {
       "label": "provider-selection.ts",
@@ -29849,7 +29889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29857,7 +29897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 471
+      "community": 472
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29865,7 +29905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 471
+      "community": 472
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29873,7 +29913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29881,7 +29921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 624
+      "community": 625
     },
     {
       "label": "llm-response-parse.ts",
@@ -30161,7 +30201,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createMockService()",
@@ -30169,7 +30209,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 398
+      "community": 399
     },
     {
       "label": "resolver()",
@@ -30177,7 +30217,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 398
+      "community": 399
     },
     {
       "label": "priority()",
@@ -30185,7 +30225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 398
+      "community": 399
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -30193,7 +30233,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "embedding-service.ts",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31321,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "createSchema()",
@@ -31329,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 472
+      "community": 473
     },
     {
       "label": "seedMemoryItem()",
@@ -31337,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 472
+      "community": 473
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31345,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31353,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31361,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31369,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31377,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 399
+      "community": 400
     },
     {
       "label": ".constructor()",
@@ -31385,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 399
+      "community": 400
     },
     {
       "label": ".handle()",
@@ -31393,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 399
+      "community": 400
     },
     {
       "label": "performance-alerts.ts",
@@ -31449,7 +31489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "PerformanceStatsTool",
@@ -31457,7 +31497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 400
+      "community": 401
     },
     {
       "label": ".constructor()",
@@ -31465,7 +31505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 400
+      "community": 401
     },
     {
       "label": ".handle()",
@@ -31473,7 +31513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 400
+      "community": 401
     },
     {
       "label": "resolve-error.ts",
@@ -31481,7 +31521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "executeResolveError()",
@@ -31489,7 +31529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 625
+      "community": 626
     },
     {
       "label": "error-stats.ts",
@@ -31497,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "executeErrorStats()",
@@ -31505,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 626
+      "community": 627
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31513,7 +31553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31521,7 +31561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31529,7 +31569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "createBaseSchema()",
@@ -31537,7 +31577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 627
+      "community": 628
     },
     {
       "label": "error-stats.spec.ts",
@@ -31545,7 +31585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "performance-monitor.ts",
@@ -32457,7 +32497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32465,7 +32505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32473,7 +32513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32481,7 +32521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32529,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "restoreEnvValue()",
@@ -32537,7 +32577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 628
+      "community": 629
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32545,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32553,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32561,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32569,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "quality-recorder.ts",
@@ -32641,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32649,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 629
+      "community": 630
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32729,7 +32769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32737,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 630
+      "community": 631
     },
     {
       "label": "quality-reporter.ts",
@@ -32825,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32833,7 +32873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32841,7 +32881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32849,7 +32889,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32857,7 +32897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "quality-assurance-service.ts",
@@ -33137,7 +33177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -33145,7 +33185,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 403
+      "community": 404
     },
     {
       "label": "createQualityMetricsTable()",
@@ -33153,7 +33193,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 403
+      "community": 404
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -33161,7 +33201,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 403
+      "community": 404
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -33353,7 +33393,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "base-tool.ts",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 631
+      "community": 632
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33665,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "measureRecall()",
@@ -33673,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 632
+      "community": 633
     },
     {
       "label": "test-embedding.ts",
@@ -33681,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33689,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 633
+      "community": 634
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33697,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "compareToolResults()",
@@ -33705,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 473
+      "community": 474
     },
     {
       "label": "testToolConsistency()",
@@ -33713,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 473
+      "community": 474
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33721,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "createQualityTables()",
@@ -33729,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 474
+      "community": 475
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33737,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 474
+      "community": 475
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33785,7 +33825,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testSearchFunctionality()",
@@ -33793,7 +33833,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 634
+      "community": 635
     },
     {
       "label": "test-forgetting.ts",
@@ -33801,7 +33841,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33809,7 +33849,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 635
+      "community": 636
     },
     {
       "label": "mock-database.spec.ts",
@@ -33817,7 +33857,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "test-m1-completion.ts",
@@ -33825,7 +33865,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "testM1Completion()",
@@ -33833,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33841,7 +33881,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33849,7 +33889,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 637
+      "community": 638
     },
     {
       "label": "vitest.setup.ts",
@@ -33857,7 +33897,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33865,7 +33905,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "parseItems()",
@@ -33873,7 +33913,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 638
+      "community": 639
     },
     {
       "label": "test-memory-resource.ts",
@@ -33881,7 +33921,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "setupResourceHandlers()",
@@ -33889,7 +33929,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 475
+      "community": 476
     },
     {
       "label": "createTestMemories()",
@@ -33897,7 +33937,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 475
+      "community": 476
     },
     {
       "label": "test-regression.ts",
@@ -33905,7 +33945,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "testRegression()",
@@ -33913,7 +33953,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 639
+      "community": 640
     },
     {
       "label": "test-anchor-system.ts",
@@ -33977,7 +34017,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -34049,7 +34089,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "testSingleProviderRegression()",
@@ -34057,7 +34097,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 640
+      "community": 641
     },
     {
       "label": "visualize-recency.ts",
@@ -34121,7 +34161,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34185,7 +34225,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "constructor()",
@@ -34193,7 +34233,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 641
+      "community": 642
     },
     {
       "label": "mock-database.ts",
@@ -34425,7 +34465,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34433,7 +34473,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "telemetryDb()",
@@ -34441,7 +34481,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 404
+      "community": 405
     },
     {
       "label": "percentile95()",
@@ -34449,7 +34489,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 404
+      "community": 405
     },
     {
       "label": "run()",
@@ -34457,7 +34497,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 404
+      "community": 405
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34465,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "createTestMemories()",
@@ -34473,7 +34513,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 642
+      "community": 643
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34481,7 +34521,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34489,7 +34529,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 643
+      "community": 644
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34497,7 +34537,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34505,7 +34545,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "seedCluster()",
@@ -34513,7 +34553,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 644
+      "community": 645
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34521,7 +34561,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "readSource()",
@@ -34529,7 +34569,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 476
+      "community": 477
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34537,7 +34577,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 476
+      "community": 477
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34545,7 +34585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34553,7 +34593,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 405
+      "community": 406
     },
     {
       "label": "normalizeTags()",
@@ -34561,7 +34601,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 405
+      "community": 406
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34569,7 +34609,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 405
+      "community": 406
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34577,7 +34617,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "writeFixtureDir()",
@@ -34585,7 +34625,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 645
+      "community": 646
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34681,7 +34721,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34745,7 +34785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "normalizeMemoryType()",
@@ -34753,7 +34793,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 406
+      "community": 407
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34761,7 +34801,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 406
+      "community": 407
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34769,7 +34809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 406
+      "community": 407
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34777,7 +34817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34785,7 +34825,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "test-database.ts",
@@ -34817,7 +34857,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "mergeCandidateIds()",
@@ -34825,7 +34865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 646
+      "community": 647
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34833,7 +34873,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34841,7 +34881,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 477
+      "community": 478
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34849,7 +34889,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 477
+      "community": 478
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34857,7 +34897,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34865,7 +34905,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -35065,7 +35105,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "query-counter.ts",
@@ -35073,7 +35113,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "extractQueryType()",
@@ -35081,7 +35121,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 407
+      "community": 408
     },
     {
       "label": "isExcluded()",
@@ -35089,7 +35129,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 407
+      "community": 408
     },
     {
       "label": "createQueryCounter()",
@@ -35097,7 +35137,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 407
+      "community": 408
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35465,7 +35505,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 647
+      "community": 648
     },
     {
       "label": "copyDir()",
@@ -35473,7 +35513,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 647
+      "community": 648
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35481,7 +35521,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "readRootPackageJson()",
@@ -35489,7 +35529,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 648
+      "community": 649
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35497,7 +35537,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "readJson()",
@@ -35505,7 +35545,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 649
+      "community": 650
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35513,7 +35553,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "readWorkflow()",
@@ -35521,7 +35561,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 650
+      "community": 651
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35585,7 +35625,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "readStaticFile()",
@@ -35593,7 +35633,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 651
+      "community": 652
     },
     {
       "label": "smoke.spec.ts",
@@ -35601,7 +35641,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "extractFencedBlocks()",
@@ -35609,7 +35649,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 652
+      "community": 653
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35681,7 +35721,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "parseArgs()",
@@ -35689,7 +35729,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 408
+      "community": 409
     },
     {
       "label": "printHelp()",
@@ -35697,7 +35737,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 408
+      "community": 409
     },
     {
       "label": "main()",
@@ -35705,7 +35745,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 408
+      "community": 409
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35793,7 +35833,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "shouldInclude()",
@@ -35801,7 +35841,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 653
+      "community": 654
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35809,7 +35849,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 478
+      "community": 479
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35817,7 +35857,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 478
+      "community": 479
     },
     {
       "label": "readTarString()",
@@ -35825,7 +35865,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 478
+      "community": 479
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35889,7 +35929,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 654
+      "community": 655
     },
     {
       "label": "fixMigration()",
@@ -35897,7 +35937,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 654
+      "community": 655
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35905,7 +35945,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 962
+      "community": 964
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35969,7 +36009,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "parseArgs()",
@@ -35977,7 +36017,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 409
+      "community": 410
     },
     {
       "label": "printHelp()",
@@ -35985,7 +36025,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 409
+      "community": 410
     },
     {
       "label": "main()",
@@ -35993,7 +36033,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 409
+      "community": 410
     },
     {
       "label": "check-path-traversal.ts",
@@ -36233,7 +36273,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 655
+      "community": 656
     },
     {
       "label": "updateEmbeddings()",
@@ -36241,7 +36281,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 655
+      "community": 656
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36409,7 +36449,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36417,7 +36457,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 656
+      "community": 657
     },
     {
       "label": "test-docker.js",
@@ -36425,7 +36465,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 657
+      "community": 658
     },
     {
       "label": "testDockerServer()",
@@ -36433,7 +36473,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 657
+      "community": 658
     },
     {
       "label": "pack-with-restore.js",
@@ -36441,7 +36481,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 963
+      "community": 965
     },
     {
       "label": "run-migration.js",
@@ -36449,7 +36489,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 658
+      "community": 659
     },
     {
       "label": "runMigration()",
@@ -36457,7 +36497,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 658
+      "community": 659
     },
     {
       "label": "safe-migration.js",
@@ -36465,7 +36505,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 659
+      "community": 660
     },
     {
       "label": "safeMigration()",
@@ -36473,7 +36513,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 659
+      "community": 660
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36537,7 +36577,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "saveWorkMemory()",
@@ -36545,7 +36585,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 660
+      "community": 661
     },
     {
       "label": "check-file-sizes.ts",
@@ -36713,7 +36753,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36721,7 +36761,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "main()",
@@ -36729,7 +36769,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 661
+      "community": 662
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36737,7 +36777,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "parseArgs()",
@@ -36745,7 +36785,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 410
+      "community": 411
     },
     {
       "label": "printHelp()",
@@ -36753,7 +36793,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 410
+      "community": 411
     },
     {
       "label": "main()",
@@ -36761,7 +36801,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 410
+      "community": 411
     },
     {
       "label": "verify-bin.js",
@@ -36769,7 +36809,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 965
+      "community": 967
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36817,7 +36857,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 662
+      "community": 663
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36825,7 +36865,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 662
+      "community": 663
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36833,7 +36873,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 663
+      "community": 664
     },
     {
       "label": "fixVectorDimensions()",
@@ -36841,7 +36881,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 663
+      "community": 664
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36849,7 +36889,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36857,7 +36897,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 411
+      "community": 412
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36865,7 +36905,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 411
+      "community": 412
     },
     {
       "label": "main()",
@@ -36873,7 +36913,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 411
+      "community": 412
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36881,7 +36921,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "loadVecExtension()",
@@ -36889,7 +36929,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 479
+      "community": 480
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36897,7 +36937,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 479
+      "community": 480
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36905,7 +36945,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "runUpdateMigration()",
@@ -36913,7 +36953,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 664
+      "community": 665
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36921,7 +36961,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "reappearanceRate()",
@@ -36929,7 +36969,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 480
+      "community": 481
     },
     {
       "label": "main()",
@@ -36937,7 +36977,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 480
+      "community": 481
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36945,7 +36985,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 665
+      "community": 666
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36953,7 +36993,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 665
+      "community": 666
     },
     {
       "label": "generate-relation-report.ts",
@@ -37105,7 +37145,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "sampleReport()",
@@ -37113,7 +37153,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 666
+      "community": 667
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -37121,7 +37161,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 966
+      "community": 968
     },
     {
       "label": "debug-embeddings.js",
@@ -37129,7 +37169,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 667
+      "community": 668
     },
     {
       "label": "debugEmbeddings()",
@@ -37137,7 +37177,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 667
+      "community": 668
     },
     {
       "label": "check-db-integrity.js",
@@ -37145,7 +37185,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 412
+      "community": 413
     },
     {
       "label": "log()",
@@ -37153,7 +37193,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 412
+      "community": 413
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -37161,7 +37201,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 412
+      "community": 413
     },
     {
       "label": "main()",
@@ -37169,7 +37209,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 412
+      "community": 413
     },
     {
       "label": "mcp-http-client.js",
@@ -37409,7 +37449,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 668
+      "community": 669
     },
     {
       "label": "backupEmbeddings()",
@@ -37417,7 +37457,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 668
+      "community": 669
     },
     {
       "label": "count-any-types.ts",
@@ -37633,7 +37673,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37641,7 +37681,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37649,7 +37689,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37657,7 +37697,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37665,7 +37705,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "jsonEmbedding()",
@@ -37673,7 +37713,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 669
+      "community": 670
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37681,7 +37721,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37689,7 +37729,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37697,7 +37737,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37705,7 +37745,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37713,7 +37753,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 670
+      "community": 671
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37721,7 +37761,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37729,7 +37769,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "jsonEmbedding()",
@@ -37737,7 +37777,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 671
+      "community": 672
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37745,7 +37785,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "main()",
@@ -37753,7 +37793,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 672
+      "community": 673
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37761,7 +37801,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37769,7 +37809,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 673
+      "community": 674
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37777,7 +37817,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "createBackup()",
@@ -37785,7 +37825,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 481
+      "community": 482
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37793,7 +37833,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 481
+      "community": 482
     },
     {
       "label": "restore-legacy.ps1",
@@ -37801,7 +37841,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 975
+      "community": 977
     },
     {
       "label": "check-retry-usage.ts",
@@ -37921,7 +37961,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37929,7 +37969,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 674
+      "community": 675
     },
     {
       "label": "check-no-console-violations.ts",
@@ -38025,7 +38065,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "fixVecTableDimensions()",
@@ -38033,7 +38073,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 675
+      "community": 676
     },
     {
       "label": "sources.ts",
@@ -38089,7 +38129,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "issue-body.ts",
@@ -38097,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "startMarker()",
@@ -38105,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 413
+      "community": 414
     },
     {
       "label": "renderManagedIssueBody()",
@@ -38113,7 +38153,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 413
+      "community": 414
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -38121,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 413
+      "community": 414
     },
     {
       "label": "fingerprint.ts",
@@ -38129,7 +38169,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "normalizeMessage()",
@@ -38137,7 +38177,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 482
+      "community": 483
     },
     {
       "label": "createFingerprint()",
@@ -38145,7 +38185,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 482
+      "community": 483
     },
     {
       "label": "sanitizer.ts",
@@ -38153,7 +38193,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "limitUtf8Bytes()",
@@ -38161,7 +38201,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 483
+      "community": 484
     },
     {
       "label": "sanitizeExcerpt()",
@@ -38169,7 +38209,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 483
+      "community": 484
     },
     {
       "label": "parsers.ts",
@@ -38177,7 +38217,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "inferLevel()",
@@ -38185,7 +38225,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 414
+      "community": 415
     },
     {
       "label": "parseAppLogLine()",
@@ -38193,7 +38233,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 414
+      "community": 415
     },
     {
       "label": "parseJsonlRecord()",
@@ -38201,7 +38241,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 414
+      "community": 415
     },
     {
       "label": "index.ts",
@@ -38209,7 +38249,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -38217,7 +38257,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 415
+      "community": 416
     },
     {
       "label": "createMonitorRuntime()",
@@ -38225,7 +38265,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 415
+      "community": 416
     },
     {
       "label": "runForever()",
@@ -38233,7 +38273,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 415
+      "community": 416
     },
     {
       "label": "promotion.ts",
@@ -38241,7 +38281,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38249,7 +38289,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 676
+      "community": 677
     },
     {
       "label": "state-store.ts",
@@ -38513,7 +38553,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "issue-body.spec.ts",
@@ -38521,7 +38561,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "github-client.spec.ts",
@@ -38529,7 +38569,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "config.spec.ts",
@@ -38537,7 +38577,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "detectors.spec.ts",
@@ -38545,7 +38585,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "sources.spec.ts",
@@ -38553,7 +38593,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "parsers.spec.ts",
@@ -38561,7 +38601,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 983
+      "community": 985
     },
     {
       "label": "monitor.spec.ts",
@@ -38569,7 +38609,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "config()",
@@ -38577,7 +38617,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 677
+      "community": 678
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38585,7 +38625,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 984
+      "community": 986
     },
     {
       "label": "state-store.spec.ts",
@@ -38593,7 +38633,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 985
+      "community": 987
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38601,7 +38641,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 986
+      "community": 988
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38609,7 +38649,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 987
+      "community": 989
     },
     {
       "label": "index.ts",
@@ -38617,7 +38657,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "main()",
@@ -38625,7 +38665,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 416
+      "community": 417
     },
     {
       "label": "index.ts",
@@ -38633,7 +38673,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "runExample()",
@@ -38641,7 +38681,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 416
+      "community": 417
     },
     {
       "label": "index.spec.ts",
@@ -38649,7 +38689,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 988
+      "community": 990
     },
     {
       "label": "memento-admin-fetch.js",
@@ -46789,7 +46829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L40",
+      "source_location": "L41",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46801,7 +46841,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L70",
+      "source_location": "L73",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46813,7 +46853,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L162",
+      "source_location": "L166",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46825,7 +46865,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L192",
+      "source_location": "L196",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46837,7 +46877,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L212",
+      "source_location": "L216",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46849,7 +46889,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L230",
+      "source_location": "L234",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
@@ -46861,7 +46901,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L242",
+      "source_location": "L246",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
@@ -46873,7 +46913,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L248",
+      "source_location": "L252",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
@@ -46885,7 +46925,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L254",
+      "source_location": "L258",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
@@ -46897,7 +46937,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L263",
+      "source_location": "L267",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapproveinteractive",
@@ -46909,7 +46949,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L316",
+      "source_location": "L320",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
@@ -46921,7 +46961,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L625",
+      "source_location": "L638",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -46933,7 +46973,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L71",
+      "source_location": "L74",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46945,7 +46985,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L111",
+      "source_location": "L114",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46957,7 +46997,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L117",
+      "source_location": "L120",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46969,7 +47009,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L321",
+      "source_location": "L325",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46981,7 +47021,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L373",
+      "source_location": "L378",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46993,7 +47033,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L329",
+      "source_location": "L333",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -47005,7 +47045,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L329",
+      "source_location": "L333",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -47017,7 +47057,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L256",
+      "source_location": "L260",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -47029,7 +47069,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L323",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -47041,7 +47081,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L388",
+      "source_location": "L393",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -47053,7 +47093,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L323",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -80731,6 +80771,42 @@
       "_tgt": "openai_chat_llm_adapter_openaichatllmadapter_complete",
       "source": "openai_chat_llm_adapter_openaichatllmadapter",
       "target": "openai_chat_llm_adapter_openaichatllmadapter_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
+      "_tgt": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "source": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
+      "target": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "_tgt": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
+      "source": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "target": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
+      "source_location": "L27",
+      "weight": 1.0,
+      "_src": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "_tgt": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
+      "source": "ollama_chat_llm_adapter_ollamachatllmadapter",
+      "target": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "after-assistant-turn.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "auto-remember-policy.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "channel-scope.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "factory.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 701
+      "community": 702
     },
     {
       "label": "test-integration.js",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "server-factory.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "batch-run-history.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "session-store.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "admin.routes.ts",
@@ -4375,7 +4375,7 @@
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L36",
+      "source_location": "L38",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
     },
@@ -4383,7 +4383,7 @@
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L66",
+      "source_location": "L68",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
     },
@@ -4391,7 +4391,7 @@
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L158",
+      "source_location": "L160",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
     },
@@ -4399,7 +4399,7 @@
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L188",
+      "source_location": "L190",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
     },
@@ -4407,7 +4407,7 @@
       "label": "resolveDbPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L208",
+      "source_location": "L210",
       "id": "agent_ask_resolvedbpath",
       "community": 90
     },
@@ -4415,7 +4415,7 @@
       "label": "jsonFailure()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L225",
+      "source_location": "L228",
       "id": "agent_ask_jsonfailure",
       "community": 90
     },
@@ -4423,7 +4423,7 @@
       "label": "writeOut()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L237",
+      "source_location": "L240",
       "id": "agent_ask_writeout",
       "community": 90
     },
@@ -4431,7 +4431,7 @@
       "label": "writeErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L243",
+      "source_location": "L246",
       "id": "agent_ask_writeerr",
       "community": 90
     },
@@ -4439,7 +4439,7 @@
       "label": "debugErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L249",
+      "source_location": "L252",
       "id": "agent_ask_debugerr",
       "community": 90
     },
@@ -4447,7 +4447,7 @@
       "label": "promptApproveInteractive()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L258",
+      "source_location": "L261",
       "id": "agent_ask_promptapproveinteractive",
       "community": 90
     },
@@ -4455,7 +4455,7 @@
       "label": "runAgentAskMain()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L311",
+      "source_location": "L314",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
@@ -4463,7 +4463,7 @@
       "label": "agentAskHelpText()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L562",
+      "source_location": "L594",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "brave-search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "types.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "utils.spec.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "logger.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "init.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "migrate.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "migration-runner.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "schema-version-manager.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "batch-scheduler.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "type-guards.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "relation-visualizer.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "cache-key-generator.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "path-validator.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "benchmark.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "index.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "retry-options-loader.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "search-local-tool.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "vector-search.factory.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "search-result-combiner.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "vector-search.service.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "llm-port.ts",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "persistence-port.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "context-port.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "agent-types.ts",
@@ -22977,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23145,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23204,6 +23204,14 @@
       "community": 320
     },
     {
+      "label": "create-personal-agent-llm-port.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
+      "community": 875
+    },
+    {
       "label": "personal-knowledge-agent-service.spec.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
@@ -23260,12 +23268,28 @@
       "community": 321
     },
     {
+      "label": "create-personal-agent-llm-port.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
+      "community": 587
+    },
+    {
+      "label": "createPersonalAgentLlmPort()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
+      "source_location": "L12",
+      "id": "create_personal_agent_llm_port_createpersonalagentllmport",
+      "community": 587
+    },
+    {
       "label": "normalize-memory-types-for-item-search.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23273,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 587
+      "community": 588
     },
     {
       "label": "core-memory-repository.ts",
@@ -23281,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23289,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23297,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23305,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23313,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "feedback-repository.ts",
@@ -23345,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23353,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23361,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23369,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23377,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23385,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "createKgTripleTable()",
@@ -23393,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 588
+      "community": 589
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23401,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23409,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 589
+      "community": 590
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23417,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23425,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23433,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23441,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23449,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 591
+      "community": 592
     },
     {
       "label": "remember-tool.ts",
@@ -23561,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23569,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 592
+      "community": 593
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -24217,7 +24241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24225,7 +24249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 593
+      "community": 594
     },
     {
       "label": "recall-tool.ts",
@@ -24361,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "forget-tool.ts",
@@ -24505,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "createSchema()",
@@ -24513,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 594
+      "community": 595
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24521,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24553,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24561,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "createSchema()",
@@ -24569,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 595
+      "community": 596
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24609,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24617,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24625,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "initializeTestDatabase()",
@@ -24633,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 596
+      "community": 597
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24641,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "parseData()",
@@ -24649,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 597
+      "community": 598
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24657,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24689,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24697,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24705,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "meta-memory-service.ts",
@@ -24937,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "createBaseSchema()",
@@ -24945,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 598
+      "community": 599
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -25025,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "baseRow()",
@@ -25033,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 599
+      "community": 600
     },
     {
       "label": "procedural-versioning.ts",
@@ -25249,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25257,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25265,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 600
+      "community": 601
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25273,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "openDb()",
@@ -25281,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 601
+      "community": 602
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25873,7 +25897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "createBaseSchema()",
@@ -25881,7 +25905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 602
+      "community": 603
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26145,7 +26169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26177,7 +26201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26185,7 +26209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "core-memory-service.ts",
@@ -26345,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createBaseSchema()",
@@ -26353,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 603
+      "community": 604
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26361,7 +26385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26369,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 604
+      "community": 605
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26449,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26457,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26465,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createSchema()",
@@ -26473,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26481,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26489,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createSchema()",
@@ -26497,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26505,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26513,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createBaseSchema()",
@@ -26521,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 607
+      "community": 608
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26529,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26537,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "createSchema()",
@@ -26545,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26553,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26561,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26681,7 +26705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26945,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26953,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26961,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 609
+      "community": 610
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26969,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "consolidation-repository.ts",
@@ -27201,7 +27225,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "row()",
@@ -27209,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 610
+      "community": 611
     },
     {
       "label": "summarization-service.ts",
@@ -27305,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "ep()",
@@ -27313,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 611
+      "community": 612
     },
     {
       "label": "relation-graph.port.ts",
@@ -27321,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "get-relations-tool.ts",
@@ -27361,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27369,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 612
+      "community": 613
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27625,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -28465,7 +28489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28497,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "createTestMemory()",
@@ -28505,7 +28529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 613
+      "community": 614
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28545,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "createTestMemory()",
@@ -28553,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 614
+      "community": 615
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28617,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28625,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28657,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28665,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28673,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28681,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -29001,7 +29025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "extract()",
@@ -29009,7 +29033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 615
+      "community": 616
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -29041,7 +29065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29225,7 +29249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29233,7 +29257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29241,7 +29265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "triple-extractor.ts",
@@ -29417,7 +29441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29457,7 +29481,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-parser.ts",
@@ -29505,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29513,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 616
+      "community": 617
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29521,7 +29545,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29529,7 +29553,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 617
+      "community": 618
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29617,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29625,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "interfaces.spec.ts",
@@ -29633,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29641,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29649,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29657,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29665,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 618
+      "community": 619
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29673,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29681,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 619
+      "community": 620
     },
     {
       "label": "types.ts",
@@ -29689,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29729,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29737,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 620
+      "community": 621
     },
     {
       "label": "provider-selection.ts",
@@ -29769,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29777,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 621
+      "community": 622
     },
     {
       "label": "llm-response-parse.ts",
@@ -30089,7 +30113,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "embedding-service.ts",
@@ -31201,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31209,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31241,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31249,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31257,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31377,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "executeResolveError()",
@@ -31385,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 622
+      "community": 623
     },
     {
       "label": "error-stats.ts",
@@ -31393,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "executeErrorStats()",
@@ -31401,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 623
+      "community": 624
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31409,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31417,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31425,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "createBaseSchema()",
@@ -31433,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 624
+      "community": 625
     },
     {
       "label": "error-stats.spec.ts",
@@ -31441,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "performance-monitor.ts",
@@ -32353,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32361,7 +32385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32369,7 +32393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32377,7 +32401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32425,7 +32449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "restoreEnvValue()",
@@ -32433,7 +32457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 625
+      "community": 626
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32537,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32545,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 626
+      "community": 627
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32625,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32633,7 +32657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 627
+      "community": 628
     },
     {
       "label": "quality-reporter.ts",
@@ -32753,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "quality-assurance-service.ts",
@@ -33249,7 +33273,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "base-tool.ts",
@@ -33545,7 +33569,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33553,7 +33577,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 628
+      "community": 629
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33561,7 +33585,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "measureRecall()",
@@ -33569,7 +33593,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 629
+      "community": 630
     },
     {
       "label": "test-embedding.ts",
@@ -33577,7 +33601,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33585,7 +33609,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 630
+      "community": 631
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33681,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testSearchFunctionality()",
@@ -33689,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 631
+      "community": 632
     },
     {
       "label": "test-forgetting.ts",
@@ -33697,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33705,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 632
+      "community": 633
     },
     {
       "label": "mock-database.spec.ts",
@@ -33713,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "test-m1-completion.ts",
@@ -33721,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testM1Completion()",
@@ -33729,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 633
+      "community": 634
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33737,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33745,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 634
+      "community": 635
     },
     {
       "label": "vitest.setup.ts",
@@ -33753,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33761,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "parseItems()",
@@ -33769,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 635
+      "community": 636
     },
     {
       "label": "test-memory-resource.ts",
@@ -33801,7 +33825,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "testRegression()",
@@ -33809,7 +33833,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-anchor-system.ts",
@@ -33873,7 +33897,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33945,7 +33969,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33953,7 +33977,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 637
+      "community": 638
     },
     {
       "label": "visualize-recency.ts",
@@ -34017,7 +34041,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34081,7 +34105,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "constructor()",
@@ -34089,7 +34113,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 638
+      "community": 639
     },
     {
       "label": "mock-database.ts",
@@ -34321,7 +34345,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34361,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "createTestMemories()",
@@ -34369,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 639
+      "community": 640
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34377,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34385,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 640
+      "community": 641
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34393,7 +34417,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34401,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "seedCluster()",
@@ -34409,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 641
+      "community": 642
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34473,7 +34497,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "writeFixtureDir()",
@@ -34481,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 642
+      "community": 643
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34577,7 +34601,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34673,7 +34697,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34681,7 +34705,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "test-database.ts",
@@ -34713,7 +34737,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "mergeCandidateIds()",
@@ -34721,7 +34745,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 643
+      "community": 644
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34753,7 +34777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34761,7 +34785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34961,7 +34985,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "query-counter.ts",
@@ -35361,7 +35385,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 644
+      "community": 645
     },
     {
       "label": "copyDir()",
@@ -35369,7 +35393,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 644
+      "community": 645
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35377,7 +35401,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "readRootPackageJson()",
@@ -35385,7 +35409,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 645
+      "community": 646
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35393,7 +35417,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "readJson()",
@@ -35401,7 +35425,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 646
+      "community": 647
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35409,7 +35433,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "readWorkflow()",
@@ -35417,7 +35441,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 647
+      "community": 648
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35481,7 +35505,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "readStaticFile()",
@@ -35489,7 +35513,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 648
+      "community": 649
     },
     {
       "label": "smoke.spec.ts",
@@ -35497,7 +35521,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "extractFencedBlocks()",
@@ -35505,7 +35529,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 649
+      "community": 650
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35689,7 +35713,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 650
+      "community": 651
     },
     {
       "label": "shouldInclude()",
@@ -35697,7 +35721,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 650
+      "community": 651
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35785,7 +35809,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 651
+      "community": 652
     },
     {
       "label": "fixMigration()",
@@ -35793,7 +35817,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 651
+      "community": 652
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35801,7 +35825,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 956
+      "community": 958
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -36129,7 +36153,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 652
+      "community": 653
     },
     {
       "label": "updateEmbeddings()",
@@ -36137,7 +36161,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 652
+      "community": 653
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36305,7 +36329,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36313,7 +36337,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 653
+      "community": 654
     },
     {
       "label": "test-docker.js",
@@ -36321,7 +36345,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 654
+      "community": 655
     },
     {
       "label": "testDockerServer()",
@@ -36329,7 +36353,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 654
+      "community": 655
     },
     {
       "label": "pack-with-restore.js",
@@ -36337,7 +36361,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 957
+      "community": 959
     },
     {
       "label": "run-migration.js",
@@ -36345,7 +36369,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 655
+      "community": 656
     },
     {
       "label": "runMigration()",
@@ -36353,7 +36377,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 655
+      "community": 656
     },
     {
       "label": "safe-migration.js",
@@ -36361,7 +36385,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 656
+      "community": 657
     },
     {
       "label": "safeMigration()",
@@ -36369,7 +36393,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 656
+      "community": 657
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36433,7 +36457,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "saveWorkMemory()",
@@ -36441,7 +36465,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 657
+      "community": 658
     },
     {
       "label": "check-file-sizes.ts",
@@ -36609,7 +36633,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36617,7 +36641,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "main()",
@@ -36625,7 +36649,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 658
+      "community": 659
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36665,7 +36689,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 959
+      "community": 961
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36713,7 +36737,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 659
+      "community": 660
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36721,7 +36745,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 659
+      "community": 660
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36729,7 +36753,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 660
+      "community": 661
     },
     {
       "label": "fixVectorDimensions()",
@@ -36737,7 +36761,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 660
+      "community": 661
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36801,7 +36825,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "runUpdateMigration()",
@@ -36809,7 +36833,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 661
+      "community": 662
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36841,7 +36865,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 662
+      "community": 663
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36849,7 +36873,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 662
+      "community": 663
     },
     {
       "label": "generate-relation-report.ts",
@@ -37001,7 +37025,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "sampleReport()",
@@ -37009,7 +37033,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 663
+      "community": 664
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -37017,7 +37041,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 960
+      "community": 962
     },
     {
       "label": "debug-embeddings.js",
@@ -37025,7 +37049,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 664
+      "community": 665
     },
     {
       "label": "debugEmbeddings()",
@@ -37033,7 +37057,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 664
+      "community": 665
     },
     {
       "label": "check-db-integrity.js",
@@ -37305,7 +37329,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 665
+      "community": 666
     },
     {
       "label": "backupEmbeddings()",
@@ -37313,7 +37337,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 665
+      "community": 666
     },
     {
       "label": "count-any-types.ts",
@@ -37529,7 +37553,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37537,7 +37561,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37545,7 +37569,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37553,7 +37577,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37561,7 +37585,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "jsonEmbedding()",
@@ -37569,7 +37593,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 666
+      "community": 667
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37577,7 +37601,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37585,7 +37609,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37593,7 +37617,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37601,7 +37625,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37609,7 +37633,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 667
+      "community": 668
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37617,7 +37641,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37625,7 +37649,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "jsonEmbedding()",
@@ -37633,7 +37657,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 668
+      "community": 669
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37641,7 +37665,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "main()",
@@ -37649,7 +37673,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 669
+      "community": 670
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37657,7 +37681,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37665,7 +37689,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 670
+      "community": 671
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37697,7 +37721,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 969
+      "community": 971
     },
     {
       "label": "check-retry-usage.ts",
@@ -37817,7 +37841,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37825,7 +37849,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 671
+      "community": 672
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37921,7 +37945,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37929,7 +37953,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 672
+      "community": 673
     },
     {
       "label": "sources.ts",
@@ -37985,7 +38009,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "issue-body.ts",
@@ -38137,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38145,7 +38169,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 673
+      "community": 674
     },
     {
       "label": "state-store.ts",
@@ -38409,7 +38433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "issue-body.spec.ts",
@@ -38417,7 +38441,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "github-client.spec.ts",
@@ -38425,7 +38449,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "config.spec.ts",
@@ -38433,7 +38457,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "detectors.spec.ts",
@@ -38441,7 +38465,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "sources.spec.ts",
@@ -38449,7 +38473,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "parsers.spec.ts",
@@ -38457,7 +38481,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "monitor.spec.ts",
@@ -38465,7 +38489,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "config()",
@@ -38473,7 +38497,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 674
+      "community": 675
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38481,7 +38505,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "state-store.spec.ts",
@@ -38489,7 +38513,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38497,7 +38521,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38505,7 +38529,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "index.ts",
@@ -38545,7 +38569,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "memento-admin-fetch.js",
@@ -46685,7 +46709,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L36",
+      "source_location": "L38",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46697,7 +46721,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L66",
+      "source_location": "L68",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46709,7 +46733,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L158",
+      "source_location": "L160",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46721,7 +46745,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L188",
+      "source_location": "L190",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46733,7 +46757,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L208",
+      "source_location": "L210",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46745,7 +46769,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L225",
+      "source_location": "L228",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
@@ -46757,7 +46781,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L237",
+      "source_location": "L240",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
@@ -46769,7 +46793,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L243",
+      "source_location": "L246",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
@@ -46781,7 +46805,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L249",
+      "source_location": "L252",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
@@ -46793,7 +46817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L258",
+      "source_location": "L261",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapproveinteractive",
@@ -46805,7 +46829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L311",
+      "source_location": "L314",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
@@ -46817,7 +46841,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L562",
+      "source_location": "L594",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -46829,7 +46853,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L67",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46841,7 +46865,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L107",
+      "source_location": "L109",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46853,7 +46877,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L113",
+      "source_location": "L115",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46865,7 +46889,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L316",
+      "source_location": "L319",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46877,7 +46901,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L368",
+      "source_location": "L371",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46889,7 +46913,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L324",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46901,7 +46925,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L324",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46913,7 +46937,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L251",
+      "source_location": "L254",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -46925,7 +46949,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L318",
+      "source_location": "L321",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -46937,7 +46961,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L383",
+      "source_location": "L386",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -46949,7 +46973,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L318",
+      "source_location": "L321",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -80855,6 +80879,18 @@
       "_tgt": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
       "source": "personal_knowledge_agent_service_personalknowledgeagentservice",
       "target": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
+      "_tgt": "create_personal_agent_llm_port_createpersonalagentllmport",
+      "source": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
+      "target": "create_personal_agent_llm_port_createpersonalagentllmport",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 416
+      "community": 417
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 416
+      "community": 417
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 483
+      "community": 484
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 417
+      "community": 418
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 417
+      "community": 418
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 484
+      "community": 485
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 485
+      "community": 486
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 418
+      "community": 419
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 418
+      "community": 419
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 486
+      "community": 487
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 703
+      "community": 704
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 487
+      "community": 488
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 487
+      "community": 488
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 488
+      "community": 489
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 489
+      "community": 490
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 490
+      "community": 491
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "createMockResponse()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 419
+      "community": 420
     },
     {
       "label": "sendOptions()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 419
+      "community": 420
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 491
+      "community": 492
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "readRepoFile()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 420
+      "community": 421
     },
     {
       "label": "sectionBetween()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 420
+      "community": 421
     },
     {
       "label": "http-server.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 492
+      "community": 493
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 493
+      "community": 494
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "createMockResponse()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 421
+      "community": 422
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 421
+      "community": 422
     },
     {
       "label": "server-state.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "batch-run-history.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 422
+      "community": 423
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 422
+      "community": 423
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 494
+      "community": 495
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 495
+      "community": 496
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 496
+      "community": 497
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 497
+      "community": 498
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 498
+      "community": 499
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 499
+      "community": 500
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 500
+      "community": 501
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 501
+      "community": 502
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 502
+      "community": 503
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 503
+      "community": 504
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 423
+      "community": 424
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 423
+      "community": 424
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "parseParams()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 424
+      "community": 425
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 424
+      "community": 425
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "parseCleanupParams()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 425
+      "community": 426
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 425
+      "community": 426
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 510
+      "community": 511
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 511
+      "community": 512
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 512
+      "community": 513
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 513
+      "community": 514
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 514
+      "community": 515
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "resolveEnvPath()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 426
+      "community": 427
     },
     {
       "label": "loadEnv()",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 426
+      "community": 427
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "runCli()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 515
+      "community": 516
     },
     {
       "label": "agent-ask.ts",
@@ -4375,7 +4375,7 @@
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
     },
@@ -4383,7 +4383,7 @@
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
     },
@@ -4391,7 +4391,7 @@
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L161",
+      "source_location": "L162",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
     },
@@ -4399,7 +4399,7 @@
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L191",
+      "source_location": "L192",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
     },
@@ -4407,7 +4407,7 @@
       "label": "resolveDbPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L211",
+      "source_location": "L212",
       "id": "agent_ask_resolvedbpath",
       "community": 90
     },
@@ -4415,7 +4415,7 @@
       "label": "jsonFailure()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L229",
+      "source_location": "L230",
       "id": "agent_ask_jsonfailure",
       "community": 90
     },
@@ -4423,7 +4423,7 @@
       "label": "writeOut()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L241",
+      "source_location": "L242",
       "id": "agent_ask_writeout",
       "community": 90
     },
@@ -4431,7 +4431,7 @@
       "label": "writeErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L247",
+      "source_location": "L248",
       "id": "agent_ask_writeerr",
       "community": 90
     },
@@ -4439,7 +4439,7 @@
       "label": "debugErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L253",
+      "source_location": "L254",
       "id": "agent_ask_debugerr",
       "community": 90
     },
@@ -4447,7 +4447,7 @@
       "label": "promptApproveInteractive()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L262",
+      "source_location": "L263",
       "id": "agent_ask_promptapproveinteractive",
       "community": 90
     },
@@ -4455,7 +4455,7 @@
       "label": "runAgentAskMain()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L315",
+      "source_location": "L316",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
@@ -4463,7 +4463,7 @@
       "label": "agentAskHelpText()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L610",
+      "source_location": "L625",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 427
+      "community": 428
     },
     {
       "label": "runQualityMeasurement()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 427
+      "community": 428
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "testSimpleAlerts()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "testBasicFunctionality()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 517
+      "community": 518
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 518
+      "community": 519
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "compareServices()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 428
+      "community": 429
     },
     {
       "label": "testServerSynchronization()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 428
+      "community": 429
     },
     {
       "label": "test-error-logging.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "testErrorLogging()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 519
+      "community": 520
     },
     {
       "label": "debug-http-v2.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "testFetch()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 520
+      "community": 521
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "initializeTestDatabase()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "testReflexionE2E()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "testAlertsDirect()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 523
+      "community": 524
     },
     {
       "label": "test-client.ts",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "assert()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 429
+      "community": 430
     },
     {
       "label": "testMementoClient()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 429
+      "community": 430
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 525
+      "community": 526
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 526
+      "community": 527
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "createBaseSchema()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 430
+      "community": 431
     },
     {
       "label": "createTestMemory()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 430
+      "community": 431
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 431
+      "community": 432
     },
     {
       "label": "findNodeForAnchor()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 431
+      "community": 432
     },
     {
       "label": "vitest.config.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "brave-search-provider.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "NoopSearchProvider",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 432
+      "community": 433
     },
     {
       "label": ".search()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 432
+      "community": 433
     },
     {
       "label": "search-factory.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "createSearchProvider()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 527
+      "community": 528
     },
     {
       "label": "search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "types.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "loadAgentConfig()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 528
+      "community": 529
     },
     {
       "label": "system-prompt.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "utils.spec.ts",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "buildMemory()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 529
+      "community": 530
     },
     {
       "label": "context-injector.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "logger.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "shouldLog()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 433
+      "community": 434
     },
     {
       "label": "log()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 433
+      "community": 434
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "createMementoCore()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 434
+      "community": 435
     },
     {
       "label": "closeDatabase()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 434
+      "community": 435
     },
     {
       "label": "bootstrap.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "initializeServices()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 530
+      "community": 531
     },
     {
       "label": "context.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 531
+      "community": 532
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 532
+      "community": 533
     },
     {
       "label": "anchor-stack.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createAnchorStack()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 533
+      "community": 534
     },
     {
       "label": "failure-reflexion.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 534
+      "community": 535
     },
     {
       "label": "search-and-embedding.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 535
+      "community": 536
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 536
+      "community": 537
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 537
+      "community": 538
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createInput()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 538
+      "community": 539
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createRelationGraph()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 539
+      "community": 540
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "createBaseSchema()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 435
+      "community": 436
     },
     {
       "label": "measureTime()",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 435
+      "community": 436
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createBaseSchema()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 540
+      "community": 541
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 541
+      "community": 542
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "openLockTestDatabase()",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 542
+      "community": 543
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createProgress()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 543
+      "community": 544
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 544
+      "community": 545
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 545
+      "community": 546
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "addMissingColumn()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 436
+      "community": 437
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 436
+      "community": 437
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "init.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createDbPath()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 546
+      "community": 547
     },
     {
       "label": "migrate.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "migrate.ts",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "isDuplicateColumnError()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 437
+      "community": 438
     },
     {
       "label": "migrateDatabase()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 437
+      "community": 438
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "migration-runner.ts",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createBaseSchema()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 547
+      "community": 548
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "schema-version-manager.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 548
+      "community": 549
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 549
+      "community": 550
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMemoryItemTable()",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 438
+      "community": 439
     },
     {
       "label": "tableExists()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 438
+      "community": 439
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMemoryItemTable()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 439
+      "community": 440
     },
     {
       "label": "tableExists()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 439
+      "community": 440
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createSchemaWith018()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 552
+      "community": 553
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createBaseSchema()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 553
+      "community": 554
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 554
+      "community": 555
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "createBaseSchema()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 555
+      "community": 556
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createBaseSchema()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 440
+      "community": 441
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "createBaseSchema()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 556
+      "community": 557
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "batch-scheduler.ts",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 557
+      "community": 558
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 558
+      "community": 559
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "readInsertedUpdated()",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 441
+      "community": 442
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 441
+      "community": 442
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 559
+      "community": 560
     },
     {
       "label": "retry-manager.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 442
+      "community": 443
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 442
+      "community": 443
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "shouldRetry()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 560
+      "community": 561
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "baseResult()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 561
+      "community": 562
     },
     {
       "label": "job-queue.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "initializeTestDatabase()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 562
+      "community": 563
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "generateId()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 444
+      "community": 445
     },
     {
       "label": "initializeTestDatabase()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 444
+      "community": 445
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "createQualityTables()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 563
+      "community": 564
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "generateId()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 445
+      "community": 446
     },
     {
       "label": "initializeTestDatabase()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 445
+      "community": 446
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "type-guards.ts",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "validateTableName()",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 446
+      "community": 447
     },
     {
       "label": "getVectorTableName()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 446
+      "community": 447
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 564
+      "community": 565
     },
     {
       "label": "environment-check.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 565
+      "community": 566
     },
     {
       "label": "error-handling.spec.ts",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "operation()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 566
+      "community": 567
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "relation-visualizer.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "issue()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 447
+      "community": 448
     },
     {
       "label": "validateConfiguration()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 447
+      "community": 448
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "cache-key-generator.ts",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "transactionFn()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 448
+      "community": 449
     },
     {
       "label": "outerTransaction()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 448
+      "community": 449
     },
     {
       "label": "write-coalescing.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "path-validator.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 567
+      "community": 568
     },
     {
       "label": "error-handling.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "withErrorHandling()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 568
+      "community": 569
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 569
+      "community": 570
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "createValidReflectionNote()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 449
+      "community": 450
     },
     {
       "label": "createLargeNote()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 449
+      "community": 450
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "initializeTestDatabase()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 570
+      "community": 571
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 571
+      "community": 572
     },
     {
       "label": "logging-helpers.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "initializeTestDatabase()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 572
+      "community": 573
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "benchmark.types.ts",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "assertMacroCategory()",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 573
+      "community": 574
     },
     {
       "label": "migration.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "index.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "isMemoryItemType()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 450
+      "community": 451
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 450
+      "community": 451
     },
     {
       "label": "error-types.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "retry-options-loader.ts",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "validateConfig()",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 574
+      "community": 575
     },
     {
       "label": "config-loader-utils.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "getMockMementoConfig()",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 451
+      "community": 452
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 451
+      "community": 452
     },
     {
       "label": "initialize.spec.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "search-local-tool.ts",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "initializeTestDatabase()",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 575
+      "community": 576
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "initializeTestDatabase()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 576
+      "community": 577
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 577
+      "community": 578
     },
     {
       "label": "embedding-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "vector-search.factory.ts",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "search-result-combiner.ts",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 579
+      "community": 580
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19913,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "initializeTestDatabase()",
@@ -19921,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 452
+      "community": 453
     },
     {
       "label": "createValidReflectionNote()",
@@ -19929,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 452
+      "community": 453
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "vector-search.service.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 580
+      "community": 581
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createMockRepository()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 581
+      "community": 582
     },
     {
       "label": "vector-index-manager.ts",
@@ -20737,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createMockRepositories()",
@@ -20745,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 582
+      "community": 583
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20761,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "createMockIndexRepository()",
@@ -20769,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 583
+      "community": 584
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22473,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "openTelemetryDb()",
@@ -22481,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 584
+      "community": 585
     },
     {
       "label": "telemetry-repository.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 585
+      "community": 586
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "llm-port.ts",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "persistence-port.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "context-port.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "agent-types.ts",
@@ -22977,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -22985,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "readProviderToken()",
@@ -22993,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 453
+      "community": 454
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -23001,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 453
+      "community": 454
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23097,7 +23097,39 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 875
+      "community": 876
+    },
+    {
+      "label": "gemini-chat-llm-adapter.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
+      "community": 374
+    },
+    {
+      "label": "GeminiChatLlmAdapter",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L11",
+      "id": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "community": 374
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
+      "community": 374
+    },
+    {
+      "label": ".complete()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L21",
+      "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
+      "community": 374
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -23180,12 +23212,20 @@
       "community": 319
     },
     {
+      "label": "gemini-chat-llm-adapter.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
+      "community": 877
+    },
+    {
       "label": "deterministic-mock-llm-adapter.spec.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23193,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "baseCandidate()",
@@ -23201,7 +23241,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 586
+      "community": 587
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23249,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -23257,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "makeDeps()",
@@ -23265,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 587
+      "community": 588
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23313,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -23321,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 588
+      "community": 589
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -23329,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23337,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 589
+      "community": 590
     },
     {
       "label": "core-memory-repository.ts",
@@ -23345,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23353,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23361,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23369,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23377,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "feedback-repository.ts",
@@ -23385,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23393,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 454
+      "community": 455
     },
     {
       "label": "FeedbackRepository",
@@ -23401,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 454
+      "community": 455
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23409,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23417,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23425,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23433,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23441,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23449,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createKgTripleTable()",
@@ -23457,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23465,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23473,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 591
+      "community": 592
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23481,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23489,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23497,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23505,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23513,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 593
+      "community": 594
     },
     {
       "label": "remember-tool.ts",
@@ -23601,7 +23641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "validateRecallQuery()",
@@ -23609,7 +23649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 455
+      "community": 456
     },
     {
       "label": "validateRecallFilters()",
@@ -23617,7 +23657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 455
+      "community": 456
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23625,7 +23665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23633,7 +23673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 594
+      "community": 595
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23641,7 +23681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23649,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23657,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -23665,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 374
+      "community": 375
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23673,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23681,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23689,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23697,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23705,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23713,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -23721,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -23729,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "feedback-tool.ts",
@@ -23785,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "CleanupMemoryTool",
@@ -23793,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -23801,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -23809,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 377
+      "community": 378
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23817,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23825,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 456
+      "community": 457
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23833,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 456
+      "community": 457
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -24033,7 +24073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "ProceduralDiffTool",
@@ -24041,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".constructor()",
@@ -24049,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".handle()",
@@ -24057,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 378
+      "community": 379
     },
     {
       "label": "unpin-tool.ts",
@@ -24177,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -24185,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".constructor()",
@@ -24193,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".handle()",
@@ -24201,7 +24241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 379
+      "community": 380
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -24209,7 +24249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "RememberProcedureTool",
@@ -24217,7 +24257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 380
+      "community": 381
     },
     {
       "label": ".constructor()",
@@ -24225,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 380
+      "community": 381
     },
     {
       "label": ".handle()",
@@ -24233,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 380
+      "community": 381
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -24281,7 +24321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24289,7 +24329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 595
+      "community": 596
     },
     {
       "label": "recall-tool.ts",
@@ -24425,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "forget-tool.ts",
@@ -24569,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "createSchema()",
@@ -24577,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 596
+      "community": 597
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24585,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24593,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "initializeTestDatabase()",
@@ -24601,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 457
+      "community": 458
     },
     {
       "label": "createValidReflectionNote()",
@@ -24609,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 457
+      "community": 458
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24617,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24625,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "createSchema()",
@@ -24633,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 597
+      "community": 598
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24641,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "generateId()",
@@ -24649,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 381
+      "community": 382
     },
     {
       "label": "initializeTestDatabase()",
@@ -24657,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 381
+      "community": 382
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24665,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 381
+      "community": 382
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24673,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24681,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24689,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "initializeTestDatabase()",
@@ -24697,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 598
+      "community": 599
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24705,7 +24745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "parseData()",
@@ -24713,7 +24753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 599
+      "community": 600
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24721,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24729,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "initializeTestDatabase()",
@@ -24737,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 458
+      "community": 459
     },
     {
       "label": "createValidReflectionNote()",
@@ -24745,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 458
+      "community": 459
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24753,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24761,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24769,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "meta-memory-service.ts",
@@ -24897,7 +24937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "fieldDiff()",
@@ -24905,7 +24945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parseStepsJson()",
@@ -24913,7 +24953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 382
+      "community": 383
     },
     {
       "label": "computeProceduralDiff()",
@@ -24921,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 382
+      "community": 383
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24969,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24977,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 383
+      "community": 384
     },
     {
       "label": "parsePositiveInt()",
@@ -24985,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 383
+      "community": 384
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24993,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 383
+      "community": 384
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -25001,7 +25041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "createBaseSchema()",
@@ -25009,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 600
+      "community": 601
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -25089,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "baseRow()",
@@ -25097,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 601
+      "community": 602
     },
     {
       "label": "procedural-versioning.ts",
@@ -25105,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "getVersionChain()",
@@ -25113,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 384
+      "community": 385
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -25121,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 384
+      "community": 385
     },
     {
       "label": "getNextVersionNumber()",
@@ -25129,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 384
+      "community": 385
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -25137,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -25145,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 459
+      "community": 460
     },
     {
       "label": ".runScan()",
@@ -25153,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 459
+      "community": 460
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -25161,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "generateMemoryId()",
@@ -25169,7 +25209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 460
+      "community": 461
     },
     {
       "label": "rollbackToVersion()",
@@ -25177,7 +25217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 460
+      "community": 461
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25249,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "selectionWindowLimit()",
@@ -25257,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 461
+      "community": 462
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25265,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 461
+      "community": 462
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25313,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25321,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25329,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 602
+      "community": 603
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25337,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "openDb()",
@@ -25345,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 603
+      "community": 604
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25937,7 +25977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createBaseSchema()",
@@ -25945,7 +25985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 604
+      "community": 605
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26209,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26217,7 +26257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26225,7 +26265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 462
+      "community": 463
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26233,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 462
+      "community": 463
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26241,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26249,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "core-memory-service.ts",
@@ -26409,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createBaseSchema()",
@@ -26417,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26425,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26433,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 606
+      "community": 607
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26513,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26521,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26529,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createSchema()",
@@ -26537,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 607
+      "community": 608
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26545,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26553,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "createSchema()",
@@ -26561,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26569,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26577,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "createBaseSchema()",
@@ -26585,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 609
+      "community": 610
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26593,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26601,7 +26641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "createSchema()",
@@ -26609,7 +26649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 610
+      "community": 611
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26617,7 +26657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26625,7 +26665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26745,7 +26785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -27009,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -27017,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -27025,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 611
+      "community": 612
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -27033,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "consolidation-repository.ts",
@@ -27265,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "row()",
@@ -27273,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 612
+      "community": 613
     },
     {
       "label": "summarization-service.ts",
@@ -27369,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "ep()",
@@ -27377,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 613
+      "community": 614
     },
     {
       "label": "relation-graph.port.ts",
@@ -27385,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "get-relations-tool.ts",
@@ -27393,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "GetRelationsTool",
@@ -27401,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".constructor()",
@@ -27409,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".handle()",
@@ -27417,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 385
+      "community": 386
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27425,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27433,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 614
+      "community": 615
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27441,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27449,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27457,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".handle()",
@@ -27465,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 386
+      "community": 387
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27473,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "RemoveRelationTool",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".handle()",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 387
+      "community": 388
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27505,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "ExtractRelationsTool",
@@ -27513,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".constructor()",
@@ -27521,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".handle()",
@@ -27529,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 388
+      "community": 389
     },
     {
       "label": "add-relation-tool.ts",
@@ -27537,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "AddRelationTool",
@@ -27545,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".constructor()",
@@ -27553,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".handle()",
@@ -27561,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 389
+      "community": 390
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27617,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createBaseSchema()",
@@ -27625,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createTestMemory()",
@@ -27633,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 463
+      "community": 464
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27641,7 +27681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createBaseSchema()",
@@ -27649,7 +27689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createTestMemory()",
@@ -27657,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 464
+      "community": 465
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27665,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createBaseSchema()",
@@ -27673,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createTestMemory()",
@@ -27681,7 +27721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27689,7 +27729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27697,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createBaseSchema()",
@@ -27705,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createTestMemory()",
@@ -27713,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 466
+      "community": 467
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27721,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "RelationRetryManager",
@@ -27729,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".constructor()",
@@ -27737,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 390
+      "community": 391
     },
     {
       "label": ".retry()",
@@ -27745,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 390
+      "community": 391
     },
     {
       "label": "relation-errors.ts",
@@ -28497,7 +28537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "loadTestDataset()",
@@ -28505,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createBaseSchema()",
@@ -28513,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createTestMemory()",
@@ -28521,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 391
+      "community": 392
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28529,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28537,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "createBaseSchema()",
@@ -28545,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 467
+      "community": 468
     },
     {
       "label": "createTestMemory()",
@@ -28553,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 467
+      "community": 468
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28561,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "createTestMemory()",
@@ -28569,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 615
+      "community": 616
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28577,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createBaseSchema()",
@@ -28585,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createTestMemory()",
@@ -28593,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createBulkMemories()",
@@ -28601,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 392
+      "community": 393
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "createTestMemory()",
@@ -28617,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 616
+      "community": 617
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28681,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28689,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28697,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "getMockMementoConfig()",
@@ -28705,7 +28745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 468
+      "community": 469
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28713,7 +28753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 468
+      "community": 469
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28721,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28729,7 +28769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28737,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28745,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28793,7 +28833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28801,7 +28841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 393
+      "community": 394
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28809,7 +28849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 393
+      "community": 394
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28817,7 +28857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 393
+      "community": 394
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -29065,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "extract()",
@@ -29073,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 617
+      "community": 618
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -29081,7 +29121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "tripleDedupeKey()",
@@ -29089,7 +29129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 469
+      "community": 470
     },
     {
       "label": "mergeTripleLists()",
@@ -29097,7 +29137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 469
+      "community": 470
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -29105,7 +29145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29289,7 +29329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29297,7 +29337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29305,7 +29345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "triple-extractor.ts",
@@ -29449,7 +29489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "TripleNormalizer",
@@ -29457,7 +29497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 394
+      "community": 395
     },
     {
       "label": ".constructor()",
@@ -29465,7 +29505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 394
+      "community": 395
     },
     {
       "label": ".normalize()",
@@ -29473,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 394
+      "community": 395
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29481,7 +29521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29489,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29497,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 395
+      "community": 396
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29505,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 395
+      "community": 396
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29513,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 395
+      "community": 396
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29521,7 +29561,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "triple-parser.ts",
@@ -29569,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29577,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 618
+      "community": 619
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29585,7 +29625,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29593,7 +29633,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 619
+      "community": 620
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29681,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29689,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "interfaces.spec.ts",
@@ -29697,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29705,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29713,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29721,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29729,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 620
+      "community": 621
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29737,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29745,7 +29785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 621
+      "community": 622
     },
     {
       "label": "types.ts",
@@ -29753,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29761,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "checkOllamaModel()",
@@ -29769,7 +29809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 396
+      "community": 397
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29777,7 +29817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 396
+      "community": 397
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29785,7 +29825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 396
+      "community": 397
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29793,7 +29833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29801,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 622
+      "community": 623
     },
     {
       "label": "provider-selection.ts",
@@ -29809,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29817,7 +29857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 470
+      "community": 471
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29825,7 +29865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 470
+      "community": 471
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29833,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29841,7 +29881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 623
+      "community": 624
     },
     {
       "label": "llm-response-parse.ts",
@@ -30121,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createMockService()",
@@ -30129,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 397
+      "community": 398
     },
     {
       "label": "resolver()",
@@ -30137,7 +30177,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 397
+      "community": 398
     },
     {
       "label": "priority()",
@@ -30145,7 +30185,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 397
+      "community": 398
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -30153,7 +30193,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "embedding-service.ts",
@@ -31265,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31273,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31281,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "createSchema()",
@@ -31289,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 471
+      "community": 472
     },
     {
       "label": "seedMemoryItem()",
@@ -31297,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 471
+      "community": 472
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31321,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31329,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31337,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 398
+      "community": 399
     },
     {
       "label": ".constructor()",
@@ -31345,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 398
+      "community": 399
     },
     {
       "label": ".handle()",
@@ -31353,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 398
+      "community": 399
     },
     {
       "label": "performance-alerts.ts",
@@ -31409,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "PerformanceStatsTool",
@@ -31417,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 399
+      "community": 400
     },
     {
       "label": ".constructor()",
@@ -31425,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 399
+      "community": 400
     },
     {
       "label": ".handle()",
@@ -31433,7 +31473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 399
+      "community": 400
     },
     {
       "label": "resolve-error.ts",
@@ -31441,7 +31481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "executeResolveError()",
@@ -31449,7 +31489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 624
+      "community": 625
     },
     {
       "label": "error-stats.ts",
@@ -31457,7 +31497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "executeErrorStats()",
@@ -31465,7 +31505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 625
+      "community": 626
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31473,7 +31513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31481,7 +31521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31489,7 +31529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createBaseSchema()",
@@ -31497,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 626
+      "community": 627
     },
     {
       "label": "error-stats.spec.ts",
@@ -31505,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "performance-monitor.ts",
@@ -32417,7 +32457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32425,7 +32465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32433,7 +32473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32441,7 +32481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32489,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "restoreEnvValue()",
@@ -32497,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 627
+      "community": 628
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32505,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32513,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32521,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32529,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "quality-recorder.ts",
@@ -32601,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32609,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 628
+      "community": 629
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32689,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32697,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 629
+      "community": 630
     },
     {
       "label": "quality-reporter.ts",
@@ -32785,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32793,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32801,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32809,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32817,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "quality-assurance-service.ts",
@@ -33097,7 +33137,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -33105,7 +33145,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityMetricsTable()",
@@ -33113,7 +33153,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -33121,7 +33161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 402
+      "community": 403
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -33313,7 +33353,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "base-tool.ts",
@@ -33609,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33617,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 630
+      "community": 631
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33625,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "measureRecall()",
@@ -33633,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 631
+      "community": 632
     },
     {
       "label": "test-embedding.ts",
@@ -33641,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 632
+      "community": 633
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "compareToolResults()",
@@ -33665,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 472
+      "community": 473
     },
     {
       "label": "testToolConsistency()",
@@ -33673,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 472
+      "community": 473
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33681,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "createQualityTables()",
@@ -33689,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 473
+      "community": 474
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33697,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 473
+      "community": 474
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33745,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testSearchFunctionality()",
@@ -33753,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 633
+      "community": 634
     },
     {
       "label": "test-forgetting.ts",
@@ -33761,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33769,7 +33809,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 634
+      "community": 635
     },
     {
       "label": "mock-database.spec.ts",
@@ -33777,7 +33817,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "test-m1-completion.ts",
@@ -33785,7 +33825,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "testM1Completion()",
@@ -33793,7 +33833,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 635
+      "community": 636
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33801,7 +33841,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33809,7 +33849,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 636
+      "community": 637
     },
     {
       "label": "vitest.setup.ts",
@@ -33817,7 +33857,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33825,7 +33865,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "parseItems()",
@@ -33833,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-memory-resource.ts",
@@ -33841,7 +33881,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "setupResourceHandlers()",
@@ -33849,7 +33889,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 474
+      "community": 475
     },
     {
       "label": "createTestMemories()",
@@ -33857,7 +33897,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 474
+      "community": 475
     },
     {
       "label": "test-regression.ts",
@@ -33865,7 +33905,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "testRegression()",
@@ -33873,7 +33913,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 638
+      "community": 639
     },
     {
       "label": "test-anchor-system.ts",
@@ -33937,7 +33977,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -34009,7 +34049,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "testSingleProviderRegression()",
@@ -34017,7 +34057,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 639
+      "community": 640
     },
     {
       "label": "visualize-recency.ts",
@@ -34081,7 +34121,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34145,7 +34185,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "constructor()",
@@ -34153,7 +34193,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 640
+      "community": 641
     },
     {
       "label": "mock-database.ts",
@@ -34385,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34393,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "telemetryDb()",
@@ -34401,7 +34441,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 403
+      "community": 404
     },
     {
       "label": "percentile95()",
@@ -34409,7 +34449,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 403
+      "community": 404
     },
     {
       "label": "run()",
@@ -34417,7 +34457,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 403
+      "community": 404
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34425,7 +34465,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "createTestMemories()",
@@ -34433,7 +34473,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 641
+      "community": 642
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34441,7 +34481,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34449,7 +34489,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 642
+      "community": 643
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34457,7 +34497,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34465,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "seedCluster()",
@@ -34473,7 +34513,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 643
+      "community": 644
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34481,7 +34521,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "readSource()",
@@ -34489,7 +34529,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 475
+      "community": 476
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34497,7 +34537,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 475
+      "community": 476
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34505,7 +34545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34513,7 +34553,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 404
+      "community": 405
     },
     {
       "label": "normalizeTags()",
@@ -34521,7 +34561,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 404
+      "community": 405
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34529,7 +34569,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 404
+      "community": 405
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34537,7 +34577,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "writeFixtureDir()",
@@ -34545,7 +34585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 644
+      "community": 645
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34641,7 +34681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34705,7 +34745,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "normalizeMemoryType()",
@@ -34713,7 +34753,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 405
+      "community": 406
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34721,7 +34761,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 405
+      "community": 406
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34729,7 +34769,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 405
+      "community": 406
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34737,7 +34777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34745,7 +34785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "test-database.ts",
@@ -34777,7 +34817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "mergeCandidateIds()",
@@ -34785,7 +34825,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 645
+      "community": 646
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34793,7 +34833,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34801,7 +34841,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 476
+      "community": 477
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34809,7 +34849,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 476
+      "community": 477
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34817,7 +34857,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34825,7 +34865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -35025,7 +35065,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "query-counter.ts",
@@ -35033,7 +35073,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "extractQueryType()",
@@ -35041,7 +35081,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 406
+      "community": 407
     },
     {
       "label": "isExcluded()",
@@ -35049,7 +35089,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 406
+      "community": 407
     },
     {
       "label": "createQueryCounter()",
@@ -35057,7 +35097,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 406
+      "community": 407
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35425,7 +35465,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 646
+      "community": 647
     },
     {
       "label": "copyDir()",
@@ -35433,7 +35473,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 646
+      "community": 647
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35441,7 +35481,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "readRootPackageJson()",
@@ -35449,7 +35489,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 647
+      "community": 648
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35457,7 +35497,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "readJson()",
@@ -35465,7 +35505,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 648
+      "community": 649
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35473,7 +35513,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "readWorkflow()",
@@ -35481,7 +35521,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 649
+      "community": 650
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35545,7 +35585,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "readStaticFile()",
@@ -35553,7 +35593,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 650
+      "community": 651
     },
     {
       "label": "smoke.spec.ts",
@@ -35561,7 +35601,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "extractFencedBlocks()",
@@ -35569,7 +35609,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 651
+      "community": 652
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35641,7 +35681,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "parseArgs()",
@@ -35649,7 +35689,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 407
+      "community": 408
     },
     {
       "label": "printHelp()",
@@ -35657,7 +35697,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 407
+      "community": 408
     },
     {
       "label": "main()",
@@ -35665,7 +35705,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 407
+      "community": 408
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35753,7 +35793,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 652
+      "community": 653
     },
     {
       "label": "shouldInclude()",
@@ -35761,7 +35801,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 652
+      "community": 653
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35769,7 +35809,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 477
+      "community": 478
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35777,7 +35817,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 477
+      "community": 478
     },
     {
       "label": "readTarString()",
@@ -35785,7 +35825,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 477
+      "community": 478
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35849,7 +35889,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "fixMigration()",
@@ -35857,7 +35897,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 653
+      "community": 654
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35865,7 +35905,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 960
+      "community": 962
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35929,7 +35969,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "parseArgs()",
@@ -35937,7 +35977,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 408
+      "community": 409
     },
     {
       "label": "printHelp()",
@@ -35945,7 +35985,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 408
+      "community": 409
     },
     {
       "label": "main()",
@@ -35953,7 +35993,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 408
+      "community": 409
     },
     {
       "label": "check-path-traversal.ts",
@@ -36193,7 +36233,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 654
+      "community": 655
     },
     {
       "label": "updateEmbeddings()",
@@ -36201,7 +36241,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 654
+      "community": 655
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36369,7 +36409,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36377,7 +36417,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 655
+      "community": 656
     },
     {
       "label": "test-docker.js",
@@ -36385,7 +36425,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 656
+      "community": 657
     },
     {
       "label": "testDockerServer()",
@@ -36393,7 +36433,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 656
+      "community": 657
     },
     {
       "label": "pack-with-restore.js",
@@ -36401,7 +36441,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 961
+      "community": 963
     },
     {
       "label": "run-migration.js",
@@ -36409,7 +36449,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 657
+      "community": 658
     },
     {
       "label": "runMigration()",
@@ -36417,7 +36457,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 657
+      "community": 658
     },
     {
       "label": "safe-migration.js",
@@ -36425,7 +36465,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 658
+      "community": 659
     },
     {
       "label": "safeMigration()",
@@ -36433,7 +36473,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 658
+      "community": 659
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36497,7 +36537,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "saveWorkMemory()",
@@ -36505,7 +36545,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 659
+      "community": 660
     },
     {
       "label": "check-file-sizes.ts",
@@ -36673,7 +36713,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36681,7 +36721,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "main()",
@@ -36689,7 +36729,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 660
+      "community": 661
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36697,7 +36737,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "parseArgs()",
@@ -36705,7 +36745,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 409
+      "community": 410
     },
     {
       "label": "printHelp()",
@@ -36713,7 +36753,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 409
+      "community": 410
     },
     {
       "label": "main()",
@@ -36721,7 +36761,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 409
+      "community": 410
     },
     {
       "label": "verify-bin.js",
@@ -36729,7 +36769,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 963
+      "community": 965
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36777,7 +36817,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 661
+      "community": 662
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36785,7 +36825,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 661
+      "community": 662
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36793,7 +36833,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 662
+      "community": 663
     },
     {
       "label": "fixVectorDimensions()",
@@ -36801,7 +36841,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 662
+      "community": 663
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36809,7 +36849,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36817,7 +36857,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 410
+      "community": 411
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36825,7 +36865,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 410
+      "community": 411
     },
     {
       "label": "main()",
@@ -36833,7 +36873,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 410
+      "community": 411
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36841,7 +36881,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "loadVecExtension()",
@@ -36849,7 +36889,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 478
+      "community": 479
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36857,7 +36897,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 478
+      "community": 479
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36865,7 +36905,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "runUpdateMigration()",
@@ -36873,7 +36913,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 663
+      "community": 664
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36881,7 +36921,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "reappearanceRate()",
@@ -36889,7 +36929,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 479
+      "community": 480
     },
     {
       "label": "main()",
@@ -36897,7 +36937,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 479
+      "community": 480
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36905,7 +36945,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 664
+      "community": 665
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36913,7 +36953,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 664
+      "community": 665
     },
     {
       "label": "generate-relation-report.ts",
@@ -37065,7 +37105,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "sampleReport()",
@@ -37073,7 +37113,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 665
+      "community": 666
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -37081,7 +37121,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 964
+      "community": 966
     },
     {
       "label": "debug-embeddings.js",
@@ -37089,7 +37129,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 666
+      "community": 667
     },
     {
       "label": "debugEmbeddings()",
@@ -37097,7 +37137,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 666
+      "community": 667
     },
     {
       "label": "check-db-integrity.js",
@@ -37105,7 +37145,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 411
+      "community": 412
     },
     {
       "label": "log()",
@@ -37113,7 +37153,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 411
+      "community": 412
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -37121,7 +37161,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 411
+      "community": 412
     },
     {
       "label": "main()",
@@ -37129,7 +37169,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 411
+      "community": 412
     },
     {
       "label": "mcp-http-client.js",
@@ -37369,7 +37409,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 667
+      "community": 668
     },
     {
       "label": "backupEmbeddings()",
@@ -37377,7 +37417,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 667
+      "community": 668
     },
     {
       "label": "count-any-types.ts",
@@ -37593,7 +37633,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37601,7 +37641,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37609,7 +37649,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37617,7 +37657,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37625,7 +37665,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "jsonEmbedding()",
@@ -37633,7 +37673,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 668
+      "community": 669
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37641,7 +37681,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37649,7 +37689,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37657,7 +37697,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37665,7 +37705,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37673,7 +37713,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 669
+      "community": 670
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37681,7 +37721,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37689,7 +37729,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "jsonEmbedding()",
@@ -37697,7 +37737,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 670
+      "community": 671
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37705,7 +37745,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "main()",
@@ -37713,7 +37753,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 671
+      "community": 672
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37721,7 +37761,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37729,7 +37769,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 672
+      "community": 673
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37737,7 +37777,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "createBackup()",
@@ -37745,7 +37785,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 480
+      "community": 481
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37753,7 +37793,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 480
+      "community": 481
     },
     {
       "label": "restore-legacy.ps1",
@@ -37761,7 +37801,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 973
+      "community": 975
     },
     {
       "label": "check-retry-usage.ts",
@@ -37881,7 +37921,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37889,7 +37929,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 673
+      "community": 674
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37985,7 +38025,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37993,7 +38033,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 674
+      "community": 675
     },
     {
       "label": "sources.ts",
@@ -38049,7 +38089,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "issue-body.ts",
@@ -38057,7 +38097,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "startMarker()",
@@ -38065,7 +38105,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 412
+      "community": 413
     },
     {
       "label": "renderManagedIssueBody()",
@@ -38073,7 +38113,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 412
+      "community": 413
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -38081,7 +38121,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 412
+      "community": 413
     },
     {
       "label": "fingerprint.ts",
@@ -38089,7 +38129,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "normalizeMessage()",
@@ -38097,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 481
+      "community": 482
     },
     {
       "label": "createFingerprint()",
@@ -38105,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 481
+      "community": 482
     },
     {
       "label": "sanitizer.ts",
@@ -38113,7 +38153,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "limitUtf8Bytes()",
@@ -38121,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 482
+      "community": 483
     },
     {
       "label": "sanitizeExcerpt()",
@@ -38129,7 +38169,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 482
+      "community": 483
     },
     {
       "label": "parsers.ts",
@@ -38137,7 +38177,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "inferLevel()",
@@ -38145,7 +38185,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 413
+      "community": 414
     },
     {
       "label": "parseAppLogLine()",
@@ -38153,7 +38193,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 413
+      "community": 414
     },
     {
       "label": "parseJsonlRecord()",
@@ -38161,7 +38201,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 413
+      "community": 414
     },
     {
       "label": "index.ts",
@@ -38169,7 +38209,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -38177,7 +38217,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 414
+      "community": 415
     },
     {
       "label": "createMonitorRuntime()",
@@ -38185,7 +38225,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 414
+      "community": 415
     },
     {
       "label": "runForever()",
@@ -38193,7 +38233,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 414
+      "community": 415
     },
     {
       "label": "promotion.ts",
@@ -38201,7 +38241,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38209,7 +38249,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 675
+      "community": 676
     },
     {
       "label": "state-store.ts",
@@ -38473,7 +38513,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "issue-body.spec.ts",
@@ -38481,7 +38521,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "github-client.spec.ts",
@@ -38489,7 +38529,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "config.spec.ts",
@@ -38497,7 +38537,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "detectors.spec.ts",
@@ -38505,7 +38545,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "sources.spec.ts",
@@ -38513,7 +38553,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "parsers.spec.ts",
@@ -38521,7 +38561,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "monitor.spec.ts",
@@ -38529,7 +38569,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "config()",
@@ -38537,7 +38577,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 676
+      "community": 677
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38545,7 +38585,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "state-store.spec.ts",
@@ -38553,7 +38593,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 983
+      "community": 985
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38561,7 +38601,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 984
+      "community": 986
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38569,7 +38609,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 985
+      "community": 987
     },
     {
       "label": "index.ts",
@@ -38577,7 +38617,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "main()",
@@ -38585,7 +38625,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 415
+      "community": 416
     },
     {
       "label": "index.ts",
@@ -38593,7 +38633,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "runExample()",
@@ -38601,7 +38641,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 415
+      "community": 416
     },
     {
       "label": "index.spec.ts",
@@ -38609,7 +38649,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 986
+      "community": 988
     },
     {
       "label": "memento-admin-fetch.js",
@@ -46749,7 +46789,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46761,7 +46801,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46773,7 +46813,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L161",
+      "source_location": "L162",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46785,7 +46825,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L191",
+      "source_location": "L192",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46797,7 +46837,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L211",
+      "source_location": "L212",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46809,7 +46849,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L229",
+      "source_location": "L230",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
@@ -46821,7 +46861,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L241",
+      "source_location": "L242",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
@@ -46833,7 +46873,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L247",
+      "source_location": "L248",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
@@ -46845,7 +46885,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L253",
+      "source_location": "L254",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
@@ -46857,7 +46897,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L262",
+      "source_location": "L263",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapproveinteractive",
@@ -46869,7 +46909,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L315",
+      "source_location": "L316",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
@@ -46881,7 +46921,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L610",
+      "source_location": "L625",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -46893,7 +46933,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L70",
+      "source_location": "L71",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46905,7 +46945,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L110",
+      "source_location": "L111",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46917,7 +46957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L116",
+      "source_location": "L117",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46929,7 +46969,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L320",
+      "source_location": "L321",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46941,7 +46981,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L372",
+      "source_location": "L373",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46953,7 +46993,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L328",
+      "source_location": "L329",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46965,7 +47005,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L328",
+      "source_location": "L329",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46977,7 +47017,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L255",
+      "source_location": "L256",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -46989,7 +47029,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L322",
+      "source_location": "L323",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -47001,7 +47041,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L387",
+      "source_location": "L388",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -47013,7 +47053,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L322",
+      "source_location": "L323",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -80691,6 +80731,42 @@
       "_tgt": "openai_chat_llm_adapter_openaichatllmadapter_complete",
       "source": "openai_chat_llm_adapter_openaichatllmadapter",
       "target": "openai_chat_llm_adapter_openaichatllmadapter_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
+      "_tgt": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "source": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
+      "target": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "_src": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "_tgt": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
+      "source": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "target": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "_src": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "_tgt": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
+      "source": "gemini_chat_llm_adapter_geminichatllmadapter",
+      "target": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 415
+      "community": 416
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 415
+      "community": 416
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 482
+      "community": 483
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 416
+      "community": 417
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 416
+      "community": 417
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 483
+      "community": 484
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 484
+      "community": 485
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 417
+      "community": 418
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 417
+      "community": 418
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 485
+      "community": 486
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 702
+      "community": 703
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 486
+      "community": 487
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 486
+      "community": 487
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 487
+      "community": 488
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 488
+      "community": 489
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 489
+      "community": 490
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "createMockResponse()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 418
+      "community": 419
     },
     {
       "label": "sendOptions()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 418
+      "community": 419
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 490
+      "community": 491
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "readRepoFile()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 419
+      "community": 420
     },
     {
       "label": "sectionBetween()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 419
+      "community": 420
     },
     {
       "label": "http-server.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 491
+      "community": 492
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 492
+      "community": 493
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "createMockResponse()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 420
+      "community": 421
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 420
+      "community": 421
     },
     {
       "label": "server-state.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "batch-run-history.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 421
+      "community": 422
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 421
+      "community": 422
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 493
+      "community": 494
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 494
+      "community": 495
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 495
+      "community": 496
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 496
+      "community": 497
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 497
+      "community": 498
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 498
+      "community": 499
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 499
+      "community": 500
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 500
+      "community": 501
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 501
+      "community": 502
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 502
+      "community": 503
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 503
+      "community": 504
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 422
+      "community": 423
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 422
+      "community": 423
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "parseParams()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 423
+      "community": 424
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 423
+      "community": 424
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "parseCleanupParams()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 424
+      "community": 425
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 424
+      "community": 425
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 510
+      "community": 511
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 511
+      "community": 512
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 512
+      "community": 513
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 513
+      "community": 514
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "resolveEnvPath()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 425
+      "community": 426
     },
     {
       "label": "loadEnv()",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 425
+      "community": 426
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "runCli()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 514
+      "community": 515
     },
     {
       "label": "agent-ask.ts",
@@ -4375,7 +4375,7 @@
       "label": "stripGlobalCliArgs()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "id": "agent_ask_stripglobalcliargs",
       "community": 90
     },
@@ -4383,7 +4383,7 @@
       "label": "parseAgentAskInvocation()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "id": "agent_ask_parseagentaskinvocation",
       "community": 90
     },
@@ -4391,7 +4391,7 @@
       "label": "validateAgentAskFlagArgv()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L160",
+      "source_location": "L161",
       "id": "agent_ask_validateagentaskflagargv",
       "community": 90
     },
@@ -4399,7 +4399,7 @@
       "label": "validateAgentAskRawTypes()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L190",
+      "source_location": "L191",
       "id": "agent_ask_validateagentaskrawtypes",
       "community": 90
     },
@@ -4407,7 +4407,7 @@
       "label": "resolveDbPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L210",
+      "source_location": "L211",
       "id": "agent_ask_resolvedbpath",
       "community": 90
     },
@@ -4415,7 +4415,7 @@
       "label": "jsonFailure()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "id": "agent_ask_jsonfailure",
       "community": 90
     },
@@ -4423,7 +4423,7 @@
       "label": "writeOut()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L240",
+      "source_location": "L241",
       "id": "agent_ask_writeout",
       "community": 90
     },
@@ -4431,7 +4431,7 @@
       "label": "writeErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L246",
+      "source_location": "L247",
       "id": "agent_ask_writeerr",
       "community": 90
     },
@@ -4439,7 +4439,7 @@
       "label": "debugErr()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "id": "agent_ask_debugerr",
       "community": 90
     },
@@ -4447,7 +4447,7 @@
       "label": "promptApproveInteractive()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L261",
+      "source_location": "L262",
       "id": "agent_ask_promptapproveinteractive",
       "community": 90
     },
@@ -4455,7 +4455,7 @@
       "label": "runAgentAskMain()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L314",
+      "source_location": "L315",
       "id": "agent_ask_runagentaskmain",
       "community": 90
     },
@@ -4463,7 +4463,7 @@
       "label": "agentAskHelpText()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L594",
+      "source_location": "L610",
       "id": "agent_ask_agentaskhelptext",
       "community": 90
     },
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 426
+      "community": 427
     },
     {
       "label": "runQualityMeasurement()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 426
+      "community": 427
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "testSimpleAlerts()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "testBasicFunctionality()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 516
+      "community": 517
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 517
+      "community": 518
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "compareServices()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 427
+      "community": 428
     },
     {
       "label": "testServerSynchronization()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 427
+      "community": 428
     },
     {
       "label": "test-error-logging.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "testErrorLogging()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 518
+      "community": 519
     },
     {
       "label": "debug-http-v2.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "testFetch()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 519
+      "community": 520
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "initializeTestDatabase()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 520
+      "community": 521
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "testReflexionE2E()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "testAlertsDirect()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-client.ts",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "assert()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 428
+      "community": 429
     },
     {
       "label": "testMementoClient()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 428
+      "community": 429
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 524
+      "community": 525
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 525
+      "community": 526
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "createBaseSchema()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 429
+      "community": 430
     },
     {
       "label": "createTestMemory()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 429
+      "community": 430
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 430
+      "community": 431
     },
     {
       "label": "findNodeForAnchor()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 430
+      "community": 431
     },
     {
       "label": "vitest.config.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "brave-search-provider.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "NoopSearchProvider",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 431
+      "community": 432
     },
     {
       "label": ".search()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 431
+      "community": 432
     },
     {
       "label": "search-factory.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "createSearchProvider()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 526
+      "community": 527
     },
     {
       "label": "search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "types.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "loadAgentConfig()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 527
+      "community": 528
     },
     {
       "label": "system-prompt.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "utils.spec.ts",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "buildMemory()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 528
+      "community": 529
     },
     {
       "label": "context-injector.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "logger.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "shouldLog()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 432
+      "community": 433
     },
     {
       "label": "log()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 432
+      "community": 433
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "createMementoCore()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 433
+      "community": 434
     },
     {
       "label": "closeDatabase()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 433
+      "community": 434
     },
     {
       "label": "bootstrap.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "initializeServices()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 529
+      "community": 530
     },
     {
       "label": "context.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 530
+      "community": 531
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 531
+      "community": 532
     },
     {
       "label": "anchor-stack.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createAnchorStack()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 532
+      "community": 533
     },
     {
       "label": "failure-reflexion.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 533
+      "community": 534
     },
     {
       "label": "search-and-embedding.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 534
+      "community": 535
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 535
+      "community": 536
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 536
+      "community": 537
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createInput()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 537
+      "community": 538
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createRelationGraph()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 538
+      "community": 539
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "createBaseSchema()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 434
+      "community": 435
     },
     {
       "label": "measureTime()",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 434
+      "community": 435
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createBaseSchema()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 539
+      "community": 540
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 540
+      "community": 541
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "openLockTestDatabase()",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 541
+      "community": 542
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createProgress()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 542
+      "community": 543
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 543
+      "community": 544
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 544
+      "community": 545
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "addMissingColumn()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 435
+      "community": 436
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 435
+      "community": 436
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "init.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createDbPath()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 545
+      "community": 546
     },
     {
       "label": "migrate.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "migrate.ts",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "isDuplicateColumnError()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 436
+      "community": 437
     },
     {
       "label": "migrateDatabase()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 436
+      "community": 437
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "migration-runner.ts",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 546
+      "community": 547
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "schema-version-manager.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createBaseSchema()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 547
+      "community": 548
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 548
+      "community": 549
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 549
+      "community": 550
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "createMemoryItemTable()",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 437
+      "community": 438
     },
     {
       "label": "tableExists()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 437
+      "community": 438
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMemoryItemTable()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 438
+      "community": 439
     },
     {
       "label": "tableExists()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 438
+      "community": 439
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createSchemaWith018()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 551
+      "community": 552
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createBaseSchema()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 552
+      "community": 553
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 553
+      "community": 554
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "createBaseSchema()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 554
+      "community": 555
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createBaseSchema()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 439
+      "community": 440
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "createBaseSchema()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 555
+      "community": 556
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "batch-scheduler.ts",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 556
+      "community": 557
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 557
+      "community": 558
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "readInsertedUpdated()",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 440
+      "community": 441
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 440
+      "community": 441
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 558
+      "community": 559
     },
     {
       "label": "retry-manager.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 441
+      "community": 442
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 441
+      "community": 442
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 442
+      "community": 443
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 442
+      "community": 443
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "shouldRetry()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 559
+      "community": 560
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "baseResult()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 560
+      "community": 561
     },
     {
       "label": "job-queue.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "initializeTestDatabase()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 561
+      "community": 562
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "generateId()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 443
+      "community": 444
     },
     {
       "label": "initializeTestDatabase()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 443
+      "community": 444
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "createQualityTables()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 562
+      "community": 563
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "generateId()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 444
+      "community": 445
     },
     {
       "label": "initializeTestDatabase()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 444
+      "community": 445
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "type-guards.ts",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "validateTableName()",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 445
+      "community": 446
     },
     {
       "label": "getVectorTableName()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 445
+      "community": 446
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 563
+      "community": 564
     },
     {
       "label": "environment-check.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 564
+      "community": 565
     },
     {
       "label": "error-handling.spec.ts",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "operation()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 565
+      "community": 566
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "relation-visualizer.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "issue()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 446
+      "community": 447
     },
     {
       "label": "validateConfiguration()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 446
+      "community": 447
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "cache-key-generator.ts",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "transactionFn()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 447
+      "community": 448
     },
     {
       "label": "outerTransaction()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 447
+      "community": 448
     },
     {
       "label": "write-coalescing.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "path-validator.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 566
+      "community": 567
     },
     {
       "label": "error-handling.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "withErrorHandling()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 567
+      "community": 568
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 568
+      "community": 569
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "createValidReflectionNote()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 448
+      "community": 449
     },
     {
       "label": "createLargeNote()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 448
+      "community": 449
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "initializeTestDatabase()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 569
+      "community": 570
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 570
+      "community": 571
     },
     {
       "label": "logging-helpers.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "initializeTestDatabase()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 571
+      "community": 572
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "benchmark.types.ts",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "assertMacroCategory()",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 572
+      "community": 573
     },
     {
       "label": "migration.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "index.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "isMemoryItemType()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 449
+      "community": 450
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 449
+      "community": 450
     },
     {
       "label": "error-types.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "retry-options-loader.ts",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "validateConfig()",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 573
+      "community": 574
     },
     {
       "label": "config-loader-utils.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "getMockMementoConfig()",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 450
+      "community": 451
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 450
+      "community": 451
     },
     {
       "label": "initialize.spec.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "search-local-tool.ts",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "initializeTestDatabase()",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 574
+      "community": 575
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "initializeTestDatabase()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 575
+      "community": 576
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 576
+      "community": 577
     },
     {
       "label": "embedding-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "vector-search.factory.ts",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 577
+      "community": 578
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "search-result-combiner.ts",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19913,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "initializeTestDatabase()",
@@ -19921,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 451
+      "community": 452
     },
     {
       "label": "createValidReflectionNote()",
@@ -19929,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 451
+      "community": 452
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "vector-search.service.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 579
+      "community": 580
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "createMockRepository()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 580
+      "community": 581
     },
     {
       "label": "vector-index-manager.ts",
@@ -20737,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createMockRepositories()",
@@ -20745,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 581
+      "community": 582
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20761,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createMockIndexRepository()",
@@ -20769,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 582
+      "community": 583
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22473,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "openTelemetryDb()",
@@ -22481,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 583
+      "community": 584
     },
     {
       "label": "telemetry-repository.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 584
+      "community": 585
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "llm-port.ts",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "persistence-port.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "context-port.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "agent-types.ts",
@@ -22977,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -22985,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "readProviderToken()",
@@ -22993,7 +22993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 452
+      "community": 453
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -23001,7 +23001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 452
+      "community": 453
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23058,6 +23058,46 @@
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
       "community": 317
+    },
+    {
+      "label": "openai-chat-llm-adapter.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
+      "community": 373
+    },
+    {
+      "label": "OpenAiChatLlmAdapter",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L11",
+      "id": "openai_chat_llm_adapter_openaichatllmadapter",
+      "community": 373
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "id": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
+      "community": 373
+    },
+    {
+      "label": ".complete()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L20",
+      "id": "openai_chat_llm_adapter_openaichatllmadapter_complete",
+      "community": 373
+    },
+    {
+      "label": "openai-chat-llm-adapter.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
+      "community": 875
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -23145,7 +23185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23153,7 +23193,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "baseCandidate()",
@@ -23161,7 +23201,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 585
+      "community": 586
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23209,7 +23249,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -23217,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "makeDeps()",
@@ -23225,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 586
+      "community": 587
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23273,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -23281,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 587
+      "community": 588
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -23289,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23297,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 588
+      "community": 589
     },
     {
       "label": "core-memory-repository.ts",
@@ -23305,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23313,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23321,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23329,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23337,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "feedback-repository.ts",
@@ -23345,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23353,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 453
+      "community": 454
     },
     {
       "label": "FeedbackRepository",
@@ -23361,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 453
+      "community": 454
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23369,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23377,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23385,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23393,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23401,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23409,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createKgTripleTable()",
@@ -23417,7 +23457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 589
+      "community": 590
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23425,7 +23465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23433,7 +23473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23441,7 +23481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23449,7 +23489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 591
+      "community": 592
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23457,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23465,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23473,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "remember-tool.ts",
@@ -23561,7 +23601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "validateRecallQuery()",
@@ -23569,7 +23609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 454
+      "community": 455
     },
     {
       "label": "validateRecallFilters()",
@@ -23577,7 +23617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 454
+      "community": 455
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23585,7 +23625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23593,7 +23633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 593
+      "community": 594
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23601,7 +23641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23609,7 +23649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".constructor()",
@@ -23617,7 +23657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".handle()",
@@ -23625,7 +23665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 373
+      "community": 374
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23633,7 +23673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23641,7 +23681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23649,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -23657,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 374
+      "community": 375
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23665,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23673,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23681,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23689,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "feedback-tool.ts",
@@ -23745,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "CleanupMemoryTool",
@@ -23753,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -23761,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -23769,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23777,7 +23817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23785,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 455
+      "community": 456
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23793,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 455
+      "community": 456
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -23993,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "ProceduralDiffTool",
@@ -24001,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -24009,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -24017,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 377
+      "community": 378
     },
     {
       "label": "unpin-tool.ts",
@@ -24137,7 +24177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -24145,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".constructor()",
@@ -24153,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".handle()",
@@ -24161,7 +24201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 378
+      "community": 379
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -24169,7 +24209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "RememberProcedureTool",
@@ -24177,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".constructor()",
@@ -24185,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 379
+      "community": 380
     },
     {
       "label": ".handle()",
@@ -24193,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 379
+      "community": 380
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -24241,7 +24281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24249,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 594
+      "community": 595
     },
     {
       "label": "recall-tool.ts",
@@ -24385,7 +24425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "forget-tool.ts",
@@ -24529,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "createSchema()",
@@ -24537,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 595
+      "community": 596
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24545,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24553,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "initializeTestDatabase()",
@@ -24561,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 456
+      "community": 457
     },
     {
       "label": "createValidReflectionNote()",
@@ -24569,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 456
+      "community": 457
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24577,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24585,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "createSchema()",
@@ -24593,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 596
+      "community": 597
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24601,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "generateId()",
@@ -24609,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 380
+      "community": 381
     },
     {
       "label": "initializeTestDatabase()",
@@ -24617,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 380
+      "community": 381
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24625,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 380
+      "community": 381
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24633,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24641,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24649,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "initializeTestDatabase()",
@@ -24657,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 597
+      "community": 598
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24665,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "parseData()",
@@ -24673,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 598
+      "community": 599
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24681,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24689,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "initializeTestDatabase()",
@@ -24697,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 457
+      "community": 458
     },
     {
       "label": "createValidReflectionNote()",
@@ -24705,7 +24745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 457
+      "community": 458
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24713,7 +24753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24721,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24729,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "meta-memory-service.ts",
@@ -24857,7 +24897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "fieldDiff()",
@@ -24865,7 +24905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 381
+      "community": 382
     },
     {
       "label": "parseStepsJson()",
@@ -24873,7 +24913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 381
+      "community": 382
     },
     {
       "label": "computeProceduralDiff()",
@@ -24881,7 +24921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 381
+      "community": 382
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24929,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24937,7 +24977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parsePositiveInt()",
@@ -24945,7 +24985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 382
+      "community": 383
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24953,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 382
+      "community": 383
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -24961,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "createBaseSchema()",
@@ -24969,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 599
+      "community": 600
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -25049,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "baseRow()",
@@ -25057,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 600
+      "community": 601
     },
     {
       "label": "procedural-versioning.ts",
@@ -25065,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "getVersionChain()",
@@ -25073,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 383
+      "community": 384
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -25081,7 +25121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 383
+      "community": 384
     },
     {
       "label": "getNextVersionNumber()",
@@ -25089,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 383
+      "community": 384
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -25097,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -25105,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".runScan()",
@@ -25113,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 458
+      "community": 459
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -25121,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "generateMemoryId()",
@@ -25129,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 459
+      "community": 460
     },
     {
       "label": "rollbackToVersion()",
@@ -25137,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 459
+      "community": 460
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25209,7 +25249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "selectionWindowLimit()",
@@ -25217,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 460
+      "community": 461
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25225,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 460
+      "community": 461
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25273,7 +25313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25281,7 +25321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25289,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 601
+      "community": 602
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25297,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "openDb()",
@@ -25305,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 602
+      "community": 603
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25897,7 +25937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createBaseSchema()",
@@ -25905,7 +25945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 603
+      "community": 604
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26169,7 +26209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26177,7 +26217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26185,7 +26225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 461
+      "community": 462
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26193,7 +26233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 461
+      "community": 462
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26201,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26209,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "core-memory-service.ts",
@@ -26369,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createBaseSchema()",
@@ -26377,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 604
+      "community": 605
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26385,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26393,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 605
+      "community": 606
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26473,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26481,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26489,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createSchema()",
@@ -26497,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26505,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26513,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createSchema()",
@@ -26521,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 607
+      "community": 608
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26529,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26537,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "createBaseSchema()",
@@ -26545,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26553,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26561,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "createSchema()",
@@ -26569,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 609
+      "community": 610
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26577,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26585,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26705,7 +26745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26969,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26977,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26985,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 610
+      "community": 611
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26993,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "consolidation-repository.ts",
@@ -27225,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "row()",
@@ -27233,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 611
+      "community": 612
     },
     {
       "label": "summarization-service.ts",
@@ -27329,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "ep()",
@@ -27337,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 612
+      "community": 613
     },
     {
       "label": "relation-graph.port.ts",
@@ -27345,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "get-relations-tool.ts",
@@ -27353,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "GetRelationsTool",
@@ -27361,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".constructor()",
@@ -27369,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".handle()",
@@ -27377,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 384
+      "community": 385
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27385,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27393,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 613
+      "community": 614
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27401,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27409,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".constructor()",
@@ -27417,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".handle()",
@@ -27425,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 385
+      "community": 386
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27433,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "RemoveRelationTool",
@@ -27441,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27449,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".handle()",
@@ -27457,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 386
+      "community": 387
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27465,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "ExtractRelationsTool",
@@ -27473,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".handle()",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 387
+      "community": 388
     },
     {
       "label": "add-relation-tool.ts",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "AddRelationTool",
@@ -27505,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".constructor()",
@@ -27513,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".handle()",
@@ -27521,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 388
+      "community": 389
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27577,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createBaseSchema()",
@@ -27585,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createTestMemory()",
@@ -27593,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27601,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createBaseSchema()",
@@ -27609,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createTestMemory()",
@@ -27617,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 463
+      "community": 464
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27625,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createBaseSchema()",
@@ -27633,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createTestMemory()",
@@ -27641,7 +27681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 464
+      "community": 465
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27649,7 +27689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27657,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createBaseSchema()",
@@ -27665,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createTestMemory()",
@@ -27673,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27681,7 +27721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "RelationRetryManager",
@@ -27689,7 +27729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".constructor()",
@@ -27697,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".retry()",
@@ -27705,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 389
+      "community": 390
     },
     {
       "label": "relation-errors.ts",
@@ -28457,7 +28497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "loadTestDataset()",
@@ -28465,7 +28505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createBaseSchema()",
@@ -28473,7 +28513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createTestMemory()",
@@ -28481,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 390
+      "community": 391
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28489,7 +28529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28497,7 +28537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createBaseSchema()",
@@ -28505,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 466
+      "community": 467
     },
     {
       "label": "createTestMemory()",
@@ -28513,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 466
+      "community": 467
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28521,7 +28561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "createTestMemory()",
@@ -28529,7 +28569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 614
+      "community": 615
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28537,7 +28577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createBaseSchema()",
@@ -28545,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createTestMemory()",
@@ -28553,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createBulkMemories()",
@@ -28561,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 391
+      "community": 392
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28569,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "createTestMemory()",
@@ -28577,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 615
+      "community": 616
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28641,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28649,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28657,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "getMockMementoConfig()",
@@ -28665,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 467
+      "community": 468
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28673,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 467
+      "community": 468
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28681,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28689,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28697,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28705,7 +28745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28753,7 +28793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28761,7 +28801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 392
+      "community": 393
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28769,7 +28809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 392
+      "community": 393
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28777,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 392
+      "community": 393
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -29025,7 +29065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "extract()",
@@ -29033,7 +29073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 616
+      "community": 617
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -29041,7 +29081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "tripleDedupeKey()",
@@ -29049,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 468
+      "community": 469
     },
     {
       "label": "mergeTripleLists()",
@@ -29057,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 468
+      "community": 469
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -29065,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29249,7 +29289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29257,7 +29297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29265,7 +29305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-extractor.ts",
@@ -29409,7 +29449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "TripleNormalizer",
@@ -29417,7 +29457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 393
+      "community": 394
     },
     {
       "label": ".constructor()",
@@ -29425,7 +29465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 393
+      "community": 394
     },
     {
       "label": ".normalize()",
@@ -29433,7 +29473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 393
+      "community": 394
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29441,7 +29481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29449,7 +29489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29457,7 +29497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 394
+      "community": 395
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29465,7 +29505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 394
+      "community": 395
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29473,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 394
+      "community": 395
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29481,7 +29521,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "triple-parser.ts",
@@ -29529,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29537,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 617
+      "community": 618
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29545,7 +29585,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29553,7 +29593,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 618
+      "community": 619
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29641,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29649,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "interfaces.spec.ts",
@@ -29657,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29665,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29673,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29681,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29689,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 619
+      "community": 620
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29697,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29705,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 620
+      "community": 621
     },
     {
       "label": "types.ts",
@@ -29713,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29721,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "checkOllamaModel()",
@@ -29729,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 395
+      "community": 396
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29737,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 395
+      "community": 396
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29745,7 +29785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 395
+      "community": 396
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29753,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29761,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 621
+      "community": 622
     },
     {
       "label": "provider-selection.ts",
@@ -29769,7 +29809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29777,7 +29817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 469
+      "community": 470
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29785,7 +29825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 469
+      "community": 470
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29793,7 +29833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29801,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 622
+      "community": 623
     },
     {
       "label": "llm-response-parse.ts",
@@ -30081,7 +30121,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createMockService()",
@@ -30089,7 +30129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 396
+      "community": 397
     },
     {
       "label": "resolver()",
@@ -30097,7 +30137,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 396
+      "community": 397
     },
     {
       "label": "priority()",
@@ -30105,7 +30145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 396
+      "community": 397
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -30113,7 +30153,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "embedding-service.ts",
@@ -31225,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31233,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31241,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "createSchema()",
@@ -31249,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 470
+      "community": 471
     },
     {
       "label": "seedMemoryItem()",
@@ -31257,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 470
+      "community": 471
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31265,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31273,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31281,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31289,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31297,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 397
+      "community": 398
     },
     {
       "label": ".constructor()",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 397
+      "community": 398
     },
     {
       "label": ".handle()",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 397
+      "community": 398
     },
     {
       "label": "performance-alerts.ts",
@@ -31369,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "PerformanceStatsTool",
@@ -31377,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 398
+      "community": 399
     },
     {
       "label": ".constructor()",
@@ -31385,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 398
+      "community": 399
     },
     {
       "label": ".handle()",
@@ -31393,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 398
+      "community": 399
     },
     {
       "label": "resolve-error.ts",
@@ -31401,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "executeResolveError()",
@@ -31409,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 623
+      "community": 624
     },
     {
       "label": "error-stats.ts",
@@ -31417,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "executeErrorStats()",
@@ -31425,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 624
+      "community": 625
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31433,7 +31473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31441,7 +31481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31449,7 +31489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createBaseSchema()",
@@ -31457,7 +31497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 625
+      "community": 626
     },
     {
       "label": "error-stats.spec.ts",
@@ -31465,7 +31505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "performance-monitor.ts",
@@ -32377,7 +32417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32385,7 +32425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32393,7 +32433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32401,7 +32441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32449,7 +32489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "restoreEnvValue()",
@@ -32457,7 +32497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 626
+      "community": 627
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32465,7 +32505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32473,7 +32513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32481,7 +32521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32489,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "quality-recorder.ts",
@@ -32561,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32569,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 627
+      "community": 628
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32649,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32657,7 +32697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 628
+      "community": 629
     },
     {
       "label": "quality-reporter.ts",
@@ -32745,7 +32785,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32753,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32761,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32769,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32777,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "quality-assurance-service.ts",
@@ -33057,7 +33097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -33065,7 +33105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityMetricsTable()",
@@ -33073,7 +33113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -33081,7 +33121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 401
+      "community": 402
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -33273,7 +33313,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "base-tool.ts",
@@ -33569,7 +33609,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33577,7 +33617,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 629
+      "community": 630
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33585,7 +33625,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "measureRecall()",
@@ -33593,7 +33633,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 630
+      "community": 631
     },
     {
       "label": "test-embedding.ts",
@@ -33601,7 +33641,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33609,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 631
+      "community": 632
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33617,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "compareToolResults()",
@@ -33625,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 471
+      "community": 472
     },
     {
       "label": "testToolConsistency()",
@@ -33633,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 471
+      "community": 472
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33641,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "createQualityTables()",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 472
+      "community": 473
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 472
+      "community": 473
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33705,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "testSearchFunctionality()",
@@ -33713,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 632
+      "community": 633
     },
     {
       "label": "test-forgetting.ts",
@@ -33721,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33729,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 633
+      "community": 634
     },
     {
       "label": "mock-database.spec.ts",
@@ -33737,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "test-m1-completion.ts",
@@ -33745,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testM1Completion()",
@@ -33753,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 634
+      "community": 635
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33761,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33769,7 +33809,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 635
+      "community": 636
     },
     {
       "label": "vitest.setup.ts",
@@ -33777,7 +33817,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33785,7 +33825,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "parseItems()",
@@ -33793,7 +33833,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-memory-resource.ts",
@@ -33801,7 +33841,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "setupResourceHandlers()",
@@ -33809,7 +33849,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 473
+      "community": 474
     },
     {
       "label": "createTestMemories()",
@@ -33817,7 +33857,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 473
+      "community": 474
     },
     {
       "label": "test-regression.ts",
@@ -33825,7 +33865,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testRegression()",
@@ -33833,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-anchor-system.ts",
@@ -33897,7 +33937,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33969,7 +34009,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33977,7 +34017,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 638
+      "community": 639
     },
     {
       "label": "visualize-recency.ts",
@@ -34041,7 +34081,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34105,7 +34145,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "constructor()",
@@ -34113,7 +34153,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 639
+      "community": 640
     },
     {
       "label": "mock-database.ts",
@@ -34345,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34353,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "telemetryDb()",
@@ -34361,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 402
+      "community": 403
     },
     {
       "label": "percentile95()",
@@ -34369,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 402
+      "community": 403
     },
     {
       "label": "run()",
@@ -34377,7 +34417,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 402
+      "community": 403
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34385,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "createTestMemories()",
@@ -34393,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 640
+      "community": 641
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34401,7 +34441,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34409,7 +34449,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 641
+      "community": 642
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34417,7 +34457,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34425,7 +34465,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "seedCluster()",
@@ -34433,7 +34473,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 642
+      "community": 643
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34441,7 +34481,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "readSource()",
@@ -34449,7 +34489,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 474
+      "community": 475
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34457,7 +34497,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 474
+      "community": 475
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34465,7 +34505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34473,7 +34513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 403
+      "community": 404
     },
     {
       "label": "normalizeTags()",
@@ -34481,7 +34521,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 403
+      "community": 404
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34489,7 +34529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 403
+      "community": 404
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34497,7 +34537,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "writeFixtureDir()",
@@ -34505,7 +34545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 643
+      "community": 644
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34601,7 +34641,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34665,7 +34705,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "normalizeMemoryType()",
@@ -34673,7 +34713,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 404
+      "community": 405
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34681,7 +34721,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 404
+      "community": 405
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34689,7 +34729,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 404
+      "community": 405
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34697,7 +34737,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34705,7 +34745,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "test-database.ts",
@@ -34737,7 +34777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "mergeCandidateIds()",
@@ -34745,7 +34785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 644
+      "community": 645
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34753,7 +34793,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34761,7 +34801,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 475
+      "community": 476
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34769,7 +34809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 475
+      "community": 476
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34777,7 +34817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34785,7 +34825,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34985,7 +35025,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "query-counter.ts",
@@ -34993,7 +35033,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "extractQueryType()",
@@ -35001,7 +35041,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 405
+      "community": 406
     },
     {
       "label": "isExcluded()",
@@ -35009,7 +35049,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 405
+      "community": 406
     },
     {
       "label": "createQueryCounter()",
@@ -35017,7 +35057,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 405
+      "community": 406
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35385,7 +35425,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 645
+      "community": 646
     },
     {
       "label": "copyDir()",
@@ -35393,7 +35433,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 645
+      "community": 646
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35401,7 +35441,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "readRootPackageJson()",
@@ -35409,7 +35449,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 646
+      "community": 647
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35417,7 +35457,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "readJson()",
@@ -35425,7 +35465,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 647
+      "community": 648
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35433,7 +35473,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "readWorkflow()",
@@ -35441,7 +35481,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 648
+      "community": 649
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35505,7 +35545,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "readStaticFile()",
@@ -35513,7 +35553,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 649
+      "community": 650
     },
     {
       "label": "smoke.spec.ts",
@@ -35521,7 +35561,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "extractFencedBlocks()",
@@ -35529,7 +35569,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 650
+      "community": 651
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35601,7 +35641,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "parseArgs()",
@@ -35609,7 +35649,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 406
+      "community": 407
     },
     {
       "label": "printHelp()",
@@ -35617,7 +35657,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 406
+      "community": 407
     },
     {
       "label": "main()",
@@ -35625,7 +35665,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 406
+      "community": 407
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35713,7 +35753,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 651
+      "community": 652
     },
     {
       "label": "shouldInclude()",
@@ -35721,7 +35761,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 651
+      "community": 652
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35729,7 +35769,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 476
+      "community": 477
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35737,7 +35777,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 476
+      "community": 477
     },
     {
       "label": "readTarString()",
@@ -35745,7 +35785,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 476
+      "community": 477
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35809,7 +35849,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 652
+      "community": 653
     },
     {
       "label": "fixMigration()",
@@ -35817,7 +35857,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 652
+      "community": 653
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35825,7 +35865,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 958
+      "community": 960
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35889,7 +35929,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "parseArgs()",
@@ -35897,7 +35937,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 407
+      "community": 408
     },
     {
       "label": "printHelp()",
@@ -35905,7 +35945,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 407
+      "community": 408
     },
     {
       "label": "main()",
@@ -35913,7 +35953,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 407
+      "community": 408
     },
     {
       "label": "check-path-traversal.ts",
@@ -36153,7 +36193,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "updateEmbeddings()",
@@ -36161,7 +36201,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 653
+      "community": 654
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36329,7 +36369,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36337,7 +36377,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 654
+      "community": 655
     },
     {
       "label": "test-docker.js",
@@ -36345,7 +36385,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 655
+      "community": 656
     },
     {
       "label": "testDockerServer()",
@@ -36353,7 +36393,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 655
+      "community": 656
     },
     {
       "label": "pack-with-restore.js",
@@ -36361,7 +36401,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 959
+      "community": 961
     },
     {
       "label": "run-migration.js",
@@ -36369,7 +36409,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 656
+      "community": 657
     },
     {
       "label": "runMigration()",
@@ -36377,7 +36417,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 656
+      "community": 657
     },
     {
       "label": "safe-migration.js",
@@ -36385,7 +36425,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 657
+      "community": 658
     },
     {
       "label": "safeMigration()",
@@ -36393,7 +36433,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 657
+      "community": 658
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36457,7 +36497,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "saveWorkMemory()",
@@ -36465,7 +36505,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 658
+      "community": 659
     },
     {
       "label": "check-file-sizes.ts",
@@ -36633,7 +36673,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36641,7 +36681,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "main()",
@@ -36649,7 +36689,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 659
+      "community": 660
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36657,7 +36697,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "parseArgs()",
@@ -36665,7 +36705,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 408
+      "community": 409
     },
     {
       "label": "printHelp()",
@@ -36673,7 +36713,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 408
+      "community": 409
     },
     {
       "label": "main()",
@@ -36681,7 +36721,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 408
+      "community": 409
     },
     {
       "label": "verify-bin.js",
@@ -36689,7 +36729,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 961
+      "community": 963
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36737,7 +36777,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 660
+      "community": 661
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36745,7 +36785,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 660
+      "community": 661
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36753,7 +36793,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 661
+      "community": 662
     },
     {
       "label": "fixVectorDimensions()",
@@ -36761,7 +36801,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 661
+      "community": 662
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36769,7 +36809,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36777,7 +36817,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 409
+      "community": 410
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36785,7 +36825,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 409
+      "community": 410
     },
     {
       "label": "main()",
@@ -36793,7 +36833,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 409
+      "community": 410
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36801,7 +36841,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "loadVecExtension()",
@@ -36809,7 +36849,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 477
+      "community": 478
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36817,7 +36857,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 477
+      "community": 478
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36825,7 +36865,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "runUpdateMigration()",
@@ -36833,7 +36873,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 662
+      "community": 663
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36841,7 +36881,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "reappearanceRate()",
@@ -36849,7 +36889,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 478
+      "community": 479
     },
     {
       "label": "main()",
@@ -36857,7 +36897,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 478
+      "community": 479
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36865,7 +36905,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 663
+      "community": 664
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36873,7 +36913,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 663
+      "community": 664
     },
     {
       "label": "generate-relation-report.ts",
@@ -37025,7 +37065,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "sampleReport()",
@@ -37033,7 +37073,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 664
+      "community": 665
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -37041,7 +37081,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 962
+      "community": 964
     },
     {
       "label": "debug-embeddings.js",
@@ -37049,7 +37089,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 665
+      "community": 666
     },
     {
       "label": "debugEmbeddings()",
@@ -37057,7 +37097,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 665
+      "community": 666
     },
     {
       "label": "check-db-integrity.js",
@@ -37065,7 +37105,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 410
+      "community": 411
     },
     {
       "label": "log()",
@@ -37073,7 +37113,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 410
+      "community": 411
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -37081,7 +37121,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 410
+      "community": 411
     },
     {
       "label": "main()",
@@ -37089,7 +37129,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 410
+      "community": 411
     },
     {
       "label": "mcp-http-client.js",
@@ -37329,7 +37369,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 666
+      "community": 667
     },
     {
       "label": "backupEmbeddings()",
@@ -37337,7 +37377,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 666
+      "community": 667
     },
     {
       "label": "count-any-types.ts",
@@ -37553,7 +37593,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37561,7 +37601,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37569,7 +37609,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37577,7 +37617,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37585,7 +37625,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "jsonEmbedding()",
@@ -37593,7 +37633,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 667
+      "community": 668
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37601,7 +37641,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37609,7 +37649,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37617,7 +37657,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37625,7 +37665,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37633,7 +37673,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 668
+      "community": 669
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37641,7 +37681,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37649,7 +37689,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "jsonEmbedding()",
@@ -37657,7 +37697,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 669
+      "community": 670
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37665,7 +37705,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "main()",
@@ -37673,7 +37713,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 670
+      "community": 671
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37681,7 +37721,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37689,7 +37729,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 671
+      "community": 672
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37697,7 +37737,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "createBackup()",
@@ -37705,7 +37745,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 479
+      "community": 480
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37713,7 +37753,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 479
+      "community": 480
     },
     {
       "label": "restore-legacy.ps1",
@@ -37721,7 +37761,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 971
+      "community": 973
     },
     {
       "label": "check-retry-usage.ts",
@@ -37841,7 +37881,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37849,7 +37889,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 672
+      "community": 673
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37945,7 +37985,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37953,7 +37993,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 673
+      "community": 674
     },
     {
       "label": "sources.ts",
@@ -38009,7 +38049,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "issue-body.ts",
@@ -38017,7 +38057,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "startMarker()",
@@ -38025,7 +38065,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 411
+      "community": 412
     },
     {
       "label": "renderManagedIssueBody()",
@@ -38033,7 +38073,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 411
+      "community": 412
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -38041,7 +38081,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 411
+      "community": 412
     },
     {
       "label": "fingerprint.ts",
@@ -38049,7 +38089,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "normalizeMessage()",
@@ -38057,7 +38097,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 480
+      "community": 481
     },
     {
       "label": "createFingerprint()",
@@ -38065,7 +38105,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 480
+      "community": 481
     },
     {
       "label": "sanitizer.ts",
@@ -38073,7 +38113,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "limitUtf8Bytes()",
@@ -38081,7 +38121,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 481
+      "community": 482
     },
     {
       "label": "sanitizeExcerpt()",
@@ -38089,7 +38129,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 481
+      "community": 482
     },
     {
       "label": "parsers.ts",
@@ -38097,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "inferLevel()",
@@ -38105,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 412
+      "community": 413
     },
     {
       "label": "parseAppLogLine()",
@@ -38113,7 +38153,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 412
+      "community": 413
     },
     {
       "label": "parseJsonlRecord()",
@@ -38121,7 +38161,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 412
+      "community": 413
     },
     {
       "label": "index.ts",
@@ -38129,7 +38169,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -38137,7 +38177,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 413
+      "community": 414
     },
     {
       "label": "createMonitorRuntime()",
@@ -38145,7 +38185,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 413
+      "community": 414
     },
     {
       "label": "runForever()",
@@ -38153,7 +38193,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 413
+      "community": 414
     },
     {
       "label": "promotion.ts",
@@ -38161,7 +38201,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38169,7 +38209,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 674
+      "community": 675
     },
     {
       "label": "state-store.ts",
@@ -38433,7 +38473,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "issue-body.spec.ts",
@@ -38441,7 +38481,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "github-client.spec.ts",
@@ -38449,7 +38489,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "config.spec.ts",
@@ -38457,7 +38497,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "detectors.spec.ts",
@@ -38465,7 +38505,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "sources.spec.ts",
@@ -38473,7 +38513,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "parsers.spec.ts",
@@ -38481,7 +38521,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "monitor.spec.ts",
@@ -38489,7 +38529,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "config()",
@@ -38497,7 +38537,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 675
+      "community": 676
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38505,7 +38545,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "state-store.spec.ts",
@@ -38513,7 +38553,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38521,7 +38561,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38529,7 +38569,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 983
+      "community": 985
     },
     {
       "label": "index.ts",
@@ -38537,7 +38577,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "main()",
@@ -38545,7 +38585,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 414
+      "community": 415
     },
     {
       "label": "index.ts",
@@ -38553,7 +38593,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "runExample()",
@@ -38561,7 +38601,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 414
+      "community": 415
     },
     {
       "label": "index.spec.ts",
@@ -38569,7 +38609,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 984
+      "community": 986
     },
     {
       "label": "memento-admin-fetch.js",
@@ -46709,7 +46749,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46721,7 +46761,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46733,7 +46773,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L160",
+      "source_location": "L161",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46745,7 +46785,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L190",
+      "source_location": "L191",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46757,7 +46797,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L210",
+      "source_location": "L211",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46769,7 +46809,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_jsonfailure",
@@ -46781,7 +46821,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L240",
+      "source_location": "L241",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeout",
@@ -46793,7 +46833,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L246",
+      "source_location": "L247",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_writeerr",
@@ -46805,7 +46845,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_debugerr",
@@ -46817,7 +46857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L261",
+      "source_location": "L262",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_promptapproveinteractive",
@@ -46829,7 +46869,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L314",
+      "source_location": "L315",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_runagentaskmain",
@@ -46841,7 +46881,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L594",
+      "source_location": "L610",
       "weight": 1.0,
       "_src": "packages_memento_server_src_cli_agent_ask_ts",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -46853,7 +46893,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_stripglobalcliargs",
@@ -46865,7 +46905,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L109",
+      "source_location": "L110",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskflagargv",
@@ -46877,7 +46917,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "weight": 1.0,
       "_src": "agent_ask_parseagentaskinvocation",
       "_tgt": "agent_ask_validateagentaskrawtypes",
@@ -46889,7 +46929,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L319",
+      "source_location": "L320",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_parseagentaskinvocation",
@@ -46901,7 +46941,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L371",
+      "source_location": "L372",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_resolvedbpath",
@@ -46913,7 +46953,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L327",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_jsonfailure",
@@ -46925,7 +46965,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L327",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeout",
@@ -46937,7 +46977,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L254",
+      "source_location": "L255",
       "weight": 1.0,
       "_src": "agent_ask_debugerr",
       "_tgt": "agent_ask_writeerr",
@@ -46949,7 +46989,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L321",
+      "source_location": "L322",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_writeerr",
@@ -46961,7 +47001,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L386",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_debugerr",
@@ -46973,7 +47013,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
-      "source_location": "L321",
+      "source_location": "L322",
       "weight": 1.0,
       "_src": "agent_ask_runagentaskmain",
       "_tgt": "agent_ask_agentaskhelptext",
@@ -80615,6 +80655,42 @@
       "_tgt": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
       "source": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
       "target": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
+      "_tgt": "openai_chat_llm_adapter_openaichatllmadapter",
+      "source": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
+      "target": "openai_chat_llm_adapter_openaichatllmadapter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "_src": "openai_chat_llm_adapter_openaichatllmadapter",
+      "_tgt": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
+      "source": "openai_chat_llm_adapter_openaichatllmadapter",
+      "target": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "openai_chat_llm_adapter_openaichatllmadapter",
+      "_tgt": "openai_chat_llm_adapter_openaichatllmadapter_complete",
+      "source": "openai_chat_llm_adapter_openaichatllmadapter",
+      "target": "openai_chat_llm_adapter_openaichatllmadapter_complete",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "SlowTransport",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 414
+      "community": 415
     },
     {
       "label": ".recall()",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 414
+      "community": 415
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 480
+      "community": 481
     },
     {
       "label": "before-user-turn.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "beforeUserTurn()",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 415
+      "community": 416
     },
     {
       "label": "withTimeout()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 415
+      "community": 416
     },
     {
       "label": "auto-recall-policy.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 481
+      "community": 482
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 482
+      "community": 483
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "channel-scope.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "scopeRecallFilters()",
@@ -497,7 +497,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 416
+      "community": 417
     },
     {
       "label": "scopeRememberTags()",
@@ -505,7 +505,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 416
+      "community": 417
     },
     {
       "label": "channel-scope.spec.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 483
+      "community": 484
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 699
+      "community": 700
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 484
+      "community": 485
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 484
+      "community": 485
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 485
+      "community": 486
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 486
+      "community": 487
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 487
+      "community": 488
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "createMockResponse()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 417
+      "community": 418
     },
     {
       "label": "sendOptions()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 417
+      "community": 418
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 488
+      "community": 489
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "readRepoFile()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 418
+      "community": 419
     },
     {
       "label": "sectionBetween()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 418
+      "community": 419
     },
     {
       "label": "http-server.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 489
+      "community": 490
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 490
+      "community": 491
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "createMockResponse()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 419
+      "community": 420
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 419
+      "community": 420
     },
     {
       "label": "server-state.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "batch-run-history.ts",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 420
+      "community": 421
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 420
+      "community": 421
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 491
+      "community": 492
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 492
+      "community": 493
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 493
+      "community": 494
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 494
+      "community": 495
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 495
+      "community": 496
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 496
+      "community": 497
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 497
+      "community": 498
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 498
+      "community": 499
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 499
+      "community": 500
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 500
+      "community": 501
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 501
+      "community": 502
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L31",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 421
+      "community": 422
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L43",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 421
+      "community": 422
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "parseParams()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 422
+      "community": 423
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 422
+      "community": 423
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 502
+      "community": 503
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 503
+      "community": 504
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "parseCleanupParams()",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 423
+      "community": 424
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 423
+      "community": 424
     },
     {
       "label": "admin-relations.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 510
+      "community": 511
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 511
+      "community": 512
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "resolveEnvPath()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 424
+      "community": 425
     },
     {
       "label": "loadEnv()",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 424
+      "community": 425
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "runCli()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 512
+      "community": 513
     },
     {
       "label": "agent-ask.ts",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 425
+      "community": 426
     },
     {
       "label": "runQualityMeasurement()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 425
+      "community": 426
     },
     {
       "label": "test-simple-alerts.ts",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "testSimpleAlerts()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "testBasicFunctionality()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 514
+      "community": 515
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 515
+      "community": 516
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "compareServices()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 426
+      "community": 427
     },
     {
       "label": "testServerSynchronization()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 426
+      "community": 427
     },
     {
       "label": "test-error-logging.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "testErrorLogging()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 516
+      "community": 517
     },
     {
       "label": "debug-http-v2.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "testFetch()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 517
+      "community": 518
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "initializeTestDatabase()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 518
+      "community": 519
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "testReflexionE2E()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 519
+      "community": 520
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "testAlertsDirect()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 520
+      "community": 521
     },
     {
       "label": "test-client.ts",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "assert()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 427
+      "community": 428
     },
     {
       "label": "testMementoClient()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 427
+      "community": 428
     },
     {
       "label": "test-performance-monitor.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 523
+      "community": 524
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "createBaseSchema()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 428
+      "community": 429
     },
     {
       "label": "createTestMemory()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 428
+      "community": 429
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 429
+      "community": 430
     },
     {
       "label": "findNodeForAnchor()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L22",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 429
+      "community": 430
     },
     {
       "label": "vitest.config.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "brave-search-provider.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "NoopSearchProvider",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 430
+      "community": 431
     },
     {
       "label": ".search()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 430
+      "community": 431
     },
     {
       "label": "search-factory.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "createSearchProvider()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 524
+      "community": 525
     },
     {
       "label": "search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "types.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "loadAgentConfig()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 525
+      "community": 526
     },
     {
       "label": "system-prompt.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "utils.spec.ts",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "buildMemory()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 526
+      "community": 527
     },
     {
       "label": "context-injector.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "logger.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "shouldLog()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 431
+      "community": 432
     },
     {
       "label": "log()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 431
+      "community": 432
     },
     {
       "label": "bootstrap.spec.ts",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "createMementoCore()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 432
+      "community": 433
     },
     {
       "label": "closeDatabase()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 432
+      "community": 433
     },
     {
       "label": "bootstrap.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "initializeServices()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 527
+      "community": 528
     },
     {
       "label": "context.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 528
+      "community": 529
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 529
+      "community": 530
     },
     {
       "label": "anchor-stack.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createAnchorStack()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 530
+      "community": 531
     },
     {
       "label": "failure-reflexion.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 531
+      "community": 532
     },
     {
       "label": "search-and-embedding.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 532
+      "community": 533
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 533
+      "community": 534
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 534
+      "community": 535
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createInput()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 535
+      "community": 536
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createRelationGraph()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 536
+      "community": 537
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "createBaseSchema()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 433
+      "community": 434
     },
     {
       "label": "measureTime()",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 433
+      "community": 434
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createBaseSchema()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 537
+      "community": 538
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 538
+      "community": 539
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "openLockTestDatabase()",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 539
+      "community": 540
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "createProgress()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 540
+      "community": 541
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 541
+      "community": 542
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 542
+      "community": 543
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "addMissingColumn()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 434
+      "community": 435
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 434
+      "community": 435
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "init.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createDbPath()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 543
+      "community": 544
     },
     {
       "label": "migrate.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "migrate.ts",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "isDuplicateColumnError()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 435
+      "community": 436
     },
     {
       "label": "migrateDatabase()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 435
+      "community": 436
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "migration-runner.ts",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createBaseSchema()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 544
+      "community": 545
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "schema-version-manager.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createBaseSchema()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 545
+      "community": 546
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 546
+      "community": 547
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createBaseSchema()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 547
+      "community": 548
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "createMemoryItemTable()",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 436
+      "community": 437
     },
     {
       "label": "tableExists()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 436
+      "community": 437
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "createMemoryItemTable()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 437
+      "community": 438
     },
     {
       "label": "tableExists()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 437
+      "community": 438
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 548
+      "community": 549
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createSchemaWith018()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 549
+      "community": 550
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createBaseSchema()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 550
+      "community": 551
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createBaseSchema()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 552
+      "community": 553
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createBaseSchema()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMemoryLinkTable()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 438
+      "community": 439
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createBaseSchema()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 553
+      "community": 554
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "batch-scheduler.ts",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 554
+      "community": 555
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 555
+      "community": 556
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "readInsertedUpdated()",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L6",
       "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "community": 439
+      "community": 440
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L23",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 439
+      "community": 440
     },
     {
       "label": "relation-validator-executor.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 556
+      "community": 557
     },
     {
       "label": "retry-manager.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 440
+      "community": 441
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 440
+      "community": 441
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 441
+      "community": 442
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 441
+      "community": 442
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "shouldRetry()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 557
+      "community": 558
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "baseResult()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 558
+      "community": 559
     },
     {
       "label": "job-queue.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "initializeTestDatabase()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 559
+      "community": 560
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "generateId()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 442
+      "community": 443
     },
     {
       "label": "initializeTestDatabase()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 442
+      "community": 443
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "createQualityTables()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 560
+      "community": 561
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "generateId()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 443
+      "community": 444
     },
     {
       "label": "initializeTestDatabase()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 443
+      "community": 444
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "type-guards.ts",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "validateTableName()",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 444
+      "community": 445
     },
     {
       "label": "getVectorTableName()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 444
+      "community": 445
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 561
+      "community": 562
     },
     {
       "label": "environment-check.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 562
+      "community": 563
     },
     {
       "label": "error-handling.spec.ts",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "operation()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 563
+      "community": 564
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "relation-visualizer.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "issue()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 445
+      "community": 446
     },
     {
       "label": "validateConfiguration()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 445
+      "community": 446
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "cache-key-generator.ts",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "transactionFn()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 446
+      "community": 447
     },
     {
       "label": "outerTransaction()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 446
+      "community": 447
     },
     {
       "label": "write-coalescing.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "path-validator.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 564
+      "community": 565
     },
     {
       "label": "error-handling.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "withErrorHandling()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 565
+      "community": 566
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 566
+      "community": 567
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "createValidReflectionNote()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 447
+      "community": 448
     },
     {
       "label": "createLargeNote()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 447
+      "community": 448
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "initializeTestDatabase()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 567
+      "community": 568
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 568
+      "community": 569
     },
     {
       "label": "logging-helpers.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "initializeTestDatabase()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 569
+      "community": 570
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "benchmark.types.ts",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "assertMacroCategory()",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 570
+      "community": 571
     },
     {
       "label": "migration.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "index.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "isMemoryItemType()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 448
+      "community": 449
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 448
+      "community": 449
     },
     {
       "label": "error-types.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "retry-options-loader.ts",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "validateConfig()",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 571
+      "community": 572
     },
     {
       "label": "config-loader-utils.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "getMockMementoConfig()",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L19",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 449
+      "community": 450
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L48",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 449
+      "community": 450
     },
     {
       "label": "initialize.spec.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "search-local-tool.ts",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "initializeTestDatabase()",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 572
+      "community": 573
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "initializeTestDatabase()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 573
+      "community": 574
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 574
+      "community": 575
     },
     {
       "label": "embedding-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "vector-search.factory.ts",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 575
+      "community": 576
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "search-result-combiner.ts",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 576
+      "community": 577
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -19913,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "initializeTestDatabase()",
@@ -19921,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 450
+      "community": 451
     },
     {
       "label": "createValidReflectionNote()",
@@ -19929,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 450
+      "community": 451
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "vector-search.service.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 577
+      "community": 578
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "createMockRepository()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vector-index-manager.ts",
@@ -20737,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "createMockRepositories()",
@@ -20745,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 579
+      "community": 580
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20761,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "createMockIndexRepository()",
@@ -20769,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 580
+      "community": 581
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22473,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "openTelemetryDb()",
@@ -22481,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 581
+      "community": 582
     },
     {
       "label": "telemetry-repository.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 582
+      "community": 583
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22908,12 +22908,52 @@
       "community": 371
     },
     {
+      "label": "personal-agent-llm-error.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
+      "community": 372
+    },
+    {
+      "label": "PersonalAgentLlmError",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L12",
+      "id": "personal_agent_llm_error_personalagentllmerror",
+      "community": 372
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L15",
+      "id": "personal_agent_llm_error_personalagentllmerror_constructor",
+      "community": 372
+    },
+    {
+      "label": "isPersonalAgentLlmError()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L22",
+      "id": "personal_agent_llm_error_ispersonalagentllmerror",
+      "community": 372
+    },
+    {
+      "label": "personal-agent-llm-error.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
+      "community": 865
+    },
+    {
       "label": "llm-port.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "persistence-port.ts",
@@ -22921,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "context-port.ts",
@@ -22929,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "agent-types.ts",
@@ -22937,7 +22977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -22945,7 +22985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23073,7 +23113,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23081,7 +23121,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "baseCandidate()",
@@ -23089,7 +23129,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 583
+      "community": 584
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23137,7 +23177,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "makeDeps()",
@@ -23145,7 +23185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 584
+      "community": 585
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23193,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23201,7 +23241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 585
+      "community": 586
     },
     {
       "label": "core-memory-repository.ts",
@@ -23209,7 +23249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23217,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23225,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23233,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23241,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "feedback-repository.ts",
@@ -23249,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23257,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 451
+      "community": 452
     },
     {
       "label": "FeedbackRepository",
@@ -23265,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 451
+      "community": 452
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23273,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23281,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23289,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23297,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23305,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23313,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "createKgTripleTable()",
@@ -23321,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 586
+      "community": 587
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23329,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23337,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23345,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23353,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 588
+      "community": 589
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23361,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23369,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23377,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 589
+      "community": 590
     },
     {
       "label": "remember-tool.ts",
@@ -23465,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "validateRecallQuery()",
@@ -23473,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 452
+      "community": 453
     },
     {
       "label": "validateRecallFilters()",
@@ -23481,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 452
+      "community": 453
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23489,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23497,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 590
+      "community": 591
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23505,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 372
+      "community": 373
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -23513,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".constructor()",
@@ -23521,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 372
+      "community": 373
     },
     {
       "label": ".handle()",
@@ -23529,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 372
+      "community": 373
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -23537,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -23545,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".constructor()",
@@ -23553,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".handle()",
@@ -23561,7 +23601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 373
+      "community": 374
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -23569,7 +23609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "ProceduralRollbackTool",
@@ -23577,7 +23617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".constructor()",
@@ -23585,7 +23625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 374
+      "community": 375
     },
     {
       "label": ".handle()",
@@ -23593,7 +23633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 374
+      "community": 375
     },
     {
       "label": "feedback-tool.ts",
@@ -23649,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "CleanupMemoryTool",
@@ -23657,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".constructor()",
@@ -23665,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 375
+      "community": 376
     },
     {
       "label": ".handle()",
@@ -23673,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 375
+      "community": 376
     },
     {
       "label": "recall-tool-filters.ts",
@@ -23681,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23689,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 453
+      "community": 454
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23697,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 453
+      "community": 454
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -23897,7 +23937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "ProceduralDiffTool",
@@ -23905,7 +23945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".constructor()",
@@ -23913,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".handle()",
@@ -23921,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 376
+      "community": 377
     },
     {
       "label": "unpin-tool.ts",
@@ -24041,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -24049,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".constructor()",
@@ -24057,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 377
+      "community": 378
     },
     {
       "label": ".handle()",
@@ -24065,7 +24105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 377
+      "community": 378
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -24073,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "RememberProcedureTool",
@@ -24081,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".constructor()",
@@ -24089,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 378
+      "community": 379
     },
     {
       "label": ".handle()",
@@ -24097,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 378
+      "community": 379
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -24145,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24153,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 591
+      "community": 592
     },
     {
       "label": "recall-tool.ts",
@@ -24289,7 +24329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "forget-tool.ts",
@@ -24433,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createSchema()",
@@ -24441,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 592
+      "community": 593
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24449,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24457,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "initializeTestDatabase()",
@@ -24465,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 454
+      "community": 455
     },
     {
       "label": "createValidReflectionNote()",
@@ -24473,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 454
+      "community": 455
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24481,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24489,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "createSchema()",
@@ -24497,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 593
+      "community": 594
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24505,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 379
+      "community": 380
     },
     {
       "label": "generateId()",
@@ -24513,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 379
+      "community": 380
     },
     {
       "label": "initializeTestDatabase()",
@@ -24521,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 379
+      "community": 380
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -24529,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 379
+      "community": 380
     },
     {
       "label": "forget-tool.spec.ts",
@@ -24537,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24545,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24553,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "initializeTestDatabase()",
@@ -24561,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 594
+      "community": 595
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24569,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "parseData()",
@@ -24577,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 595
+      "community": 596
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24585,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24593,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "initializeTestDatabase()",
@@ -24601,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 455
+      "community": 456
     },
     {
       "label": "createValidReflectionNote()",
@@ -24609,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 455
+      "community": 456
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24617,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24625,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24633,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "meta-memory-service.ts",
@@ -24761,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 380
+      "community": 381
     },
     {
       "label": "fieldDiff()",
@@ -24769,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 380
+      "community": 381
     },
     {
       "label": "parseStepsJson()",
@@ -24777,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 380
+      "community": 381
     },
     {
       "label": "computeProceduralDiff()",
@@ -24785,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 380
+      "community": 381
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -24833,7 +24873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 381
+      "community": 382
     },
     {
       "label": "parseImportanceThreshold()",
@@ -24841,7 +24881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L7",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 381
+      "community": 382
     },
     {
       "label": "parsePositiveInt()",
@@ -24849,7 +24889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 381
+      "community": 382
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
@@ -24857,7 +24897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L29",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 381
+      "community": 382
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -24865,7 +24905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "createBaseSchema()",
@@ -24873,7 +24913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 596
+      "community": 597
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -24953,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "baseRow()",
@@ -24961,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 597
+      "community": 598
     },
     {
       "label": "procedural-versioning.ts",
@@ -24969,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "getVersionChain()",
@@ -24977,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 382
+      "community": 383
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -24985,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 382
+      "community": 383
     },
     {
       "label": "getNextVersionNumber()",
@@ -24993,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 382
+      "community": 383
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -25001,7 +25041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -25009,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 456
+      "community": 457
     },
     {
       "label": ".runScan()",
@@ -25017,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 456
+      "community": 457
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -25025,7 +25065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "generateMemoryId()",
@@ -25033,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 457
+      "community": 458
     },
     {
       "label": "rollbackToVersion()",
@@ -25041,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 457
+      "community": 458
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25113,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "selectionWindowLimit()",
@@ -25121,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 458
+      "community": 459
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25129,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 458
+      "community": 459
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25177,7 +25217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25185,7 +25225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25193,7 +25233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 598
+      "community": 599
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25201,7 +25241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "openDb()",
@@ -25209,7 +25249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 599
+      "community": 600
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25801,7 +25841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "createBaseSchema()",
@@ -25809,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 600
+      "community": 601
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26073,7 +26113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26081,7 +26121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26089,7 +26129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 459
+      "community": 460
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26097,7 +26137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 459
+      "community": 460
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26105,7 +26145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26113,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "core-memory-service.ts",
@@ -26273,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "createBaseSchema()",
@@ -26281,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 601
+      "community": 602
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26289,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26297,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 602
+      "community": 603
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26377,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26385,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26393,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createSchema()",
@@ -26401,7 +26441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 603
+      "community": 604
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26409,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26417,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createSchema()",
@@ -26425,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 604
+      "community": 605
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26433,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26441,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createBaseSchema()",
@@ -26449,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26457,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26465,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createSchema()",
@@ -26473,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26481,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26489,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26609,7 +26649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26873,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26881,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26889,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 607
+      "community": 608
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26897,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "consolidation-repository.ts",
@@ -27129,7 +27169,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "row()",
@@ -27137,7 +27177,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 608
+      "community": 609
     },
     {
       "label": "summarization-service.ts",
@@ -27233,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "ep()",
@@ -27241,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 609
+      "community": 610
     },
     {
       "label": "relation-graph.port.ts",
@@ -27249,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "get-relations-tool.ts",
@@ -27257,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_get_relations_tool_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "GetRelationsTool",
@@ -27265,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L21",
       "id": "get_relations_tool_getrelationstool",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".constructor()",
@@ -27273,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L22",
       "id": "get_relations_tool_getrelationstool_constructor",
-      "community": 383
+      "community": 384
     },
     {
       "label": ".handle()",
@@ -27281,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/get-relations-tool.ts",
       "source_location": "L60",
       "id": "get_relations_tool_getrelationstool_handle",
-      "community": 383
+      "community": 384
     },
     {
       "label": "extract-triples-tool.spec.ts",
@@ -27289,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27297,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 610
+      "community": 611
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27305,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "VisualizeRelationsTool",
@@ -27313,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".constructor()",
@@ -27321,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 384
+      "community": 385
     },
     {
       "label": ".handle()",
@@ -27329,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 384
+      "community": 385
     },
     {
       "label": "remove-relation-tool.ts",
@@ -27337,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "RemoveRelationTool",
@@ -27345,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".constructor()",
@@ -27353,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 385
+      "community": 386
     },
     {
       "label": ".handle()",
@@ -27361,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 385
+      "community": 386
     },
     {
       "label": "extract-relations-tool.ts",
@@ -27369,7 +27409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "ExtractRelationsTool",
@@ -27377,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".constructor()",
@@ -27385,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 386
+      "community": 387
     },
     {
       "label": ".handle()",
@@ -27393,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 386
+      "community": 387
     },
     {
       "label": "add-relation-tool.ts",
@@ -27401,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "AddRelationTool",
@@ -27409,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L19",
       "id": "add_relation_tool_addrelationtool",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".constructor()",
@@ -27417,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L20",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 387
+      "community": 388
     },
     {
       "label": ".handle()",
@@ -27425,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L58",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 387
+      "community": 388
     },
     {
       "label": "extract-triples-tool.ts",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createBaseSchema()",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 460
+      "community": 461
     },
     {
       "label": "createTestMemory()",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 460
+      "community": 461
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27505,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createBaseSchema()",
@@ -27513,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createTestMemory()",
@@ -27521,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 461
+      "community": 462
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27529,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createBaseSchema()",
@@ -27537,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createTestMemory()",
@@ -27545,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27553,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27561,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createBaseSchema()",
@@ -27569,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createTestMemory()",
@@ -27577,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 463
+      "community": 464
     },
     {
       "label": "relation-retry-manager.ts",
@@ -27585,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "RelationRetryManager",
@@ -27593,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".constructor()",
@@ -27601,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 388
+      "community": 389
     },
     {
       "label": ".retry()",
@@ -27609,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 388
+      "community": 389
     },
     {
       "label": "relation-errors.ts",
@@ -28361,7 +28401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "loadTestDataset()",
@@ -28369,7 +28409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createBaseSchema()",
@@ -28377,7 +28417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 389
+      "community": 390
     },
     {
       "label": "createTestMemory()",
@@ -28385,7 +28425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 389
+      "community": 390
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -28393,7 +28433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28401,7 +28441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createBaseSchema()",
@@ -28409,7 +28449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createTestMemory()",
@@ -28417,7 +28457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 464
+      "community": 465
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28425,7 +28465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "createTestMemory()",
@@ -28433,7 +28473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 611
+      "community": 612
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28441,7 +28481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createBaseSchema()",
@@ -28449,7 +28489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createTestMemory()",
@@ -28457,7 +28497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 390
+      "community": 391
     },
     {
       "label": "createBulkMemories()",
@@ -28465,7 +28505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 390
+      "community": 391
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -28473,7 +28513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "createTestMemory()",
@@ -28481,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 612
+      "community": 613
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28545,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28553,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28561,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "getMockMementoConfig()",
@@ -28569,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 465
+      "community": 466
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28577,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 465
+      "community": 466
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28585,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28593,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28601,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28657,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -28665,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 391
+      "community": 392
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -28673,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 391
+      "community": 392
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -28681,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 391
+      "community": 392
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -28929,7 +28969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "extract()",
@@ -28937,7 +28977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 613
+      "community": 614
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -28945,7 +28985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "tripleDedupeKey()",
@@ -28953,7 +28993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 466
+      "community": 467
     },
     {
       "label": "mergeTripleLists()",
@@ -28961,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 466
+      "community": 467
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -28969,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29153,7 +29193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29161,7 +29201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29169,7 +29209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "triple-extractor.ts",
@@ -29313,7 +29353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "TripleNormalizer",
@@ -29321,7 +29361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 392
+      "community": 393
     },
     {
       "label": ".constructor()",
@@ -29329,7 +29369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 392
+      "community": 393
     },
     {
       "label": ".normalize()",
@@ -29337,7 +29377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 392
+      "community": 393
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -29345,7 +29385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29353,7 +29393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -29361,7 +29401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 393
+      "community": 394
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -29369,7 +29409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 393
+      "community": 394
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -29377,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 393
+      "community": 394
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -29385,7 +29425,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "triple-parser.ts",
@@ -29433,7 +29473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29441,7 +29481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 614
+      "community": 615
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29449,7 +29489,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29457,7 +29497,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 615
+      "community": 616
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29545,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29553,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "interfaces.spec.ts",
@@ -29561,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29569,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29577,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29585,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29593,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 616
+      "community": 617
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29601,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29609,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 617
+      "community": 618
     },
     {
       "label": "types.ts",
@@ -29617,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29625,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "checkOllamaModel()",
@@ -29633,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 394
+      "community": 395
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -29641,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 394
+      "community": 395
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -29649,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 394
+      "community": 395
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -29657,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29665,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 618
+      "community": 619
     },
     {
       "label": "provider-selection.ts",
@@ -29673,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29681,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 467
+      "community": 468
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29689,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 467
+      "community": 468
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29697,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29705,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 619
+      "community": 620
     },
     {
       "label": "llm-response-parse.ts",
@@ -29985,7 +30025,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "createMockService()",
@@ -29993,7 +30033,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 395
+      "community": 396
     },
     {
       "label": "resolver()",
@@ -30001,7 +30041,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 395
+      "community": 396
     },
     {
       "label": "priority()",
@@ -30009,7 +30049,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 395
+      "community": 396
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -30017,7 +30057,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "embedding-service.ts",
@@ -31129,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31137,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31145,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "createSchema()",
@@ -31153,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 468
+      "community": 469
     },
     {
       "label": "seedMemoryItem()",
@@ -31161,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 468
+      "community": 469
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31169,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31177,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31185,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31193,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -31201,7 +31241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 396
+      "community": 397
     },
     {
       "label": ".constructor()",
@@ -31209,7 +31249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 396
+      "community": 397
     },
     {
       "label": ".handle()",
@@ -31217,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 396
+      "community": 397
     },
     {
       "label": "performance-alerts.ts",
@@ -31273,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "PerformanceStatsTool",
@@ -31281,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 397
+      "community": 398
     },
     {
       "label": ".constructor()",
@@ -31289,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 397
+      "community": 398
     },
     {
       "label": ".handle()",
@@ -31297,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 397
+      "community": 398
     },
     {
       "label": "resolve-error.ts",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "executeResolveError()",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 620
+      "community": 621
     },
     {
       "label": "error-stats.ts",
@@ -31321,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "executeErrorStats()",
@@ -31329,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 621
+      "community": 622
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31337,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31345,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31353,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "createBaseSchema()",
@@ -31361,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 622
+      "community": 623
     },
     {
       "label": "error-stats.spec.ts",
@@ -31369,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "performance-monitor.ts",
@@ -32281,7 +32321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32289,7 +32329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32297,7 +32337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32305,7 +32345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32353,7 +32393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "restoreEnvValue()",
@@ -32361,7 +32401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 623
+      "community": 624
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32369,7 +32409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32377,7 +32417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32385,7 +32425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32393,7 +32433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "quality-recorder.ts",
@@ -32465,7 +32505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32473,7 +32513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 624
+      "community": 625
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32553,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32561,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 625
+      "community": 626
     },
     {
       "label": "quality-reporter.ts",
@@ -32649,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32657,7 +32697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32665,7 +32705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32673,7 +32713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -32681,7 +32721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "quality-assurance-service.ts",
@@ -32961,7 +33001,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -32969,7 +33009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityMetricsTable()",
@@ -32977,7 +33017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32985,7 +33025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 400
+      "community": 401
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -33177,7 +33217,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "base-tool.ts",
@@ -33473,7 +33513,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33481,7 +33521,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 626
+      "community": 627
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33489,7 +33529,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "measureRecall()",
@@ -33497,7 +33537,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 627
+      "community": 628
     },
     {
       "label": "test-embedding.ts",
@@ -33505,7 +33545,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33513,7 +33553,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 628
+      "community": 629
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33521,7 +33561,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "compareToolResults()",
@@ -33529,7 +33569,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 469
+      "community": 470
     },
     {
       "label": "testToolConsistency()",
@@ -33537,7 +33577,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 469
+      "community": 470
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33545,7 +33585,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "createQualityTables()",
@@ -33553,7 +33593,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 470
+      "community": 471
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33561,7 +33601,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 470
+      "community": 471
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33609,7 +33649,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "testSearchFunctionality()",
@@ -33617,7 +33657,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 629
+      "community": 630
     },
     {
       "label": "test-forgetting.ts",
@@ -33625,7 +33665,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33633,7 +33673,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 630
+      "community": 631
     },
     {
       "label": "mock-database.spec.ts",
@@ -33641,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "test-m1-completion.ts",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testM1Completion()",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 631
+      "community": 632
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33665,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33673,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 632
+      "community": 633
     },
     {
       "label": "vitest.setup.ts",
@@ -33681,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33689,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "parseItems()",
@@ -33697,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 633
+      "community": 634
     },
     {
       "label": "test-memory-resource.ts",
@@ -33705,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "setupResourceHandlers()",
@@ -33713,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 471
+      "community": 472
     },
     {
       "label": "createTestMemories()",
@@ -33721,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 471
+      "community": 472
     },
     {
       "label": "test-regression.ts",
@@ -33729,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "testRegression()",
@@ -33737,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 634
+      "community": 635
     },
     {
       "label": "test-anchor-system.ts",
@@ -33801,7 +33841,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33873,7 +33913,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33881,7 +33921,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 635
+      "community": 636
     },
     {
       "label": "visualize-recency.ts",
@@ -33945,7 +33985,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34009,7 +34049,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "constructor()",
@@ -34017,7 +34057,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 636
+      "community": 637
     },
     {
       "label": "mock-database.ts",
@@ -34249,7 +34289,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34257,7 +34297,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "telemetryDb()",
@@ -34265,7 +34305,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 401
+      "community": 402
     },
     {
       "label": "percentile95()",
@@ -34273,7 +34313,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 401
+      "community": 402
     },
     {
       "label": "run()",
@@ -34281,7 +34321,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 401
+      "community": 402
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -34289,7 +34329,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "createTestMemories()",
@@ -34297,7 +34337,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34305,7 +34345,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34313,7 +34353,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 638
+      "community": 639
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34321,7 +34361,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34329,7 +34369,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "seedCluster()",
@@ -34337,7 +34377,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 639
+      "community": 640
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34345,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "readSource()",
@@ -34353,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 472
+      "community": 473
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34361,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 472
+      "community": 473
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34369,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -34377,7 +34417,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 402
+      "community": 403
     },
     {
       "label": "normalizeTags()",
@@ -34385,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 402
+      "community": 403
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -34393,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 402
+      "community": 403
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -34401,7 +34441,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "writeFixtureDir()",
@@ -34409,7 +34449,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 640
+      "community": 641
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34505,7 +34545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34569,7 +34609,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "normalizeMemoryType()",
@@ -34577,7 +34617,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L21",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 403
+      "community": 404
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -34585,7 +34625,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L38",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 403
+      "community": 404
     },
     {
       "label": "seedOneCorpusRow()",
@@ -34593,7 +34633,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L101",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 403
+      "community": 404
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -34601,7 +34641,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34609,7 +34649,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "test-database.ts",
@@ -34641,7 +34681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "mergeCandidateIds()",
@@ -34649,7 +34689,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 641
+      "community": 642
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34657,7 +34697,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34665,7 +34705,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 473
+      "community": 474
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34673,7 +34713,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 473
+      "community": 474
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34681,7 +34721,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34689,7 +34729,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34889,7 +34929,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "query-counter.ts",
@@ -34897,7 +34937,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "extractQueryType()",
@@ -34905,7 +34945,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 404
+      "community": 405
     },
     {
       "label": "isExcluded()",
@@ -34913,7 +34953,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 404
+      "community": 405
     },
     {
       "label": "createQueryCounter()",
@@ -34921,7 +34961,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 404
+      "community": 405
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -35289,7 +35329,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 642
+      "community": 643
     },
     {
       "label": "copyDir()",
@@ -35297,7 +35337,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 642
+      "community": 643
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35305,7 +35345,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "readRootPackageJson()",
@@ -35313,7 +35353,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 643
+      "community": 644
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35321,7 +35361,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "readJson()",
@@ -35329,7 +35369,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 644
+      "community": 645
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35337,7 +35377,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "readWorkflow()",
@@ -35345,7 +35385,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 645
+      "community": 646
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35409,7 +35449,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "readStaticFile()",
@@ -35417,7 +35457,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 646
+      "community": 647
     },
     {
       "label": "smoke.spec.ts",
@@ -35425,7 +35465,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "extractFencedBlocks()",
@@ -35433,7 +35473,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 647
+      "community": 648
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35505,7 +35545,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "parseArgs()",
@@ -35513,7 +35553,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 405
+      "community": 406
     },
     {
       "label": "printHelp()",
@@ -35521,7 +35561,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 405
+      "community": 406
     },
     {
       "label": "main()",
@@ -35529,7 +35569,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 405
+      "community": 406
     },
     {
       "label": "check-magic-numbers.ts",
@@ -35617,7 +35657,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 648
+      "community": 649
     },
     {
       "label": "shouldInclude()",
@@ -35625,7 +35665,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 648
+      "community": 649
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35633,7 +35673,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 474
+      "community": 475
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35641,7 +35681,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 474
+      "community": 475
     },
     {
       "label": "readTarString()",
@@ -35649,7 +35689,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 474
+      "community": 475
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35713,7 +35753,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 649
+      "community": 650
     },
     {
       "label": "fixMigration()",
@@ -35721,7 +35761,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 649
+      "community": 650
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35729,7 +35769,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 952
+      "community": 954
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -35793,7 +35833,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "parseArgs()",
@@ -35801,7 +35841,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 406
+      "community": 407
     },
     {
       "label": "printHelp()",
@@ -35809,7 +35849,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 406
+      "community": 407
     },
     {
       "label": "main()",
@@ -35817,7 +35857,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 406
+      "community": 407
     },
     {
       "label": "check-path-traversal.ts",
@@ -36057,7 +36097,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 650
+      "community": 651
     },
     {
       "label": "updateEmbeddings()",
@@ -36065,7 +36105,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 650
+      "community": 651
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36233,7 +36273,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36241,7 +36281,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 651
+      "community": 652
     },
     {
       "label": "test-docker.js",
@@ -36249,7 +36289,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 652
+      "community": 653
     },
     {
       "label": "testDockerServer()",
@@ -36257,7 +36297,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 652
+      "community": 653
     },
     {
       "label": "pack-with-restore.js",
@@ -36265,7 +36305,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 953
+      "community": 955
     },
     {
       "label": "run-migration.js",
@@ -36273,7 +36313,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "runMigration()",
@@ -36281,7 +36321,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 653
+      "community": 654
     },
     {
       "label": "safe-migration.js",
@@ -36289,7 +36329,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 654
+      "community": 655
     },
     {
       "label": "safeMigration()",
@@ -36297,7 +36337,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 654
+      "community": 655
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36361,7 +36401,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "saveWorkMemory()",
@@ -36369,7 +36409,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 655
+      "community": 656
     },
     {
       "label": "check-file-sizes.ts",
@@ -36537,7 +36577,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36545,7 +36585,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "main()",
@@ -36553,7 +36593,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 656
+      "community": 657
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36561,7 +36601,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "parseArgs()",
@@ -36569,7 +36609,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 407
+      "community": 408
     },
     {
       "label": "printHelp()",
@@ -36577,7 +36617,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 407
+      "community": 408
     },
     {
       "label": "main()",
@@ -36585,7 +36625,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 407
+      "community": 408
     },
     {
       "label": "verify-bin.js",
@@ -36593,7 +36633,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 955
+      "community": 957
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36641,7 +36681,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 657
+      "community": 658
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36649,7 +36689,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 657
+      "community": 658
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36657,7 +36697,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 658
+      "community": 659
     },
     {
       "label": "fixVectorDimensions()",
@@ -36665,7 +36705,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 658
+      "community": 659
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36673,7 +36713,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "formatCategoryReportLine()",
@@ -36681,7 +36721,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 408
+      "community": 409
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -36689,7 +36729,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 408
+      "community": 409
     },
     {
       "label": "main()",
@@ -36697,7 +36737,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 408
+      "community": 409
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -36705,7 +36745,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "loadVecExtension()",
@@ -36713,7 +36753,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 475
+      "community": 476
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36721,7 +36761,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 475
+      "community": 476
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36729,7 +36769,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "runUpdateMigration()",
@@ -36737,7 +36777,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 659
+      "community": 660
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36745,7 +36785,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "reappearanceRate()",
@@ -36753,7 +36793,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 476
+      "community": 477
     },
     {
       "label": "main()",
@@ -36761,7 +36801,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 476
+      "community": 477
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36769,7 +36809,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 660
+      "community": 661
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36777,7 +36817,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 660
+      "community": 661
     },
     {
       "label": "generate-relation-report.ts",
@@ -36929,7 +36969,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "sampleReport()",
@@ -36937,7 +36977,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 661
+      "community": 662
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -36945,7 +36985,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 956
+      "community": 958
     },
     {
       "label": "debug-embeddings.js",
@@ -36953,7 +36993,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 662
+      "community": 663
     },
     {
       "label": "debugEmbeddings()",
@@ -36961,7 +37001,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 662
+      "community": 663
     },
     {
       "label": "check-db-integrity.js",
@@ -36969,7 +37009,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 409
+      "community": 410
     },
     {
       "label": "log()",
@@ -36977,7 +37017,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 409
+      "community": 410
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -36985,7 +37025,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 409
+      "community": 410
     },
     {
       "label": "main()",
@@ -36993,7 +37033,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 409
+      "community": 410
     },
     {
       "label": "mcp-http-client.js",
@@ -37233,7 +37273,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 663
+      "community": 664
     },
     {
       "label": "backupEmbeddings()",
@@ -37241,7 +37281,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 663
+      "community": 664
     },
     {
       "label": "count-any-types.ts",
@@ -37457,7 +37497,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37465,7 +37505,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37473,7 +37513,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37481,7 +37521,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37489,7 +37529,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "jsonEmbedding()",
@@ -37497,7 +37537,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 664
+      "community": 665
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37505,7 +37545,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37513,7 +37553,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37521,7 +37561,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37529,7 +37569,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37537,7 +37577,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 665
+      "community": 666
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37545,7 +37585,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37553,7 +37593,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "jsonEmbedding()",
@@ -37561,7 +37601,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 666
+      "community": 667
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37569,7 +37609,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "main()",
@@ -37577,7 +37617,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 667
+      "community": 668
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37585,7 +37625,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37593,7 +37633,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 668
+      "community": 669
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37601,7 +37641,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "createBackup()",
@@ -37609,7 +37649,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 477
+      "community": 478
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37617,7 +37657,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 477
+      "community": 478
     },
     {
       "label": "restore-legacy.ps1",
@@ -37625,7 +37665,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 965
+      "community": 967
     },
     {
       "label": "check-retry-usage.ts",
@@ -37745,7 +37785,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37753,7 +37793,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 669
+      "community": 670
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37849,7 +37889,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37857,7 +37897,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 670
+      "community": 671
     },
     {
       "label": "sources.ts",
@@ -37913,7 +37953,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "issue-body.ts",
@@ -37921,7 +37961,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "startMarker()",
@@ -37929,7 +37969,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 410
+      "community": 411
     },
     {
       "label": "renderManagedIssueBody()",
@@ -37937,7 +37977,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 410
+      "community": 411
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -37945,7 +37985,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 410
+      "community": 411
     },
     {
       "label": "fingerprint.ts",
@@ -37953,7 +37993,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "normalizeMessage()",
@@ -37961,7 +38001,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 478
+      "community": 479
     },
     {
       "label": "createFingerprint()",
@@ -37969,7 +38009,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 478
+      "community": 479
     },
     {
       "label": "sanitizer.ts",
@@ -37977,7 +38017,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "limitUtf8Bytes()",
@@ -37985,7 +38025,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 479
+      "community": 480
     },
     {
       "label": "sanitizeExcerpt()",
@@ -37993,7 +38033,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 479
+      "community": 480
     },
     {
       "label": "parsers.ts",
@@ -38001,7 +38041,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "inferLevel()",
@@ -38009,7 +38049,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 411
+      "community": 412
     },
     {
       "label": "parseAppLogLine()",
@@ -38017,7 +38057,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 411
+      "community": 412
     },
     {
       "label": "parseJsonlRecord()",
@@ -38025,7 +38065,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 411
+      "community": 412
     },
     {
       "label": "index.ts",
@@ -38033,7 +38073,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -38041,7 +38081,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 412
+      "community": 413
     },
     {
       "label": "createMonitorRuntime()",
@@ -38049,7 +38089,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 412
+      "community": 413
     },
     {
       "label": "runForever()",
@@ -38057,7 +38097,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 412
+      "community": 413
     },
     {
       "label": "promotion.ts",
@@ -38065,7 +38105,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38073,7 +38113,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 671
+      "community": 672
     },
     {
       "label": "state-store.ts",
@@ -38337,7 +38377,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "issue-body.spec.ts",
@@ -38345,7 +38385,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "github-client.spec.ts",
@@ -38353,7 +38393,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "config.spec.ts",
@@ -38361,7 +38401,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "detectors.spec.ts",
@@ -38369,7 +38409,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "sources.spec.ts",
@@ -38377,7 +38417,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "parsers.spec.ts",
@@ -38385,7 +38425,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "monitor.spec.ts",
@@ -38393,7 +38433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "config()",
@@ -38401,7 +38441,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 672
+      "community": 673
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38409,7 +38449,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "state-store.spec.ts",
@@ -38417,7 +38457,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38425,7 +38465,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38433,7 +38473,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "index.ts",
@@ -38441,7 +38481,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "main()",
@@ -38449,7 +38489,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 413
+      "community": 414
     },
     {
       "label": "index.ts",
@@ -38457,7 +38497,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "runExample()",
@@ -38465,7 +38505,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 413
+      "community": 414
     },
     {
       "label": "index.spec.ts",
@@ -38473,7 +38513,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "memento-admin-fetch.js",
@@ -80387,6 +80427,42 @@
       "_tgt": "knowledge_candidate_extractor_pushunique",
       "source": "knowledge_candidate_extractor_pushunique",
       "target": "knowledge_candidate_extractor_extractknowledgecandidates",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
+      "_tgt": "personal_agent_llm_error_personalagentllmerror",
+      "source": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
+      "target": "personal_agent_llm_error_personalagentllmerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
+      "_tgt": "personal_agent_llm_error_ispersonalagentllmerror",
+      "source": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
+      "target": "personal_agent_llm_error_ispersonalagentllmerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
+      "source_location": "L15",
+      "weight": 1.0,
+      "_src": "personal_agent_llm_error_personalagentllmerror",
+      "_tgt": "personal_agent_llm_error_personalagentllmerror_constructor",
+      "source": "personal_agent_llm_error_personalagentllmerror",
+      "target": "personal_agent_llm_error_personalagentllmerror_constructor",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "block-navigation.js",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "assistant.spec.ts",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "types.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "types.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "assistant.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "after-assistant-turn.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "afterAssistantTurn()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 481
+      "community": 482
     },
     {
       "label": "before-user-turn.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "shouldAutoRecall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 482
+      "community": 483
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "auto-remember-policy.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "rememberDispatch()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 483
+      "community": 484
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "channel-scope.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "http-transport.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "mock-transport.spec.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "transport.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "index.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "http-transport.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "factory.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "createTransportFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 484
+      "community": 485
     },
     {
       "label": "stdio-transport.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "mock-transport.ts",
@@ -849,7 +849,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "retry-queue.spec.ts",
@@ -857,7 +857,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "retry-queue.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -953,7 +953,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -961,7 +961,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "http.integration.spec.ts",
@@ -969,7 +969,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "start-http-server.ts",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 700
+      "community": 701
     },
     {
       "label": "test-integration.js",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 485
+      "community": 486
     },
     {
       "label": "testBasicFunctionality()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 485
+      "community": 486
     },
     {
       "label": "performance-optimizer.js",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "basicUsageExample()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 486
+      "community": 487
     },
     {
       "label": "performance-examples.ts",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "advancedUsageExample()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 487
+      "community": 488
     },
     {
       "label": "migration-guide.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "makeNullRunner()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 488
+      "community": 489
     },
     {
       "label": "telemetry-cli.ts",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "index-factory.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "context.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "server-factory.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "createServerFactory()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 489
+      "community": 490
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "startStdioServer()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 490
+      "community": 491
     },
     {
       "label": "server-factory.spec.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "server-state.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 491
+      "community": 492
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "bootstrap.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "sse-server-impl.ts",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "batch-run-history.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "makeMocks()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 492
+      "community": 493
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 493
+      "community": 494
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "createMockResponse()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 494
+      "community": 495
     },
     {
       "label": "index.ts",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createServiceInjector()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 495
+      "community": 496
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 496
+      "community": 497
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createMockResponse()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 497
+      "community": 498
     },
     {
       "label": "session-store.spec.ts",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "session-store.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createSessionStore()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 498
+      "community": 499
     },
     {
       "label": "stdio-server.ts",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "admin.routes.ts",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "createAdminRouter()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L26",
       "id": "admin_routes_createadminrouter",
-      "community": 499
+      "community": 500
     },
     {
       "label": "auth.routes.ts",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "createToolsRouter()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 500
+      "community": 501
     },
     {
       "label": "api.routes.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createApiRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 501
+      "community": 502
     },
     {
       "label": "quality.routes.ts",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "createQualityRouter()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 502
+      "community": 503
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 503
+      "community": 504
     },
     {
       "label": "admin-graph-response.ts",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "buildGraphResponse()",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 504
+      "community": 505
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 505
+      "community": 506
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 506
+      "community": 507
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 507
+      "community": 508
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 508
+      "community": 509
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 509
+      "community": 510
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 510
+      "community": 511
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 511
+      "community": 512
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "argv()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 512
+      "community": 513
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "runCli()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 513
+      "community": 514
     },
     {
       "label": "agent-ask.ts",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "testSimpleAlerts()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "testBasicFunctionality()",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 515
+      "community": 516
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 516
+      "community": 517
     },
     {
       "label": "test-server-synchronization.ts",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "testErrorLogging()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 517
+      "community": 518
     },
     {
       "label": "debug-http-v2.ts",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "testFetch()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 518
+      "community": 519
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "initializeTestDatabase()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 519
+      "community": 520
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "testReflexionE2E()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 520
+      "community": 521
     },
     {
       "label": "test-alerts-direct.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "testAlertsDirect()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 521
+      "community": 522
     },
     {
       "label": "test-client.ts",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "test-http-server-v2.ts",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "testPerformanceAlerts()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "testPathTraversalE2E()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 523
+      "community": 524
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 524
+      "community": 525
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "brave-search-provider.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "createSearchProvider()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 525
+      "community": 526
     },
     {
       "label": "search-provider.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "llm-provider.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "types.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "loadAgentConfig()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 526
+      "community": 527
     },
     {
       "label": "system-prompt.ts",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "vitest.config.ts",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "utils.spec.ts",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "buildMemory()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 527
+      "community": 528
     },
     {
       "label": "context-injector.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "logger.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "initializeServices()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 528
+      "community": 529
     },
     {
       "label": "context.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 529
+      "community": 530
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 530
+      "community": 531
     },
     {
       "label": "anchor-stack.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createAnchorStack()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 531
+      "community": 532
     },
     {
       "label": "failure-reflexion.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "startFailureAndReflexion()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 532
+      "community": 533
     },
     {
       "label": "search-and-embedding.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 533
+      "community": 534
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 534
+      "community": 535
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 535
+      "community": 536
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createInput()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 536
+      "community": 537
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createRelationGraph()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 537
+      "community": 538
     },
     {
       "label": "consolidation-score-service.ts",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createBaseSchema()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 538
+      "community": 539
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 539
+      "community": 540
     },
     {
       "label": "migration-monitor-service.ts",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "openLockTestDatabase()",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 540
+      "community": 541
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createProgress()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 541
+      "community": 542
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 542
+      "community": 543
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createCoreMemoryTable()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 543
+      "community": 544
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "init.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createDbPath()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 544
+      "community": 545
     },
     {
       "label": "migrate.spec.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "migrate.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "migration-runner.ts",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "createBaseSchema()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 545
+      "community": 546
     },
     {
       "label": "migration-logger.spec.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "migration-detector.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "migration-detector.spec.ts",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "backup-manager.ts",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "dependency-validator.ts",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "schema-version-manager.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "createBaseSchema()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 546
+      "community": 547
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "createBaseSchema()",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 547
+      "community": 548
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "createBaseSchema()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 548
+      "community": 549
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "createBaseSchema()",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 549
+      "community": 550
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "createSchemaWith018()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 550
+      "community": 551
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBaseSchema()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 551
+      "community": 552
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 552
+      "community": 553
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "createBaseSchema()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 553
+      "community": 554
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "createBaseSchema()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 554
+      "community": 555
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "cache-service.ts",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "batch-scheduler.ts",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 555
+      "community": 556
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 556
+      "community": 557
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "validateBatchJobConfig()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 557
+      "community": 558
     },
     {
       "label": "retry-manager.ts",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "retry-manager.spec.ts",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "shouldRetry()",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 558
+      "community": 559
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "baseResult()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 559
+      "community": 560
     },
     {
       "label": "job-queue.spec.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "initializeTestDatabase()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 560
+      "community": 561
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "createQualityTables()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 561
+      "community": 562
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "stopwords.spec.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "type-guards.ts",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 562
+      "community": 563
     },
     {
       "label": "environment-check.ts",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 563
+      "community": 564
     },
     {
       "label": "error-handling.spec.ts",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "operation()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 564
+      "community": 565
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "relation-visualizer.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "cache-key-generator.ts",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "path-validator.ts",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 565
+      "community": 566
     },
     {
       "label": "error-handling.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "withErrorHandling()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 566
+      "community": 567
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 567
+      "community": 568
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "initializeTestDatabase()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 568
+      "community": 569
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 569
+      "community": 570
     },
     {
       "label": "logging-helpers.ts",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "pii-masker.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "path-validator.spec.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "triple-cache.spec.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "logger-schema.spec.ts",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "initializeTestDatabase()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 570
+      "community": 571
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "benchmark.types.ts",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "assertMacroCategory()",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 571
+      "community": 572
     },
     {
       "label": "migration.types.ts",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "consolidation-score.types.ts",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "consolidation.types.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "vector-search.types.ts",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "procedural-versioning.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "triple-extraction.ts",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "feedback.types.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "embedding.types.ts",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "relation-graph.ts",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "failure-event.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "index.ts",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "ranking.types.ts",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "alerts.types.ts",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "relation.ts",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "index.spec.ts",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "constants.ts",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "environment.ts",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "retry-options-loader.ts",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "validateConfig()",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L152",
       "id": "index_validateconfig",
-      "community": 572
+      "community": 573
     },
     {
       "label": "config-loader-utils.ts",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "constants.spec.ts",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "config-validation.spec.ts",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "environment-paths.spec.ts",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "relation-constants.ts",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "introspection-constants.ts",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "http-bind-policy.ts",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "retry-manager.interface.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "cache.interface.ts",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "error-logging.interface.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "database.interface.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "llm-client-initializer.ts",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "openai-client.spec.ts",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "environment-priority.spec.ts",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "gemini-client.spec.ts",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "search-local-tool.ts",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "initializeTestDatabase()",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 573
+      "community": 574
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "initializeTestDatabase()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 574
+      "community": 575
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "query-filter-strategy.ts",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "local-search-service.ts",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "anchor-interfaces.ts",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 575
+      "community": 576
     },
     {
       "label": "embedding-types.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "fallback-strategy.ts",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "anchor-cache-service.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "local-search-service.spec.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "vector-search.factory.ts",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 576
+      "community": 577
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "search-result-combiner.ts",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 577
+      "community": 578
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "search-ranking.spec.ts",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -20017,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "search-engine.spec.ts",
@@ -20057,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "vector-search.repository.ts",
@@ -20249,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -20257,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "vector-search.service.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 578
+      "community": 579
     },
     {
       "label": "vector-performance-tester.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "createMockRepository()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 579
+      "community": 580
     },
     {
       "label": "vector-index-manager.ts",
@@ -20737,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "createMockRepositories()",
@@ -20745,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 580
+      "community": 581
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -20753,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -20761,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createMockIndexRepository()",
@@ -20769,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 581
+      "community": 582
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "spaced-repetition.ts",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -21329,7 +21329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "priority-calculation.service.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "recall-probability.service.ts",
@@ -22457,7 +22457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "telemetry.types.ts",
@@ -22465,7 +22465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -22473,7 +22473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "openTelemetryDb()",
@@ -22481,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 582
+      "community": 583
     },
     {
       "label": "telemetry-repository.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "telemetry-service.ts",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 583
+      "community": 584
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -22945,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "llm-port.ts",
@@ -22953,7 +22953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "persistence-port.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "context-port.ts",
@@ -22969,7 +22969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "agent-types.ts",
@@ -22977,7 +22977,39 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 869
+      "community": 870
+    },
+    {
+      "label": "personal-agent-llm-env.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
+      "community": 452
+    },
+    {
+      "label": "readProviderToken()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L21",
+      "id": "personal_agent_llm_env_readprovidertoken",
+      "community": 452
+    },
+    {
+      "label": "parsePersonalAgentLlmEnv()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L33",
+      "id": "personal_agent_llm_env_parsepersonalagentllmenv",
+      "community": 452
+    },
+    {
+      "label": "personal-agent-llm-env.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
+      "community": 871
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -22985,7 +23017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -23113,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -23121,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "baseCandidate()",
@@ -23129,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 584
+      "community": 585
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -23177,7 +23209,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "makeDeps()",
@@ -23185,7 +23217,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 585
+      "community": 586
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -23233,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -23241,7 +23273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 586
+      "community": 587
     },
     {
       "label": "core-memory-repository.ts",
@@ -23249,7 +23281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "kg-triple-repository.ts",
@@ -23257,7 +23289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "process-attribute-repository.ts",
@@ -23265,7 +23297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -23273,7 +23305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -23281,7 +23313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "feedback-repository.ts",
@@ -23289,7 +23321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -23297,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 452
+      "community": 453
     },
     {
       "label": "FeedbackRepository",
@@ -23305,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 452
+      "community": 453
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -23313,7 +23345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -23321,7 +23353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -23329,7 +23361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -23337,7 +23369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -23345,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -23353,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createKgTripleTable()",
@@ -23361,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -23369,7 +23401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "createProcessAttributeTable()",
@@ -23377,7 +23409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 588
+      "community": 589
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -23385,7 +23417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -23393,7 +23425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 589
+      "community": 590
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -23401,7 +23433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -23409,7 +23441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createCoreMemoryTable()",
@@ -23417,7 +23449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "remember-tool.ts",
@@ -23505,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "validateRecallQuery()",
@@ -23513,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 453
+      "community": 454
     },
     {
       "label": "validateRecallFilters()",
@@ -23521,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 453
+      "community": 454
     },
     {
       "label": "recall-tool-schema.ts",
@@ -23529,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "normalizeProviderFilter()",
@@ -23537,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 591
+      "community": 592
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -23721,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -23729,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 454
+      "community": 455
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -23737,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 454
+      "community": 455
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -24185,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -24193,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 592
+      "community": 593
     },
     {
       "label": "recall-tool.ts",
@@ -24329,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "forget-tool.ts",
@@ -24473,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "createSchema()",
@@ -24481,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 593
+      "community": 594
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -24489,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "remember-tool.spec.ts",
@@ -24497,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "initializeTestDatabase()",
@@ -24505,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 455
+      "community": 456
     },
     {
       "label": "createValidReflectionNote()",
@@ -24513,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 455
+      "community": 456
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -24521,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -24529,7 +24561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "createSchema()",
@@ -24537,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 594
+      "community": 595
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -24577,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -24585,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -24593,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "initializeTestDatabase()",
@@ -24601,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 595
+      "community": 596
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -24609,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "parseData()",
@@ -24617,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 596
+      "community": 597
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -24625,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "recall-tool.spec.ts",
@@ -24633,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "initializeTestDatabase()",
@@ -24641,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 456
+      "community": 457
     },
     {
       "label": "createValidReflectionNote()",
@@ -24649,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 456
+      "community": 457
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -24657,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -24665,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "pin-tool.spec.ts",
@@ -24673,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "meta-memory-service.ts",
@@ -24905,7 +24937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "createBaseSchema()",
@@ -24913,7 +24945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 597
+      "community": 598
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -24993,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "baseRow()",
@@ -25001,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 598
+      "community": 599
     },
     {
       "label": "procedural-versioning.ts",
@@ -25041,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -25049,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 457
+      "community": 458
     },
     {
       "label": ".runScan()",
@@ -25057,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 457
+      "community": 458
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -25065,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "generateMemoryId()",
@@ -25073,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 458
+      "community": 459
     },
     {
       "label": "rollbackToVersion()",
@@ -25081,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 458
+      "community": 459
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -25153,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "selectionWindowLimit()",
@@ -25161,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 459
+      "community": 460
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -25169,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 459
+      "community": 460
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -25217,7 +25249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -25225,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -25233,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 599
+      "community": 600
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -25241,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "openDb()",
@@ -25249,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 600
+      "community": 601
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -25841,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "createBaseSchema()",
@@ -25849,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 601
+      "community": 602
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -26113,7 +26145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -26121,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -26129,7 +26161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 460
+      "community": 461
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -26137,7 +26169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 460
+      "community": 461
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -26145,7 +26177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -26153,7 +26185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "core-memory-service.ts",
@@ -26313,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "createBaseSchema()",
@@ -26321,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 602
+      "community": 603
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -26329,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26337,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 603
+      "community": 604
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -26417,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -26425,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -26433,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createSchema()",
@@ -26441,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 604
+      "community": 605
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -26449,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -26457,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createSchema()",
@@ -26465,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 605
+      "community": 606
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -26473,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -26481,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createBaseSchema()",
@@ -26489,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 606
+      "community": 607
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -26497,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -26505,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createSchema()",
@@ -26513,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 607
+      "community": 608
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -26521,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -26529,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -26649,7 +26681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -26913,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -26921,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -26929,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -26937,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "consolidation-repository.ts",
@@ -27169,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "row()",
@@ -27177,7 +27209,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 609
+      "community": 610
     },
     {
       "label": "summarization-service.ts",
@@ -27273,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "ep()",
@@ -27281,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 610
+      "community": 611
     },
     {
       "label": "relation-graph.port.ts",
@@ -27289,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "get-relations-tool.ts",
@@ -27329,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -27337,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 611
+      "community": 612
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -27521,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createBaseSchema()",
@@ -27529,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 461
+      "community": 462
     },
     {
       "label": "createTestMemory()",
@@ -27537,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 461
+      "community": 462
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -27545,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createBaseSchema()",
@@ -27553,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 462
+      "community": 463
     },
     {
       "label": "createTestMemory()",
@@ -27561,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -27569,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createBaseSchema()",
@@ -27577,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 463
+      "community": 464
     },
     {
       "label": "createTestMemory()",
@@ -27585,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 463
+      "community": 464
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -27593,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -27601,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createBaseSchema()",
@@ -27609,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 464
+      "community": 465
     },
     {
       "label": "createTestMemory()",
@@ -27617,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 464
+      "community": 465
     },
     {
       "label": "relation-retry-manager.ts",
@@ -28433,7 +28465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "relation-graph.spec.ts",
@@ -28441,7 +28473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createBaseSchema()",
@@ -28449,7 +28481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 465
+      "community": 466
     },
     {
       "label": "createTestMemory()",
@@ -28457,7 +28489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -28465,7 +28497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "createTestMemory()",
@@ -28473,7 +28505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 612
+      "community": 613
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -28513,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "createTestMemory()",
@@ -28521,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 613
+      "community": 614
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -28585,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -28593,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -28601,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "getMockMementoConfig()",
@@ -28609,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L19",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 466
+      "community": 467
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -28617,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L54",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 466
+      "community": 467
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -28625,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "provider-openai.spec.ts",
@@ -28633,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -28641,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -28649,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -28969,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "extract()",
@@ -28977,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 614
+      "community": 615
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -28985,7 +29017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "tripleDedupeKey()",
@@ -28993,7 +29025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 467
+      "community": 468
     },
     {
       "label": "mergeTripleLists()",
@@ -29001,7 +29033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 467
+      "community": 468
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -29009,7 +29041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -29193,7 +29225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -29201,7 +29233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -29209,7 +29241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "triple-extractor.ts",
@@ -29385,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -29425,7 +29457,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "triple-parser.ts",
@@ -29473,7 +29505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "splitTextIntoChunks()",
@@ -29481,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 615
+      "community": 616
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -29489,7 +29521,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "home_jee1lee_git_memento_packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -29497,7 +29529,7 @@
       "source_file": "/home/jee1lee/git/memento/packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 616
+      "community": 617
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -29585,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -29593,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "interfaces.spec.ts",
@@ -29601,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -29609,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "triple-parser.spec.ts",
@@ -29617,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -29625,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -29633,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 617
+      "community": 618
     },
     {
       "label": "extract-relations-openai.ts",
@@ -29641,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -29649,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 618
+      "community": 619
     },
     {
       "label": "types.ts",
@@ -29657,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "ollama-chat-support.ts",
@@ -29697,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -29705,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 619
+      "community": 620
     },
     {
       "label": "provider-selection.ts",
@@ -29713,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -29721,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 468
+      "community": 469
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -29729,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 468
+      "community": 469
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -29737,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -29745,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L25",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 620
+      "community": 621
     },
     {
       "label": "llm-response-parse.ts",
@@ -30057,7 +30089,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "embedding-service.ts",
@@ -31169,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -31177,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -31185,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "createSchema()",
@@ -31193,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 469
+      "community": 470
     },
     {
       "label": "seedMemoryItem()",
@@ -31201,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 469
+      "community": 470
     },
     {
       "label": "embedding-service.spec.ts",
@@ -31209,7 +31241,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -31217,7 +31249,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -31225,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -31345,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "executeResolveError()",
@@ -31353,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 621
+      "community": 622
     },
     {
       "label": "error-stats.ts",
@@ -31361,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "executeErrorStats()",
@@ -31369,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 622
+      "community": 623
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -31377,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "resolve-error.spec.ts",
@@ -31385,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -31393,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "createBaseSchema()",
@@ -31401,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 623
+      "community": 624
     },
     {
       "label": "error-stats.spec.ts",
@@ -31409,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "performance-monitor.ts",
@@ -32321,7 +32353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -32329,7 +32361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -32337,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -32345,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -32393,7 +32425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "restoreEnvValue()",
@@ -32401,7 +32433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 624
+      "community": 625
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -32505,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32513,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 625
+      "community": 626
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -32593,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -32601,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 626
+      "community": 627
     },
     {
       "label": "quality-reporter.ts",
@@ -32721,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "quality-assurance-service.ts",
@@ -33217,7 +33249,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "base-tool.ts",
@@ -33513,7 +33545,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "testBootstrapIntegration()",
@@ -33521,7 +33553,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 627
+      "community": 628
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -33529,7 +33561,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "measureRecall()",
@@ -33537,7 +33569,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 628
+      "community": 629
     },
     {
       "label": "test-embedding.ts",
@@ -33545,7 +33577,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -33553,7 +33585,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 629
+      "community": 630
     },
     {
       "label": "test-tool-consistency.ts",
@@ -33561,7 +33593,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "compareToolResults()",
@@ -33569,7 +33601,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 470
+      "community": 471
     },
     {
       "label": "testToolConsistency()",
@@ -33577,7 +33609,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 470
+      "community": 471
     },
     {
       "label": "test-quality-assurance.ts",
@@ -33585,7 +33617,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "createQualityTables()",
@@ -33593,7 +33625,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 471
+      "community": 472
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -33601,7 +33633,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 471
+      "community": 472
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -33649,7 +33681,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "testSearchFunctionality()",
@@ -33657,7 +33689,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 630
+      "community": 631
     },
     {
       "label": "test-forgetting.ts",
@@ -33665,7 +33697,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "testForgettingFunctionality()",
@@ -33673,7 +33705,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 631
+      "community": 632
     },
     {
       "label": "mock-database.spec.ts",
@@ -33681,7 +33713,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "test-m1-completion.ts",
@@ -33689,7 +33721,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "testM1Completion()",
@@ -33697,7 +33729,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 632
+      "community": 633
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -33705,7 +33737,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -33713,7 +33745,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 633
+      "community": 634
     },
     {
       "label": "vitest.setup.ts",
@@ -33721,7 +33753,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -33729,7 +33761,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "parseItems()",
@@ -33737,7 +33769,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 634
+      "community": 635
     },
     {
       "label": "test-memory-resource.ts",
@@ -33745,7 +33777,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "setupResourceHandlers()",
@@ -33753,7 +33785,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 472
+      "community": 473
     },
     {
       "label": "createTestMemories()",
@@ -33761,7 +33793,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 472
+      "community": 473
     },
     {
       "label": "test-regression.ts",
@@ -33769,7 +33801,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "testRegression()",
@@ -33777,7 +33809,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 635
+      "community": 636
     },
     {
       "label": "test-anchor-system.ts",
@@ -33841,7 +33873,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -33913,7 +33945,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "testSingleProviderRegression()",
@@ -33921,7 +33953,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 636
+      "community": 637
     },
     {
       "label": "visualize-recency.ts",
@@ -33985,7 +34017,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -34049,7 +34081,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "constructor()",
@@ -34057,7 +34089,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 637
+      "community": 638
     },
     {
       "label": "mock-database.ts",
@@ -34289,7 +34321,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -34329,7 +34361,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "createTestMemories()",
@@ -34337,7 +34369,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 638
+      "community": 639
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -34345,7 +34377,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -34353,7 +34385,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 639
+      "community": 640
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -34361,7 +34393,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -34369,7 +34401,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "seedCluster()",
@@ -34377,7 +34409,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 640
+      "community": 641
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -34385,7 +34417,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "readSource()",
@@ -34393,7 +34425,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 473
+      "community": 474
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -34401,7 +34433,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 473
+      "community": 474
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -34441,7 +34473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "writeFixtureDir()",
@@ -34449,7 +34481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 641
+      "community": 642
     },
     {
       "label": "search-quality-metrics.ts",
@@ -34545,7 +34577,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -34641,7 +34673,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -34649,7 +34681,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "test-database.ts",
@@ -34681,7 +34713,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "mergeCandidateIds()",
@@ -34689,7 +34721,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 642
+      "community": 643
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -34697,7 +34729,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -34705,7 +34737,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 474
+      "community": 475
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -34713,7 +34745,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 474
+      "community": 475
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -34721,7 +34753,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -34729,7 +34761,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -34929,7 +34961,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "query-counter.ts",
@@ -35329,7 +35361,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 643
+      "community": 644
     },
     {
       "label": "copyDir()",
@@ -35337,7 +35369,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 643
+      "community": 644
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -35345,7 +35377,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "readRootPackageJson()",
@@ -35353,7 +35385,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 644
+      "community": 645
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -35361,7 +35393,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "readJson()",
@@ -35369,7 +35401,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 645
+      "community": 646
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -35377,7 +35409,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "readWorkflow()",
@@ -35385,7 +35417,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 646
+      "community": 647
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -35449,7 +35481,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "readStaticFile()",
@@ -35457,7 +35489,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 647
+      "community": 648
     },
     {
       "label": "smoke.spec.ts",
@@ -35465,7 +35497,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "extractFencedBlocks()",
@@ -35473,7 +35505,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 648
+      "community": 649
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -35657,7 +35689,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 649
+      "community": 650
     },
     {
       "label": "shouldInclude()",
@@ -35665,7 +35697,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 649
+      "community": 650
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -35673,7 +35705,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 475
+      "community": 476
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -35681,7 +35713,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 475
+      "community": 476
     },
     {
       "label": "readTarString()",
@@ -35689,7 +35721,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 475
+      "community": 476
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -35753,7 +35785,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 650
+      "community": 651
     },
     {
       "label": "fixMigration()",
@@ -35761,7 +35793,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 650
+      "community": 651
     },
     {
       "label": "sync-root-server-dist.js",
@@ -35769,7 +35801,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 954
+      "community": 956
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -36097,7 +36129,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 651
+      "community": 652
     },
     {
       "label": "updateEmbeddings()",
@@ -36105,7 +36137,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 651
+      "community": 652
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -36273,7 +36305,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36281,7 +36313,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 652
+      "community": 653
     },
     {
       "label": "test-docker.js",
@@ -36289,7 +36321,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 653
+      "community": 654
     },
     {
       "label": "testDockerServer()",
@@ -36297,7 +36329,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 653
+      "community": 654
     },
     {
       "label": "pack-with-restore.js",
@@ -36305,7 +36337,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 955
+      "community": 957
     },
     {
       "label": "run-migration.js",
@@ -36313,7 +36345,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 654
+      "community": 655
     },
     {
       "label": "runMigration()",
@@ -36321,7 +36353,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 654
+      "community": 655
     },
     {
       "label": "safe-migration.js",
@@ -36329,7 +36361,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 655
+      "community": 656
     },
     {
       "label": "safeMigration()",
@@ -36337,7 +36369,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 655
+      "community": 656
     },
     {
       "label": "generate-ground-truth.ts",
@@ -36401,7 +36433,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "saveWorkMemory()",
@@ -36409,7 +36441,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 656
+      "community": 657
     },
     {
       "label": "check-file-sizes.ts",
@@ -36577,7 +36609,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -36585,7 +36617,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "main()",
@@ -36593,7 +36625,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 657
+      "community": 658
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -36633,7 +36665,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 957
+      "community": 959
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -36681,7 +36713,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 658
+      "community": 659
     },
     {
       "label": "analyzeEmbeddings()",
@@ -36689,7 +36721,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 658
+      "community": 659
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -36697,7 +36729,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 659
+      "community": 660
     },
     {
       "label": "fixVectorDimensions()",
@@ -36705,7 +36737,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 659
+      "community": 660
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -36745,7 +36777,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "loadVecExtension()",
@@ -36753,7 +36785,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 476
+      "community": 477
     },
     {
       "label": "fixTfidfDimensions()",
@@ -36761,7 +36793,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 476
+      "community": 477
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -36769,7 +36801,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "runUpdateMigration()",
@@ -36777,7 +36809,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 660
+      "community": 661
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -36785,7 +36817,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "reappearanceRate()",
@@ -36793,7 +36825,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 477
+      "community": 478
     },
     {
       "label": "main()",
@@ -36801,7 +36833,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 477
+      "community": 478
     },
     {
       "label": "regenerate-embeddings.js",
@@ -36809,7 +36841,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 661
+      "community": 662
     },
     {
       "label": "regenerateEmbeddings()",
@@ -36817,7 +36849,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 661
+      "community": 662
     },
     {
       "label": "generate-relation-report.ts",
@@ -36969,7 +37001,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "sampleReport()",
@@ -36977,7 +37009,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 662
+      "community": 663
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -36985,7 +37017,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 958
+      "community": 960
     },
     {
       "label": "debug-embeddings.js",
@@ -36993,7 +37025,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 663
+      "community": 664
     },
     {
       "label": "debugEmbeddings()",
@@ -37001,7 +37033,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 663
+      "community": 664
     },
     {
       "label": "check-db-integrity.js",
@@ -37273,7 +37305,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 664
+      "community": 665
     },
     {
       "label": "backupEmbeddings()",
@@ -37281,7 +37313,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 664
+      "community": 665
     },
     {
       "label": "count-any-types.ts",
@@ -37497,7 +37529,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -37505,7 +37537,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -37513,7 +37545,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -37521,7 +37553,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -37529,7 +37561,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "jsonEmbedding()",
@@ -37537,7 +37569,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 665
+      "community": 666
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -37545,7 +37577,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -37553,7 +37585,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -37561,7 +37593,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -37569,7 +37601,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -37577,7 +37609,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 666
+      "community": 667
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -37585,7 +37617,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -37593,7 +37625,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "jsonEmbedding()",
@@ -37601,7 +37633,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 667
+      "community": 668
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -37609,7 +37641,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "main()",
@@ -37617,7 +37649,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 668
+      "community": 669
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -37625,7 +37657,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -37633,7 +37665,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 669
+      "community": 670
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -37641,7 +37673,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "createBackup()",
@@ -37649,7 +37681,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 478
+      "community": 479
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -37657,7 +37689,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 478
+      "community": 479
     },
     {
       "label": "restore-legacy.ps1",
@@ -37665,7 +37697,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 967
+      "community": 969
     },
     {
       "label": "check-retry-usage.ts",
@@ -37785,7 +37817,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -37793,7 +37825,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 670
+      "community": 671
     },
     {
       "label": "check-no-console-violations.ts",
@@ -37889,7 +37921,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "fixVecTableDimensions()",
@@ -37897,7 +37929,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 671
+      "community": 672
     },
     {
       "label": "sources.ts",
@@ -37953,7 +37985,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "issue-body.ts",
@@ -37993,7 +38025,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "normalizeMessage()",
@@ -38001,7 +38033,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 479
+      "community": 480
     },
     {
       "label": "createFingerprint()",
@@ -38009,7 +38041,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 479
+      "community": 480
     },
     {
       "label": "sanitizer.ts",
@@ -38017,7 +38049,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "limitUtf8Bytes()",
@@ -38025,7 +38057,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 480
+      "community": 481
     },
     {
       "label": "sanitizeExcerpt()",
@@ -38033,7 +38065,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 480
+      "community": 481
     },
     {
       "label": "parsers.ts",
@@ -38105,7 +38137,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -38113,7 +38145,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 672
+      "community": 673
     },
     {
       "label": "state-store.ts",
@@ -38377,7 +38409,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "issue-body.spec.ts",
@@ -38385,7 +38417,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "github-client.spec.ts",
@@ -38393,7 +38425,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "config.spec.ts",
@@ -38401,7 +38433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "detectors.spec.ts",
@@ -38409,7 +38441,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "sources.spec.ts",
@@ -38417,7 +38449,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "parsers.spec.ts",
@@ -38425,7 +38457,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "monitor.spec.ts",
@@ -38433,7 +38465,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "config()",
@@ -38441,7 +38473,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 673
+      "community": 674
     },
     {
       "label": "fingerprint.spec.ts",
@@ -38449,7 +38481,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "state-store.spec.ts",
@@ -38457,7 +38489,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "sanitizer.spec.ts",
@@ -38465,7 +38497,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "entrypoint.spec.ts",
@@ -38473,7 +38505,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "index.ts",
@@ -38513,7 +38545,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "memento-admin-fetch.js",
@@ -80463,6 +80495,42 @@
       "_tgt": "personal_agent_llm_error_personalagentllmerror_constructor",
       "source": "personal_agent_llm_error_personalagentllmerror",
       "target": "personal_agent_llm_error_personalagentllmerror_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
+      "_tgt": "personal_agent_llm_env_readprovidertoken",
+      "source": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
+      "target": "personal_agent_llm_env_readprovidertoken",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L33",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
+      "_tgt": "personal_agent_llm_env_parsepersonalagentllmenv",
+      "source": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
+      "target": "personal_agent_llm_env_parsepersonalagentllmenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "_src": "personal_agent_llm_env_parsepersonalagentllmenv",
+      "_tgt": "personal_agent_llm_env_readprovidertoken",
+      "source": "personal_agent_llm_env_readprovidertoken",
+      "target": "personal_agent_llm_env_parsepersonalagentllmenv",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerateContent } = vi.hoisted(() => ({
+  mockGenerateContent: vi.fn(),
+}));
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: vi.fn().mockReturnValue({
+      generateContent: mockGenerateContent,
+    }),
+  })),
+}));
+
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GeminiChatLlmAdapter } from './gemini-chat-llm-adapter.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+describe('GeminiChatLlmAdapter', () => {
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+    vi.mocked(GoogleGenerativeAI).mockClear();
+  });
+
+  it('calls generateContent with merged prompt and returns gemini metadata', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: {
+        text: () => 'hello gemini',
+      },
+    });
+    const adapter = new GeminiChatLlmAdapter({
+      apiKey: 'AIza-test',
+      model: 'gemini-2.0-flash',
+    });
+    const result = await adapter.complete([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hi' },
+    ]);
+    expect(GoogleGenerativeAI).toHaveBeenCalledWith('AIza-test');
+    expect(mockGenerateContent).toHaveBeenCalledWith({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: 'You are helpful.\n\nuser: Hi',
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.content).toBe('hello gemini');
+    expect(result.metadata.provider).toBe('gemini');
+    expect(result.metadata.model).toBe('gemini-2.0-flash');
+  });
+
+  it('omits empty system block', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => 'ok' },
+    });
+    const adapter = new GeminiChatLlmAdapter({
+      apiKey: 'k',
+      model: 'gemini-2.0-flash',
+    });
+    await adapter.complete([{ role: 'user', content: 'only user' }]);
+    expect(mockGenerateContent).toHaveBeenCalledWith({
+      contents: [{ role: 'user', parts: [{ text: 'user: only user' }] }],
+    });
+  });
+
+  it('throws PersonalAgentLlmError on generateContent failure', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('quota'));
+    const adapter = new GeminiChatLlmAdapter({
+      apiKey: 'k',
+      model: 'gemini-2.0-flash',
+    });
+    await expect(adapter.complete([{ role: 'user', content: 'x' }])).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof PersonalAgentLlmError && e.code === 'provider_runtime_failed',
+    );
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts
@@ -1,0 +1,49 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import type { GenerativeModel } from '@google/generative-ai';
+import type { ILLMPort, LLMCompletionResult, LLMMessage } from '../ports/llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type GeminiChatLlmAdapterOptions = {
+  apiKey: string;
+  model: string;
+};
+
+export class GeminiChatLlmAdapter implements ILLMPort {
+  private readonly generativeModel: GenerativeModel;
+  private readonly modelName: string;
+
+  constructor(options: GeminiChatLlmAdapterOptions) {
+    this.modelName = options.model;
+    const genAI = new GoogleGenerativeAI(options.apiKey);
+    this.generativeModel = genAI.getGenerativeModel({ model: options.model });
+  }
+
+  async complete(messages: LLMMessage[]): Promise<LLMCompletionResult> {
+    try {
+      const system = messages.find((m) => m.role === 'system')?.content ?? '';
+      const rest = messages.filter((m) => m.role !== 'system');
+      const prompt = [system, ...rest.map((m) => `${m.role}: ${m.content}`)]
+        .filter((s) => s.length > 0)
+        .join('\n\n');
+
+      const result = await this.generativeModel.generateContent({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      });
+      const text = result.response.text();
+      return {
+        content: text,
+        metadata: {
+          provider: 'gemini',
+          model: this.modelName,
+          finishReason: undefined,
+        },
+      };
+    } catch (cause) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_runtime_failed',
+        message: 'Gemini generateContent failed',
+        cause,
+      });
+    }
+  }
+}

--- a/packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OllamaChatLlmAdapter } from './ollama-chat-llm-adapter.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+describe('OllamaChatLlmAdapter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POST /api/chat and maps assistant message', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { role: 'assistant', content: 'hi ollama' } }),
+      text: async () => '',
+    });
+    const adapter = new OllamaChatLlmAdapter({
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'llama3.2',
+    });
+    const out = await adapter.complete([
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'hello' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:11434/api/chat');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: 'llama3.2',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      stream: false,
+    });
+    expect(out.content).toBe('hi ollama');
+    expect(out.metadata.provider).toBe('ollama');
+    expect(out.metadata.model).toBe('llama3.2');
+  });
+
+  it('throws on non-OK HTTP', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+      text: async () => 'service unavailable',
+    });
+    const adapter = new OllamaChatLlmAdapter({
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'm',
+    });
+    await expect(adapter.complete([{ role: 'user', content: 'x' }])).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof PersonalAgentLlmError && e.code === 'provider_runtime_failed',
+    );
+  });
+
+  it('normalizes trailing slash on base URL', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { content: '' } }),
+      text: async () => '',
+    });
+    const adapter = new OllamaChatLlmAdapter({
+      baseUrl: 'http://127.0.0.1:11434///',
+      model: 'm',
+    });
+    await adapter.complete([{ role: 'user', content: 'x' }]);
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:11434/api/chat');
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts
@@ -1,0 +1,83 @@
+import type { ILLMPort, LLMCompletionResult, LLMMessage } from '../ports/llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type OllamaChatLlmAdapterOptions = {
+  baseUrl: string;
+  model: string;
+  /** 기본 120초 */
+  timeoutMs?: number;
+};
+
+type OllamaChatResponseJson = {
+  message?: { role?: string; content?: string };
+};
+
+export class OllamaChatLlmAdapter implements ILLMPort {
+  private readonly chatUrl: string;
+  private readonly model: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: OllamaChatLlmAdapterOptions) {
+    const base = options.baseUrl.trim().replace(/\/+$/, '');
+    this.chatUrl = new URL('/api/chat', `${base}/`).toString();
+    this.model = options.model;
+    this.timeoutMs = options.timeoutMs ?? 120_000;
+  }
+
+  async complete(messages: LLMMessage[]): Promise<LLMCompletionResult> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(this.chatUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: this.model,
+          messages: messages.map((m) => ({ role: m.role, content: m.content })),
+          stream: false,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new PersonalAgentLlmError({
+          code: 'provider_runtime_failed',
+          message: `Ollama HTTP ${res.status}${detail ? `: ${detail.slice(0, 500)}` : ''}`,
+        });
+      }
+
+      let body: OllamaChatResponseJson;
+      try {
+        body = (await res.json()) as OllamaChatResponseJson;
+      } catch (cause) {
+        throw new PersonalAgentLlmError({
+          code: 'provider_runtime_failed',
+          message: 'Ollama response JSON parse failed',
+          cause,
+        });
+      }
+
+      const text = body.message?.content ?? '';
+      return {
+        content: text,
+        metadata: {
+          provider: 'ollama',
+          model: this.model,
+          finishReason: undefined,
+        },
+      };
+    } catch (cause) {
+      if (cause instanceof PersonalAgentLlmError) {
+        throw cause;
+      }
+      throw new PersonalAgentLlmError({
+        code: 'provider_runtime_failed',
+        message: 'Ollama chat request failed',
+        cause,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+}));
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockCreate,
+      },
+    };
+  },
+}));
+
+import { OpenAiChatLlmAdapter } from './openai-chat-llm-adapter.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+describe('OpenAiChatLlmAdapter', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it('maps completion to LLMCompletionResult', async () => {
+    mockCreate.mockResolvedValue({
+      id: 'resp-1',
+      choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+    });
+    const adapter = new OpenAiChatLlmAdapter({ apiKey: 'sk-test', model: 'gpt-4o-mini' });
+    const result = await adapter.complete([
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+    ]);
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'hi' },
+      ],
+    });
+    expect(result.metadata.provider).toBe('openai');
+    expect(result.content).toBe('hello');
+    expect(result.metadata.requestId).toBe('resp-1');
+    expect(result.metadata.finishReason).toBe('stop');
+  });
+
+  it('uses empty string when content is null', async () => {
+    mockCreate.mockResolvedValue({
+      id: 'resp-2',
+      choices: [{ message: { content: null }, finish_reason: 'stop' }],
+    });
+    const adapter = new OpenAiChatLlmAdapter({ apiKey: 'sk-test', model: 'gpt-4o-mini' });
+    const result = await adapter.complete([{ role: 'user', content: 'x' }]);
+    expect(result.content).toBe('');
+  });
+
+  it('throws PersonalAgentLlmError on API failure', async () => {
+    mockCreate.mockRejectedValue(new Error('network'));
+    const adapter = new OpenAiChatLlmAdapter({ apiKey: 'sk-test', model: 'gpt-4o-mini' });
+    await expect(adapter.complete([{ role: 'user', content: 'x' }])).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof PersonalAgentLlmError && e.code === 'provider_runtime_failed',
+    );
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts
+++ b/packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts
@@ -1,0 +1,45 @@
+import OpenAI from 'openai';
+import type { ILLMPort, LLMCompletionResult, LLMMessage } from '../ports/llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+export type OpenAiChatLlmAdapterOptions = {
+  apiKey: string;
+  model: string;
+  timeoutMs?: number;
+};
+
+export class OpenAiChatLlmAdapter implements ILLMPort {
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor(options: OpenAiChatLlmAdapterOptions) {
+    this.client = new OpenAI({ apiKey: options.apiKey, timeout: options.timeoutMs ?? 60_000 });
+    this.model = options.model;
+  }
+
+  async complete(messages: LLMMessage[]): Promise<LLMCompletionResult> {
+    try {
+      const completion = await this.client.chat.completions.create({
+        model: this.model,
+        messages,
+      });
+      const raw = completion.choices[0]?.message?.content;
+      const text = raw === null || raw === undefined ? '' : raw;
+      return {
+        content: text,
+        metadata: {
+          provider: 'openai',
+          model: this.model,
+          requestId: completion.id,
+          finishReason: completion.choices[0]?.finish_reason ?? undefined,
+        },
+      };
+    } catch (cause) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_runtime_failed',
+        message: 'OpenAI chat completion failed',
+        cause,
+      });
+    }
+  }
+}

--- a/packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parsePersonalAgentLlmEnv } from './personal-agent-llm-env.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('parsePersonalAgentLlmEnv', () => {
+  it('defaults to mock when provider unset', () => {
+    delete process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER;
+    expect(parsePersonalAgentLlmEnv(process.env)).toEqual({ provider: 'mock' });
+  });
+
+  it('defaults to mock when provider is empty string', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = '   ';
+    expect(parsePersonalAgentLlmEnv(process.env)).toEqual({ provider: 'mock' });
+  });
+
+  it('throws when openai is selected without api key', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'openai';
+    expect(() => parsePersonalAgentLlmEnv(process.env, {})).toThrow(PersonalAgentLlmError);
+    try {
+      parsePersonalAgentLlmEnv(process.env, {});
+    } catch (e) {
+      expect(e).toBeInstanceOf(PersonalAgentLlmError);
+      expect((e as PersonalAgentLlmError).code).toBe('provider_misconfigured');
+    }
+  });
+
+  it('returns openai when key is injected', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'openai';
+    const result = parsePersonalAgentLlmEnv(process.env, {
+      openaiApiKey: 'sk-test',
+    });
+    expect(result).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+  });
+
+  it('throws when gemini is selected without api key', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'gemini';
+    expect(() => parsePersonalAgentLlmEnv(process.env, {})).toThrow(PersonalAgentLlmError);
+  });
+
+  it('returns gemini when key is injected', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'gemini';
+    const result = parsePersonalAgentLlmEnv(process.env, {
+      geminiApiKey: 'AIza-test',
+    });
+    expect(result).toEqual({ provider: 'gemini', model: 'gemini-2.0-flash' });
+  });
+
+  it('throws when ollama is selected without model', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'ollama';
+    delete process.env.MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL;
+    expect(() =>
+      parsePersonalAgentLlmEnv(process.env, {
+        openaiApiKey: 'x',
+      }),
+    ).toThrow(PersonalAgentLlmError);
+  });
+
+  it('returns ollama when model is set', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'ollama';
+    process.env.MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL = 'llama3.2';
+    const result = parsePersonalAgentLlmEnv(process.env);
+    expect(result).toEqual({
+      provider: 'ollama',
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'llama3.2',
+    });
+  });
+
+  it('throws on invalid provider token', () => {
+    process.env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER = 'azure';
+    expect(() => parsePersonalAgentLlmEnv(process.env)).toThrow(PersonalAgentLlmError);
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts
+++ b/packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+
+const providerEnum = z.enum(['mock', 'openai', 'gemini', 'ollama']);
+
+export type ParsedPersonalAgentLlmEnv =
+  | { provider: 'mock' }
+  | { provider: 'openai'; model: string }
+  | { provider: 'gemini'; model: string }
+  | { provider: 'ollama'; baseUrl: string; model: string };
+
+export type ParsePersonalAgentLlmEnvKeys = {
+  openaiApiKey?: string | undefined;
+  geminiApiKey?: string | undefined;
+};
+
+const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash';
+const DEFAULT_OLLAMA_URL = 'http://127.0.0.1:11434';
+
+function readProviderToken(env: NodeJS.ProcessEnv): string {
+  const raw = env.MEMENTO_PERSONAL_AGENT_LLM_PROVIDER;
+  if (raw === undefined || String(raw).trim() === '') {
+    return 'mock';
+  }
+  return String(raw).trim().toLowerCase();
+}
+
+/**
+ * personal-agent LLM 활성화용 환경 변수를 파싱한다.
+ * API 키는 env가 아닌 `keys`로 주입해 테스트·호출부에서 통제한다.
+ */
+export function parsePersonalAgentLlmEnv(
+  env: NodeJS.ProcessEnv,
+  keys: ParsePersonalAgentLlmEnvKeys = {},
+): ParsedPersonalAgentLlmEnv {
+  const token = readProviderToken(env);
+  const parsed = providerEnum.safeParse(token);
+  if (!parsed.success) {
+    throw new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: `Invalid MEMENTO_PERSONAL_AGENT_LLM_PROVIDER: ${token}`,
+    });
+  }
+
+  const provider = parsed.data;
+
+  if (provider === 'mock') {
+    return { provider: 'mock' };
+  }
+
+  if (provider === 'openai') {
+    const key = keys.openaiApiKey?.trim();
+    if (!key) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'OPENAI_API_KEY (or injected openaiApiKey) is required when MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=openai',
+      });
+    }
+    const model =
+      env.MEMENTO_PERSONAL_AGENT_OPENAI_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
+    return { provider: 'openai', model };
+  }
+
+  if (provider === 'gemini') {
+    const key = keys.geminiApiKey?.trim();
+    if (!key) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'GEMINI_API_KEY (or injected geminiApiKey) is required when MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=gemini',
+      });
+    }
+    const model =
+      env.MEMENTO_PERSONAL_AGENT_GEMINI_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
+    return { provider: 'gemini', model };
+  }
+
+  const baseUrlRaw = env.MEMENTO_PERSONAL_AGENT_OLLAMA_URL?.trim();
+  const baseUrl = baseUrlRaw && baseUrlRaw.length > 0 ? baseUrlRaw : DEFAULT_OLLAMA_URL;
+  const model = env.MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL?.trim();
+  if (!model) {
+    throw new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: 'MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL is required when MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=ollama',
+    });
+  }
+
+  return { provider: 'ollama', baseUrl, model };
+}

--- a/packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PersonalAgentLlmError,
+  isPersonalAgentLlmError,
+} from './personal-agent-llm-error.js';
+
+describe('PersonalAgentLlmError', () => {
+  it('exposes provider_misconfigured code', () => {
+    const err = new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: 'OPENAI_API_KEY is missing',
+    });
+    expect(err.code).toBe('provider_misconfigured');
+    expect(isPersonalAgentLlmError(err)).toBe(true);
+  });
+
+  it('narrows unknown', () => {
+    expect(isPersonalAgentLlmError(new Error('x'))).toBe(false);
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts
+++ b/packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts
@@ -1,0 +1,24 @@
+export type PersonalAgentLlmErrorCode =
+  | 'provider_disabled'
+  | 'provider_misconfigured'
+  | 'provider_runtime_failed';
+
+export type PersonalAgentLlmErrorOptions = {
+  code: PersonalAgentLlmErrorCode;
+  message: string;
+  cause?: unknown;
+};
+
+export class PersonalAgentLlmError extends Error {
+  readonly code: PersonalAgentLlmErrorCode;
+
+  constructor(options: PersonalAgentLlmErrorOptions) {
+    super(options.message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = 'PersonalAgentLlmError';
+    this.code = options.code;
+  }
+}
+
+export function isPersonalAgentLlmError(value: unknown): value is PersonalAgentLlmError {
+  return value instanceof PersonalAgentLlmError;
+}

--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -46,6 +46,9 @@ export type { OpenAiChatLlmAdapterOptions } from './adapters/openai-chat-llm-ada
 export { GeminiChatLlmAdapter } from './adapters/gemini-chat-llm-adapter.js';
 export type { GeminiChatLlmAdapterOptions } from './adapters/gemini-chat-llm-adapter.js';
 
+export { OllamaChatLlmAdapter } from './adapters/ollama-chat-llm-adapter.js';
+export type { OllamaChatLlmAdapterOptions } from './adapters/ollama-chat-llm-adapter.js';
+
 export {
   ToolContextKnowledgeContextAdapter,
 } from './adapters/tool-context-knowledge-context-adapter.js';

--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -50,3 +50,18 @@ export {
   PersonalKnowledgeAgentService,
 } from './services/personal-knowledge-agent-service.js';
 export type { PersonalKnowledgeAgentDeps } from './services/personal-knowledge-agent-service.js';
+
+export {
+  PersonalAgentLlmError,
+  isPersonalAgentLlmError,
+} from './errors/personal-agent-llm-error.js';
+export type { PersonalAgentLlmErrorCode } from './errors/personal-agent-llm-error.js';
+
+export { parsePersonalAgentLlmEnv } from './config/personal-agent-llm-env.js';
+export type {
+  ParsedPersonalAgentLlmEnv,
+  ParsePersonalAgentLlmEnvKeys,
+} from './config/personal-agent-llm-env.js';
+
+export { createPersonalAgentLlmPort } from './services/create-personal-agent-llm-port.js';
+export type { CreatePersonalAgentLlmPortDeps } from './services/create-personal-agent-llm-port.js';

--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -43,6 +43,9 @@ export type {
 export { OpenAiChatLlmAdapter } from './adapters/openai-chat-llm-adapter.js';
 export type { OpenAiChatLlmAdapterOptions } from './adapters/openai-chat-llm-adapter.js';
 
+export { GeminiChatLlmAdapter } from './adapters/gemini-chat-llm-adapter.js';
+export type { GeminiChatLlmAdapterOptions } from './adapters/gemini-chat-llm-adapter.js';
+
 export {
   ToolContextKnowledgeContextAdapter,
 } from './adapters/tool-context-knowledge-context-adapter.js';

--- a/packages/memento-core/src/domains/personal-agent/index.ts
+++ b/packages/memento-core/src/domains/personal-agent/index.ts
@@ -40,6 +40,9 @@ export type {
   DeterministicMockLlmAdapterOptions,
 } from './adapters/deterministic-mock-llm-adapter.js';
 
+export { OpenAiChatLlmAdapter } from './adapters/openai-chat-llm-adapter.js';
+export type { OpenAiChatLlmAdapterOptions } from './adapters/openai-chat-llm-adapter.js';
+
 export {
   ToolContextKnowledgeContextAdapter,
 } from './adapters/tool-context-knowledge-context-adapter.js';

--- a/packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createPersonalAgentLlmPort } from './create-personal-agent-llm-port.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+import type { ILLMPort } from '../ports/llm-port.js';
+
+describe('createPersonalAgentLlmPort', () => {
+  it('returns DeterministicMockLlmAdapter for mock', async () => {
+    const llm = createPersonalAgentLlmPort({ provider: 'mock' });
+    const out = await llm.complete([{ role: 'user', content: 'hi' }]);
+    expect(out.metadata.provider).toBe('mock');
+    expect(out.content).toContain('Mock response:');
+  });
+
+  it('uses createOpenAi when provided', async () => {
+    const stub: ILLMPort = {
+      async complete() {
+        return {
+          content: 'from-stub',
+          metadata: { provider: 'openai', model: 'stub-model' },
+        };
+      },
+    };
+    const llm = createPersonalAgentLlmPort(
+      { provider: 'openai', model: 'gpt-4o-mini' },
+      {
+        createOpenAi: () => stub,
+      },
+    );
+    const out = await llm.complete([]);
+    expect(out.content).toBe('from-stub');
+    expect(out.metadata.provider).toBe('openai');
+  });
+
+  it('throws when openai is requested without factory', () => {
+    expect(() =>
+      createPersonalAgentLlmPort({ provider: 'openai', model: 'gpt-4o-mini' }),
+    ).toThrow(PersonalAgentLlmError);
+  });
+
+  it('throws when gemini is requested without factory', () => {
+    expect(() =>
+      createPersonalAgentLlmPort({ provider: 'gemini', model: 'gemini-2.0-flash' }),
+    ).toThrow(PersonalAgentLlmError);
+  });
+
+  it('throws when ollama is requested without factory', () => {
+    expect(() =>
+      createPersonalAgentLlmPort({
+        provider: 'ollama',
+        baseUrl: 'http://127.0.0.1:11434',
+        model: 'llama3.2',
+      }),
+    ).toThrow(PersonalAgentLlmError);
+  });
+});

--- a/packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts
+++ b/packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts
@@ -1,0 +1,47 @@
+import { DeterministicMockLlmAdapter } from '../adapters/deterministic-mock-llm-adapter.js';
+import type { ParsedPersonalAgentLlmEnv } from '../config/personal-agent-llm-env.js';
+import { PersonalAgentLlmError } from '../errors/personal-agent-llm-error.js';
+import type { ILLMPort } from '../ports/llm-port.js';
+
+export type CreatePersonalAgentLlmPortDeps = {
+  createOpenAi?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'openai' }>) => ILLMPort;
+  createGemini?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'gemini' }>) => ILLMPort;
+  createOllama?: (cfg: Extract<ParsedPersonalAgentLlmEnv, { provider: 'ollama' }>) => ILLMPort;
+};
+
+export function createPersonalAgentLlmPort(
+  parsed: ParsedPersonalAgentLlmEnv,
+  deps: CreatePersonalAgentLlmPortDeps = {},
+): ILLMPort {
+  if (parsed.provider === 'mock') {
+    return new DeterministicMockLlmAdapter();
+  }
+
+  if (parsed.provider === 'openai') {
+    if (!deps.createOpenAi) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'OpenAI adapter is not registered in this build path',
+      });
+    }
+    return deps.createOpenAi(parsed);
+  }
+
+  if (parsed.provider === 'gemini') {
+    if (!deps.createGemini) {
+      throw new PersonalAgentLlmError({
+        code: 'provider_misconfigured',
+        message: 'Gemini adapter is not registered in this build path',
+      });
+    }
+    return deps.createGemini(parsed);
+  }
+
+  if (!deps.createOllama) {
+    throw new PersonalAgentLlmError({
+      code: 'provider_misconfigured',
+      message: 'Ollama adapter is not registered in this build path',
+    });
+  }
+  return deps.createOllama(parsed);
+}

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -152,6 +152,7 @@ export {
   isPersonalAgentLlmError,
   parsePersonalAgentLlmEnv,
   createPersonalAgentLlmPort,
+  OpenAiChatLlmAdapter,
 } from './domains/personal-agent/index.js';
 export type {
   PersonalKnowledgeAgentDeps,
@@ -162,6 +163,7 @@ export type {
   ParsePersonalAgentLlmEnvKeys,
   CreatePersonalAgentLlmPortDeps,
   ILLMPort,
+  OpenAiChatLlmAdapterOptions,
 } from './domains/personal-agent/index.js';
 
 // 타입·인터페이스 re-export (서버/앱에서 사용)

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -154,6 +154,7 @@ export {
   createPersonalAgentLlmPort,
   OpenAiChatLlmAdapter,
   GeminiChatLlmAdapter,
+  OllamaChatLlmAdapter,
 } from './domains/personal-agent/index.js';
 export type {
   PersonalKnowledgeAgentDeps,
@@ -166,6 +167,7 @@ export type {
   ILLMPort,
   OpenAiChatLlmAdapterOptions,
   GeminiChatLlmAdapterOptions,
+  OllamaChatLlmAdapterOptions,
 } from './domains/personal-agent/index.js';
 
 // 타입·인터페이스 re-export (서버/앱에서 사용)

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -161,6 +161,7 @@ export type {
   ParsedPersonalAgentLlmEnv,
   ParsePersonalAgentLlmEnvKeys,
   CreatePersonalAgentLlmPortDeps,
+  ILLMPort,
 } from './domains/personal-agent/index.js';
 
 // 타입·인터페이스 re-export (서버/앱에서 사용)

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -153,6 +153,7 @@ export {
   parsePersonalAgentLlmEnv,
   createPersonalAgentLlmPort,
   OpenAiChatLlmAdapter,
+  GeminiChatLlmAdapter,
 } from './domains/personal-agent/index.js';
 export type {
   PersonalKnowledgeAgentDeps,
@@ -164,6 +165,7 @@ export type {
   CreatePersonalAgentLlmPortDeps,
   ILLMPort,
   OpenAiChatLlmAdapterOptions,
+  GeminiChatLlmAdapterOptions,
 } from './domains/personal-agent/index.js';
 
 // 타입·인터페이스 re-export (서버/앱에서 사용)

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -148,11 +148,19 @@ export {
   DeterministicMockLlmAdapter,
   ToolContextKnowledgeContextAdapter,
   ToolContextRememberPersistenceAdapter,
+  PersonalAgentLlmError,
+  isPersonalAgentLlmError,
+  parsePersonalAgentLlmEnv,
+  createPersonalAgentLlmPort,
 } from './domains/personal-agent/index.js';
 export type {
   PersonalKnowledgeAgentDeps,
   KnowledgeCandidate,
   PersonalKnowledgePersistItemResult,
+  PersonalAgentLlmErrorCode,
+  ParsedPersonalAgentLlmEnv,
+  ParsePersonalAgentLlmEnvKeys,
+  CreatePersonalAgentLlmPortDeps,
 } from './domains/personal-agent/index.js';
 
 // 타입·인터페이스 re-export (서버/앱에서 사용)

--- a/packages/memento-server/src/cli/agent-ask.spec.ts
+++ b/packages/memento-server/src/cli/agent-ask.spec.ts
@@ -35,6 +35,17 @@ describe('parseAgentAskInvocation', () => {
       expect(p.json).toBe(true);
       expect(p.noSave).toBe(true);
       expect(p.jsonImplicitNoSave).toBe(false);
+      expect(p.forceLlmMock).toBe(false);
+    }
+  });
+
+  it('--llm mock 이면 forceLlmMock', () => {
+    const p = parseAgentAskInvocation(
+      argv('agent', 'ask', 'hi', '--json', '--no-save', '--llm', 'mock'),
+    );
+    expect(p.kind).toBe('run');
+    if (p.kind === 'run') {
+      expect(p.forceLlmMock).toBe(true);
     }
   });
 
@@ -43,6 +54,7 @@ describe('parseAgentAskInvocation', () => {
     expect(p.kind).toBe('run');
     if (p.kind === 'run') {
       expect(p.jsonImplicitNoSave).toBe(true);
+      expect(p.forceLlmMock).toBe(false);
     }
   });
 

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -16,6 +16,7 @@ import {
   mementoConfig,
   GeminiChatLlmAdapter,
   OpenAiChatLlmAdapter,
+  OllamaChatLlmAdapter,
   parsePersonalAgentLlmEnv,
   PersonalAgentLlmError,
   PersonalKnowledgeAgentService,
@@ -62,6 +63,8 @@ export type ParsedAgentAsk =
       noSave: boolean;
       /** `--json`만 있고 `--no-save`는 없을 때 true — stderr 안내 한 줄 출력 */
       jsonImplicitNoSave: boolean;
+      /** `--llm mock`이면 환경 변수 provider보다 mock을 우선한다. */
+      forceLlmMock: boolean;
     };
 
 /**
@@ -145,6 +148,7 @@ export function parseAgentAskInvocation(argv: string[]): ParsedAgentAsk {
     json,
     noSave,
     jsonImplicitNoSave: json && !noSave,
+    forceLlmMock: raw.llm === 'mock',
   };
 }
 
@@ -318,17 +322,17 @@ export async function runAgentAskMain(
   argv: string[],
   hooks?: AgentAskRuntimeHooks,
 ): Promise<number> {
-  const parsed = parseAgentAskInvocation(argv);
-  if (parsed.kind === 'help') {
+  const invocation = parseAgentAskInvocation(argv);
+  if (invocation.kind === 'help') {
     await writeErr(agentAskHelpText());
     return 0;
   }
-  if (parsed.kind === 'usage') {
+  if (invocation.kind === 'usage') {
     const useJson = argv.includes('--json');
     if (useJson) {
-      await writeOut(jsonFailure('INVALID_OPTION', 'usage', parsed.message));
+      await writeOut(jsonFailure('INVALID_OPTION', 'usage', invocation.message));
     } else {
-      await writeErr(parsed.message + '\n');
+      await writeErr(invocation.message + '\n');
     }
     return 1;
   }
@@ -340,7 +344,8 @@ export async function runAgentAskMain(
     json,
     noSave,
     jsonImplicitNoSave,
-  } = parsed;
+    forceLlmMock,
+  } = invocation;
 
   const prevCliQuiet = process.env.MEMENTO_CLI_QUIET;
   if (json) {
@@ -400,11 +405,14 @@ export async function runAgentAskMain(
 
   let llm: ILLMPort;
   try {
-    const parsed = parsePersonalAgentLlmEnv(process.env, {
+    const envForLlm = forceLlmMock
+      ? { ...process.env, MEMENTO_PERSONAL_AGENT_LLM_PROVIDER: 'mock' }
+      : process.env;
+    const llmEnv = parsePersonalAgentLlmEnv(envForLlm, {
       openaiApiKey: mementoConfig.openaiApiKey,
       geminiApiKey: mementoConfig.geminiApiKey,
     });
-    llm = createPersonalAgentLlmPort(parsed, {
+    llm = createPersonalAgentLlmPort(llmEnv, {
       createOpenAi: (cfg) => {
         const apiKey = mementoConfig.openaiApiKey?.trim();
         if (!apiKey) {
@@ -433,6 +441,11 @@ export async function runAgentAskMain(
           model: cfg.model,
         });
       },
+      createOllama: (cfg) =>
+        new OllamaChatLlmAdapter({
+          baseUrl: cfg.baseUrl,
+          model: cfg.model,
+        }),
     });
   } catch (e) {
     debugErr(e);
@@ -632,7 +645,9 @@ export function agentAskHelpText(): string {
     '  --token-budget <n>    memory_injection 추정 예산\n' +
     '  --json                stdout에 JSON 한 줄 (--json 단독 시 저장 생략)\n' +
     '  --no-save             승인·저장 단계 생략\n' +
-    '  --llm mock            LLM 어댑터(현재 mock만)\n\n' +
+    '  --llm mock            환경 변수 LLM provider를 무시하고 mock만 사용\n\n' +
+    'LLM provider(선택): 환경 변수 MEMENTO_PERSONAL_AGENT_LLM_PROVIDER(mock|openai|gemini|ollama).\n' +
+    '  미설정 시 mock. Ollama: MEMENTO_PERSONAL_AGENT_OLLAMA_MODEL 필수, URL은 MEMENTO_PERSONAL_AGENT_OLLAMA_URL(기본 http://127.0.0.1:11434).\n\n' +
     'Global options: --config-dir, --db-path (in-process DB 경로), --env-file\n'
   );
 }

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -14,6 +14,7 @@ import {
   createPersonalAgentLlmPort,
   createToolContext,
   mementoConfig,
+  OpenAiChatLlmAdapter,
   parsePersonalAgentLlmEnv,
   PersonalAgentLlmError,
   PersonalKnowledgeAgentService,
@@ -402,7 +403,22 @@ export async function runAgentAskMain(
       openaiApiKey: mementoConfig.openaiApiKey,
       geminiApiKey: mementoConfig.geminiApiKey,
     });
-    llm = createPersonalAgentLlmPort(parsed, {});
+    llm = createPersonalAgentLlmPort(parsed, {
+      createOpenAi: (cfg) => {
+        const apiKey = mementoConfig.openaiApiKey?.trim();
+        if (!apiKey) {
+          throw new PersonalAgentLlmError({
+            code: 'provider_misconfigured',
+            message:
+              'OPENAI_API_KEY is required when MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=openai',
+          });
+        }
+        return new OpenAiChatLlmAdapter({
+          apiKey,
+          model: cfg.model,
+        });
+      },
+    });
   } catch (e) {
     debugErr(e);
     if (e instanceof PersonalAgentLlmError) {

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -11,14 +11,16 @@ import { stdin as stdinStream, stderr as stderrStream } from 'node:process';
 import {
   closeDatabase,
   createMementoCore,
+  createPersonalAgentLlmPort,
   createToolContext,
   mementoConfig,
+  parsePersonalAgentLlmEnv,
+  PersonalAgentLlmError,
   PersonalKnowledgeAgentService,
-  DeterministicMockLlmAdapter,
   ToolContextKnowledgeContextAdapter,
   ToolContextRememberPersistenceAdapter,
 } from '@memento/core';
-import type { KnowledgeCandidate, PersonalKnowledgePersistItemResult } from '@memento/core';
+import type { ILLMPort, KnowledgeCandidate, PersonalKnowledgePersistItemResult } from '@memento/core';
 
 import { parseArgvToParams } from './option-map.js';
 
@@ -220,7 +222,8 @@ type ErrorCode =
   | 'AGENT_RUN_FAILED'
   | 'PERSIST_FAILED'
   | 'INTERRUPTED'
-  | 'NON_INTERACTIVE';
+  | 'NON_INTERACTIVE'
+  | 'PROVIDER_MISCONFIGURED';
 
 function jsonFailure(
   code: ErrorCode,
@@ -392,7 +395,36 @@ export async function runAgentAskMain(
 
   const { db, services } = core;
   const toolContext = createToolContext(db, services);
-  const llm = new DeterministicMockLlmAdapter();
+
+  let llm: ILLMPort;
+  try {
+    const parsed = parsePersonalAgentLlmEnv(process.env, {
+      openaiApiKey: mementoConfig.openaiApiKey,
+      geminiApiKey: mementoConfig.geminiApiKey,
+    });
+    llm = createPersonalAgentLlmPort(parsed, {});
+  } catch (e) {
+    debugErr(e);
+    if (e instanceof PersonalAgentLlmError) {
+      const msg = e.message;
+      if (json) {
+        await writeOut(jsonFailure('PROVIDER_MISCONFIGURED', 'usage', msg));
+      } else {
+        await writeErr(msg + '\n');
+      }
+    } else {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (json) {
+        await writeOut(jsonFailure('BOOTSTRAP_FAILED', 'bootstrap', msg));
+      } else {
+        await writeErr(msg + '\n');
+      }
+    }
+    await services.runtimeDiagnosticsSamplerCleanup?.().catch(() => {});
+    closeDatabase(db);
+    return 2;
+  }
+
   const context = new ToolContextKnowledgeContextAdapter(toolContext);
   const persistence = new ToolContextRememberPersistenceAdapter(toolContext);
   const service = new PersonalKnowledgeAgentService({ llm, context, persistence });

--- a/packages/memento-server/src/cli/agent-ask.ts
+++ b/packages/memento-server/src/cli/agent-ask.ts
@@ -14,6 +14,7 @@ import {
   createPersonalAgentLlmPort,
   createToolContext,
   mementoConfig,
+  GeminiChatLlmAdapter,
   OpenAiChatLlmAdapter,
   parsePersonalAgentLlmEnv,
   PersonalAgentLlmError,
@@ -414,6 +415,20 @@ export async function runAgentAskMain(
           });
         }
         return new OpenAiChatLlmAdapter({
+          apiKey,
+          model: cfg.model,
+        });
+      },
+      createGemini: (cfg) => {
+        const apiKey = mementoConfig.geminiApiKey?.trim();
+        if (!apiKey) {
+          throw new PersonalAgentLlmError({
+            code: 'provider_misconfigured',
+            message:
+              'GEMINI_API_KEY is required when MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=gemini',
+          });
+        }
+        return new GeminiChatLlmAdapter({
           apiKey,
           model: cfg.model,
         });


### PR DESCRIPTION
## Summary

- **#334**: `PersonalAgentLlmError`, `parsePersonalAgentLlmEnv`, `createPersonalAgentLlmPort`, `memento agent ask`에서 환경 기반 LLM 선택 및 `PROVIDER_MISCONFIGURED` JSON 처리. `--llm mock`이면 env provider보다 mock을 우선한다.
- **#335–#337**: `OpenAiChatLlmAdapter`, `GeminiChatLlmAdapter`, `OllamaChatLlmAdapter`로 `ILLMPort` 구현 및 CLI `createOpenAi` / `createGemini` / `createOllama` 연결.
- **문서**: 이슈 #238 스펙을 #334–#337과 동기화, 구현 계획(`docs/superpowers/plans/2026-05-15-issue-238-personal-agent-llm-providers.md`), 한국어 MVP 가이드에 Ollama 로컬 smoke 절차 추가.
- **graphify-out**: 코드 변경에 따른 그래프 재생성 커밋 포함.

Closes: 없음 (umbrella #238은 하위 이슈로 추적 중이면 PR 본문에서만 링크).

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run type-check -w @memento/core && npm run type-check -w memento-server`
- [ ] (선택) 실제 API: `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=openai|gemini` + 각 API 키로 `memento agent ask` 스모크
- [ ] (선택) Ollama: `ollama serve` 후 MVP 가이드 §2 절차로 `agent ask` 스모크

## 지식 복리

- **증상**: `agent ask` 내부에서 `parseAgentAskInvocation` 결과와 `parsePersonalAgentLlmEnv` 결과를 둘 다 `parsed`로 두면 TypeScript/런타임에서 LLM env 파싱 변수가 가려질 수 있음.
- **해결**: CLI 파싱 결과는 `invocation`, LLM env는 `llmEnv`로 분리. `--llm mock`은 `forceLlmMock`로 플래그화해 `process.env`에 `MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=mock` 오버레이.
- **재발 방지**: 동일 함수 스코프에서 `parsed` 같은 범용 이름 재사용 지양; CLI 플래그와 env 파싱 단계를 이름으로 구분해 리뷰하기 쉽게 유지.

Made with [Cursor](https://cursor.com)