### PR TITLE
feat(dashboard): memory evolution demo tab shell (#340)

### DIFF
--- a/packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts
+++ b/packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(process.cwd());
+const dashboardHtml = readFileSync(resolve(root, 'static/dashboard.html'), 'utf8');
+const tabsJs = readFileSync(resolve(root, 'static/js/dashboard-tabs.js'), 'utf8');
+const shellJs = readFileSync(resolve(root, 'static/js/memory-evolution-demo-shell.js'), 'utf8');
+const authJs = readFileSync(resolve(root, 'static/js/dashboard-auth.js'), 'utf8');
+const dashboardCss = readFileSync(resolve(root, 'static/css/dashboard.css'), 'utf8');
+
+describe('dashboard memory evolution demo shell (#340)', () => {
+  it('dashboard.html includes evolution demo tab, panel, and script', () => {
+    expect(dashboardHtml).toContain('id="dashboard-tab-evolution-demo"');
+    expect(dashboardHtml).toContain('data-tab="evolution-demo"');
+    expect(dashboardHtml).toContain('id="tab-evolution-demo"');
+    expect(dashboardHtml).toContain('/static/js/memory-evolution-demo-shell.js');
+    expect(dashboardHtml).toContain('id="med-loading"');
+    expect(dashboardHtml).toContain('id="med-empty"');
+    expect(dashboardHtml).toContain('id="med-error"');
+    expect(dashboardHtml).toContain('id="med-content"');
+    expect(dashboardHtml).toContain('id="med-question-text"');
+    expect(dashboardHtml).toContain('id="med-answer-text"');
+    expect(dashboardHtml).toContain('id="med-memory-summary"');
+    expect(dashboardHtml).toContain('기억 진화 데모');
+  });
+
+  it('tab bar is visible without session; session tabs keep session-only', () => {
+    expect(dashboardHtml).not.toContain('class="m-tab-bar session-only"');
+    expect(dashboardHtml).toContain('id="dashboard-tab-evolution-demo" class="m-tab-btn active"');
+    expect(dashboardHtml).toContain('id="dashboard-tab-anchor" class="m-tab-btn session-only"');
+    expect(dashboardHtml).toContain('id="dashboard-tab-review" class="m-tab-btn session-only"');
+    expect(dashboardHtml).not.toMatch(/id="tab-evolution-demo"[^>]*session-only/);
+    expect(dashboardHtml).toContain('id="tab-anchor-map" class="tab-panel session-only"');
+  });
+
+  it('dashboard-tabs.js handles evolution-demo and exports activateTab', () => {
+    expect(tabsJs).toContain("'tab-evolution-demo'");
+    expect(tabsJs).toContain("name === 'evolution-demo'");
+    expect(tabsJs).toContain('__MEMENTO_DASHBOARD_TABS__');
+    expect(tabsJs).toContain('activateTab');
+    expect(tabsJs).toContain('__MEMENTO_EVOLUTION_DEMO_SHELL__');
+  });
+
+  it('memory-evolution-demo-shell.js exposes view state API (shell only)', () => {
+    expect(shellJs).toContain('__MEMENTO_EVOLUTION_DEMO_SHELL__');
+    expect(shellJs).toContain('setViewState');
+    expect(shellJs).toContain("'loading'");
+    expect(shellJs).toContain("'empty'");
+    expect(shellJs).toContain("'error'");
+    expect(shellJs).toContain("'ready'");
+    expect(shellJs).not.toContain('fetch(');
+  });
+
+  it('dashboard-auth.js activates evolution-demo when signed out', () => {
+    expect(authJs).toContain('maybeActivateTabForAuth');
+    expect(authJs).toContain("tabs.activateTab('evolution-demo')");
+    expect(authJs).toContain("tabs.activateTab('anchor')");
+  });
+
+  it('dashboard.css defines med-* layout using design tokens', () => {
+    expect(dashboardCss).toContain('.med-layout');
+    expect(dashboardCss).toContain('.med-section');
+    expect(dashboardCss).toContain('var(--spacing-md)');
+    expect(dashboardCss).toContain('#tab-evolution-demo.tab-panel.active');
+  });
+});

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -996,3 +996,82 @@ body {
   outline: 2px solid var(--color-border-focus);
   outline-offset: -2px;
 }
+
+/* Memory evolution demo shell (#340) */
+.med-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  flex: 1;
+  min-height: 0;
+  padding: var(--spacing-md);
+  overflow: auto;
+}
+
+.med-header {
+  flex-shrink: 0;
+}
+
+.med-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-text-main);
+}
+
+.med-intro {
+  margin: 0;
+  max-width: 48rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed, 1.45);
+}
+
+.med-loading,
+.med-empty,
+.med-error {
+  flex-shrink: 0;
+}
+
+.med-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  flex: 1;
+  min-height: 0;
+}
+
+.med-section {
+  padding: var(--spacing-md);
+  border: 1px solid var(--color-tab-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-card);
+}
+
+.med-section-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-main);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.med-section-body {
+  margin: 0;
+  color: var(--color-text-main);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed, 1.45);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.med-placeholder {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+#tab-evolution-demo.tab-panel.active {
+  display: flex;
+  flex-direction: column;
+}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -64,14 +64,45 @@
       </div>
     </header>
 
-    <div class="m-tab-bar session-only" role="tablist" aria-label="대시보드 보기 전환">
-      <button type="button" id="dashboard-tab-anchor" class="m-tab-btn active" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-anchor-map" data-tab="anchor">Anchor Map</button>
-      <button type="button" id="dashboard-tab-embedding" class="m-tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-embedding-map" data-tab="embedding">Embedding Map</button>
-      <button type="button" id="dashboard-tab-graph" class="m-tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-graph" data-tab="graph">Memory Graph</button>
-      <button type="button" id="dashboard-tab-review" class="m-tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-review-candidates" data-tab="review">Review Queue <span id="rc-tab-badge" class="m-tab-badge hidden" aria-hidden="true"></span></button>
+    <div class="m-tab-bar" role="tablist" aria-label="대시보드 보기 전환">
+      <button type="button" id="dashboard-tab-evolution-demo" class="m-tab-btn active" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-evolution-demo" data-tab="evolution-demo">기억 진화 데모</button>
+      <button type="button" id="dashboard-tab-anchor" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-anchor-map" data-tab="anchor">Anchor Map</button>
+      <button type="button" id="dashboard-tab-embedding" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-embedding-map" data-tab="embedding">Embedding Map</button>
+      <button type="button" id="dashboard-tab-graph" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-graph" data-tab="graph">Memory Graph</button>
+      <button type="button" id="dashboard-tab-review" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-review-candidates" data-tab="review">Review Queue <span id="rc-tab-badge" class="m-tab-badge hidden" aria-hidden="true"></span></button>
     </div>
 
-    <div id="tab-anchor-map" class="tab-panel active session-only" role="tabpanel" aria-labelledby="dashboard-tab-anchor" aria-hidden="false">
+    
+    <div id="tab-evolution-demo" class="tab-panel active" role="tabpanel" aria-labelledby="dashboard-tab-evolution-demo" aria-hidden="false">
+      <div class="med-layout">
+        <header class="med-header">
+          <h2 class="med-title">기억 진화 데모</h2>
+        </header>
+        <p class="med-intro">
+          시간이 지나면서 동일한 질문에 대한 답변과 기억 상태가 어떻게 변하는지 보여 주는 인터랙티브 데모입니다.
+          이 탭은 로그인 없이 미리 볼 수 있으며, 시뮬레이션 데이터 연동은 이후 단계에서 추가됩니다.
+        </p>
+        <div id="med-loading" class="med-loading rc-banner hidden" role="status" aria-live="polite">시뮬레이션 데이터를 불러오는 중…</div>
+        <div id="med-empty" class="med-empty rc-banner">데모 콘텐츠가 아직 준비되지 않았습니다. 곧 타임라인과 기억 변화 시각화가 이 영역에 표시됩니다.</div>
+        <div id="med-error" class="med-error rc-banner rc-banner--error hidden" role="alert"></div>
+        <div id="med-content" class="med-content hidden">
+          <section class="med-section med-section--question" aria-label="질문">
+            <h3 class="med-section-title">질문</h3>
+            <p id="med-question-text" class="med-section-body med-placeholder">질문 텍스트가 여기에 표시됩니다.</p>
+          </section>
+          <section class="med-section med-section--answer" aria-label="답변">
+            <h3 class="med-section-title">답변</h3>
+            <p id="med-answer-text" class="med-section-body med-placeholder">선택한 시점의 답변이 여기에 표시됩니다.</p>
+          </section>
+          <section class="med-section med-section--memory" aria-label="기억 요약">
+            <h3 class="med-section-title">기억 요약</h3>
+            <p id="med-memory-summary" class="med-section-body med-placeholder">활성 기억 유형·상태 요약이 여기에 표시됩니다.</p>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <div id="tab-anchor-map" class="tab-panel session-only" role="tabpanel" aria-labelledby="dashboard-tab-anchor" aria-hidden="true">
       <main class="dashboard-main">
         <div class="sidebar">
           <section class="anchor-info">
@@ -289,6 +320,7 @@
 
   <!-- Anchor Map 시각화 스크립트 -->
   <script src="/static/js/anchor-map.js"></script>
+  <script src="/static/js/memory-evolution-demo-shell.js"></script>
   <script src="/static/js/dashboard-tabs.js"></script>
   <script src="/static/js/embedding-map.js"></script>
   <!--MEMENTO_REVIEW_QUEUE_BOOT-->

--- a/static/js/dashboard-auth.js
+++ b/static/js/dashboard-auth.js
@@ -80,6 +80,26 @@
     createSessionGate();
   }
 
+
+  function maybeActivateTabForAuth(nextState) {
+    const tabs = global.__MEMENTO_DASHBOARD_TABS__;
+    if (!tabs || typeof tabs.activateTab !== 'function') {
+      return;
+    }
+    if (nextState === 'signed-in') {
+      tabs.activateTab('anchor');
+      return;
+    }
+    if (
+      nextState === 'signed-out' ||
+      nextState === 'checking' ||
+      nextState === 'signing-in' ||
+      nextState === 'signing-out'
+    ) {
+      tabs.activateTab('evolution-demo');
+    }
+  }
+
   function setMessage(text, tone) {
     if (!messageEl) {
       return;
@@ -123,6 +143,7 @@
     }
 
     setMessage(message, nextState === 'signed-out' ? 'error' : 'neutral');
+    maybeActivateTabForAuth(nextState);
   }
 
   function readErrorMessage(response, fallbackMessage) {

--- a/static/js/dashboard-tabs.js
+++ b/static/js/dashboard-tabs.js
@@ -1,12 +1,12 @@
 /**
- * Dashboard Anchor / Embedding / Memory Graph 탭 전환
+ * Dashboard Anchor / Embedding / Memory Graph / Evolution demo 탭 전환
  * CSP(script-src에 unsafe-inline 없음) 대응: 인라인 스크립트 대신 외부 파일로 로드
  *
  * WAI-ARIA Tabs — Manual activation:
  * - 좌/우/Home/End: 같은 tablist 안에서 포커스만 이동(roving tabindex); 패널은 바꾸지 않음(그래프 iframe 지연 로드 유지)
  * - Enter/Space 또는 클릭: 해당 탭 활성화
  */
-(function () {
+(function (global) {
   'use strict';
 
   const GRAPH_IFRAME_SRC = '/graph';
@@ -29,6 +29,7 @@
   }
 
   function activateTab(name) {
+    const evolutionPanel = document.getElementById('tab-evolution-demo');
     const anchorPanel = document.getElementById('tab-anchor-map');
     const embedPanel = document.getElementById('tab-embedding-map');
     const graphPanel = document.getElementById('tab-graph');
@@ -39,6 +40,10 @@
       b.classList.toggle('active', on);
       b.setAttribute('aria-selected', on ? 'true' : 'false');
     });
+    if (evolutionPanel) {
+      evolutionPanel.classList.toggle('active', name === 'evolution-demo');
+      evolutionPanel.setAttribute('aria-hidden', name === 'evolution-demo' ? 'false' : 'true');
+    }
     if (anchorPanel) {
       anchorPanel.classList.toggle('active', name === 'anchor');
       anchorPanel.setAttribute('aria-hidden', name === 'anchor' ? 'false' : 'true');
@@ -55,11 +60,20 @@
       reviewPanel.classList.toggle('active', name === 'review');
       reviewPanel.setAttribute('aria-hidden', name === 'review' ? 'false' : 'true');
     }
-    if (name === 'embedding' && typeof window.initEmbeddingMap === 'function') {
-      window.initEmbeddingMap();
+    if (name === 'evolution-demo') {
+      const shell = global.__MEMENTO_EVOLUTION_DEMO_SHELL__;
+      if (shell && typeof shell.init === 'function') {
+        shell.init();
+      }
+      requestAnimationFrame(function () {
+        global.dispatchEvent(new Event('resize'));
+      });
     }
-    if (name === 'review' && typeof window.initReviewCandidatesPanel === 'function') {
-      window.initReviewCandidatesPanel();
+    if (name === 'embedding' && typeof global.initEmbeddingMap === 'function') {
+      global.initEmbeddingMap();
+    }
+    if (name === 'review' && typeof global.initReviewCandidatesPanel === 'function') {
+      global.initReviewCandidatesPanel();
     }
     if (name === 'graph') {
       const iframe = document.getElementById('graph-view-iframe');
@@ -68,20 +82,20 @@
         iframe.addEventListener('load', function onGraphFrameLoad() {
           iframe.removeEventListener('load', onGraphFrameLoad);
           requestAnimationFrame(function () {
-            window.dispatchEvent(new Event('resize'));
+            global.dispatchEvent(new Event('resize'));
             dispatchGraphIframeResize(iframe);
           });
         });
         iframe.src = GRAPH_IFRAME_SRC;
       } else if (iframe) {
         requestAnimationFrame(function () {
-          window.dispatchEvent(new Event('resize'));
+          global.dispatchEvent(new Event('resize'));
           dispatchGraphIframeResize(iframe);
         });
       }
     } else if (name === 'anchor' || name === 'embedding' || name === 'review') {
       requestAnimationFrame(function () {
-        window.dispatchEvent(new Event('resize'));
+        global.dispatchEvent(new Event('resize'));
       });
     }
 
@@ -145,8 +159,12 @@
     });
   });
 
-  const initial = document.querySelector('.m-tab-btn[data-tab="anchor"]');
+  const initial = document.querySelector('.m-tab-btn[data-tab="evolution-demo"]');
   if (initial) {
     setRovingTabindex(initial);
   }
-})();
+
+  global.__MEMENTO_DASHBOARD_TABS__ = {
+    activateTab: activateTab,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/memory-evolution-demo-shell.js
+++ b/static/js/memory-evolution-demo-shell.js
@@ -1,0 +1,71 @@
+/**
+ * Memory evolution demo tab — shell only (#340).
+ * View states: loading | empty | error | ready (no API fetch).
+ */
+(function (global) {
+  'use strict';
+
+  const VALID_STATES = ['loading', 'empty', 'error', 'ready'];
+
+  let viewState = 'empty';
+  let bound = false;
+
+  const els = {
+    loading: null,
+    empty: null,
+    error: null,
+    content: null,
+  };
+
+  function bindDom() {
+    if (bound) {
+      return;
+    }
+    els.loading = document.getElementById('med-loading');
+    els.empty = document.getElementById('med-empty');
+    els.error = document.getElementById('med-error');
+    els.content = document.getElementById('med-content');
+    bound = Boolean(els.loading && els.empty && els.error && els.content);
+  }
+
+  function setVisible(el, visible) {
+    if (!el) {
+      return;
+    }
+    el.classList.toggle('hidden', !visible);
+  }
+
+  function setViewState(state) {
+    if (VALID_STATES.indexOf(state) < 0) {
+      return;
+    }
+    bindDom();
+    if (!bound) {
+      return;
+    }
+    viewState = state;
+    setVisible(els.loading, state === 'loading');
+    setVisible(els.empty, state === 'empty');
+    setVisible(els.error, state === 'error');
+    setVisible(els.content, state === 'ready');
+  }
+
+  function init() {
+    bindDom();
+    setViewState(viewState);
+  }
+
+  global.__MEMENTO_EVOLUTION_DEMO_SHELL__ = {
+    init: init,
+    setViewState: setViewState,
+    getViewState: function () {
+      return viewState;
+    },
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- `/dashboard`에 **기억 진화 데모** 탭 셸을 추가합니다 (API 연결 없음).
- 로딩/빈/오류/콘텐츠(ready) 상태를 `memory-evolution-demo-shell.js`로 전환할 수 있습니다.
- 미인증 시에도 탭·셸이 보이도록 `session-only`를 세션 탭/패널에만 적용했습니다.

## Related
- Closes #340
- Parent: #80

## Test plan
- [x] `dashboard-memory-evolution-demo-shell.spec.ts`
- [x] `npm run lint`
- [ ] 수동: `/dashboard`에서 기억 진화 데모 탭·빈 상태 확인 (미로그인/로그인)


Made with [Cursor](https://cursor.com)