### PR TITLE
feat(admin): evolution demo snapshot read API (#341)

### DIFF
--- a/packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts
+++ b/packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEvolutionDemoSnapshot,
+  listEvolutionDemoScenarios,
+  EvolutionDemoNotFoundError,
+  EvolutionDemoSnapshotSchema,
+} from './index.js';
+
+describe('evolution-demo getters', () => {
+  it('lists answer-over-time scenario with early, mid, late points', () => {
+    const catalog = listEvolutionDemoScenarios();
+    expect(catalog.scenarios).toHaveLength(1);
+    const scenario = catalog.scenarios[0];
+    expect(scenario?.scenario_id).toBe('answer-over-time');
+    expect(scenario?.points.map(p => p.point_id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('returns snapshot for each point with same question and different answers', () => {
+    const early = getEvolutionDemoSnapshot('answer-over-time', 'early');
+    const mid = getEvolutionDemoSnapshot('answer-over-time', 'mid');
+    const late = getEvolutionDemoSnapshot('answer-over-time', 'late');
+
+    expect(early.question).toBe(mid.question);
+    expect(mid.question).toBe(late.question);
+    expect(early.answer).not.toBe(mid.answer);
+    expect(mid.answer).not.toBe(late.answer);
+    expect(EvolutionDemoSnapshotSchema.safeParse(early).success).toBe(true);
+    expect(EvolutionDemoSnapshotSchema.safeParse(late).success).toBe(true);
+  });
+
+  it('throws EvolutionDemoNotFoundError for unknown scenario or point', () => {
+    expect(() => getEvolutionDemoSnapshot('missing', 'early')).toThrow(
+      EvolutionDemoNotFoundError
+    );
+    expect(() => getEvolutionDemoSnapshot('answer-over-time', 'missing')).toThrow(
+      EvolutionDemoNotFoundError
+    );
+  });
+});

--- a/packages/memento-core/src/domains/evolution-demo/getters.ts
+++ b/packages/memento-core/src/domains/evolution-demo/getters.ts
@@ -1,0 +1,66 @@
+/**
+ * Evolution demo read accessors (fixture-backed; #346 may add DB)
+ */
+
+import { getFixtureSnapshot } from './store.js';
+import {
+  EvolutionDemoScenarioCatalogSchema,
+  EvolutionDemoSnapshotSchema,
+} from './spec.js';
+import type {
+  EvolutionDemoScenario,
+  EvolutionDemoScenarioCatalog,
+  EvolutionDemoSnapshot,
+} from './types.js';
+
+const SCENARIO_CATALOG: EvolutionDemoScenario[] = [
+  {
+    scenario_id: 'answer-over-time',
+    title: 'Answer changes over time',
+    points: [
+      { point_id: 'early', label: 'Early (day 1)' },
+      { point_id: 'mid', label: 'Mid (day 30)' },
+      { point_id: 'late', label: 'Late (day 90)' },
+    ],
+  },
+];
+
+export class EvolutionDemoNotFoundError extends Error {
+  constructor(
+    public readonly scenarioId: string,
+    public readonly pointId?: string
+  ) {
+    const target = pointId ? `${scenarioId}/${pointId}` : scenarioId;
+    super(`Evolution demo snapshot not found: ${target}`);
+    this.name = 'EvolutionDemoNotFoundError';
+  }
+}
+
+export function listEvolutionDemoScenarios(): EvolutionDemoScenarioCatalog {
+  const catalog: EvolutionDemoScenarioCatalog = { scenarios: SCENARIO_CATALOG };
+  return EvolutionDemoScenarioCatalogSchema.parse(catalog);
+}
+
+export function getEvolutionDemoSnapshot(
+  scenarioId: string,
+  pointId: string
+): EvolutionDemoSnapshot {
+  const scenario = SCENARIO_CATALOG.find(s => s.scenario_id === scenarioId);
+  if (!scenario) {
+    throw new EvolutionDemoNotFoundError(scenarioId);
+  }
+  const point = scenario.points.find(p => p.point_id === pointId);
+  if (!point) {
+    throw new EvolutionDemoNotFoundError(scenarioId, pointId);
+  }
+
+  const snapshot = getFixtureSnapshot(scenarioId, pointId);
+  if (!snapshot) {
+    throw new EvolutionDemoNotFoundError(scenarioId, pointId);
+  }
+
+  return EvolutionDemoSnapshotSchema.parse({
+    ...snapshot,
+    point_label: point.label,
+  });
+}

--- a/packages/memento-core/src/domains/evolution-demo/getters.ts
+++ b/packages/memento-core/src/domains/evolution-demo/getters.ts
@@ -38,7 +38,8 @@ export class EvolutionDemoNotFoundError extends Error {
 
 export function listEvolutionDemoScenarios(): EvolutionDemoScenarioCatalog {
   const catalog: EvolutionDemoScenarioCatalog = { scenarios: SCENARIO_CATALOG };
-  return EvolutionDemoScenarioCatalogSchema.parse(catalog);
+  EvolutionDemoScenarioCatalogSchema.parse(catalog);
+  return catalog;
 }
 
 export function getEvolutionDemoSnapshot(
@@ -59,8 +60,10 @@ export function getEvolutionDemoSnapshot(
     throw new EvolutionDemoNotFoundError(scenarioId, pointId);
   }
 
-  return EvolutionDemoSnapshotSchema.parse({
+  const result: EvolutionDemoSnapshot = {
     ...snapshot,
     point_label: point.label,
-  });
+  };
+  EvolutionDemoSnapshotSchema.parse(result);
+  return result;
 }

--- a/packages/memento-core/src/domains/evolution-demo/index.ts
+++ b/packages/memento-core/src/domains/evolution-demo/index.ts
@@ -1,0 +1,22 @@
+export type {
+  EvolutionDemoMemorySummary,
+  EvolutionDemoSnapshot,
+  EvolutionDemoPoint,
+  EvolutionDemoScenario,
+  EvolutionDemoScenarioCatalog,
+} from './types.js';
+
+export {
+  EVOLUTION_DEMO_SCENARIO_IDS,
+  EvolutionDemoMemorySummarySchema,
+  EvolutionDemoSnapshotSchema,
+  EvolutionDemoPointSchema,
+  EvolutionDemoScenarioSchema,
+  EvolutionDemoScenarioCatalogSchema,
+} from './spec.js';
+
+export {
+  listEvolutionDemoScenarios,
+  getEvolutionDemoSnapshot,
+  EvolutionDemoNotFoundError,
+} from './getters.js';

--- a/packages/memento-core/src/domains/evolution-demo/spec.ts
+++ b/packages/memento-core/src/domains/evolution-demo/spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Evolution demo API contract (Issue #341)
+ */
+
+import { z } from 'zod';
+
+export const EVOLUTION_DEMO_SCENARIO_IDS = ['answer-over-time'] as const;
+
+export const EvolutionDemoMemorySummarySchema = z.object({
+  episodic_count: z.number().int().nonnegative(),
+  semantic_count: z.number().int().nonnegative(),
+  forgotten_count: z.number().int().nonnegative(),
+  preserved_count: z.number().int().nonnegative(),
+  summary_text: z.string(),
+});
+
+export const EvolutionDemoSnapshotSchema = z.object({
+  scenario_id: z.string().min(1),
+  point_id: z.string().min(1),
+  point_label: z.string().min(1),
+  question: z.string(),
+  answer: z.string(),
+  memory_summary: EvolutionDemoMemorySummarySchema,
+  explanation: z.string(),
+  timestamp: z.string().datetime(),
+});
+
+export const EvolutionDemoPointSchema = z.object({
+  point_id: z.string().min(1),
+  label: z.string().min(1),
+});
+
+export const EvolutionDemoScenarioSchema = z.object({
+  scenario_id: z.string().min(1),
+  title: z.string().min(1),
+  points: z.array(EvolutionDemoPointSchema).min(1),
+});
+
+export const EvolutionDemoScenarioCatalogSchema = z.object({
+  scenarios: z.array(EvolutionDemoScenarioSchema).min(1),
+});

--- a/packages/memento-core/src/domains/evolution-demo/store.ts
+++ b/packages/memento-core/src/domains/evolution-demo/store.ts
@@ -1,0 +1,82 @@
+/**
+ * In-code fixtures for evolution demo snapshots.
+ * Designed for #346 to replace with DB seed later.
+ */
+
+import type { EvolutionDemoSnapshot } from './types.js';
+
+const DEMO_QUESTION =
+  'What authentication approach did we choose for the admin API?';
+
+type SnapshotKey = `${string}:${string}`;
+
+function key(scenarioId: string, pointId: string): SnapshotKey {
+  return `${scenarioId}:${pointId}`;
+}
+
+const SNAPSHOTS: Record<SnapshotKey, EvolutionDemoSnapshot> = {
+  [key('answer-over-time', 'early')]: {
+    scenario_id: 'answer-over-time',
+    point_id: 'early',
+    point_label: 'Early (day 1)',
+    question: DEMO_QUESTION,
+    answer:
+      'We chose JWT bearer tokens with short-lived access tokens and refresh rotation, stored in httpOnly cookies for the dashboard.',
+    memory_summary: {
+      episodic_count: 12,
+      semantic_count: 0,
+      forgotten_count: 0,
+      preserved_count: 12,
+      summary_text:
+        'Twelve episodic memories from recent meetings; no consolidation yet.',
+    },
+    explanation:
+      'Immediately after the decision, the agent recalls detailed episodic context from recent discussions.',
+    timestamp: '2026-01-21T10:00:00.000Z',
+  },
+  [key('answer-over-time', 'mid')]: {
+    scenario_id: 'answer-over-time',
+    point_id: 'mid',
+    point_label: 'Mid (day 30)',
+    question: DEMO_QUESTION,
+    answer:
+      'JWT bearer auth with refresh rotation. Some meeting details have faded, but the core decision remains.',
+    memory_summary: {
+      episodic_count: 5,
+      semantic_count: 2,
+      forgotten_count: 5,
+      preserved_count: 7,
+      summary_text:
+        'Five episodic memories remain; two semantic facts distilled; five low-importance episodic items forgotten.',
+    },
+    explanation:
+      'Forgetting policy removed stale episodic noise while sleep consolidation promoted durable semantic facts.',
+    timestamp: '2026-02-20T10:00:00.000Z',
+  },
+  [key('answer-over-time', 'late')]: {
+    scenario_id: 'answer-over-time',
+    point_id: 'late',
+    point_label: 'Late (day 90)',
+    question: DEMO_QUESTION,
+    answer:
+      'Admin API uses JWT bearer authentication with refresh token rotation.',
+    memory_summary: {
+      episodic_count: 1,
+      semantic_count: 3,
+      forgotten_count: 8,
+      preserved_count: 4,
+      summary_text:
+        'Most episodic detail consolidated or forgotten; three semantic memories preserve the durable decision.',
+    },
+    explanation:
+      'Over time, repeated recall and consolidation produce a concise semantic answer with minimal episodic overhead.',
+    timestamp: '2026-04-21T10:00:00.000Z',
+  },
+};
+
+export function getFixtureSnapshot(
+  scenarioId: string,
+  pointId: string
+): EvolutionDemoSnapshot | undefined {
+  return SNAPSHOTS[key(scenarioId, pointId)];
+}

--- a/packages/memento-core/src/domains/evolution-demo/types.ts
+++ b/packages/memento-core/src/domains/evolution-demo/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Evolution demo snapshot types (Issue #341)
+ * Stable response shape for frontend #342
+ */
+
+export interface EvolutionDemoMemorySummary {
+  episodic_count: number;
+  semantic_count: number;
+  forgotten_count: number;
+  preserved_count: number;
+  summary_text: string;
+}
+
+export interface EvolutionDemoSnapshot {
+  scenario_id: string;
+  point_id: string;
+  point_label: string;
+  question: string;
+  answer: string;
+  memory_summary: EvolutionDemoMemorySummary;
+  explanation: string;
+  timestamp: string;
+}
+
+export interface EvolutionDemoPoint {
+  point_id: string;
+  label: string;
+}
+
+export interface EvolutionDemoScenario {
+  scenario_id: string;
+  title: string;
+  points: EvolutionDemoPoint[];
+}
+
+export interface EvolutionDemoScenarioCatalog {
+  scenarios: EvolutionDemoScenario[];
+}

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -182,3 +182,23 @@ export { MemoryReviewCandidateSchemaMigration } from './infrastructure/database/
 export { ReviewQueueHealthSnapshotMigration } from './infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.js';
 
 export type { RecallResultItem } from './domains/memory/tools/recall-tool.js';
+
+// Evolution demo (Issue #341)
+export {
+  listEvolutionDemoScenarios,
+  getEvolutionDemoSnapshot,
+  EvolutionDemoNotFoundError,
+  EVOLUTION_DEMO_SCENARIO_IDS,
+  EvolutionDemoMemorySummarySchema,
+  EvolutionDemoSnapshotSchema,
+  EvolutionDemoPointSchema,
+  EvolutionDemoScenarioSchema,
+  EvolutionDemoScenarioCatalogSchema,
+} from './domains/evolution-demo/index.js';
+export type {
+  EvolutionDemoMemorySummary,
+  EvolutionDemoSnapshot,
+  EvolutionDemoPoint,
+  EvolutionDemoScenario,
+  EvolutionDemoScenarioCatalog,
+} from './domains/evolution-demo/index.js';

--- a/packages/memento-server/src/server/routes/admin.routes.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.ts
@@ -17,6 +17,7 @@ import { registerAdminBatchRoutes } from './admin/admin-batch.routes.js';
 import { registerAdminRuntimePerformanceRoutes } from './admin/admin-runtime-performance.routes.js';
 import { registerAdminToolRoutes } from './admin/admin-tools.routes.js';
 import { registerAdminProjectMemoryRoutes } from './admin/admin-project-memory.routes.js';
+import { registerAdminEvolutionDemoRoutes } from './admin/admin-evolution-demo.routes.js';
 
 export type { GraphNode, GraphEdge, GraphFilter, GraphResponse } from './admin/admin-graph-response.js';
 
@@ -41,6 +42,7 @@ export function createAdminRouter(
   registerAdminTelemetryRoutes(router, db, serverServices);
   registerAdminGraphRoute(router, db);
   registerAdminEmbeddingMapRoute(router, db);
+  registerAdminEvolutionDemoRoutes(router);
 
   return router;
 }

--- a/packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Admin evolution demo routes (Issue #341)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import http from 'http';
+import Database from 'better-sqlite3';
+import { createAdminRouter } from '../admin.routes.js';
+
+async function listen(app: express.Express): Promise<{ server: http.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        resolve({ server, port: addr.port });
+      } else {
+        reject(new Error('no port'));
+      }
+    });
+  });
+}
+
+function getAdmin(port: number, path: string): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers: { Connection: 'close' },
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('admin evolution-demo routes', () => {
+  let db: Database.Database;
+  let server: http.Server | undefined;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('GET /admin/evolution-demo/scenarios returns catalog', async () => {
+    const app = express();
+    app.use('/admin', createAdminRouter(db, null));
+    const listened = await listen(app);
+    server = listened.server;
+
+    const res = await getAdmin(listened.port, '/admin/evolution-demo/scenarios');
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(res.body) as {
+      scenarios: Array<{ scenario_id: string; title: string; points: Array<{ point_id: string }> }>;
+    };
+    expect(body.scenarios).toHaveLength(1);
+    expect(body.scenarios[0]?.scenario_id).toBe('answer-over-time');
+    expect(body.scenarios[0]?.points.map(p => p.point_id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('GET /admin/evolution-demo/snapshots/:scenario_id/:point_id returns snapshot body', async () => {
+    const app = express();
+    app.use('/admin', createAdminRouter(db, null));
+    const listened = await listen(app);
+    server = listened.server;
+
+    const res = await getAdmin(
+      listened.port,
+      '/admin/evolution-demo/snapshots/answer-over-time/mid'
+    );
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(res.body) as {
+      scenario_id: string;
+      point_id: string;
+      point_label: string;
+      question: string;
+      answer: string;
+      memory_summary: {
+        episodic_count: number;
+        semantic_count: number;
+        forgotten_count: number;
+        preserved_count: number;
+        summary_text: string;
+      };
+      explanation: string;
+      timestamp: string;
+    };
+
+    expect(body.scenario_id).toBe('answer-over-time');
+    expect(body.point_id).toBe('mid');
+    expect(body.point_label).toBe('Mid (day 30)');
+    expect(body.question).toContain('authentication');
+    expect(body.answer.length).toBeGreaterThan(0);
+    expect(body.memory_summary.episodic_count).toBeGreaterThanOrEqual(0);
+    expect(body.explanation.length).toBeGreaterThan(0);
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('GET snapshot returns 404 for unknown scenario or point', async () => {
+    const app = express();
+    app.use('/admin', createAdminRouter(db, null));
+    const listened = await listen(app);
+    server = listened.server;
+
+    const missingScenario = await getAdmin(
+      listened.port,
+      '/admin/evolution-demo/snapshots/unknown/early'
+    );
+    expect(missingScenario.statusCode).toBe(404);
+
+    const missingPoint = await getAdmin(
+      listened.port,
+      '/admin/evolution-demo/snapshots/answer-over-time/unknown'
+    );
+    expect(missingPoint.statusCode).toBe(404);
+  });
+});

--- a/packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts
@@ -1,0 +1,51 @@
+/**
+ * Admin: evolution demo snapshot read API (Issue #341)
+ */
+
+import type { Router } from 'express';
+import {
+  getEvolutionDemoSnapshot,
+  listEvolutionDemoScenarios,
+  EvolutionDemoNotFoundError,
+  logger,
+} from '@memento/core';
+
+export function registerAdminEvolutionDemoRoutes(router: Router): void {
+  router.get('/evolution-demo/scenarios', (_req, res) => {
+    try {
+      const catalog = listEvolutionDemoScenarios();
+      return res.json(catalog);
+    } catch (error) {
+      logger.error('evolution-demo scenarios failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({
+        error: '시나리오 목록 조회 실패',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+
+  router.get('/evolution-demo/snapshots/:scenario_id/:point_id', (req, res) => {
+    try {
+      const { scenario_id, point_id } = req.params;
+      if (!scenario_id || !point_id) {
+        return res.status(400).json({ error: 'scenario_id와 point_id가 필요합니다' });
+      }
+
+      const snapshot = getEvolutionDemoSnapshot(scenario_id, point_id);
+      return res.json(snapshot);
+    } catch (error) {
+      if (error instanceof EvolutionDemoNotFoundError) {
+        return res.status(404).json({ error: error.message });
+      }
+      logger.error('evolution-demo snapshot failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({
+        error: '스냅샷 조회 실패',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- 데모 스냅샷 조회용 admin read API를 추가합니다 (`GET /admin/evolution-demo/scenarios`, `GET /admin/evolution-demo/snapshots/:scenario_id/:point_id`).
- `@memento/core`의 `evolution-demo` 도메인에 인코드 fixture(`answer-over-time` / `early|mid|late`)를 두었습니다. (#346에서 DB 시드로 교체 가능)

## Related
- Closes #341
- Parent: #80
- 후속: #342 (Dashboard 연결), #394 (카피 확장)

## Test plan
- [x] `evolution-demo.spec.ts`, `admin-evolution-demo.routes.spec.ts`
- [x] `npm run lint`


Made with [Cursor](https://cursor.com)