### PR TITLE
feat(core): RuntimeDiagnosticsLogger JSONL rotation (#422)

### DIFF
--- a/packages/memento-core/src/bootstrap.spec.ts
+++ b/packages/memento-core/src/bootstrap.spec.ts
@@ -15,6 +15,8 @@ const mockState = vi.hoisted(() => {
     diagnosticsEnabled: false,
     diagnosticsIntervalMs: 15000,
     diagnosticsLogDir: '/tmp/memento-diagnostics',
+    diagnosticsJsonlMaxBytes: 67108864,
+    diagnosticsJsonlRetainFiles: 3,
     consolidationScoreEnabled: false,
     batchSchedulerEnabled: true,
     walCheckpointEnabled: true,

--- a/packages/memento-core/src/bootstrap/monitoring-schedulers.ts
+++ b/packages/memento-core/src/bootstrap/monitoring-schedulers.ts
@@ -16,7 +16,9 @@ export async function createMonitoringAndSchedulers(db: Database.Database): Prom
   performanceMonitor.initialize(db);
   const runtimeDiagnosticsLogger = new RuntimeDiagnosticsLogger(
     mementoConfig.diagnosticsEnabled,
-    mementoConfig.diagnosticsLogDir
+    mementoConfig.diagnosticsLogDir,
+    mementoConfig.diagnosticsJsonlMaxBytes,
+    mementoConfig.diagnosticsJsonlRetainFiles,
   );
   await runtimeDiagnosticsLogger.writeEvent({
     type: 'bootstrap_start',

--- a/packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts
+++ b/packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts
@@ -84,19 +84,24 @@ describe('RuntimeDiagnosticsLogger', () => {
   it('writeSample이 JSONL 파일에 기록해야 한다', async () => {
     const appendFileMock = vi.fn().mockResolvedValue(undefined);
     const mkdirMock = vi.fn().mockResolvedValue(undefined);
+    const rotateMock = vi.fn().mockResolvedValue(false);
 
     vi.doMock('fs/promises', () => ({
       appendFile: appendFileMock,
       mkdir: mkdirMock
     }));
+    vi.doMock('../../../../shared/utils/jsonl-rotation.js', () => ({
+      rotateJsonlIfNeeded: rotateMock
+    }));
 
     try {
       const { RuntimeDiagnosticsLogger } = await import('../runtime-diagnostics-logger.js');
-      const logger = new RuntimeDiagnosticsLogger(true, '/tmp/memento-diagnostics');
+      const logger = new RuntimeDiagnosticsLogger(true, '/tmp/memento-diagnostics', 1024, 2);
 
       await expect(logger.writeSample({ type: 'sample', count: 1 })).resolves.toBeUndefined();
 
       expect(mkdirMock).toHaveBeenCalledWith('/tmp/memento-diagnostics', { recursive: true });
+      expect(rotateMock).toHaveBeenCalledWith('/tmp/memento-diagnostics/app-runtime.jsonl', 1024, 2);
       expect(appendFileMock).toHaveBeenCalledWith(
         '/tmp/memento-diagnostics/app-runtime.jsonl',
         '{"type":"sample","count":1}\n',
@@ -104,6 +109,7 @@ describe('RuntimeDiagnosticsLogger', () => {
       );
     } finally {
       vi.doUnmock('fs/promises');
+      vi.doUnmock('../../../../shared/utils/jsonl-rotation.js');
     }
   });
 

--- a/packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts
+++ b/packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts
@@ -1,10 +1,13 @@
 import { appendFile, mkdir } from 'fs/promises';
 import { join } from 'path';
+import { rotateJsonlIfNeeded } from '../../../shared/utils/jsonl-rotation.js';
 
 export class RuntimeDiagnosticsLogger {
   constructor(
     private readonly enabled: boolean,
-    private readonly logDir: string
+    private readonly logDir: string,
+    private readonly jsonlMaxBytes = 64 * 1024 * 1024,
+    private readonly jsonlRetainFiles = 3,
   ) {}
 
   async writeSample(sample: Record<string, unknown>): Promise<void> {
@@ -26,7 +29,9 @@ export class RuntimeDiagnosticsLogger {
   private async appendJsonl(fileName: string, record: Record<string, unknown>): Promise<void> {
     try {
       await mkdir(this.logDir, { recursive: true });
-      await appendFile(join(this.logDir, fileName), `${JSON.stringify(record)}\n`, 'utf8');
+      const filePath = join(this.logDir, fileName);
+      await rotateJsonlIfNeeded(filePath, this.jsonlMaxBytes, this.jsonlRetainFiles);
+      await appendFile(filePath, `${JSON.stringify(record)}\n`, 'utf8');
     } catch {
       return;
     }

--- a/packages/memento-core/src/shared/config/index.ts
+++ b/packages/memento-core/src/shared/config/index.ts
@@ -91,6 +91,8 @@ export const mementoConfig: MementoConfig = {
   diagnosticsEnabled: resolveBoolean('DIAGNOSTICS_ENABLED', { defaultValue: false }),
   diagnosticsIntervalMs: resolveNumber('DIAGNOSTICS_INTERVAL_MS', { defaultValue: 15000 }),
   diagnosticsLogDir: resolveString('DIAGNOSTICS_LOG_DIR', { defaultValue: '/app/logs/diagnostics' }),
+  diagnosticsJsonlMaxBytes: resolveNumber('DIAGNOSTICS_JSONL_MAX_BYTES', { defaultValue: 64 * 1024 * 1024 }),
+  diagnosticsJsonlRetainFiles: resolveNumber('DIAGNOSTICS_JSONL_RETAIN_FILES', { defaultValue: 3 }),
 
   // 데이터베이스 락 모니터 설정
   lockMonitorIntervalMs: resolveNumber('LOCK_MONITOR_INTERVAL_MS', { defaultValue: 60000 }),

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -279,6 +279,8 @@ export interface MementoConfig {
   diagnosticsEnabled: boolean;
   diagnosticsIntervalMs: number;
   diagnosticsLogDir: string;
+  diagnosticsJsonlMaxBytes: number;
+  diagnosticsJsonlRetainFiles: number;
   // 데이터베이스 락 모니터 설정
   lockMonitorIntervalMs: number;
   lockMonitorWarningThresholdMs: number;

--- a/packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts
+++ b/packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts
@@ -1,0 +1,38 @@
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { rotateJsonlIfNeeded } from '../jsonl-rotation.js';
+
+describe('rotateJsonlIfNeeded', () => {
+  let dir: string;
+
+  afterEach(async () => {
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does nothing when the file is below maxBytes', async () => {
+    dir = join(tmpdir(), `jsonl-rotation-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'sample.jsonl');
+    await writeFile(filePath, '{"a":1}\n', 'utf8');
+
+    await expect(rotateJsonlIfNeeded(filePath, 1024, 3)).resolves.toBe(false);
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('{"a":1}\n');
+  });
+
+  it('rotates numbered backups when maxBytes is exceeded', async () => {
+    dir = join(tmpdir(), `jsonl-rotation-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    const filePath = join(dir, 'sample.jsonl');
+    await writeFile(filePath, 'x'.repeat(20), 'utf8');
+    await writeFile(`${filePath}.1`, 'first-backup\n', 'utf8');
+
+    await expect(rotateJsonlIfNeeded(filePath, 10, 2)).resolves.toBe(true);
+    await expect(stat(filePath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(`${filePath}.1`, 'utf8')).resolves.toBe('x'.repeat(20));
+    await expect(readFile(`${filePath}.2`, 'utf8')).resolves.toBe('first-backup\n');
+  });
+});

--- a/packages/memento-core/src/shared/utils/jsonl-rotation.ts
+++ b/packages/memento-core/src/shared/utils/jsonl-rotation.ts
@@ -1,0 +1,49 @@
+import { rename, stat, unlink } from 'fs/promises';
+
+export async function rotateJsonlIfNeeded(
+  filePath: string,
+  maxBytes: number,
+  retainFiles: number,
+): Promise<boolean> {
+  if (maxBytes <= 0 || retainFiles < 1) {
+    return false;
+  }
+
+  let size = 0;
+  try {
+    size = (await stat(filePath)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+
+  if (size < maxBytes) {
+    return false;
+  }
+
+  const oldest = `${filePath}.${retainFiles}`;
+  try {
+    await unlink(oldest);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  for (let index = retainFiles - 1; index >= 1; index -= 1) {
+    const from = `${filePath}.${index}`;
+    const to = `${filePath}.${index + 1}`;
+    try {
+      await rename(from, to);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  await rename(filePath, `${filePath}.1`);
+  return true;
+}


### PR DESCRIPTION
## Summary

- `rotateJsonlIfNeeded()` 유틸 추가 (numbered backup: `.1`, `.2`, …)
- `RuntimeDiagnosticsLogger` append 전 rotation 적용
- env: `DIAGNOSTICS_JSONL_MAX_BYTES` (default 64MB), `DIAGNOSTICS_JSONL_RETAIN_FILES` (default 3)

## Test plan

- [x] `jsonl-rotation.spec.ts`
- [x] `runtime-diagnostics-logger.spec.ts`

Closes #422
Part of #420

Made with [Cursor](https://cursor.com)