### PR TITLE
fix(diagnostics): rotate docker-diagnostics JSONL files (#423)

### DIFF
--- a/docker-compose.diagnostics.yml
+++ b/docker-compose.diagnostics.yml
@@ -15,6 +15,8 @@ services:
       - memento-mcp-server
     environment:
       DIAGNOSTICS_INTERVAL_SECONDS: ${DIAGNOSTICS_INTERVAL_SECONDS:-10}
+      DIAGNOSTICS_JSONL_MAX_BYTES: ${DIAGNOSTICS_JSONL_MAX_BYTES:-67108864}
+      DIAGNOSTICS_JSONL_RETAIN_FILES: ${DIAGNOSTICS_JSONL_RETAIN_FILES:-3}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./scripts/collect-docker-diagnostics.sh:/workspace/collect-docker-diagnostics.sh:ro

--- a/scripts/collect-docker-diagnostics.sh
+++ b/scripts/collect-docker-diagnostics.sh
@@ -4,13 +4,39 @@ set -euo pipefail
 CONTAINER_NAME="${1:-memento-mcp-server}"
 OUT_DIR="${2:-${HOME}/.memento/logs/docker-diagnostics}"
 INTERVAL_SECONDS="${DIAGNOSTICS_INTERVAL_SECONDS:-10}"
+DIAGNOSTICS_JSONL_MAX_BYTES="${DIAGNOSTICS_JSONL_MAX_BYTES:-67108864}"
+DIAGNOSTICS_JSONL_RETAIN_FILES="${DIAGNOSTICS_JSONL_RETAIN_FILES:-3}"
 
 mkdir -p "$OUT_DIR"
+
+rotate_jsonl_if_needed() {
+  local file="$1"
+  if [[ "$DIAGNOSTICS_JSONL_MAX_BYTES" -le 0 || "$DIAGNOSTICS_JSONL_RETAIN_FILES" -lt 1 ]]; then
+    return 0
+  fi
+  [[ -f "$file" ]] || return 0
+
+  local size
+  size="$(wc -c < "$file" | tr -d ' ')"
+  if [[ "$size" -lt "$DIAGNOSTICS_JSONL_MAX_BYTES" ]]; then
+    return 0
+  fi
+
+  rm -f "${file}.${DIAGNOSTICS_JSONL_RETAIN_FILES}" 2>/dev/null || true
+  local i
+  for ((i = DIAGNOSTICS_JSONL_RETAIN_FILES - 1; i >= 1; i--)); do
+    if [[ -f "${file}.${i}" ]]; then
+      mv "${file}.${i}" "${file}.$((i + 1))"
+    fi
+  done
+  mv "$file" "${file}.1"
+}
 
 write_json_error() {
   local file="$1"
   local timestamp="$2"
   local message="$3"
+  rotate_jsonl_if_needed "$file"
   printf '{"timestamp":"%s","container":"%s","error":"%s"}\n' \
     "$timestamp" \
     "$CONTAINER_NAME" \
@@ -21,10 +47,12 @@ collect_once() {
   local timestamp
   timestamp="$(date -Iseconds)"
 
+  rotate_jsonl_if_needed "$OUT_DIR/docker-stats.jsonl"
   if ! docker stats --no-stream --format '{{json .}}' "$CONTAINER_NAME" >> "$OUT_DIR/docker-stats.jsonl" 2>/dev/null; then
     write_json_error "$OUT_DIR/docker-stats.jsonl" "$timestamp" "docker stats failed"
   fi
 
+  rotate_jsonl_if_needed "$OUT_DIR/docker-inspect.jsonl"
   if ! docker inspect --format '{{json .}}' "$CONTAINER_NAME" >> "$OUT_DIR/docker-inspect.jsonl" 2>/dev/null; then
     write_json_error "$OUT_DIR/docker-inspect.jsonl" "$timestamp" "docker inspect failed"
   fi
@@ -39,6 +67,7 @@ collect_once() {
   if [[ -n "$log_path" && -f "$log_path" ]]; then
     local log_size_bytes
     log_size_bytes="$(wc -c < "$log_path" | tr -d ' ')"
+    rotate_jsonl_if_needed "$OUT_DIR/docker-log-size.jsonl"
     printf '{"timestamp":"%s","container":"%s","logPath":"%s","sizeBytes":%s}\n' \
       "$timestamp" \
       "$CONTAINER_NAME" \


### PR DESCRIPTION
## Summary
- `collect-docker-diagnostics.sh`에 `rotate_jsonl_if_needed()` 추가 — append 전 JSONL 크기 검사 및 `.1`~`.N` 로테이션
- `DIAGNOSTICS_JSONL_MAX_BYTES`(기본 64MB), `DIAGNOSTICS_JSONL_RETAIN_FILES`(기본 3) 환경 변수 지원 (#422와 동일 정책)
- `docker-compose.diagnostics.yml`에 해당 env 전달

## Context
Epic #420 — `docker-diagnostics/*.jsonl` 무한 증가로 log-issue-monitor가 `Invalid string length` 발생.

## Test plan
- [x] `bash -n scripts/collect-docker-diagnostics.sh`
- [ ] 로컬에서 JSONL이 max bytes 초과 시 `.1` 로테이션 확인

Closes #423

Made with [Cursor](https://cursor.com)