### PR TITLE
fix(log-issue-monitor): JSONL byte cursor incremental reads (#424)

### DIFF
--- a/scripts/log-issue-monitor/__tests__/monitor.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/monitor.spec.ts
@@ -36,7 +36,7 @@ describe('runMonitorCycle', () => {
   it('records detected app log errors locally in dry-run mode', async () => {
     await runMonitorCycle(config(), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => [],
+      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
       githubClient: undefined,
       onMonitorError: vi.fn(),
     });
@@ -59,7 +59,7 @@ describe('runMonitorCycle', () => {
 
     await runMonitorCycle(config({ dryRun: false, githubToken: 'ghp_token' }), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => [],
+      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
       githubClient: githubClient as never,
       onMonitorError: vi.fn(),
     });

--- a/scripts/log-issue-monitor/__tests__/sources.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/sources.spec.ts
@@ -88,7 +88,7 @@ describe('readJsonlFiles', () => {
     });
     await writeFile(join(dockerDiag, 'docker-inspect.jsonl'), `${oldUnhealthy}\n${newHealthy}\n`, 'utf8');
 
-    const lines = await readJsonlFiles(root);
+    const { lines } = await readJsonlFiles(root);
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]!).State.Health.Status).toBe('healthy');
 
@@ -101,8 +101,26 @@ describe('readJsonlFiles', () => {
     await mkdir(diag, { recursive: true });
     await writeFile(join(diag, 'events.jsonl'), '{"x":1}\n{"x":2}\n', 'utf8');
 
-    const lines = await readJsonlFiles(root);
+    const { lines } = await readJsonlFiles(root);
     expect(lines).toEqual(['{"x":1}', '{"x":2}']);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('reads only appended lines on subsequent calls using byte cursors', async () => {
+    const root = join(tmpdir(), `memento-sources-test-cursor-${Date.now()}`);
+    const diag = join(root, 'diagnostics');
+    await mkdir(diag, { recursive: true });
+    const filePath = join(diag, 'events.jsonl');
+    await writeFile(filePath, '{"x":1}\n', 'utf8');
+
+    const first = await readJsonlFiles(root);
+    expect(first.lines).toEqual(['{"x":1}']);
+    expect(first.cursors['diagnostics/events.jsonl']).toBeGreaterThan(0);
+
+    await writeFile(filePath, '{"x":1}\n{"x":2}\n', 'utf8');
+    const second = await readJsonlFiles(root, first.cursors);
+    expect(second.lines).toEqual(['{"x":2}']);
 
     await rm(root, { recursive: true, force: true });
   });

--- a/scripts/log-issue-monitor/monitor.ts
+++ b/scripts/log-issue-monitor/monitor.ts
@@ -8,11 +8,12 @@ import { parseAppLogLine, parseJsonlRecord } from './parsers.js';
 import { shouldSyncToGitHub } from './promotion.js';
 import { sanitizeExcerpt } from './sanitizer.js';
 import { appendOccurrence, loadState, saveState, upsertOccurrence } from './state-store.js';
-import type { LogIssueOccurrence, MonitorConfig } from './types.js';
+import type { JsonlFileCursors, LogIssueOccurrence, MonitorConfig } from './types.js';
+import type { ReadJsonlFilesResult } from './sources.js';
 
 export interface MonitorCycleDeps {
   readDockerLogs: (containerName: string, since?: string) => Promise<string[]>;
-  readJsonlFiles: (logsRoot: string) => Promise<string[]>;
+  readJsonlFiles: (logsRoot: string, cursors?: JsonlFileCursors) => Promise<ReadJsonlFilesResult>;
   githubClient?: GitHubIssueClient;
   onMonitorError: (error: Error) => void;
 }
@@ -103,8 +104,9 @@ async function syncFingerprint(
 export async function runMonitorCycle(config: MonitorConfig, deps: MonitorCycleDeps): Promise<void> {
   try {
     let state = await loadState(config.stateDir);
-    const dockerLines = await deps.readDockerLogs(config.containerName, state.cursors.dockerLogsSince as string | undefined);
-    const jsonlLines = await deps.readJsonlFiles(config.logsRoot);
+    const dockerLines = await deps.readDockerLogs(config.containerName, state.cursors.dockerLogsSince);
+    const jsonlResult = await deps.readJsonlFiles(config.logsRoot, state.cursors.jsonlFiles);
+    const jsonlLines = jsonlResult.lines;
 
     const occurrences: LogIssueOccurrence[] = [];
     for (const line of dockerLines) {
@@ -126,6 +128,7 @@ export async function runMonitorCycle(config: MonitorConfig, deps: MonitorCycleD
     }
 
     state.cursors.dockerLogsSince = new Date().toISOString();
+    state.cursors.jsonlFiles = jsonlResult.cursors;
     await saveState(config.stateDir, state);
 
     for (const occurrence of occurrences) {

--- a/scripts/log-issue-monitor/sources.ts
+++ b/scripts/log-issue-monitor/sources.ts
@@ -1,6 +1,8 @@
 import { execFile, type ExecFileOptions } from 'node:child_process';
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { open, readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import type { JsonlFileCursors } from './types.js';
 
 const execOpts: ExecFileOptions = { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 };
 
@@ -18,6 +20,68 @@ export function splitJsonlLines(content: string): string[] {
 }
 
 export type ExecFileLike = typeof execFile;
+
+export interface ReadJsonlFilesResult {
+  lines: string[];
+  cursors: JsonlFileCursors;
+}
+
+function cursorKey(logsRoot: string, filePath: string): string {
+  return relative(logsRoot, filePath);
+}
+
+async function readIncrementalJsonlLines(
+  filePath: string,
+  offset: number,
+): Promise<{ lines: string[]; nextOffset: number }> {
+  const handle = await open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    if (offset > size) {
+      offset = 0;
+    }
+
+    const length = size - offset;
+    if (length <= 0) {
+      return { lines: [], nextOffset: offset };
+    }
+
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, offset);
+    const chunk = buffer.subarray(0, bytesRead);
+
+    let start = 0;
+    if (offset > 0) {
+      const priorByte = Buffer.alloc(1);
+      await handle.read(priorByte, 0, 1, offset - 1);
+      if (priorByte[0] !== 0x0a) {
+        const firstNewline = chunk.indexOf(0x0a);
+        if (firstNewline === -1) {
+          return { lines: [], nextOffset: offset };
+        }
+        start = firstNewline + 1;
+      }
+    }
+
+    if (start >= chunk.length) {
+      return { lines: [], nextOffset: size };
+    }
+
+    let end = chunk.length;
+    if (chunk[chunk.length - 1] !== 0x0a) {
+      const lastNewline = chunk.lastIndexOf(0x0a);
+      if (lastNewline < start) {
+        return { lines: [], nextOffset: offset };
+      }
+      end = lastNewline + 1;
+    }
+
+    const lines = splitJsonlLines(chunk.subarray(start, end).toString('utf8'));
+    return { lines, nextOffset: offset + end };
+  } finally {
+    await handle.close();
+  }
+}
 
 function runDocker(
   args: readonly string[],
@@ -115,11 +179,15 @@ export async function readDockerLogs(
     .filter(Boolean);
 }
 
-export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
+export async function readJsonlFiles(
+  logsRoot: string,
+  cursors: JsonlFileCursors = {},
+): Promise<ReadJsonlFilesResult> {
   const diagnosticsDir = join(logsRoot, 'diagnostics');
   const dockerDiagnosticsDir = join(logsRoot, 'docker-diagnostics');
   const directories = [diagnosticsDir, dockerDiagnosticsDir];
   const records: string[] = [];
+  const nextCursors: JsonlFileCursors = { ...cursors };
 
   for (const directory of directories) {
     let files: string[] = [];
@@ -134,7 +202,11 @@ export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
       const info = await stat(path);
       if (!info.isFile()) continue;
 
-      const lines = splitJsonlLines(await readFile(path, 'utf8'));
+      const key = cursorKey(logsRoot, path);
+      const offset = cursors[key] ?? 0;
+      const { lines, nextOffset } = await readIncrementalJsonlLines(path, offset);
+      nextCursors[key] = nextOffset;
+
       if (lines.length === 0) continue;
 
       if (directory === dockerDiagnosticsDir && file === DOCKER_INSPECT_JSONL) {
@@ -145,6 +217,5 @@ export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
     }
   }
 
-  return records;
+  return { lines: records, cursors: nextCursors };
 }
-

--- a/scripts/log-issue-monitor/types.ts
+++ b/scripts/log-issue-monitor/types.ts
@@ -48,8 +48,15 @@ export interface LogIssueFingerprintState {
   lastSyncError?: string;
 }
 
+/** Byte offsets keyed by path relative to logs root (e.g. `diagnostics/app-runtime.jsonl`). */
+export type JsonlFileCursors = Record<string, number>;
+
 export interface LogIssueState {
   version: 1;
-  cursors: Record<string, unknown>;
+  cursors: {
+    dockerLogsSince?: string;
+    jsonlFiles?: JsonlFileCursors;
+    [key: string]: unknown;
+  };
   fingerprints: Record<string, LogIssueFingerprintState>;
 }


### PR DESCRIPTION
## Summary
- `readJsonlFiles()`가 파일별 byte offset cursor로 증분 읽기
- monitor state `cursors.jsonlFiles`에 cursor 저장/복원
- `docker-inspect.jsonl`은 증분 chunk의 마지막 줄만 사용 (기존 동작 유지)

## Context
Epic #420 — 매 주기 전체 JSONL reload가 `Invalid string length` 유발.

## Test plan
- [x] `npm test -- scripts/log-issue-monitor`
- [ ] 대용량 JSONL 환경에서 cursor가 EOF까지 진행되는지 확인

Closes #424
Part of #420

Made with [Cursor](https://cursor.com)