### PR TITLE
fix(log-issue-monitor): stream JSONL reads and skip oversized files (#425)

### DIFF
--- a/scripts/log-issue-monitor/__tests__/config.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/config.spec.ts
@@ -20,6 +20,7 @@ describe('loadMonitorConfig', () => {
     expect(config.stateDir).toBe(join(expectedLogs, 'log-issue-monitor'));
     expect(config.maxExcerptBytes).toBe(6000);
     expect(config.includeStack).toBe(true);
+    expect(config.jsonlMaxReadBytes).toBe(64 * 1024 * 1024);
   });
 
   it('parses overrides and treats missing GitHub token as local-only capable', () => {

--- a/scripts/log-issue-monitor/__tests__/monitor.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/monitor.spec.ts
@@ -28,6 +28,7 @@ function config(overrides: Partial<MonitorConfig> = {}): MonitorConfig {
     labels: ['bug', 'memento-log-monitor'],
     maxExcerptBytes: 6000,
     includeStack: true,
+    jsonlMaxReadBytes: 64 * 1024 * 1024,
     ...overrides,
   };
 }
@@ -36,7 +37,7 @@ describe('runMonitorCycle', () => {
   it('records detected app log errors locally in dry-run mode', async () => {
     await runMonitorCycle(config(), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
+      readJsonlFiles: async () => ({ lines: [], cursors: {}, skips: [] }),
       githubClient: undefined,
       onMonitorError: vi.fn(),
     });
@@ -59,7 +60,7 @@ describe('runMonitorCycle', () => {
 
     await runMonitorCycle(config({ dryRun: false, githubToken: 'ghp_token' }), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
+      readJsonlFiles: async () => ({ lines: [], cursors: {}, skips: [] }),
       githubClient: githubClient as never,
       onMonitorError: vi.fn(),
     });

--- a/scripts/log-issue-monitor/__tests__/monitor.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/monitor.spec.ts
@@ -36,7 +36,7 @@ describe('runMonitorCycle', () => {
   it('records detected app log errors locally in dry-run mode', async () => {
     await runMonitorCycle(config(), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => [],
+      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
       githubClient: undefined,
       onMonitorError: vi.fn(),
     });
@@ -59,7 +59,7 @@ describe('runMonitorCycle', () => {
 
     await runMonitorCycle(config({ dryRun: false, githubToken: 'ghp_token' }), {
       readDockerLogs: async () => ['2026-05-02T00:00:00.000Z | ERROR | DB failed | {"component":"db"}'],
-      readJsonlFiles: async () => [],
+      readJsonlFiles: async () => ({ lines: [], cursors: {} }),
       githubClient: githubClient as never,
       onMonitorError: vi.fn(),
     });

--- a/scripts/log-issue-monitor/__tests__/sources.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/sources.spec.ts
@@ -88,7 +88,7 @@ describe('readJsonlFiles', () => {
     });
     await writeFile(join(dockerDiag, 'docker-inspect.jsonl'), `${oldUnhealthy}\n${newHealthy}\n`, 'utf8');
 
-    const lines = await readJsonlFiles(root);
+    const { lines } = await readJsonlFiles(root);
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]!).State.Health.Status).toBe('healthy');
 
@@ -101,8 +101,26 @@ describe('readJsonlFiles', () => {
     await mkdir(diag, { recursive: true });
     await writeFile(join(diag, 'events.jsonl'), '{"x":1}\n{"x":2}\n', 'utf8');
 
-    const lines = await readJsonlFiles(root);
+    const { lines } = await readJsonlFiles(root);
     expect(lines).toEqual(['{"x":1}', '{"x":2}']);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('reads only appended lines on subsequent calls using byte cursors', async () => {
+    const root = join(tmpdir(), `memento-sources-test-cursor-${Date.now()}`);
+    const diag = join(root, 'diagnostics');
+    await mkdir(diag, { recursive: true });
+    const filePath = join(diag, 'events.jsonl');
+    await writeFile(filePath, '{"x":1}\n', 'utf8');
+
+    const first = await readJsonlFiles(root);
+    expect(first.lines).toEqual(['{"x":1}']);
+    expect(first.cursors['diagnostics/events.jsonl']).toBeGreaterThan(0);
+
+    await writeFile(filePath, '{"x":1}\n{"x":2}\n', 'utf8');
+    const second = await readJsonlFiles(root, first.cursors);
+    expect(second.lines).toEqual(['{"x":2}']);
 
     await rm(root, { recursive: true, force: true });
   });

--- a/scripts/log-issue-monitor/__tests__/sources.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/sources.spec.ts
@@ -124,4 +124,19 @@ describe('readJsonlFiles', () => {
 
     await rm(root, { recursive: true, force: true });
   });
+
+  it('skips oversized unread JSONL without throwing', async () => {
+    const root = join(tmpdir(), `memento-sources-test-skip-${Date.now()}`);
+    const diag = join(root, 'diagnostics');
+    await mkdir(diag, { recursive: true });
+    await writeFile(join(diag, 'huge.jsonl'), '{"x":1}\n', 'utf8');
+
+    const { lines, skips, cursors } = await readJsonlFiles(root, {}, 1);
+    expect(lines).toEqual([]);
+    expect(skips).toHaveLength(1);
+    expect(skips[0]?.unreadBytes).toBeGreaterThan(1);
+    expect(cursors['diagnostics/huge.jsonl']).toBeGreaterThan(0);
+
+    await rm(root, { recursive: true, force: true });
+  });
 });

--- a/scripts/log-issue-monitor/config.ts
+++ b/scripts/log-issue-monitor/config.ts
@@ -44,5 +44,6 @@ export function loadMonitorConfig(env: NodeJS.ProcessEnv = process.env): Monitor
     labels: labelsFromEnv(env.LOG_ISSUE_MONITOR_LABELS),
     maxExcerptBytes: numberFromEnv(env.LOG_ISSUE_MONITOR_MAX_EXCERPT_BYTES, 6000),
     includeStack: booleanFromEnv(env.LOG_ISSUE_MONITOR_INCLUDE_STACK, true),
+    jsonlMaxReadBytes: numberFromEnv(env.LOG_ISSUE_MONITOR_JSONL_MAX_READ_BYTES, 64 * 1024 * 1024),
   };
 }

--- a/scripts/log-issue-monitor/index.ts
+++ b/scripts/log-issue-monitor/index.ts
@@ -34,7 +34,8 @@ export async function runForever(): Promise<void> {
   const run = async (): Promise<void> => {
     await runMonitorCycle(config, {
       readDockerLogs,
-      readJsonlFiles,
+      readJsonlFiles: (logsRoot, cursors, maxReadBytes) =>
+        readJsonlFiles(logsRoot, cursors, maxReadBytes ?? config.jsonlMaxReadBytes),
       githubClient,
       onMonitorError: error => {
         process.stderr.write(`log-issue-monitor error: ${error.message}\n`);

--- a/scripts/log-issue-monitor/monitor.ts
+++ b/scripts/log-issue-monitor/monitor.ts
@@ -8,11 +8,12 @@ import { parseAppLogLine, parseJsonlRecord } from './parsers.js';
 import { shouldSyncToGitHub } from './promotion.js';
 import { sanitizeExcerpt } from './sanitizer.js';
 import { appendOccurrence, loadState, saveState, upsertOccurrence } from './state-store.js';
-import type { LogIssueOccurrence, MonitorConfig } from './types.js';
+import type { JsonlFileCursors, LogIssueOccurrence, MonitorConfig } from './types.js';
+import type { ReadJsonlFilesResult } from './sources.js';
 
 export interface MonitorCycleDeps {
   readDockerLogs: (containerName: string, since?: string) => Promise<string[]>;
-  readJsonlFiles: (logsRoot: string) => Promise<string[]>;
+  readJsonlFiles: (logsRoot: string, cursors?: JsonlFileCursors) => Promise<ReadJsonlFilesResult>;
   githubClient?: GitHubIssueClient;
   onMonitorError: (error: Error) => void;
 }
@@ -103,8 +104,9 @@ async function syncFingerprint(
 export async function runMonitorCycle(config: MonitorConfig, deps: MonitorCycleDeps): Promise<void> {
   try {
     let state = await loadState(config.stateDir);
-    const dockerLines = await deps.readDockerLogs(config.containerName, state.cursors.dockerLogsSince as string | undefined);
-    const jsonlLines = await deps.readJsonlFiles(config.logsRoot);
+    const dockerLines = await deps.readDockerLogs(config.containerName, state.cursors.dockerLogsSince);
+    const jsonlResult = await deps.readJsonlFiles(config.logsRoot, state.cursors.jsonlFiles);
+    const jsonlLines = jsonlResult.lines;
 
     const occurrences: LogIssueOccurrence[] = [];
     for (const line of dockerLines) {
@@ -126,6 +128,7 @@ export async function runMonitorCycle(config: MonitorConfig, deps: MonitorCycleD
     }
 
     state.cursors.dockerLogsSince = new Date().toISOString();
+    state.cursors.jsonlFiles = jsonlResult.cursors;
     await saveState(config.stateDir, state);
 
     for (const occurrence of occurrences) {

--- a/scripts/log-issue-monitor/monitor.ts
+++ b/scripts/log-issue-monitor/monitor.ts
@@ -8,12 +8,12 @@ import { parseAppLogLine, parseJsonlRecord } from './parsers.js';
 import { shouldSyncToGitHub } from './promotion.js';
 import { sanitizeExcerpt } from './sanitizer.js';
 import { appendOccurrence, loadState, saveState, upsertOccurrence } from './state-store.js';
-import type { JsonlFileCursors, LogIssueOccurrence, MonitorConfig } from './types.js';
+import type { JsonlFileCursors, JsonlReadSkip, LogIssueOccurrence, MonitorConfig } from './types.js';
 import type { ReadJsonlFilesResult } from './sources.js';
 
 export interface MonitorCycleDeps {
   readDockerLogs: (containerName: string, since?: string) => Promise<string[]>;
-  readJsonlFiles: (logsRoot: string, cursors?: JsonlFileCursors) => Promise<ReadJsonlFilesResult>;
+  readJsonlFiles: (logsRoot: string, cursors?: JsonlFileCursors, maxReadBytes?: number) => Promise<ReadJsonlFilesResult>;
   githubClient?: GitHubIssueClient;
   onMonitorError: (error: Error) => void;
 }
@@ -23,6 +23,22 @@ async function recordMonitorError(stateDir: string, error: Error): Promise<void>
   await appendFile(
     join(stateDir, 'monitor-errors.jsonl'),
     `${JSON.stringify({ timestamp: new Date().toISOString(), error: error.message })}\n`,
+    'utf8',
+  );
+}
+
+async function recordJsonlSkip(stateDir: string, skip: JsonlReadSkip): Promise<void> {
+  await mkdir(stateDir, { recursive: true });
+  await appendFile(
+    join(stateDir, 'monitor-errors.jsonl'),
+    `${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      kind: 'jsonl_skip',
+      path: skip.path,
+      unreadBytes: skip.unreadBytes,
+      maxReadBytes: skip.maxReadBytes,
+      runbook: 'docs/operations/en/log-issue-monitor.md',
+    })}\n`,
     'utf8',
   );
 }
@@ -105,8 +121,16 @@ export async function runMonitorCycle(config: MonitorConfig, deps: MonitorCycleD
   try {
     let state = await loadState(config.stateDir);
     const dockerLines = await deps.readDockerLogs(config.containerName, state.cursors.dockerLogsSince);
-    const jsonlResult = await deps.readJsonlFiles(config.logsRoot, state.cursors.jsonlFiles);
+    const jsonlResult = await deps.readJsonlFiles(
+      config.logsRoot,
+      state.cursors.jsonlFiles,
+      config.jsonlMaxReadBytes,
+    );
     const jsonlLines = jsonlResult.lines;
+
+    for (const skip of jsonlResult.skips) {
+      await recordJsonlSkip(config.stateDir, skip);
+    }
 
     const occurrences: LogIssueOccurrence[] = [];
     for (const line of dockerLines) {

--- a/scripts/log-issue-monitor/sources.ts
+++ b/scripts/log-issue-monitor/sources.ts
@@ -1,8 +1,10 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import { execFile, type ExecFileOptions } from 'node:child_process';
 import { open, readdir, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
-import type { JsonlFileCursors } from './types.js';
+import type { JsonlFileCursors, JsonlReadSkip } from './types.js';
 
 const execOpts: ExecFileOptions = { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 };
 
@@ -24,16 +26,95 @@ export type ExecFileLike = typeof execFile;
 export interface ReadJsonlFilesResult {
   lines: string[];
   cursors: JsonlFileCursors;
+  skips: JsonlReadSkip[];
 }
 
 function cursorKey(logsRoot: string, filePath: string): string {
   return relative(logsRoot, filePath);
 }
 
+async function findLastNewlineBefore(
+  handle: Awaited<ReturnType<typeof open>>,
+  size: number,
+): Promise<number> {
+  const chunkSize = 4096;
+  let position = size;
+  while (position > 0) {
+    const readSize = Math.min(chunkSize, position);
+    position -= readSize;
+    const buffer = Buffer.alloc(readSize);
+    await handle.read(buffer, 0, readSize, position);
+    for (let index = readSize - 1; index >= 0; index -= 1) {
+      if (buffer[index] === 0x0a) {
+        return position + index;
+      }
+    }
+  }
+  return -1;
+}
+
+async function readStreamLines(
+  filePath: string,
+  offset: number,
+  length: number,
+): Promise<{ lines: string[]; nextOffset: number }> {
+  if (length <= 0) {
+    return { lines: [], nextOffset: offset };
+  }
+
+  const end = offset + length - 1;
+  let droppedPartialFirstLine = false;
+  if (offset > 0) {
+    const handle = await open(filePath, 'r');
+    try {
+      const priorByte = Buffer.alloc(1);
+      await handle.read(priorByte, 0, 1, offset - 1);
+      droppedPartialFirstLine = priorByte[0] !== 0x0a;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  const lines: string[] = [];
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath, { start: offset, end });
+    const reader = createInterface({ input: stream, crlfDelay: Infinity });
+    reader.on('line', line => {
+      if (droppedPartialFirstLine) {
+        droppedPartialFirstLine = false;
+        return;
+      }
+      const trimmed = line.trim();
+      if (trimmed) lines.push(trimmed);
+    });
+    reader.on('close', resolve);
+    reader.on('error', reject);
+    stream.on('error', reject);
+  });
+
+  const handle = await open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    if (size > offset && lines.length > 0) {
+      const tail = Buffer.alloc(1);
+      await handle.read(tail, 0, 1, size - 1);
+      if (tail[0] !== 0x0a) {
+        lines.pop();
+        const lastNewline = await findLastNewlineBefore(handle, size);
+        return { lines, nextOffset: lastNewline >= offset ? lastNewline + 1 : offset };
+      }
+    }
+    return { lines, nextOffset: size };
+  } finally {
+    await handle.close();
+  }
+}
+
 async function readIncrementalJsonlLines(
   filePath: string,
   offset: number,
-): Promise<{ lines: string[]; nextOffset: number }> {
+  maxReadBytes: number,
+): Promise<{ lines: string[]; nextOffset: number; skipped?: JsonlReadSkip }> {
   const handle = await open(filePath, 'r');
   try {
     const { size } = await handle.stat();
@@ -41,43 +122,24 @@ async function readIncrementalJsonlLines(
       offset = 0;
     }
 
-    const length = size - offset;
-    if (length <= 0) {
+    const unread = size - offset;
+    if (unread <= 0) {
       return { lines: [], nextOffset: offset };
     }
 
-    const buffer = Buffer.alloc(length);
-    const { bytesRead } = await handle.read(buffer, 0, length, offset);
-    const chunk = buffer.subarray(0, bytesRead);
-
-    let start = 0;
-    if (offset > 0) {
-      const priorByte = Buffer.alloc(1);
-      await handle.read(priorByte, 0, 1, offset - 1);
-      if (priorByte[0] !== 0x0a) {
-        const firstNewline = chunk.indexOf(0x0a);
-        if (firstNewline === -1) {
-          return { lines: [], nextOffset: offset };
-        }
-        start = firstNewline + 1;
-      }
+    if (maxReadBytes > 0 && unread > maxReadBytes) {
+      process.stderr.write(
+        `log-issue-monitor: skipping oversized JSONL ${filePath} (${unread} unread bytes > ${maxReadBytes}); ` +
+          'truncate or rotate the file — see docs/operations/en/log-issue-monitor.md\n',
+      );
+      return {
+        lines: [],
+        nextOffset: size,
+        skipped: { path: filePath, unreadBytes: unread, maxReadBytes },
+      };
     }
 
-    if (start >= chunk.length) {
-      return { lines: [], nextOffset: size };
-    }
-
-    let end = chunk.length;
-    if (chunk[chunk.length - 1] !== 0x0a) {
-      const lastNewline = chunk.lastIndexOf(0x0a);
-      if (lastNewline < start) {
-        return { lines: [], nextOffset: offset };
-      }
-      end = lastNewline + 1;
-    }
-
-    const lines = splitJsonlLines(chunk.subarray(start, end).toString('utf8'));
-    return { lines, nextOffset: offset + end };
+    return readStreamLines(filePath, offset, unread);
   } finally {
     await handle.close();
   }
@@ -182,12 +244,14 @@ export async function readDockerLogs(
 export async function readJsonlFiles(
   logsRoot: string,
   cursors: JsonlFileCursors = {},
+  maxReadBytes = 0,
 ): Promise<ReadJsonlFilesResult> {
   const diagnosticsDir = join(logsRoot, 'diagnostics');
   const dockerDiagnosticsDir = join(logsRoot, 'docker-diagnostics');
   const directories = [diagnosticsDir, dockerDiagnosticsDir];
   const records: string[] = [];
   const nextCursors: JsonlFileCursors = { ...cursors };
+  const skips: JsonlReadSkip[] = [];
 
   for (const directory of directories) {
     let files: string[] = [];
@@ -204,8 +268,12 @@ export async function readJsonlFiles(
 
       const key = cursorKey(logsRoot, path);
       const offset = cursors[key] ?? 0;
-      const { lines, nextOffset } = await readIncrementalJsonlLines(path, offset);
+      const { lines, nextOffset, skipped } = await readIncrementalJsonlLines(path, offset, maxReadBytes);
       nextCursors[key] = nextOffset;
+      if (skipped) {
+        skips.push(skipped);
+        continue;
+      }
 
       if (lines.length === 0) continue;
 
@@ -217,5 +285,5 @@ export async function readJsonlFiles(
     }
   }
 
-  return { lines: records, cursors: nextCursors };
+  return { lines: records, cursors: nextCursors, skips };
 }

--- a/scripts/log-issue-monitor/sources.ts
+++ b/scripts/log-issue-monitor/sources.ts
@@ -1,6 +1,8 @@
 import { execFile, type ExecFileOptions } from 'node:child_process';
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { open, readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import type { JsonlFileCursors } from './types.js';
 
 const execOpts: ExecFileOptions = { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 };
 
@@ -18,6 +20,68 @@ export function splitJsonlLines(content: string): string[] {
 }
 
 export type ExecFileLike = typeof execFile;
+
+export interface ReadJsonlFilesResult {
+  lines: string[];
+  cursors: JsonlFileCursors;
+}
+
+function cursorKey(logsRoot: string, filePath: string): string {
+  return relative(logsRoot, filePath);
+}
+
+async function readIncrementalJsonlLines(
+  filePath: string,
+  offset: number,
+): Promise<{ lines: string[]; nextOffset: number }> {
+  const handle = await open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    if (offset > size) {
+      offset = 0;
+    }
+
+    const length = size - offset;
+    if (length <= 0) {
+      return { lines: [], nextOffset: offset };
+    }
+
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, offset);
+    const chunk = buffer.subarray(0, bytesRead);
+
+    let start = 0;
+    if (offset > 0) {
+      const priorByte = Buffer.alloc(1);
+      await handle.read(priorByte, 0, 1, offset - 1);
+      if (priorByte[0] !== 0x0a) {
+        const firstNewline = chunk.indexOf(0x0a);
+        if (firstNewline === -1) {
+          return { lines: [], nextOffset: offset };
+        }
+        start = firstNewline + 1;
+      }
+    }
+
+    if (start >= chunk.length) {
+      return { lines: [], nextOffset: size };
+    }
+
+    let end = chunk.length;
+    if (chunk[chunk.length - 1] !== 0x0a) {
+      const lastNewline = chunk.lastIndexOf(0x0a);
+      if (lastNewline < start) {
+        return { lines: [], nextOffset: offset };
+      }
+      end = lastNewline + 1;
+    }
+
+    const lines = splitJsonlLines(chunk.subarray(start, end).toString('utf8'));
+    return { lines, nextOffset: offset + end };
+  } finally {
+    await handle.close();
+  }
+}
 
 function runDocker(
   args: readonly string[],
@@ -115,11 +179,15 @@ export async function readDockerLogs(
     .filter(Boolean);
 }
 
-export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
+export async function readJsonlFiles(
+  logsRoot: string,
+  cursors: JsonlFileCursors = {},
+): Promise<ReadJsonlFilesResult> {
   const diagnosticsDir = join(logsRoot, 'diagnostics');
   const dockerDiagnosticsDir = join(logsRoot, 'docker-diagnostics');
   const directories = [diagnosticsDir, dockerDiagnosticsDir];
   const records: string[] = [];
+  const nextCursors: JsonlFileCursors = { ...cursors };
 
   for (const directory of directories) {
     let files: string[] = [];
@@ -134,7 +202,11 @@ export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
       const info = await stat(path);
       if (!info.isFile()) continue;
 
-      const lines = splitJsonlLines(await readFile(path, 'utf8'));
+      const key = cursorKey(logsRoot, path);
+      const offset = cursors[key] ?? 0;
+      const { lines, nextOffset } = await readIncrementalJsonlLines(path, offset);
+      nextCursors[key] = nextOffset;
+
       if (lines.length === 0) continue;
 
       if (directory === dockerDiagnosticsDir && file === DOCKER_INSPECT_JSONL) {
@@ -145,6 +217,5 @@ export async function readJsonlFiles(logsRoot: string): Promise<string[]> {
     }
   }
 
-  return records;
+  return { lines: records, cursors: nextCursors };
 }
-

--- a/scripts/log-issue-monitor/types.ts
+++ b/scripts/log-issue-monitor/types.ts
@@ -15,6 +15,7 @@ export interface MonitorConfig {
   labels: string[];
   maxExcerptBytes: number;
   includeStack: boolean;
+  jsonlMaxReadBytes: number;
 }
 
 export interface LogIssueOccurrence {
@@ -50,6 +51,12 @@ export interface LogIssueFingerprintState {
 
 /** Byte offsets keyed by path relative to logs root (e.g. `diagnostics/app-runtime.jsonl`). */
 export type JsonlFileCursors = Record<string, number>;
+
+export interface JsonlReadSkip {
+  path: string;
+  unreadBytes: number;
+  maxReadBytes: number;
+}
 
 export interface LogIssueState {
   version: 1;

--- a/scripts/log-issue-monitor/types.ts
+++ b/scripts/log-issue-monitor/types.ts
@@ -48,8 +48,15 @@ export interface LogIssueFingerprintState {
   lastSyncError?: string;
 }
 
+/** Byte offsets keyed by path relative to logs root (e.g. `diagnostics/app-runtime.jsonl`). */
+export type JsonlFileCursors = Record<string, number>;
+
 export interface LogIssueState {
   version: 1;
-  cursors: Record<string, unknown>;
+  cursors: {
+    dockerLogsSince?: string;
+    jsonlFiles?: JsonlFileCursors;
+    [key: string]: unknown;
+  };
   fingerprints: Record<string, LogIssueFingerprintState>;
 }


### PR DESCRIPTION
## Summary
- JSONL 읽기를 `createReadStream` + `readline` 기반으로 변경 (전체 `readFile` 제거)
- `LOG_ISSUE_MONITOR_JSONL_MAX_READ_BYTES`(기본 64MB) 초과 unread 파일은 skip + stderr warn
- skip 이벤트를 `monitor-errors.jsonl`에 `kind: jsonl_skip`로 기록 (path, size, runbook)

## Stacking
- **Base: #429** (#424 cursor) — merge 순서: #429 → 본 PR

## Context
Epic #420 — legacy 512MB+ JSONL에서 `Invalid string length` 방어층.

## Test plan
- [x] `npm test -- scripts/log-issue-monitor` (39 passed)
- [ ] 600MB+ legacy file 환경에서 monitor cycle이 throw 없이 skip/warn

Closes #425
Part of #420

Made with [Cursor](https://cursor.com)