### PR TITLE
fix(log-issue-monitor): avoid spread stack overflow on large JSONL reads

### DIFF
--- a/scripts/log-issue-monitor/__tests__/sources.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/sources.spec.ts
@@ -139,4 +139,16 @@ describe('readJsonlFiles', () => {
 
     await rm(root, { recursive: true, force: true });
   });
+
+  it('concatenates many lines without spread stack overflow', async () => {
+    const root = join(tmpdir(), `memento-sources-test-many-${Date.now()}`);
+    const diag = join(root, 'diagnostics');
+    await mkdir(diag, { recursive: true });
+    const payload = `${'{"n":1}\n'.repeat(20_000)}`;
+    await writeFile(join(diag, 'events.jsonl'), payload, 'utf8');
+
+    await expect(readJsonlFiles(root)).resolves.toMatchObject({ lines: expect.any(Array) });
+
+    await rm(root, { recursive: true, force: true });
+  });
 });

--- a/scripts/log-issue-monitor/index.ts
+++ b/scripts/log-issue-monitor/index.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { loadMonitorConfig } from './config.js';
 import { GitHubIssueClient } from './github-client.js';
 import { runMonitorCycle } from './monitor.js';
-import { readDockerLogs, readJsonlFiles } from './sources.js';
+import { readDockerLogs, readJsonlFiles as readJsonlFilesFromSources } from './sources.js';
 import type { MonitorConfig } from './types.js';
 
 function isExecutedAsMainCli(): boolean {
@@ -35,7 +35,7 @@ export async function runForever(): Promise<void> {
     await runMonitorCycle(config, {
       readDockerLogs,
       readJsonlFiles: (logsRoot, cursors, maxReadBytes) =>
-        readJsonlFiles(logsRoot, cursors, maxReadBytes ?? config.jsonlMaxReadBytes),
+        readJsonlFilesFromSources(logsRoot, cursors, maxReadBytes ?? config.jsonlMaxReadBytes),
       githubClient,
       onMonitorError: error => {
         process.stderr.write(`log-issue-monitor error: ${error.message}\n`);

--- a/scripts/log-issue-monitor/sources.ts
+++ b/scripts/log-issue-monitor/sources.ts
@@ -280,7 +280,9 @@ export async function readJsonlFiles(
       if (directory === dockerDiagnosticsDir && file === DOCKER_INSPECT_JSONL) {
         records.push(lines[lines.length - 1]!);
       } else {
-        records.push(...lines);
+        for (const line of lines) {
+          records.push(line);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- `readJsonlFiles()`에서 `records.push(...lines)`를 loop push로 변경
- cursor 첫 주기에 대용량 JSONL(예: `app-events.jsonl` 수만 줄)을 읽을 때 `Maximum call stack size exceeded` 방지
- `index.ts` import alias를 `readJsonlFilesFromSources`로 명확화

## Context
#430 merge 후 Docker에서 monitor가 30초마다 stack overflow로 실패. spread operator가 함수 인자 한도를 초과한 것이 원인.

## Test plan
- [x] `npm test -- scripts/log-issue-monitor/__tests__/sources.spec.ts` (9 passed)
- [x] 로컬 `~/.memento/logs` 대상 monitor cycle 수동 실행 (`cycle ok`)
- [ ] Docker `log-issue-monitor` 재빌드 후 로그에 stack overflow 미재현 확인


Made with [Cursor](https://cursor.com)