### PR TITLE
chore(docker): per-container memory limit compose overlay

### DIFF
--- a/DOCKER_SETUP_GUIDE.md
+++ b/DOCKER_SETUP_GUIDE.md
@@ -42,6 +42,26 @@ docker exec memento-mcp-server sqlite3 /app/data/memory.db "SELECT COUNT(*) FROM
 curl http://localhost:9001/health
 ```
 
+## 컨테이너 메모리 상한 (선택)
+
+Docker Desktop UI는 컨테이너별 1GB 미만 설정이 어려울 수 있습니다. `docker-compose.mem-limits.yml`로 서비스별 cgroup 상한을 둡니다.
+
+| 기본값 | 서비스 |
+| --- | --- |
+| `768m` | `memento-mcp-server` |
+| `256m` | `log-issue-monitor` |
+| `128m` | `docker-diagnostics` |
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.mem-limits.yml up -d
+```
+
+`.env` 예: `MEMENTO_MCP_MEM_LIMIT=512m`, `LOG_ISSUE_MONITOR_MEM_LIMIT=192m`. OOM이면 올리고, 여유가 크면 monitor/diagnostics부터 내립니다. 진단·monitor 전체 스택은 [Log Issue Monitor 운영 가이드](docs/operations/ko/log-issue-monitor.md)를 참고하세요.
+
+```bash
+docker stats --no-stream
+```
+
 ## 🧪 진단 모드
 
 Docker Desktop이 일정 시간 뒤 죽거나 멈추는 문제를 재현할 때는 앱 내부 진단 로그와 Docker 외부 관측 로그를 같이 수집해야 합니다.

--- a/docker-compose.mem-limits.yml
+++ b/docker-compose.mem-limits.yml
@@ -1,0 +1,29 @@
+# Per-container cgroup memory caps (Compose `mem_limit`).
+# Docker Desktop UI may not expose sub-1GB limits; this overlay applies them reliably.
+#
+# Tune via shell env or `.env` (examples):
+#   MEMENTO_MCP_MEM_LIMIT=512m
+#   LOG_ISSUE_MONITOR_MEM_LIMIT=192m
+#   DOCKER_DIAGNOSTICS_MEM_LIMIT=96m
+#
+# Apply with your usual compose stack, e.g.:
+#   docker compose -f docker-compose.yml \
+#     -f docker-compose.diagnostics.yml \
+#     -f docker-compose.issue-monitor.yml \
+#     -f docker-compose.mem-limits.yml up -d
+#
+# Verify: docker inspect <container> --format '{{.HostConfig.Memory}}'
+# OOM / slowness → raise the service limit; headroom waste → lower it.
+
+services:
+  memento-mcp-server:
+    mem_limit: ${MEMENTO_MCP_MEM_LIMIT:-768m}
+    memswap_limit: ${MEMENTO_MCP_MEM_SWAP_LIMIT:-768m}
+
+  log-issue-monitor:
+    mem_limit: ${LOG_ISSUE_MONITOR_MEM_LIMIT:-256m}
+    memswap_limit: ${LOG_ISSUE_MONITOR_MEM_SWAP_LIMIT:-256m}
+
+  docker-diagnostics:
+    mem_limit: ${DOCKER_DIAGNOSTICS_MEM_LIMIT:-128m}
+    memswap_limit: ${DOCKER_DIAGNOSTICS_MEM_SWAP_LIMIT:-128m}

--- a/docs/operations/en/log-issue-monitor.md
+++ b/docs/operations/en/log-issue-monitor.md
@@ -9,8 +9,11 @@ docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
+
+Per-container memory caps live in `docker-compose.mem-limits.yml` (defaults: MCP 768MB, monitor 256MB, docker-diagnostics 128MB). Override with `MEMENTO_MCP_MEM_LIMIT` and related env vars.
 
 ## Local-Only Mode
 
@@ -23,6 +26,7 @@ LOG_ISSUE_MONITOR_DRY_RUN=true docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
 
@@ -35,6 +39,7 @@ GITHUB_TOKEN=... docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
 
@@ -51,6 +56,18 @@ When an open issue already contains the same fingerprint, the monitor updates on
 | `LOG_ISSUE_MONITOR_WARN_WINDOW_SECONDS` | `600` | Time window for repetition checks |
 | `LOG_ISSUE_MONITOR_LABELS` | `bug,needs-triage,memento-log-monitor` | GitHub labels used for create/search |
 | `LOG_ISSUE_MONITOR_MAX_EXCERPT_BYTES` | `6000` | Maximum stored/sent excerpt length |
+
+## Container memory limits
+
+Docker Desktop may not expose sub-1GB per-container limits in the UI. Use the `docker-compose.mem-limits.yml` overlay instead.
+
+| Environment variable | Default | Service |
+| --- | --- | --- |
+| `MEMENTO_MCP_MEM_LIMIT` | `768m` | `memento-mcp-server` |
+| `LOG_ISSUE_MONITOR_MEM_LIMIT` | `256m` | `log-issue-monitor` |
+| `DOCKER_DIAGNOSTICS_MEM_LIMIT` | `128m` | `docker-diagnostics` |
+
+Optional `*_MEM_SWAP_LIMIT` vars default to the same value (no swap). Raise limits on OOM/`Killed`; lower monitor/diagnostics first if trimming headroom.
 
 `critical` and `error` events sync immediately. `warn` and `anomaly` events sync only after crossing the threshold within the time window.
 

--- a/docs/operations/ko/log-issue-monitor.md
+++ b/docs/operations/ko/log-issue-monitor.md
@@ -9,8 +9,11 @@ docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
+
+컨테이너별 메모리 상한은 `docker-compose.mem-limits.yml`에서 설정합니다 (Desktop UI 1GB 제한과 무관). 기본값은 MCP 768MB, monitor 256MB, docker-diagnostics 128MB이며 `.env` 또는 셸에서 `MEMENTO_MCP_MEM_LIMIT` 등으로 조절할 수 있습니다.
 
 ## Local-only 모드
 
@@ -23,6 +26,7 @@ LOG_ISSUE_MONITOR_DRY_RUN=true docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
 
@@ -35,6 +39,7 @@ GITHUB_TOKEN=... docker compose \
   -f docker-compose.yml \
   -f docker-compose.diagnostics.yml \
   -f docker-compose.issue-monitor.yml \
+  -f docker-compose.mem-limits.yml \
   up -d
 ```
 
@@ -51,6 +56,22 @@ GITHUB_TOKEN=... docker compose \
 | `LOG_ISSUE_MONITOR_WARN_WINDOW_SECONDS` | `600` | 반복 횟수 판정 시간 창 |
 | `LOG_ISSUE_MONITOR_LABELS` | `bug,needs-triage,memento-log-monitor` | 생성/검색에 사용할 GitHub label |
 | `LOG_ISSUE_MONITOR_MAX_EXCERPT_BYTES` | `6000` | 저장/전송할 excerpt 최대 길이 |
+
+## 컨테이너 메모리 상한
+
+Docker Desktop UI는 컨테이너별 1GB 미만 설정이 어려울 수 있습니다. `docker-compose.mem-limits.yml` 오버레이로 cgroup 상한을 서비스별로 둡니다.
+
+| 환경변수 | 기본값 | 서비스 |
+| --- | --- | --- |
+| `MEMENTO_MCP_MEM_LIMIT` | `768m` | `memento-mcp-server` (Node + SQLite + 임베딩) |
+| `LOG_ISSUE_MONITOR_MEM_LIMIT` | `256m` | `log-issue-monitor` |
+| `DOCKER_DIAGNOSTICS_MEM_LIMIT` | `128m` | `docker-diagnostics` |
+
+`memswap_limit`은 각각 `*_MEM_SWAP_LIMIT`으로 덮어쓸 수 있으며, 기본은 limit과 동일(swap 비활성)입니다.
+
+- **OOM / `Killed`**: 해당 service limit을 올립니다 (MCP는 `512m`→`768m`→`1g` 순).
+- **여유가 크면**: monitor·diagnostics부터 낮춥니다.
+- **확인**: `docker stats --no-stream` 또는 `docker inspect <name> --format '{{.HostConfig.Memory}}'`
 
 `critical`과 `error`는 즉시 GitHub 동기화 대상입니다. `warn`과 `anomaly`는 시간 창 안에서 threshold를 넘을 때만 동기화됩니다.
 


### PR DESCRIPTION
## Summary
- `docker-compose.mem-limits.yml` 추가 — 서비스별 cgroup memory/swap 상한
- 기본값: MCP **768m**, log-issue-monitor **256m**, docker-diagnostics **128m**
- `MEMENTO_MCP_MEM_LIMIT` 등 env로 Desktop UI(1GB floor) 없이 조절
- KO/EN log-issue-monitor 가이드 및 `DOCKER_SETUP_GUIDE.md` 반영

## Why
Docker Desktop UI는 컨테이너별 1GB 미만 설정이 어렵지만, Compose `mem_limit`으로는 더 작은 상한을 줄 수 있습니다. 서비스별 요구가 다르므로 오버레이로 분리했습니다.

## Usage

```bash
docker compose \
  -f docker-compose.yml \
  -f docker-compose.diagnostics.yml \
  -f docker-compose.issue-monitor.yml \
  -f docker-compose.mem-limits.yml \
  up -d --force-recreate
```

## Test plan
- [x] `docker compose ... config` — limit 값 merge 확인 (128m / 256m / 768m)
- [ ] merge 후 `docker stats --no-stream`으로 실제 상한 확인
- [ ] OOM 없으면 monitor/diagnostics limit 추가 하향 검토


Made with [Cursor](https://cursor.com)