### PR TITLE
fix(scripts): repair weekly relation validation imports (#431-433)

### DIFF
--- a/scripts/generate-relation-report.ts
+++ b/scripts/generate-relation-report.ts
@@ -13,12 +13,15 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import Database from 'better-sqlite3';
-import { RelationExtractor } from '../src/services/relation-extractor.js';
-import { RelationQualityValidator } from '../src/services/relation-quality-validator.js';
-import type { ExpectedRelation, ExtractedRelation } from '../src/services/relation-quality-validator.js';
-import { DatabaseUtils } from '../src/utils/database.js';
-import { RelationEngineSchemaMigration } from '../src/database/migration/migrations/005-relation-engine-schema.js';
-import type { MemoryItem } from '../src/types/index.js';
+import { RelationExtractor } from '../packages/memento-core/src/domains/relation/services/relation-extractor.js';
+import {
+  RelationQualityValidator,
+  type ExpectedRelation,
+  type ExtractedRelation,
+} from '../packages/memento-core/src/domains/relation/services/relation-quality-validator.js';
+import { DatabaseUtils } from '../packages/memento-core/src/shared/utils/database.js';
+import { RelationEngineSchemaMigration } from '../packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.js';
+import type { MemoryItem } from '../packages/memento-core/src/shared/types/index.js';
 
 /**
  * 명령줄 인자 파싱

--- a/scripts/weekly-relation-validation.ts
+++ b/scripts/weekly-relation-validation.ts
@@ -12,12 +12,15 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import Database from 'better-sqlite3';
-import { RelationExtractor } from '../src/services/relation-extractor.js';
-import { RelationQualityValidator } from '../src/services/relation-quality-validator.js';
-import type { ExpectedRelation, ExtractedRelation } from '../src/services/relation-quality-validator.js';
-import { DatabaseUtils } from '../src/utils/database.js';
-import { RelationEngineSchemaMigration } from '../src/database/migration/migrations/005-relation-engine-schema.js';
-import type { MemoryItem } from '../src/types/index.js';
+import { RelationExtractor } from '../packages/memento-core/src/domains/relation/services/relation-extractor.js';
+import {
+  RelationQualityValidator,
+  type ExpectedRelation,
+  type ExtractedRelation,
+} from '../packages/memento-core/src/domains/relation/services/relation-quality-validator.js';
+import { DatabaseUtils } from '../packages/memento-core/src/shared/utils/database.js';
+import { RelationEngineSchemaMigration } from '../packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.js';
+import type { MemoryItem } from '../packages/memento-core/src/shared/types/index.js';
 
 /**
  * 명령줄 인자 파싱


### PR DESCRIPTION
## Summary
- `scripts/weekly-relation-validation.ts`와 `scripts/generate-relation-report.ts`의 import를 모노레포 `@memento/core` 경로로 수정
- batch 스케줄러의 weekly relation validation이 `ERR_MODULE_NOT_FOUND`로 실패하던 문제 해결

## Root cause
스크립트가 삭제된 `src/services/*` 경로를 참조하고 있었습니다. monitor가 등록한 #431–#433은 동일한 root cause입니다.

## Test plan
- [x] `npx tsx`로 import smoke test 통과
- [ ] `npm run weekly-relation-validation -- --allow-soft-fail` (로컬, 수 분 소요)

Closes #431
Closes #432
Closes #433

Made with [Cursor](https://cursor.com)