### PR TITLE
fix(core): prevent 384 vs 512 vec MATCH mismatch (#436)

### DIFF
--- a/packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts
+++ b/packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts
@@ -249,6 +249,31 @@ describe('VectorSearchRepositoryImpl', () => {
       logSpy.mockRestore();
     });
 
+    it('512차원 쿼리를 minilm(384 vec)에 넘겨도 sqlite Dimension mismatch가 나면 안 됨 (issue #436)', async () => {
+      if (!repository.checkVecAvailability()) {
+        return;
+      }
+
+      const logSpy = vi.spyOn(mcpLogger, 'logServer');
+      const query: VectorSearchQuery = {
+        queryVector: new Array(512).fill(0.03),
+        provider: 'minilm',
+      };
+
+      await repository.search(query);
+
+      const dimensionMismatchLogs = logSpy.mock.calls.filter((call) => {
+        if (call[0] !== 'error' || call[1] !== '벡터 검색 실패') {
+          return false;
+        }
+        const payload = call[2] as { error?: string } | undefined;
+        return Boolean(payload?.error?.includes('Dimension mismatch'));
+      });
+      expect(dimensionMismatchLogs.length).toBe(0);
+
+      logSpy.mockRestore();
+    });
+
     it('checkVecAvailability와 search가 동일한 provider/dimension 규칙을 사용해야 함', async () => {
       const query: VectorSearchQuery = {
         queryVector: new Array(512).fill(0.03),

--- a/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
+++ b/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
@@ -726,6 +726,22 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
     return (provider ?? 'tfidf').toLowerCase() === 'tfidf';
   }
 
+  /**
+   * vec0 가상 테이블 스키마 차원. getTableName()이 dimensions 인자를 무시하는 provider에서
+   * metadata targetDimensions(예: 512)와 실제 테이블(384) 불일치로 MATCH 오류가 나는 것을 막습니다.
+   */
+  private getVecTableSchemaDimensions(tableName: string): number {
+    const { providerDimensions, defaultDimensions } = VECTOR_SEARCH_CONFIG;
+    const schemaByTable: Record<string, number> = {
+      memory_item_vec: providerDimensions.lightweight ?? defaultDimensions,
+      memory_item_vec_tfidf: providerDimensions.tfidf ?? defaultDimensions,
+      memory_item_vec_minilm: providerDimensions.minilm ?? defaultDimensions,
+      memory_item_vec_openai: providerDimensions.openai ?? defaultDimensions,
+      memory_item_vec_gemini: providerDimensions.gemini ?? defaultDimensions,
+    };
+    return schemaByTable[tableName] ?? defaultDimensions;
+  }
+
   private resolveRuntimeVectorContext(provider?: string): {
     provider: string;
     expectedDimensions: number;
@@ -759,8 +775,18 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       });
     }
 
-    const targetDimensions = actualStoredDimensions ?? expectedDimensions;
-    const tableName = this.getTableName(effectiveProvider, targetDimensions);
+    const preliminaryTargetDimensions = actualStoredDimensions ?? expectedDimensions;
+    const tableName = this.getTableName(effectiveProvider, preliminaryTargetDimensions);
+    const targetDimensions = this.getVecTableSchemaDimensions(tableName);
+
+    if (targetDimensions !== preliminaryTargetDimensions) {
+      mcpLogger.logServer('warn', 'vec0 테이블 스키마 차원으로 MATCH 차원을 보정했습니다', {
+        provider: effectiveProvider,
+        preliminaryTargetDimensions,
+        targetDimensions,
+        tableName,
+      });
+    }
 
     return {
       provider: effectiveProvider,


### PR DESCRIPTION
## Summary
- `VectorSearchRepositoryImpl.resolveRuntimeVectorContext`에서 선택된 vec0 테이블 스키마 차원으로 MATCH 정렬 차원을 보정
- metadata `targetDimensions`(예: 512)와 실제 테이블(`memory_item_vec_minilm` = 384) 불일치로 발생하던 sqlite-vec 오류 방지

## Root cause
`getTableName()`은 minilm/lightweight 등에서 `dimensions` 인자를 테이블 선택에 반영하지 않는데, runtime `targetDimensions`는 metadata에 따라 512로 잡힐 수 있었습니다. `alignQueryVectorToStoredDimensions`가 `query.length === targetDimensions`이면 투영 없이 512 벡터를 그대로 MATCH에 넘겨 **Expected 384 but received 512** 오류가 발생했습니다.

## Test plan
- [x] `vector-search.repository.spec.ts` 34 tests pass
- [x] issue #436 regression test 추가 (512-dim query + minilm provider)

Closes #436

Made with [Cursor](https://cursor.com)