### PR TITLE
fix(scripts): weekly relation validation in Docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ WORKDIR /app
 # Copy package files and scripts, then install dependencies
 COPY package*.json ./
 COPY scripts/ ./scripts/
+COPY tests/fixtures/relation_testset.json ./tests/fixtures/relation_testset.json
 # 소스·워크스페이스 미복사 상태 — postinstall(auto-setup)은 패키지 경로가 없어 실패하므로 스크립트 생략
 RUN npm cache clean --force && npm install --omit=dev --ignore-scripts
 

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -122,6 +122,12 @@ export { SchemaVersionManager } from './infrastructure/database/database/migrati
 export { MigrationDetector } from './infrastructure/database/database/migration/migration-detector.js';
 export { createRelationGraph } from './infrastructure/relation-graph-factory.js';
 export { RelationExtractor } from './domains/relation/services/relation-extractor.js';
+export {
+  RelationQualityValidator,
+  type ExpectedRelation,
+  type ExtractedRelation,
+} from './domains/relation/services/relation-quality-validator.js';
+export { RelationEngineSchemaMigration } from './infrastructure/database/database/migration/migrations/005-relation-engine-schema.js';
 export { ExtractRelationsTool } from './domains/relation/tools/extract-relations-tool.js';
 export { GetRelationsTool } from './domains/relation/tools/get-relations-tool.js';
 export { AddRelationTool } from './domains/relation/tools/add-relation-tool.js';

--- a/scripts/generate-relation-report.ts
+++ b/scripts/generate-relation-report.ts
@@ -13,15 +13,15 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import Database from 'better-sqlite3';
-import { RelationExtractor } from '../packages/memento-core/src/domains/relation/services/relation-extractor.js';
 import {
+  RelationExtractor,
   RelationQualityValidator,
+  DatabaseUtils,
+  RelationEngineSchemaMigration,
   type ExpectedRelation,
   type ExtractedRelation,
-} from '../packages/memento-core/src/domains/relation/services/relation-quality-validator.js';
-import { DatabaseUtils } from '../packages/memento-core/src/shared/utils/database.js';
-import { RelationEngineSchemaMigration } from '../packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.js';
-import type { MemoryItem } from '../packages/memento-core/src/shared/types/index.js';
+  type MemoryItem,
+} from '@memento/core';
 
 /**
  * 명령줄 인자 파싱

--- a/scripts/weekly-relation-validation.ts
+++ b/scripts/weekly-relation-validation.ts
@@ -12,15 +12,15 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import Database from 'better-sqlite3';
-import { RelationExtractor } from '../packages/memento-core/src/domains/relation/services/relation-extractor.js';
 import {
+  RelationExtractor,
   RelationQualityValidator,
+  DatabaseUtils,
+  RelationEngineSchemaMigration,
   type ExpectedRelation,
   type ExtractedRelation,
-} from '../packages/memento-core/src/domains/relation/services/relation-quality-validator.js';
-import { DatabaseUtils } from '../packages/memento-core/src/shared/utils/database.js';
-import { RelationEngineSchemaMigration } from '../packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.js';
-import type { MemoryItem } from '../packages/memento-core/src/shared/types/index.js';
+  type MemoryItem,
+} from '@memento/core';
 
 /**
  * 명령줄 인자 파싱


### PR DESCRIPTION
## Summary
- relation validation 스크립트 import를 `@memento/core` dist export로 변경
- Docker production 이미지에 `tests/fixtures/relation_testset.json` 포함

## Root cause
#437 merge 후에도 컨테이너에는 `packages/memento-core/src`가 없어 batch weekly validation이 여전히 실패했습니다.

## Test plan
- [x] `npm run weekly-relation-validation -- --allow-soft-fail --method rule` 시작·fixture 로드 확인
- [ ] Docker rebuild 후 컨테이너 내 동일 스크립트 smoke test

Made with [Cursor](https://cursor.com)