### PR TITLE
docs: define agent integration contracts

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - .  (2026-05-31)
+# Graph Report - .  (2026-06-06)
 
 ## Corpus Check
-- 1028 files · ~1,609,284 words
+- 1028 files · ~1,617,685 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/specs/017-agent-integration-contracts/checklists/requirements.md
+++ b/specs/017-agent-integration-contracts/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Requirements Quality Checklist: Agent Integration Contracts
+
+**Created**: 2026-06-06
+**Feature**: [spec.md](../spec.md)
+
+## Completeness
+
+- [x] lifecycle 5종과 필수 field
+- [x] identifier, sequence, late, idempotency
+- [x] redaction, sensitive path, binary, limits
+- [x] queue priority, timeout, retry, reason
+- [x] package ownership/dependency
+- [x] schema/migration/rollback
+- [x] Start/Ingest/PreCompact/Stop/Get/List/Trace
+- [x] threat/failure fixtures and leak surfaces
+
+## Clarity
+
+- [x] 모든 MUST는 검증 가능하다.
+- [x] status와 reason code가 분리되었다.
+- [x] retention은 30일로 결정되었다.
+- [x] 신규 workspace가 결정되었다.
+- [x] legacy attribution과 provenance가 구분되었다.
+- [x] `[NEEDS CLARIFICATION]`이 없다.
+
+## Compatibility and Security
+
+- [x] MCP/assistant 공개 API 변화 없음
+- [x] additive schema와 old-server rollback
+- [x] version mismatch 결과 정의
+- [x] redaction이 hash/storage/log/telemetry보다 선행
+- [x] capture redaction 비활성화 불가
+- [x] matched secret fragment 저장 금지

--- a/specs/017-agent-integration-contracts/contracts/api-capabilities.md
+++ b/specs/017-agent-integration-contracts/contracts/api-capabilities.md
@@ -1,0 +1,78 @@
+# Contract: Agent Integration API v1
+
+**Base path**: `/api/v1/agent`
+**Auth**: Bearer 또는 `X-API-Key`, 기존 programmatic auth
+**Error**: `{ "status", "reason_code", "message", "retryable" }`
+
+## GET /capabilities
+
+```json
+{
+  "contract_versions": [1],
+  "event_types": ["SESSION_START", "USER_PROMPT", "TOOL_RESULT", "PRE_COMPACT", "STOP"],
+  "limits": {
+    "event_payload_bytes": 32768,
+    "batch_events": 50,
+    "batch_payload_bytes": 524288,
+    "hook_return_target_ms": 50
+  },
+  "features": {
+    "session_storage": true,
+    "provenance_trace": true,
+    "pre_compact_injection": false
+  },
+  "schema_ready": true
+}
+```
+
+## Capabilities
+
+| Method/path | Input | Output |
+| --- | --- | --- |
+| `POST /sessions` | SESSION_START | session, observation, initial injection |
+| `POST /observations:ingest` | 최대 50 events | ordered per-event results |
+| `POST /sessions/{id}:pre-compact` | PRE_COMPACT | 독립 capture + injection result |
+| `POST /sessions/{id}:stop` | STOP | terminal state + summary job id |
+| `GET /sessions/{id}` | session id | metadata + aggregate, payload 제외 |
+| `GET /sessions/{id}/observations` | cursor/filter | canonical timeline |
+| `GET /provenance` | memory_id 또는 observation_id | bounded directional graph |
+
+Ingest는 partial success를 허용한다. 개별 policy drop은 HTTP 200의 `DROPPED` result이고 request/batch limit 초과는 전체 413이다. PreCompact injection 실패는 capture를 rollback하지 않는다.
+
+## Capture Result
+
+```json
+{
+  "event_id": "evt-03",
+  "status": "REDACTED",
+  "reason_code": "NONE",
+  "observation_id": "obs-03",
+  "late_arrival": false,
+  "redaction": {
+    "count": 2,
+    "rules": ["API_KEY", "EMAIL"]
+  }
+}
+```
+
+## Pagination and Trace
+
+- observation list: opaque cursor, default 50, max 100.
+- filters: event type, status, from/to.
+- provenance: `direction=sources|derived|both`, `max_depth` default 3, max 10.
+- cycle은 visited set으로 중단하고 `truncated=true`를 표시한다.
+
+## HTTP Mapping
+
+| HTTP | Meaning |
+| --- | --- |
+| 200/201 | accepted, duplicate, per-event dropped/degraded |
+| 400 | invalid envelope/payload |
+| 401 | auth failed |
+| 404 | session/source not found |
+| 409 | idempotency conflict, invalid state |
+| 413 | request/batch limit exceeded |
+| 422 | unsupported contract/event |
+| 503 | schema not ready/server unavailable |
+
+Hook-facing SDK는 모든 결과를 non-throwing `CaptureResult`로 변환한다. 직접 client API는 기존 client error convention을 유지할 수 있다.

--- a/specs/017-agent-integration-contracts/contracts/event-envelope.md
+++ b/specs/017-agent-integration-contracts/contracts/event-envelope.md
@@ -1,0 +1,95 @@
+# Contract: Agent Lifecycle Event Envelope v1
+
+```typescript
+type AgentEventType =
+  | 'SESSION_START'
+  | 'USER_PROMPT'
+  | 'TOOL_RESULT'
+  | 'PRE_COMPACT'
+  | 'STOP';
+
+interface AgentEventEnvelope<TType extends AgentEventType, TPayload> {
+  contract_version: 1;
+  event_id: string;
+  event_type: TType;
+  occurred_at: string;
+  adapter_name: string;
+  adapter_version: string;
+  session_id: string;
+  sequence_no: number;
+  scope: {
+    owner_id?: string;
+    project_id?: string;
+    process_id?: string;
+  };
+  payload: TPayload;
+}
+```
+
+## Common Rules
+
+- identifier는 trim 후 1..255자이며 control character를 허용하지 않는다.
+- `adapter_name`은 lowercase kebab-case, 최대 64자다.
+- `occurred_at`은 timezone이 포함된 ISO 8601 instant다.
+- `sequence_no`는 safe non-negative integer다.
+- unknown top-level field는 v1에서 `INVALID_ENVELOPE`다.
+- optional extension은 `payload.extensions` 안에서만 허용한다.
+
+## Event Payloads
+
+| Event | Required payload | Optional bounded payload |
+| --- | --- | --- |
+| `SESSION_START` | `client_version` | `model`, masked `working_directory`, `initial_context` |
+| `USER_PROMPT` | `content`, `content_format` | attachment metadata; binary body 금지 |
+| `TOOL_RESULT` | `tool_name`, `outcome` | `duration_ms`, redacted `input/output`, `file_changes` |
+| `PRE_COMPACT` | `context_summary`, `token_budget` | extensions |
+| `STOP` | `outcome` | `summary`, redacted `error` |
+
+`TOOL_RESULT.outcome`: `success`, `error`, `cancelled`, `timeout`.
+`STOP.outcome`: `completed`, `cancelled`, `failed`, `abandoned`.
+`PRE_COMPACT.token_budget`: 1..32768.
+
+## Example
+
+```json
+{
+  "contract_version": 1,
+  "event_id": "evt-01J...",
+  "event_type": "TOOL_RESULT",
+  "occurred_at": "2026-06-06T01:02:00.000Z",
+  "adapter_name": "codex",
+  "adapter_version": "1.0.0",
+  "session_id": "ses-01J...",
+  "sequence_no": 2,
+  "scope": {
+    "owner_id": "local-user",
+    "project_id": "github.com/jee1/memento",
+    "process_id": "issue-453"
+  },
+  "payload": {
+    "tool_name": "exec_command",
+    "outcome": "success",
+    "duration_ms": 42,
+    "input": { "command": "npm test" },
+    "output": { "summary": "42 tests passed", "content": "..." },
+    "file_changes": ["packages/example.ts"]
+  }
+}
+```
+
+## Canonicalization and Hashing
+
+1. object key를 Unicode code point 순으로 정렬한다.
+2. undefined는 제거하고 null은 보존한다.
+3. finite JSON number만 허용한다.
+4. redaction과 size policy 후 UTF-8 JSON을 SHA-256 한다.
+5. hash는 lowercase hex 64자다.
+
+## Idempotency and Ordering
+
+- 동일 key + 동일 hash: `DUPLICATE`, 기존 observation id 반환.
+- 동일 key + 다른 hash: `INVALID/IDEMPOTENCY_CONFLICT`.
+- duplicate는 state transition과 success metric을 재적용하지 않는다.
+- `sequence_no < max_seen_sequence_no`면 `late_arrival=true`.
+- timeline order는 `(sequence_no, occurred_at, received_at, observation_id)`다.
+- terminal session은 5분 grace window의 late event를 저장해도 상태를 되돌리지 않는다.

--- a/specs/017-agent-integration-contracts/contracts/security-failure-matrix.md
+++ b/specs/017-agent-integration-contracts/contracts/security-failure-matrix.md
@@ -1,0 +1,91 @@
+# Contract: Security and Failure Matrix
+
+## Processing Order
+
+```text
+allowlisted structure
+  -> sensitive path/binary/private-key blocking
+  -> recursive secret and PII redaction
+  -> canonical serialization
+  -> deterministic size reduction
+  -> redacted payload hash
+  -> queue
+  -> persistence
+```
+
+redaction 전 payload를 logger, telemetry, error, retry metadata에 전달하지 않는다.
+
+## Redaction
+
+| Rule | Action |
+| --- | --- |
+| `API_KEY`, `TOKEN`, `PASSWORD`, `CREDENTIAL` | `[REDACTED:<RULE>]` |
+| `EMAIL`, `PHONE` | `[REDACTED:<RULE>]` |
+| `PRIVATE_KEY_MATERIAL` | field 또는 observation drop |
+| `SENSITIVE_PATH` | content drop; path category만 유지 |
+| `BINARY_CONTENT` | content drop |
+| `HIGH_ENTROPY_SECRET` | placeholder 또는 fail-closed drop |
+
+metadata에는 `{ rule, count }`만 남기며 matched value/prefix/suffix를 저장하지 않는다.
+
+Sensitive path는 `.env*`, `~/.ssh/*`, AWS/GCP/Azure credential stores, `.npmrc`, `.pypirc`, `.git-credentials`, kubeconfig/service-account token을 포함한다.
+
+## Size Policy
+
+| Event | Preserve | Reduce first |
+| --- | --- | --- |
+| SESSION_START | client/model/scope | context, path detail |
+| USER_PROMPT | content prefix/format | attachments, content tail |
+| TOOL_RESULT | tool/outcome/summary | output, optional input, file list tail |
+| PRE_COMPACT | budget/summary prefix | summary tail |
+| STOP | outcome/summary prefix | error detail, summary tail |
+
+축소 후 32KiB 초과면 `DROPPED/PAYLOAD_TOO_LARGE`다.
+
+## Queue Priority
+
+P0: STOP, failed/cancelled/timeout TOOL_RESULT
+P1: PRE_COMPACT, SESSION_START
+P2: USER_PROMPT
+P3: successful TOOL_RESULT
+
+overflow 시 P3부터 drop하고 같은 priority에서는 oldest non-terminal event를 drop한다.
+
+## Fixture Matrix
+
+| ID | Fixture | Expected |
+| --- | --- | --- |
+| F01 | valid lifecycle 5종 | ACCEPTED |
+| F02 | repeated identical event | DUPLICATE, one row |
+| F03 | same key/different hash | IDEMPOTENCY_CONFLICT |
+| F04 | sequence inversion | accepted, late=true |
+| F05 | invalid timestamp/schema | INVALID_ENVELOPE |
+| F06 | API keys | redacted, raw 0 |
+| F07 | JWT/password | redacted, raw 0 |
+| F08 | email/phone | redacted, raw 0 |
+| F09 | PEM private key | PRIVATE_KEY_MATERIAL |
+| F10 | credential path content | SENSITIVE_PATH |
+| F11 | binary/NUL | BINARY_CONTENT |
+| F12 | 32KiB - 1 byte | accepted |
+| F13 | oversized reducible | truncated accepted |
+| F14 | oversized irreducible | PAYLOAD_TOO_LARGE |
+| F15 | 51 events/>512KiB | BATCH_TOO_LARGE |
+| F16 | invalid auth | AUTH_FAILED, no retry |
+| F17 | timeout/down | bounded DEGRADED |
+| F18 | queue overflow | priority-aware drop |
+| F19 | schema missing | SCHEMA_NOT_READY |
+| F20 | unsupported major | UNSUPPORTED_CONTRACT_VERSION |
+| F21 | late within grace | stored, terminal unchanged |
+| F22 | event after grace | INVALID_SESSION_STATE |
+
+## Leak Verification
+
+각 secret marker를 persistence input spy, SQLite dump, structured logs, telemetry attributes, retry queue state, error messages에서 exact search한다. 모든 surface에서 marker count는 0이어야 한다.
+
+## Timeout and Retry
+
+- hook enqueue target 50ms.
+- network timeout default 1000ms, max 5000ms.
+- transient failure 최대 2회 jittered bounded retry.
+- auth, validation, unsupported contract, conflict는 retry하지 않는다.
+- hook surface는 실패를 result로 변환하고 throw하지 않는다.

--- a/specs/017-agent-integration-contracts/data-model.md
+++ b/specs/017-agent-integration-contracts/data-model.md
@@ -1,0 +1,68 @@
+# Data Model: Agent Session, Observation, Provenance
+
+## Ownership
+
+| Model | Owner | Consumers |
+| --- | --- | --- |
+| Wire envelope/result/capability | `@memento/agent-integration` | adapters, client, server |
+| Session/observation/provenance domain | `@memento/core` | server |
+| HTTP DTO mapping | `memento-server` | client |
+| Agent API transport | `@memento/client` | agent integration |
+| Turn lifecycle | `@memento/assistant` | external assistants |
+
+```text
+@memento/core <- memento-server
+@memento/client <- @memento/assistant
+@memento/client <- @memento/agent-integration
+```
+
+## AgentSession
+
+Fields: `id` PK, `adapter_name`, `adapter_version`, `contract_version`, nullable `owner_id/project_id/process_id`, `status`, `started_at`, nullable `ended_at`, `last_event_at`, `max_sequence_no`, redacted `agent_metadata_json`, nullable `summary_memory_id`, nullable `degraded_reason`, `created_at`, `updated_at`.
+
+```text
+SESSION_START: (none) -> ACTIVE
+PRE_COMPACT: ACTIVE|DEGRADED -> COMPACTING -> ACTIVE|DEGRADED
+STOP: ACTIVE|COMPACTING|DEGRADED -> STOPPING -> COMPLETED|DEGRADED
+TTL: ACTIVE|COMPACTING|DEGRADED -> ABANDONED
+failure: ACTIVE|COMPACTING -> DEGRADED
+late <= 5 min: terminal state unchanged
+```
+
+## AgentObservation
+
+Fields: `id` PK, `adapter_name`, `event_id`, `session_id` FK, `event_type`, `sequence_no`, nullable `tool_name/outcome`, nullable redacted `payload_json`, `payload_sha256`, `redaction_metadata_json`, `status`, nullable `drop_reason`, `late_arrival`, `occurred_at`, `received_at`, nullable `expires_at`.
+
+Constraints/indexes:
+
+- `UNIQUE(adapter_name, event_id)`
+- `(session_id, sequence_no, occurred_at, received_at)`
+- `(expires_at)`
+- `(status, drop_reason)`
+- dropped observation은 payload 없이 audit row를 유지할 수 있다.
+
+## MemoryProvenance
+
+Fields: `id` PK, `memory_id` FK, nullable `session_id`, nullable `observation_id`, `derivation_type`, `source_deleted`, `created_at`.
+
+- session 또는 observation 중 하나 이상 필수.
+- observation이 있으면 `(memory_id, observation_id, derivation_type)` unique.
+- `memory_link.derived_from`는 memory-to-memory 관계로 유지한다.
+- `memory_item.session_id`는 attribution이므로 자동 provenance backfill하지 않는다.
+
+## Enums
+
+Capture status: `ACCEPTED`, `REDACTED`, `DUPLICATE`, `DROPPED`, `DEGRADED`, `INVALID`.
+
+Reason code: `NONE`, `AUTH_FAILED`, `SERVER_UNAVAILABLE`, `TIMEOUT`, `QUEUE_OVERFLOW`, `INVALID_ENVELOPE`, `INVALID_PAYLOAD`, `UNSUPPORTED_CONTRACT_VERSION`, `UNSUPPORTED_EVENT_TYPE`, `SESSION_NOT_STARTED`, `INVALID_SESSION_STATE`, `IDEMPOTENCY_CONFLICT`, `SENSITIVE_PATH`, `BINARY_CONTENT`, `PRIVATE_KEY_MATERIAL`, `PAYLOAD_TOO_LARGE`, `BATCH_TOO_LARGE`, `SCHEMA_NOT_READY`, `INTERNAL_ERROR`.
+
+## Migration
+
+1. schema readiness check 추가.
+2. 세 table과 index를 additive migration으로 생성.
+3. `schema.sql` 동기화.
+4. repository/read API를 feature-disabled로 배포.
+5. tests/readiness 통과 후 write capability 활성화.
+6. retention cleanup 별도 활성화.
+
+Rollback은 write off, old server 복원, 신규 table 유지가 기본이다. table 제거는 backup과 명시 승인 후 별도 migration이다.

--- a/specs/017-agent-integration-contracts/plan.md
+++ b/specs/017-agent-integration-contracts/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: Agent Integration Contracts
+
+**Branch**: `017-agent-integration-contracts` | **Date**: 2026-06-06 | **Spec**: `/specs/017-agent-integration-contracts/spec.md`
+**Input**: Issue #453, `tasks/0452-prd-agent-integration.md`
+
+## Summary
+
+구현 전에 lifecycle envelope, 보안·크기·queue 정책, package ownership, data model, API capability, migration/rollback을 고정한다. production runtime과 schema 변경은 #454/#461에서 수행한다.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js 24+, JSON Schema draft 2020-12 예정
+**Dependencies**: npm workspaces, Express 5, Zod 3, SQLite, programmatic auth
+**Storage**: additive SQLite table 설계; 실제 migration은 #454
+**Testing**: contract fixtures와 leak verification 계획; runtime tests는 후속 이슈
+**Performance**: hook 50ms, event 32KiB, batch 50/512KiB
+**Constraints**: non-throwing, redaction-before-storage, backward compatibility, 신규 dependency 없음
+
+## Constitution Check
+
+- **Test-First**: PASS. 현재는 documentation/type-contract design only다. 후속 behavior 구현은 fixture test-first다.
+- **Backward Compatibility**: PASS. 기존 MCP, `/tools`, assistant 변화 없음.
+- **Schema Discipline**: PASS. additive schema, `schema.sql` sync, expand/contract, rollback을 명시했다.
+- **Quality Gates**: 완료 전 docs audit, lint, type-check, test를 실행한다.
+- **Failure Isolation**: PASS. stable reason code와 non-throwing degraded 계약을 정의했다.
+
+초기/설계 후 게이트: **PASS**
+
+## Structure
+
+```text
+specs/017-agent-integration-contracts/
+├── spec.md
+├── research.md
+├── data-model.md
+├── plan.md
+├── tasks.md
+├── quickstart.md
+├── checklists/requirements.md
+└── contracts/
+    ├── event-envelope.md
+    ├── api-capabilities.md
+    └── security-failure-matrix.md
+```
+
+Future source ownership:
+
+```text
+packages/memento-agent-integration  # wire, normalization, policy, queue, adapters
+packages/memento-client             # agent API transport
+packages/memento-assistant          # existing turn lifecycle
+packages/memento-core               # provenance domain/persistence
+packages/memento-server             # authenticated API/telemetry
+```
+
+## Research Decisions
+
+1. 신규 workspace와 assistant 분리.
+2. TypeScript union + generated JSON Schema.
+3. redaction 후 canonical hash.
+4. late arrival 허용, terminal grace 5분.
+5. 비활성화 불가 fail-closed redaction.
+6. redacted payload retention 30일.
+7. programmatic auth와 `/api/v1/agent`.
+8. additive expand/contract migration.
+
+## Design Outputs
+
+1. `data-model.md`: ownership, state, entity/index/retention, migration.
+2. `event-envelope.md`: lifecycle union, examples, canonicalization.
+3. `api-capabilities.md`: Start/Ingest/PreCompact/Stop/Get/List/Trace.
+4. `security-failure-matrix.md`: redaction, size, queue, fixture.
+5. `quickstart.md`: 후속 구현 검증 순서.
+
+## Follow-up Mapping
+
+### #454
+
+- core entities/repositories/migration
+- server lifecycle/read/trace API
+- client transport/capability
+- idempotency, state, retention
+
+### #461
+
+- `@memento/agent-integration`
+- generated schema/normalizer
+- redaction/size pipeline
+- priority queue/timeout/retry/degraded
+- leak scan/telemetry
+
+## Verification
+
+- requirements ID와 contract mapping 검색.
+- Markdown link audit.
+- lint, type-check, full test.
+- graphify rebuild.
+
+## Complexity
+
+| Decision | Reason | Simpler alternative rejected |
+| --- | --- | --- |
+| 신규 workspace | 책임·배포 분리 | assistant 결합은 turn/coding 계약을 혼합 |
+| TS + JSON Schema | typed/custom adapters | TS only는 wire validation 부족 |
+| 3 tables | lifecycle와 provenance 분리 | memory_item 확장은 cardinality 부적합 |

--- a/specs/017-agent-integration-contracts/quickstart.md
+++ b/specs/017-agent-integration-contracts/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Issue #453 Contracts
+
+## Read Order
+
+1. `spec.md`
+2. `research.md`
+3. `data-model.md`
+4. `contracts/event-envelope.md`
+5. `contracts/security-failure-matrix.md`
+6. `contracts/api-capabilities.md`
+7. `tasks.md`
+
+## #454 Start
+
+1. migration/repository failing tests.
+2. three additive tables and `schema.sql`.
+3. core state/idempotency pure rules.
+4. programmatic `/api/v1/agent` routes.
+5. client capability/transport.
+6. MCP/assistant compatibility tests.
+
+Stop: persistence/API contract tests pass with no public regression.
+
+## #461 Start
+
+1. lifecycle TS/JSON Schema failing fixtures.
+2. create `@memento/agent-integration`.
+3. allowlist → block → redact → size → hash pipeline.
+4. priority queue and bounded retry shell.
+5. non-throwing capture result mapping.
+6. secret marker count 0 across DB/log/telemetry/queue/error.
+
+Stop: F01~F22 pass and server failure never throws through hook.
+
+## Compatibility Gates
+
+```bash
+npm run lint
+npm run type-check
+npm test
+```
+
+- assistant public exports unchanged
+- MCP tool schemas unchanged
+- programmatic auth behavior unchanged
+- `memory_item.session_id` semantics unchanged
+
+## Security Review
+
+다음 중 하나라도 yes면 계약 위반이다.
+
+- redaction 전 값이 logger/error/telemetry로 전달되는가?
+- hash를 redaction 전에 계산하는가?
+- capture redaction을 환경변수로 끌 수 있는가?
+- sensitive file body를 읽은 뒤 차단하는가?
+- truncation이 JSON/UTF-8을 손상시키는가?
+- retry queue가 원문을 disk에 기록하는가?

--- a/specs/017-agent-integration-contracts/research.md
+++ b/specs/017-agent-integration-contracts/research.md
@@ -1,0 +1,37 @@
+# Research: Agent Integration Contracts
+
+## Decisions
+
+### 신규 workspace
+
+`@memento/agent-integration`이 wire contract, adapter normalization, redaction/size policy, queue를 소유한다. `@memento/assistant` 하위 모듈은 turn lifecycle 공개 API와 coding hook 계약을 결합하므로 기각한다. server/core 소유는 agent별 형식을 내부 계층으로 유입시키므로 기각한다.
+
+### 계약 표현
+
+TypeScript discriminated union과 동일 의미의 generated JSON Schema를 제공한다. source of truth는 하나이며 수동 이중 편집은 허용하지 않는다.
+
+### 식별자와 idempotency
+
+`session_id`와 `event_id`는 adapter가 생성한 opaque ID다. key는 `(adapter_name, event_id)`이며 충돌 검증 hash는 redaction과 canonical JSON 이후 SHA-256으로 계산한다.
+
+### sequence와 late arrival
+
+`sequence_no`는 0 이상 단조 증가 의도지만 server는 역전을 거절하지 않는다. `sequence_no < max_seen`이면 late다. timeline은 `(sequence_no, occurred_at, received_at, observation_id)`로 정렬한다. STOP 후 grace window는 5분이다.
+
+### 보안 처리 순서
+
+allowlist → sensitive path/binary block → recursive redaction → canonical serialization → 32KiB policy → hash → queue/persistence 순이다.
+
+기존 `PIIMasker` 패턴은 참고할 수 있으나 `ENABLE_PII_MASKING=false`가 가능하므로 agent capture 경계로 직접 사용하지 않는다. capture redaction은 비활성화 불가능한 fail-closed policy다.
+
+### Limits와 retention
+
+event redacted payload 32KiB, batch 50 events/512KiB다. redacted observation payload retention 기본은 30일, 설정 범위는 1~90일이다.
+
+### API와 인증
+
+`/api/v1/agent` namespace와 기존 Bearer/X-API-Key programmatic auth를 재사용한다. browser session cookie와 혼용하지 않는다.
+
+### Migration과 rollback
+
+expand/contract 전략을 사용한다. table/index를 additive로 추가하고 schema readiness 이후 write를 켠다. legacy `memory_item.session_id`를 provenance로 추정 backfill하지 않는다. rollback은 write off → old server → 승인된 별도 destructive cleanup 순이다.

--- a/specs/017-agent-integration-contracts/spec.md
+++ b/specs/017-agent-integration-contracts/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Agent Integration Contracts
+
+**Feature Branch**: `017-agent-integration-contracts`
+**Created**: 2026-06-06
+**Status**: Ready for Implementation
+**Input**: Issue #453 and `tasks/0452-prd-agent-integration.md`
+
+## User Scenarios & Testing
+
+### User Story 1 - Adapter 독립 이벤트 계약 (Priority: P1)
+
+adapter 개발자는 Codex 또는 Claude Code의 원본 hook 형식과 관계없이 하나의 공통 lifecycle envelope로 세션 이벤트를 전달할 수 있어야 한다.
+
+**Why this priority**: 공통 계약이 없으면 adapter별 조건문이 server와 core로 유입되어 후속 저장, provenance, 보안 구현을 독립적으로 진행할 수 없다.
+
+**Independent Test**: lifecycle 5종 fixture를 공통 계약으로 검증하고 필수 필드 누락·중복·순서 역전 결과를 예측할 수 있으면 검증된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 지원 adapter가 lifecycle event를 생성한 상태, **When** envelope 검증을 수행하면, **Then** 필수 식별자·시각·sequence·payload 규칙을 통과하거나 안정된 reason code로 거절된다.
+2. **Given** 동일 `(adapter_name, event_id)`가 재전송된 상태, **When** ingest하면, **Then** 기존 결과를 반환하고 observation을 중복 생성하지 않는다.
+3. **Given** 높은 sequence가 먼저 저장된 상태, **When** 낮은 sequence가 도착하면, **Then** 수신하되 late arrival로 표시한다.
+
+### User Story 2 - 저장 전 민감정보 차단 (Priority: P1)
+
+사용자는 lifecycle payload에 secret, PII, credential 경로 또는 과도한 tool output이 포함되어도 원문이 DB, 로그, telemetry에 남지 않을 것을 신뢰할 수 있어야 한다.
+
+**Why this priority**: 자동 수집은 수동 저장보다 데이터 범위가 넓으므로 저장 전에 적용되는 fail-closed 보안 계약이 선행되어야 한다.
+
+**Independent Test**: 보안 fixture 처리 후 persistence input, log, telemetry 전체에서 금지 문자열이 0건인지 검사한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** token·password·API key·PII가 포함된 상태, **When** redaction하면, **Then** 안정된 placeholder와 규칙명·개수만 남는다.
+2. **Given** `.env`, SSH private key, cloud credential 경로 또는 바이너리 내용인 상태, **When** 정책을 적용하면, **Then** 원문 없이 필드 또는 observation이 차단된다.
+3. **Given** redaction 후 payload가 32KiB를 초과한 상태, **When** size 정책을 적용하면, **Then** deterministic truncation 또는 명시적 drop이 수행된다.
+
+### User Story 3 - 구현 가능한 패키지·API·schema 경계 (Priority: P2)
+
+Core, Server, Client, Assistant, Agent Integration 기여자는 책임과 의존성 방향, API capability, schema migration 순서를 추가 제품 결정 없이 구현할 수 있어야 한다.
+
+**Why this priority**: 경계를 먼저 고정해야 #454와 #461을 병렬 진행하면서 중복 타입, 순환 의존, assistant breaking change를 피할 수 있다.
+
+**Independent Test**: 각 후속 이슈가 소유 패키지, 입출력 계약, migration 단계, rollback 조건을 문서만으로 식별할 수 있으면 검증된다.
+
+**Acceptance Scenarios**:
+
+1. **Given** 신규 adapter 구현이 필요한 상태, **When** 경계를 확인하면, **Then** agent-specific payload 해석은 `@memento/agent-integration` 밖으로 유출되지 않는다.
+2. **Given** persistence를 추가하는 상태, **When** migration 계획을 따르면, **Then** additive schema로 배포되고 legacy memory와 MCP 도구는 그대로 동작한다.
+3. **Given** server와 adapter 버전이 다른 상태, **When** capability negotiation을 수행하면, **Then** 지원 범위를 확인하거나 명시적 degraded 결과를 받는다.
+
+### User Story 4 - 장애 격리 (Priority: P2)
+
+사용자는 Memento timeout, 인증 실패, queue overflow, migration 미완료가 발생해도 코딩 작업을 계속할 수 있어야 한다.
+
+**Independent Test**: 장애 fixture마다 adapter 호출이 throw하지 않고 제한 시간 안에 accepted, degraded 또는 dropped를 반환하는지 검증한다.
+
+**Acceptance Scenarios**:
+
+1. **Given** server가 응답하지 않는 상태, **When** capture하면, **Then** bounded timeout 후 `DEGRADED`를 반환하고 예외를 전파하지 않는다.
+2. **Given** queue가 포화된 상태, **When** 이벤트가 추가되면, **Then** 낮은 우선순위부터 drop하고 종료·오류 이벤트를 우선 보존한다.
+3. **Given** 인증이 실패한 상태, **When** 전송하면, **Then** 무한 재시도하지 않고 `AUTH_FAILED`를 집계한다.
+
+### Edge Cases
+
+- `SESSION_START` 전 observation은 `SESSION_NOT_STARTED`다.
+- `STOP` 후 5분 grace window의 late event는 저장하되 terminal 상태를 되돌리지 않는다.
+- 같은 idempotency key와 다른 redacted hash는 기존 observation을 덮어쓰지 않는다.
+- clock skew가 있어도 `received_at`을 별도 저장한다.
+- 직렬화 불가 payload는 `INVALID_PAYLOAD`다.
+- unknown required semantic은 capability mismatch다.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: lifecycle 5종을 discriminated union으로 표현하는 versioned envelope를 정의해야 한다.
+- **FR-002**: envelope는 `contract_version`, `event_id`, `event_type`, `occurred_at`, `adapter_name`, `adapter_version`, `session_id`, `sequence_no`, `scope`, `payload`를 포함해야 한다.
+- **FR-003**: `(adapter_name, event_id)`는 idempotency key이며 같은 key와 다른 redacted payload hash는 충돌이어야 한다.
+- **FR-004**: sequence 역전은 허용하며 late arrival와 clock skew를 표현해야 한다.
+- **FR-005**: session 상태 전이와 terminal grace-window를 정의해야 한다.
+- **FR-006**: redaction은 serialization, hashing, persistence, logging, telemetry보다 먼저 수행되어야 한다.
+- **FR-007**: secret·PII는 placeholder로, credential file·binary·private key는 fail-closed drop해야 한다.
+- **FR-008**: redaction 후 event payload는 32KiB, batch는 50건 또는 512KiB로 제한해야 한다.
+- **FR-009**: payload 축소는 event별 필수 필드를 보존하는 deterministic truncation이어야 한다.
+- **FR-010**: 결과는 `accepted`, `redacted`, `duplicate`, `dropped`, `degraded`, `invalid`와 안정된 reason code를 구분해야 한다.
+- **FR-011**: queue priority는 `STOP`·실패 tool > `PRE_COMPACT`·start > prompt > 성공 tool 순이어야 한다.
+- **FR-012**: hook-facing 호출은 목표 50ms 안에 반환하고 server 작업을 기다리거나 예외를 전파하지 않아야 한다.
+- **FR-013**: 신규 `@memento/agent-integration`은 wire contract, normalization, redaction/size policy, queue runtime을 소유해야 한다.
+- **FR-014**: `@memento/assistant`는 기존 turn lifecycle API를 유지하고 신규 package에 의존하지 않아야 한다.
+- **FR-015**: `@memento/client`는 agent API transport를 제공하되 adapter-specific 타입에 의존하지 않아야 한다.
+- **FR-016**: `@memento/core`는 provenance 규칙을 소유하되 adapter payload와 HTTP 타입에 의존하지 않아야 한다.
+- **FR-017**: server는 programmatic auth 아래 Start, Ingest, PreCompact, Stop, Get/List, Trace를 제공해야 한다.
+- **FR-018**: additive migration으로 `agent_session`, `agent_observation`, `memory_provenance`를 추가하고 기존 `memory_item.session_id` 의미를 변경하지 않아야 한다.
+- **FR-019**: rollback은 새 write 중지, 구버전 read compatibility, 신규 table 제거를 분리해야 한다.
+- **FR-020**: capability discovery와 `UNSUPPORTED_CONTRACT_VERSION`을 제공해야 한다.
+- **FR-021**: log/telemetry에 payload 원문, redaction 전 hash, secret fragment를 포함하지 않아야 한다.
+- **FR-022**: 정상, duplicate, late, secret, PII, path, oversized, auth, timeout, overflow, migration mismatch fixture를 포함해야 한다.
+- **FR-023**: 기존 MCP 도구, `/tools`, `@memento/assistant` 공개 API는 변경 없이 동작해야 한다.
+
+### Key Entities
+
+- **Agent Event Envelope**: versioned lifecycle wire contract.
+- **Agent Session**: coding-agent 실행 구간과 상태·scope.
+- **Agent Observation**: redaction·size 정책이 적용된 lifecycle 사건.
+- **Memory Provenance**: memory와 source session/observation의 파생 관계.
+- **Capture Result**: 처리 상태, reason code, observation 참조.
+- **Capability Document**: 지원 version, event type, limit, feature.
+
+## Success Criteria
+
+- **SC-001**: lifecycle 5종 정상·오류 example이 공통 schema로 검증 가능하다.
+- **SC-002**: secret fixture 원문이 persistence, log, telemetry에 나타나는 경우가 0건이다.
+- **SC-003**: #454와 #461 scope가 package owner와 contract에 100% 매핑된다.
+- **SC-004**: duplicate, late, timeout, auth, overflow의 결과와 reason code가 100% 결정된다.
+- **SC-005**: 기존 MCP/assistant 공개 계약 breaking change가 0건이다.
+- **SC-006**: spec, plan, model, contracts, tasks 간 미결정 항목이 0건이다.
+
+## Assumptions
+
+- contract major는 `1`, URI는 `/api/v1/agent/*`다.
+- redacted observation payload 기본 retention은 30일(설정 범위 1~90일)이다.
+- adapter는 opt-in 설치 후에만 전송한다.
+- 실제 migration/runtime 구현은 #454와 #461 범위다.
+
+## Out of Scope
+
+- 실제 DB migration, repository, HTTP route, redaction engine, queue runtime
+- Codex/Claude adapter, summary/promotion/injection, dashboard, CLI, benchmark 구현

--- a/specs/017-agent-integration-contracts/tasks.md
+++ b/specs/017-agent-integration-contracts/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Agent Integration Contracts
+
+## Specification
+
+- [x] T001 #453와 parent PRD 범위를 추출한다.
+- [x] T002 scenarios, acceptance, edge cases, outcomes를 작성한다.
+- [x] T003 package placement와 retention을 결정한다.
+
+## Research and Boundaries
+
+- [x] T004 assistant/client/core/server 책임을 조사한다.
+- [x] T005 신규 workspace 결정을 기록한다.
+- [x] T006 기존 PIIMasker 한계와 fail-closed 정책을 결정한다.
+- [x] T007 API auth와 migration 전략을 결정한다.
+
+## Contracts
+
+- [x] T008 lifecycle 5종 envelope와 example을 작성한다.
+- [x] T009 idempotency, hash, sequence, late/grace 규칙을 확정한다.
+- [x] T010 Start/Ingest/PreCompact/Stop/Get/List/Trace API를 작성한다.
+- [x] T011 capture status/reason과 HTTP/SDK mapping을 확정한다.
+- [x] T012 redaction, path, binary, 32KiB, batch, queue를 작성한다.
+- [x] T013 정상·보안·장애 fixture 22종과 leak surface를 작성한다.
+
+## Data and Migration
+
+- [x] T014 Session state machine을 작성한다.
+- [x] T015 Observation constraints/index/retention을 작성한다.
+- [x] T016 Provenance와 legacy attribution 차이를 작성한다.
+- [x] T017 additive migration과 rollback을 작성한다.
+
+## Handoff and Verification
+
+- [x] T018 #454/#461 ownership을 plan에 매핑한다.
+- [x] T019 quickstart를 작성한다.
+- [x] T020 checklist에서 unresolved clarification이 없음을 확인한다.
+- [x] T021 `npm run docs:audit-links` 실행
+- [x] T022 `npm run lint`, `npm run type-check`, `npm test` 실행
+- [x] T023 graphify rebuild
+- [ ] T024 GitHub #453에 산출물과 검증 결과 반영
+
+### Validation Notes
+
+- `npm run docs:audit-links`: 이번 spec 경로 오류는 없었으나, `.omx/state/sessions/omx-1779702102519-huowdk/AGENTS.md`의 기존 상대 링크 6건으로 실패했다.
+- `npm run lint`: 오류 없이 통과했다. 기존 security warning 245건은 유지된다.
+- `npm run type-check`: 모든 workspace에서 통과했다.
+- `npm test`: 변경되지 않은 HTTP 통합 테스트가 30초 타임아웃에 걸려 전체 게이트는 실패했다. 이 작업은 문서와 graphify 산출물만 변경한다.
+- graphify rebuild: 5,088 nodes, 6,216 edges, 1,025 communities로 완료했다.
+
+## #454 Test-First Handoff
+
+- [ ] H001 migration table/index/schema sync failing tests
+- [ ] H002 repository duplicate/conflict/late/state tests
+- [ ] H003 route capability/lifecycle tests
+- [ ] H004 MCP/assistant compatibility tests
+
+## #461 Test-First Handoff
+
+- [ ] H005 TypeScript/JSON Schema fixture tests
+- [ ] H006 secret leak scan tests
+- [ ] H007 32KiB/batch/reduction boundary tests
+- [ ] H008 queue/timeout/retry/non-throwing tests

--- a/specs/017-agent-integration-contracts/tasks.md
+++ b/specs/017-agent-integration-contracts/tasks.md
@@ -44,7 +44,7 @@
 - `npm run docs:audit-links`: 이번 spec 경로 오류는 없었으나, `.omx/state/sessions/omx-1779702102519-huowdk/AGENTS.md`의 기존 상대 링크 6건으로 실패했다.
 - `npm run lint`: 오류 없이 통과했다. 기존 security warning 245건은 유지된다.
 - `npm run type-check`: 모든 workspace에서 통과했다.
-- `npm test`: 변경되지 않은 HTTP 통합 테스트가 30초 타임아웃에 걸려 전체 게이트는 실패했다. 이 작업은 문서와 graphify 산출물만 변경한다.
+- `npm test`: sandbox가 `127.0.0.1` listen을 `EPERM`으로 차단해 HTTP 통합 테스트가 연쇄 타임아웃됐다. 최종 결과는 344 files/4,307 tests 통과, 10 files/68 tests 실패다. 이 작업은 문서와 graphify 산출물만 변경한다.
 - graphify rebuild: 5,088 nodes, 6,216 edges, 1,025 communities로 완료했다.
 
 ## #454 Test-First Handoff

--- a/specs/017-agent-integration-contracts/tasks.md
+++ b/specs/017-agent-integration-contracts/tasks.md
@@ -37,7 +37,7 @@
 - [x] T021 `npm run docs:audit-links` 실행
 - [x] T022 `npm run lint`, `npm run type-check`, `npm test` 실행
 - [x] T023 graphify rebuild
-- [ ] T024 GitHub #453에 산출물과 검증 결과 반영
+- [x] T024 GitHub #453에 산출물과 검증 결과 반영
 
 ### Validation Notes
 


### PR DESCRIPTION
# Pull Request

## 변경 사항

이슈 #453와 parent PRD를 바탕으로 agent integration의 구현 선행 계약을 Spec Kit 산출물로 확정합니다.

## 변경 유형

- [x] 문서 업데이트
- [ ] Breaking Change

## 관련 이슈

- Closes #453
- Related to #452
- Related to #454
- Related to #461

## 변경 사항 상세

- lifecycle 5종의 versioned event envelope, idempotency, sequence, late-arrival 규칙
- 저장 전 redaction, fail-closed 차단, 32KiB/event와 50건/512KiB batch 제한
- `@memento/agent-integration`, assistant, client, core, server의 패키지 책임
- programmatic auth 기반 agent API capability와 상태/reason code
- additive schema migration, retention, rollback, provenance 모델
- 정상·보안·장애 fixture 22종과 #454/#461 test-first handoff

주요 문서:

- `specs/017-agent-integration-contracts/spec.md`
- `specs/017-agent-integration-contracts/plan.md`
- `specs/017-agent-integration-contracts/contracts/`
- `specs/017-agent-integration-contracts/tasks.md`

## 테스트

- [x] `npm run lint` 통과: 오류 0, 기존 security warning 245
- [x] `npm run type-check` 통과
- [x] `git diff --check` 통과
- [x] graphify rebuild 완료: 5,088 nodes, 6,216 edges, 1,025 communities
- [ ] `npm test`: sandbox의 `127.0.0.1` listen `EPERM`으로 HTTP 통합 테스트 연쇄 실패
  - 344 files/4,307 tests 통과
  - 10 files/68 tests 실패
- [ ] `npm run docs:audit-links`: 기존 `.omx/state/.../AGENTS.md` 상대 링크 6건으로 실패

세부 검증 기록은 `tasks.md`의 Validation Notes에 남겼습니다.

## 코드 리뷰 포인트

- 기존 `@memento/assistant` API를 유지하면서 신규 package를 두는 경계가 적절한지
- redaction이 serialize/hash/store/log/telemetry보다 선행하는 계약이 충분한지
- 5분 terminal grace, 30일 retention, 32KiB/event 제한이 후속 구현에 적절한지
- #454와 #461이 추가 제품 결정을 하지 않고 병렬 구현 가능한지

## 지식 복리

- [x] 해당 없음: 구현 장애 해결이 아닌 기술 계약 문서화 작업

## 주의사항

- 이 PR은 runtime, migration, adapter를 구현하지 않습니다.
- 실제 persistence/API는 #454, contract/runtime/fixture는 #461 범위입니다.

## 체크리스트

- [x] 자체 검토 완료
- [x] 변경사항에 해당하는 문서 업데이트
- [x] 신규 의존성 없음
- [x] Breaking Change 없음

## 배포 관련

- [x] 특별한 사항 없음
