### PR TITLE
feat(agent-memory): terminal session episodic summary와 provenance

### DIFF
--- a/packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts
+++ b/packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts
@@ -41,7 +41,15 @@ export interface AgentIntegrationRepository {
       to?: string;
     },
   ): ObservationPage;
-  markExpiredSessionsAbandoned(cutoff: string, now: string): number;
+  listAllObservations(sessionId: string): AgentObservation[];
+  persistSessionSummary(input: {
+    memoryId: string;
+    session: AgentSession;
+    content: string;
+    observationIds: string[];
+    createdAt: string;
+  }): { memoryId: string; created: boolean };
+  markExpiredSessionsAbandoned(cutoff: string, now: string): string[];
   clearExpiredObservationPayloads(cutoff: string): number;
   createProvenance(input: {
     id: string;

--- a/packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentIntegrationSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/035-agent-integration-schema.js';
 import { SqliteAgentIntegrationRepository } from '../../../infrastructure/database/repositories/sqlite-agent-integration-repository.js';
 import { AgentIntegrationError, AgentLifecycleService } from './agent-lifecycle-service.js';
@@ -182,6 +182,43 @@ describe('AgentLifecycleService', () => {
 
     expect(service.abandonExpiredSessions(new Date('2026-06-06T00:10:00.000Z'))).toBe(0);
     expect(repository.getSession('session-1')?.status).toBe('DEGRADED');
+  });
+
+  it('requests a summary after stop and retries it for an idempotent stop replay', () => {
+    const summarize = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('temporary summary failure');
+      })
+      .mockReturnValue({ status: 'CREATED', memoryId: 'summary-1', observationCount: 2 });
+    service = new AgentLifecycleService(repository, {
+      now: () => new Date('2026-06-06T00:00:10.000Z'),
+    }, { summarize });
+    service.capture(startEvent);
+    const stop = {
+      ...startEvent,
+      eventId: 'evt-stop-summary',
+      eventType: 'STOP' as const,
+      sequenceNo: 1,
+      payloadSha256: '6'.repeat(64),
+      outcome: 'completed',
+    };
+
+    expect(service.capture(stop).status).toBe('ACCEPTED');
+    expect(service.capture(stop).status).toBe('DUPLICATE');
+    expect(summarize).toHaveBeenNthCalledWith(1, 'session-1');
+    expect(summarize).toHaveBeenNthCalledWith(2, 'session-1');
+  });
+
+  it('requests summaries for sessions newly marked abandoned', () => {
+    const summarize = vi.fn();
+    service = new AgentLifecycleService(repository, {
+      abandonedTtlMs: 60_000,
+      now: () => new Date('2026-06-06T00:00:10.000Z'),
+    }, { summarize });
+    service.capture(startEvent);
+
+    expect(service.abandonExpiredSessions(new Date('2026-06-06T00:01:01.000Z'))).toBe(1);
+    expect(summarize).toHaveBeenCalledWith('session-1');
   });
 
   it('rejects events that do not match the session adapter contract or scope', () => {

--- a/packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.ts
@@ -49,6 +49,10 @@ export interface AgentLifecycleServiceOptions {
   now?: () => Date;
 }
 
+export interface AgentSessionSummarizer {
+  summarize(sessionId: string): unknown;
+}
+
 const TERMINAL_STATUSES = new Set<AgentSession['status']>([
   'COMPLETED',
   'DEGRADED',
@@ -69,6 +73,7 @@ export class AgentLifecycleService {
   constructor(
     private readonly repository: AgentIntegrationRepository,
     options: AgentLifecycleServiceOptions = {},
+    private readonly sessionSummarizer?: AgentSessionSummarizer,
   ) {
     this.retentionDays = boundedNumber(options.retentionDays, 30, 1, 90);
     this.abandonedTtlMs = boundedNumber(
@@ -104,9 +109,15 @@ export class AgentLifecycleService {
     const abandonedCutoff = new Date(
       Date.parse(receivedAt) - this.abandonedTtlMs,
     ).toISOString();
-    this.repository.markExpiredSessionsAbandoned(abandonedCutoff, receivedAt);
+    const abandonedSessionIds = this.repository.markExpiredSessionsAbandoned(
+      abandonedCutoff,
+      receivedAt,
+    );
+    for (const sessionId of abandonedSessionIds) {
+      this.trySummarize(sessionId);
+    }
 
-    return this.repository.runInTransaction(() => {
+    const result: CaptureResult = this.repository.runInTransaction(() => {
       const existing = this.repository.findObservationByIdempotencyKey(
         event.adapterName,
         event.eventId,
@@ -219,6 +230,10 @@ export class AgentLifecycleService {
         lateArrival: observation.lateArrival,
       };
     });
+    if (event.eventType === 'STOP') {
+      this.trySummarize(event.sessionId);
+    }
+    return result;
   }
 
   getSession(id: string): AgentSession | null {
@@ -234,7 +249,19 @@ export class AgentLifecycleService {
 
   abandonExpiredSessions(at = this.now()): number {
     const cutoff = new Date(at.getTime() - this.abandonedTtlMs).toISOString();
-    return this.repository.markExpiredSessionsAbandoned(cutoff, at.toISOString());
+    const sessionIds = this.repository.markExpiredSessionsAbandoned(cutoff, at.toISOString());
+    for (const sessionId of sessionIds) {
+      this.trySummarize(sessionId);
+    }
+    return sessionIds.length;
+  }
+
+  private trySummarize(sessionId: string): void {
+    try {
+      this.sessionSummarizer?.summarize(sessionId);
+    } catch {
+      // Summary failures are recorded by the summarizer and retried on duplicate stop or sweep.
+    }
   }
 
   linkProvenance(input: {

--- a/packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts
@@ -1,0 +1,260 @@
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentIntegrationSchemaMigration } from '../../../infrastructure/database/database/migration/migrations/035-agent-integration-schema.js';
+import { SqliteAgentIntegrationRepository } from '../../../infrastructure/database/repositories/sqlite-agent-integration-repository.js';
+import type { PersistedAgentEventInput } from '../types.js';
+import {
+  AgentSessionSummaryService,
+  type AgentSummaryTelemetryEvent,
+} from './agent-session-summary-service.js';
+
+const startEvent: PersistedAgentEventInput = {
+  contractVersion: 1,
+  eventId: 'evt-start',
+  eventType: 'SESSION_START',
+  occurredAt: '2026-06-06T00:00:00.000Z',
+  adapterName: 'codex',
+  adapterVersion: '1.0.0',
+  sessionId: 'session-1',
+  sequenceNo: 0,
+  scope: { ownerId: 'owner-1', projectId: 'project-1', processId: 'issue-464' },
+  payloadJson: '{"client_version":"1.0.0"}',
+  payloadSha256: 'a'.repeat(64),
+  redactionMetadataJson: '{}',
+  captureStatus: 'ACCEPTED',
+};
+
+describe('AgentSessionSummaryService', () => {
+  let db: Database.Database;
+  let repository: SqliteAgentIntegrationRepository;
+  let telemetry: AgentSummaryTelemetryEvent[];
+  let service: AgentSessionSummaryService;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+      CREATE TABLE memory_item (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL DEFAULT 'episodic',
+        content TEXT NOT NULL DEFAULT '',
+        importance REAL DEFAULT 0.5,
+        privacy_scope TEXT DEFAULT 'private',
+        tags TEXT,
+        source TEXT,
+        origin_source TEXT,
+        owner_id TEXT,
+        process_id TEXT,
+        session_id TEXT,
+        project_id TEXT,
+        source_session_id TEXT,
+        created_at TEXT
+      )
+    `);
+    await new AgentIntegrationSchemaMigration().up(db);
+    repository = new SqliteAgentIntegrationRepository(db);
+    telemetry = [];
+    service = new AgentSessionSummaryService(repository, {
+      now: () => new Date('2026-06-06T00:00:10.000Z'),
+      recordTelemetry: event => telemetry.push(event),
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function createSession(): void {
+    repository.createSession(startEvent, '2026-06-06T00:00:01.000Z');
+    repository.createObservation({
+      ...startEvent,
+      id: 'observation-start',
+      lateArrival: false,
+      receivedAt: '2026-06-06T00:00:01.000Z',
+      expiresAt: null,
+    });
+  }
+
+  function addObservation(input: Partial<PersistedAgentEventInput> & { id: string }): void {
+    repository.createObservation({
+      ...startEvent,
+      eventId: `evt-${input.id}`,
+      eventType: 'USER_PROMPT',
+      sequenceNo: 1,
+      payloadJson: '{"prompt":"fix the retry bug"}',
+      payloadSha256: input.id.padEnd(64, '0').slice(0, 64),
+      ...input,
+      lateArrival: false,
+      receivedAt: '2026-06-06T00:00:02.000Z',
+      expiresAt: null,
+    });
+  }
+
+  it('creates one episodic summary and provenance for every used observation', () => {
+    createSession();
+    addObservation({ id: 'observation-prompt' });
+    addObservation({
+      id: 'observation-tool',
+      eventType: 'TOOL_RESULT',
+      sequenceNo: 2,
+      toolName: 'exec_command',
+      outcome: 'success',
+      payloadJson: JSON.stringify({
+        decision: 'use a bounded retry',
+        files: ['src/retry.ts'],
+        result: 'tests pass',
+      }),
+    });
+    repository.updateSession('session-1', {
+      status: 'COMPLETED',
+      endedAt: '2026-06-06T00:00:09.000Z',
+    }, '2026-06-06T00:00:09.000Z');
+
+    const result = service.summarize('session-1');
+    const session = repository.getSession('session-1');
+    const memory = db.prepare(`
+      SELECT type, content, owner_id, project_id, process_id, session_id, source_session_id
+      FROM memory_item WHERE id = ?
+    `).get(result.memoryId) as Record<string, unknown>;
+    const provenance = repository.listProvenance({ memoryId: result.memoryId! });
+
+    expect(result).toMatchObject({ status: 'CREATED', observationCount: 3 });
+    expect(session?.summaryMemoryId).toBe(result.memoryId);
+    expect(memory).toMatchObject({
+      type: 'episodic',
+      owner_id: 'owner-1',
+      project_id: 'project-1',
+      process_id: 'issue-464',
+      session_id: 'session-1',
+      source_session_id: 'session-1',
+    });
+    expect(memory.content).toContain('use a bounded retry');
+    expect(memory.content).toContain('src/retry.ts');
+    expect(provenance).toHaveLength(3);
+    expect(provenance.every(row => row.derivationType === 'summary')).toBe(true);
+    expect(telemetry).toEqual([
+      expect.objectContaining({
+        outcome: 'success',
+        sessionId: 'session-1',
+        observationCount: 3,
+      }),
+    ]);
+  });
+
+  it('returns the existing summary without creating duplicates', () => {
+    createSession();
+    addObservation({ id: 'observation-prompt' });
+    repository.updateSession('session-1', { status: 'COMPLETED' }, '2026-06-06T00:00:09.000Z');
+
+    const first = service.summarize('session-1');
+    const second = service.summarize('session-1');
+
+    expect(second).toEqual({
+      status: 'EXISTING',
+      memoryId: first.memoryId,
+      observationCount: 2,
+    });
+    expect(db.prepare('SELECT COUNT(*) AS count FROM memory_item').get()).toEqual({ count: 1 });
+    expect(repository.listProvenance({ memoryId: first.memoryId! })).toHaveLength(2);
+  });
+
+  it('summarizes abandoned sessions from the observations that remain available', () => {
+    createSession();
+    addObservation({
+      id: 'observation-partial',
+      eventType: 'TOOL_RESULT',
+      outcome: 'failed',
+      payloadJson: '{"error":"build failed before the agent stopped"}',
+    });
+    repository.updateSession('session-1', {
+      status: 'ABANDONED',
+      endedAt: '2026-06-06T00:00:09.000Z',
+    }, '2026-06-06T00:00:09.000Z');
+
+    const result = service.summarize('session-1');
+    const content = db.prepare('SELECT content FROM memory_item WHERE id = ?')
+      .get(result.memoryId) as { content: string };
+
+    expect(result.status).toBe('CREATED');
+    expect(content.content).toContain('ABANDONED');
+    expect(content.content).toContain('build failed before the agent stopped');
+  });
+
+  it('skips empty sessions with an explicit reason and telemetry', () => {
+    repository.createSession(
+      { ...startEvent, payloadJson: null, captureStatus: 'DROPPED', dropReason: 'SENSITIVE_PATH' },
+      '2026-06-06T00:00:01.000Z',
+    );
+    repository.createObservation({
+      ...startEvent,
+      id: 'observation-dropped',
+      payloadJson: null,
+      captureStatus: 'DROPPED',
+      dropReason: 'SENSITIVE_PATH',
+      lateArrival: false,
+      receivedAt: '2026-06-06T00:00:01.000Z',
+      expiresAt: null,
+    });
+    repository.updateSession('session-1', { status: 'ABANDONED' }, '2026-06-06T00:00:09.000Z');
+
+    expect(service.summarize('session-1')).toEqual({
+      status: 'SKIPPED',
+      memoryId: null,
+      observationCount: 0,
+      reason: 'NO_USABLE_OBSERVATIONS',
+    });
+    expect(telemetry).toEqual([
+      expect.objectContaining({
+        outcome: 'empty',
+        reason: 'NO_USABLE_OBSERVATIONS',
+        observationCount: 0,
+      }),
+    ]);
+  });
+
+  it('redacts secrets again and bounds the final summary payload', () => {
+    createSession();
+    addObservation({
+      id: 'observation-secret',
+      payloadJson: JSON.stringify({
+        prompt: `token=sk-${'a'.repeat(48)}`,
+        output: 'x'.repeat(20_000),
+      }),
+    });
+    repository.updateSession('session-1', { status: 'COMPLETED' }, '2026-06-06T00:00:09.000Z');
+
+    const result = service.summarize('session-1');
+    const memory = db.prepare('SELECT content FROM memory_item WHERE id = ?')
+      .get(result.memoryId) as { content: string };
+
+    expect(memory.content).not.toContain(`sk-${'a'.repeat(48)}`);
+    expect(memory.content).toContain('[REDACTED]');
+    expect(Buffer.byteLength(memory.content, 'utf8')).toBeLessThanOrEqual(16 * 1024);
+    expect(JSON.stringify(telemetry)).not.toContain(`sk-${'a'.repeat(48)}`);
+  });
+
+  it('records failure telemetry and allows a later retry', () => {
+    createSession();
+    addObservation({ id: 'observation-prompt' });
+    repository.updateSession('session-1', { status: 'COMPLETED' }, '2026-06-06T00:00:09.000Z');
+    const original = repository.persistSessionSummary.bind(repository);
+    const persist = vi.spyOn(repository, 'persistSessionSummary')
+      .mockImplementationOnce(() => {
+        throw new Error('database unavailable with secret=do-not-record');
+      })
+      .mockImplementation(original);
+
+    expect(() => service.summarize('session-1')).toThrow('database unavailable');
+    expect(repository.getSession('session-1')?.summaryMemoryId).toBeNull();
+    expect(telemetry).toEqual([
+      expect.objectContaining({
+        outcome: 'failure',
+        reason: 'SUMMARY_PERSIST_FAILED',
+      }),
+    ]);
+    expect(JSON.stringify(telemetry)).not.toContain('do-not-record');
+
+    expect(service.summarize('session-1').status).toBe('CREATED');
+    expect(persist).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'crypto';
+import type { AgentIntegrationRepository } from '../repositories/agent-integration-repository.js';
+import type { AgentObservation, AgentSession } from '../types.js';
+
+const MAX_SUMMARY_BYTES = 16 * 1024;
+const SECRET_PATTERNS = [
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\b(?:api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;"'}]+/gi,
+  /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/gi,
+];
+
+export interface AgentSummaryTelemetryEvent {
+  outcome: 'success' | 'failure' | 'empty';
+  sessionId: string;
+  observationCount: number;
+  latencyMs: number;
+  reason?: 'NO_USABLE_OBSERVATIONS' | 'SUMMARY_PERSIST_FAILED';
+}
+
+export interface AgentSessionSummaryServiceOptions {
+  now?: () => Date;
+  recordTelemetry?: (event: AgentSummaryTelemetryEvent) => void;
+}
+
+export type AgentSessionSummaryResult =
+  | {
+      status: 'CREATED' | 'EXISTING';
+      memoryId: string;
+      observationCount: number;
+    }
+  | {
+      status: 'SKIPPED';
+      memoryId: null;
+      observationCount: 0;
+      reason: 'NO_USABLE_OBSERVATIONS';
+    };
+
+function redactSecrets(value: string): string {
+  return SECRET_PATTERNS.reduce(
+    (redacted, pattern) => redacted.replace(pattern, '[REDACTED]'),
+    value,
+  );
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, 'utf8');
+  if (buffer.byteLength <= maxBytes) return value;
+  return `${buffer.subarray(0, Math.max(0, maxBytes - 32)).toString('utf8')}\n[TRUNCATED]`;
+}
+
+function formatPayload(payloadJson: string): string {
+  try {
+    return JSON.stringify(JSON.parse(payloadJson), null, 2);
+  } catch {
+    return payloadJson;
+  }
+}
+
+export function buildAgentSessionSummary(
+  session: AgentSession,
+  observations: AgentObservation[],
+): { content: string; observationIds: string[] } | null {
+  const usable = observations.filter(observation =>
+    observation.payloadJson !== null
+    && (observation.status === 'ACCEPTED' || observation.status === 'REDACTED'),
+  );
+  if (usable.length === 0) return null;
+
+  const parts = [
+    `# Agent session summary: ${session.id}`,
+    `status=${session.status}`,
+    `started_at=${session.startedAt}`,
+    `ended_at=${session.endedAt ?? 'unknown'}`,
+    '',
+  ];
+  const observationIds: string[] = [];
+  let usedBytes = Buffer.byteLength(parts.join('\n'), 'utf8');
+  for (const observation of usable) {
+    const metadata = [
+      `event=${observation.eventType}`,
+      `sequence=${observation.sequenceNo}`,
+      observation.toolName ? `tool=${observation.toolName}` : null,
+      observation.outcome ? `outcome=${observation.outcome}` : null,
+    ].filter(Boolean).join(' ');
+    const remainingBytes = MAX_SUMMARY_BYTES - usedBytes;
+    if (remainingBytes <= 64) break;
+    const section = truncateUtf8(
+      redactSecrets(`## ${metadata}\n${formatPayload(observation.payloadJson!)}`),
+      remainingBytes,
+    );
+    parts.push(section);
+    observationIds.push(observation.id);
+    usedBytes += Buffer.byteLength(`\n${section}`, 'utf8');
+  }
+
+  return {
+    content: truncateUtf8(redactSecrets(parts.join('\n')), MAX_SUMMARY_BYTES),
+    observationIds,
+  };
+}
+
+export class AgentSessionSummaryService {
+  private readonly now: () => Date;
+  private readonly recordTelemetry: (event: AgentSummaryTelemetryEvent) => void;
+
+  constructor(
+    private readonly repository: AgentIntegrationRepository,
+    options: AgentSessionSummaryServiceOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.recordTelemetry = options.recordTelemetry ?? (() => undefined);
+  }
+
+  summarize(sessionId: string): AgentSessionSummaryResult {
+    const startedAt = Date.now();
+    const session = this.repository.getSession(sessionId);
+    if (!session) throw new Error(`Agent session not found: ${sessionId}`);
+
+    const observations = this.repository.listAllObservations(sessionId);
+    const summary = buildAgentSessionSummary(session, observations);
+    if (!summary) {
+      this.safeRecordTelemetry({
+        outcome: 'empty',
+        sessionId,
+        observationCount: 0,
+        latencyMs: Date.now() - startedAt,
+        reason: 'NO_USABLE_OBSERVATIONS',
+      });
+      return {
+        status: 'SKIPPED',
+        memoryId: null,
+        observationCount: 0,
+        reason: 'NO_USABLE_OBSERVATIONS',
+      };
+    }
+
+    try {
+      const persisted = this.repository.persistSessionSummary({
+        memoryId: randomUUID(),
+        session,
+        content: summary.content,
+        observationIds: summary.observationIds,
+        createdAt: this.now().toISOString(),
+      });
+      this.safeRecordTelemetry({
+        outcome: 'success',
+        sessionId,
+        observationCount: summary.observationIds.length,
+        latencyMs: Date.now() - startedAt,
+      });
+      return {
+        status: persisted.created ? 'CREATED' : 'EXISTING',
+        memoryId: persisted.memoryId,
+        observationCount: summary.observationIds.length,
+      };
+    } catch (error) {
+      this.safeRecordTelemetry({
+        outcome: 'failure',
+        sessionId,
+        observationCount: summary.observationIds.length,
+        latencyMs: Date.now() - startedAt,
+        reason: 'SUMMARY_PERSIST_FAILED',
+      });
+      throw error;
+    }
+  }
+
+  private safeRecordTelemetry(event: AgentSummaryTelemetryEvent): void {
+    try {
+      this.recordTelemetry(event);
+    } catch {
+      // Telemetry must never change summary persistence or retry semantics.
+    }
+  }
+}

--- a/packages/memento-core/src/domains/telemetry/types/telemetry.types.ts
+++ b/packages/memento-core/src/domains/telemetry/types/telemetry.types.ts
@@ -14,7 +14,10 @@ export type EventType =
   | 'memory.feedback.positive'
   | 'memory.feedback.negative'
   | 'consolidation.performed'
-  | 'telemetry.cleanup.performed';
+  | 'telemetry.cleanup.performed'
+  | 'agent.summary.completed'
+  | 'agent.summary.failed'
+  | 'agent.summary.skipped';
 
 export type Outcome = 'success' | 'failure' | 'empty';
 

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -192,10 +192,20 @@ export {
   AgentIntegrationError,
   AgentLifecycleService,
 } from './domains/agent-integration/services/agent-lifecycle-service.js';
+export {
+  AgentSessionSummaryService,
+  buildAgentSessionSummary,
+} from './domains/agent-integration/services/agent-session-summary-service.js';
 export type {
   AgentIntegrationReasonCode,
   AgentLifecycleServiceOptions,
+  AgentSessionSummarizer,
 } from './domains/agent-integration/services/agent-lifecycle-service.js';
+export type {
+  AgentSessionSummaryResult,
+  AgentSessionSummaryServiceOptions,
+  AgentSummaryTelemetryEvent,
+} from './domains/agent-integration/services/agent-session-summary-service.js';
 export type {
   AgentCaptureStatus,
   AgentEventType,
@@ -236,4 +246,3 @@ export type {
   EvolutionDemoScenario,
   EvolutionDemoScenarioCatalog,
 } from './domains/evolution-demo/index.js';
-

--- a/packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.ts
+++ b/packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
 import type {
   AgentIntegrationRepository,
   CreateObservationInput,
@@ -363,8 +364,81 @@ export class SqliteAgentIntegrationRepository implements AgentIntegrationReposit
     };
   }
 
-  markExpiredSessionsAbandoned(cutoff: string, now: string): number {
-    return this.db.prepare(`
+  listAllObservations(sessionId: string): AgentObservation[] {
+    return (
+      this.db.prepare(`
+        SELECT * FROM agent_observation
+        WHERE session_id = ?
+        ORDER BY sequence_no, occurred_at, received_at, id
+      `).all(sessionId) as ObservationRow[]
+    ).map(mapObservation);
+  }
+
+  persistSessionSummary(input: {
+    memoryId: string;
+    session: AgentSession;
+    content: string;
+    observationIds: string[];
+    createdAt: string;
+  }): { memoryId: string; created: boolean } {
+    return this.runInTransaction(() => {
+      const current = this.getSession(input.session.id);
+      if (!current) throw new Error(`Agent session not found: ${input.session.id}`);
+      if (current.summaryMemoryId) {
+        return { memoryId: current.summaryMemoryId, created: false };
+      }
+      if (!['COMPLETED', 'DEGRADED', 'ABANDONED'].includes(current.status)) {
+        throw new Error(`Agent session is not terminal: ${input.session.id}`);
+      }
+
+      this.db.prepare(`
+        INSERT INTO memory_item (
+          id, type, content, importance, privacy_scope, tags, source, origin_source,
+          owner_id, process_id, session_id, project_id, source_session_id, created_at
+        ) VALUES (?, 'episodic', ?, 0.7, 'private', ?, 'agent_session_summary', ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        input.memoryId,
+        input.content,
+        JSON.stringify(['agent-session', 'summary', current.adapterName]),
+        JSON.stringify({
+          tool: 'agent-session-summary',
+          caller: 'agent-integration',
+          timestamp: input.createdAt,
+        }),
+        current.ownerId,
+        current.processId,
+        current.id,
+        current.projectId,
+        current.id,
+        input.createdAt,
+      );
+
+      const insertProvenance = this.db.prepare(`
+        INSERT INTO memory_provenance (
+          id, memory_id, session_id, observation_id, derivation_type, created_at
+        ) VALUES (?, ?, ?, ?, 'summary', ?)
+      `);
+      for (const observationId of input.observationIds) {
+        insertProvenance.run(
+          randomUUID(),
+          input.memoryId,
+          current.id,
+          observationId,
+          input.createdAt,
+        );
+      }
+
+      this.db.prepare(`
+        UPDATE agent_session
+        SET summary_memory_id = ?, updated_at = ?
+        WHERE id = ? AND summary_memory_id IS NULL
+      `).run(input.memoryId, input.createdAt, current.id);
+      return { memoryId: input.memoryId, created: true };
+    });
+  }
+
+  markExpiredSessionsAbandoned(cutoff: string, now: string): string[] {
+    const rows = this.db.prepare(`
       UPDATE agent_session
       SET status = 'ABANDONED', ended_at = last_event_at, updated_at = ?
       WHERE (
@@ -372,7 +446,9 @@ export class SqliteAgentIntegrationRepository implements AgentIntegrationReposit
           OR (status = 'DEGRADED' AND ended_at IS NULL)
         )
         AND last_event_at < ?
-    `).run(now, cutoff).changes;
+      RETURNING id
+    `).all(now, cutoff) as Array<{ id: string }>;
+    return rows.map(row => row.id);
   }
 
   clearExpiredObservationPayloads(cutoff: string): number {

--- a/packages/memento-server/src/server/routes/agent.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.spec.ts
@@ -32,7 +32,46 @@ describe('agent integration routes', () => {
   beforeEach(async () => {
     db = new Database(':memory:');
     db.pragma('foreign_keys = ON');
-    db.exec('CREATE TABLE memory_item (id TEXT PRIMARY KEY, session_id TEXT)');
+    db.exec(`
+      CREATE TABLE memory_item (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL DEFAULT 'episodic',
+        content TEXT NOT NULL DEFAULT '',
+        importance REAL DEFAULT 0.5,
+        privacy_scope TEXT DEFAULT 'private',
+        tags TEXT,
+        source TEXT,
+        origin_source TEXT,
+        owner_id TEXT,
+        process_id TEXT,
+        session_id TEXT,
+        project_id TEXT,
+        source_session_id TEXT,
+        created_at TEXT
+      );
+      CREATE TABLE telemetry_events (
+        id TEXT PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        request_id TEXT NOT NULL,
+        owner_id TEXT,
+        latency_ms INTEGER,
+        outcome TEXT NOT NULL,
+        error_code TEXT,
+        extra_data TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE telemetry_daily_metrics (
+        id TEXT PRIMARY KEY,
+        date TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        owner_id TEXT NOT NULL DEFAULT '',
+        event_count INTEGER NOT NULL DEFAULT 0,
+        avg_latency_ms REAL,
+        error_count INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL,
+        UNIQUE(date, event_type, owner_id)
+      )
+    `);
     await new AgentIntegrationSchemaMigration().up(db);
     router = createAgentRouter(db, {
       now: () => new Date('2026-06-06T00:00:10.000Z'),
@@ -137,7 +176,27 @@ describe('agent integration routes', () => {
     expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
       session: expect.objectContaining({ status: 'COMPLETED' }),
       result: expect.objectContaining({ status: 'ACCEPTED' }),
-      summary_job_id: null,
+      summary_job_id: expect.any(String),
+    }));
+    const stopped = vi.mocked(response.json).mock.calls.at(-1)?.[0] as {
+      summary_job_id: string;
+    };
+    expect(db.prepare(`
+      SELECT type, session_id, source_session_id
+      FROM memory_item WHERE id = ?
+    `).get(stopped.summary_job_id)).toEqual({
+      type: 'episodic',
+      session_id: 'session-1',
+      source_session_id: 'session-1',
+    });
+    expect(db.prepare(`
+      SELECT event_type, outcome, extra_data
+      FROM telemetry_events
+      WHERE event_type = 'agent.summary.completed'
+    `).get()).toEqual(expect.objectContaining({
+      event_type: 'agent.summary.completed',
+      outcome: 'success',
+      extra_data: expect.stringContaining('"observation_count":3'),
     }));
   });
 

--- a/packages/memento-server/src/server/routes/agent.routes.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.ts
@@ -1,7 +1,9 @@
 import {
   AgentIntegrationError,
   AgentLifecycleService,
+  AgentSessionSummaryService,
   SqliteAgentIntegrationRepository,
+  TelemetryRepository,
   type AgentLifecycleServiceOptions,
   type AgentObservation,
   type AgentSession,
@@ -219,8 +221,35 @@ export function createAgentRouter(
   options: AgentLifecycleServiceOptions = {},
 ): Router {
   const router = Router();
-  const service = db
-    ? new AgentLifecycleService(new SqliteAgentIntegrationRepository(db), options)
+  const repository = db ? new SqliteAgentIntegrationRepository(db) : null;
+  const telemetryRepository = db ? new TelemetryRepository(db) : null;
+  const summarizer = repository
+    ? new AgentSessionSummaryService(repository, {
+        now: options.now,
+        recordTelemetry: event => {
+          const eventType = event.outcome === 'success'
+            ? 'agent.summary.completed'
+            : event.outcome === 'empty'
+              ? 'agent.summary.skipped'
+              : 'agent.summary.failed';
+          telemetryRepository?.insertEventSync({
+            eventType,
+            requestId: `agent-summary:${event.sessionId}`,
+            ownerId: repository.getSession(event.sessionId)?.ownerId ?? null,
+            latencyMs: event.latencyMs,
+            outcome: event.outcome,
+            errorCode: event.reason,
+            extraData: {
+              session_id: event.sessionId,
+              observation_count: event.observationCount,
+              ...(event.reason ? { reason: event.reason } : {}),
+            },
+          });
+        },
+      })
+    : null;
+  const service = repository
+    ? new AgentLifecycleService(repository, options, summarizer ?? undefined)
     : null;
 
   router.get('/capabilities', (_req, res) => {
@@ -370,8 +399,9 @@ export function createAgentRouter(
           throw new AgentIntegrationError(`${expectedType} is required`, 'INTERNAL_ERROR', 400);
         }
         const result = service.capture(prepared);
+        const session = service.getSession(prepared.sessionId)!;
         return res.json({
-          session: sessionDto(service.getSession(prepared.sessionId)!),
+          session: sessionDto(session),
           result: {
             event_id: result.eventId,
             status: result.status,
@@ -381,7 +411,7 @@ export function createAgentRouter(
           },
           ...(expectedType === 'PRE_COMPACT'
             ? { injection: null }
-            : { summary_job_id: null }),
+            : { summary_job_id: session.summaryMemoryId }),
         });
       } catch (error) {
         return writeError(res, error);
@@ -470,7 +500,11 @@ export function createAgentRouter(
   router.post('/retention:enforce', (_req, res) => {
     try {
       if (!service) throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
-      return res.json(service.enforceRetention());
+      const abandonedSessions = service.abandonExpiredSessions();
+      return res.json({
+        ...service.enforceRetention(),
+        abandonedSessions,
+      });
     } catch (error) {
       return writeError(res, error);
     }


### PR DESCRIPTION
## 변경 사항
- STOP 및 abandoned session에 대해 bounded episodic summary를 생성합니다.
- summary 생성 시 secret 재마스킹과 16KiB payload 상한을 적용합니다.
- `agent_session.summary_memory_id`와 observation별 `derivation_type=summary` provenance를 원자적으로 저장합니다.
- duplicate STOP 및 일시적 저장 실패에서 idempotent retry를 지원합니다.
- 완료/실패/빈 session summary telemetry와 server 응답의 `summary_job_id`를 연결합니다.

## 변경 유형
- [x] 새로운 기능
- [x] 테스트 추가/수정

## 관련 이슈
- Closes #464
- Related to #456
- Related to #452

## 테스트
- 타깃 테스트 34개 통과
- core build, core/server typecheck, 변경 파일 ESLint 통과
- SQL injection, PII masking, path traversal 정적 검사 통과

전체 core suite는 로컬 ignore-scripts 설치에서 native better-sqlite3 binding이 없어 실행 불가했으며, GitHub Actions의 정상 npm ci 환경에서 전체 매트릭스를 확인합니다.

## 코드 리뷰 포인트
- persistSessionSummary 트랜잭션의 exactly-once/idempotency 보장
- summary의 redaction 및 UTF-8 byte 상한
- duplicate STOP과 abandoned sweep의 retry 동작

## 문서 업데이트
- [x] 문서 업데이트 불필요 (PRD/issue 계약 구현)

## 지식 복리
- [x] 문서화 생략 — 신규 기능 구현이며 해결 사례로 분리할 반복 장애가 없음

## 체크리스트
- [x] 코드 스타일 준수
- [x] 자체 검토 완료
- [x] 새로운 경고나 오류 없음
- [x] 새 의존성 없음

## 배포 관련
- [x] 특별한 사항 없음