### PR TITLE
feat(agent-memory): scope-aware recall과 hard token budget packer

### DIFF
--- a/packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts
@@ -1,0 +1,427 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AgentContextRecallService,
+  type AgentContextCandidate,
+  type AgentContextRecallSource,
+} from './agent-context-recall-service.js';
+
+const NOW = '2026-06-07T00:00:00.000Z';
+
+function candidate(
+  id: string,
+  content: string,
+  overrides: Partial<AgentContextCandidate> = {},
+): AgentContextCandidate {
+  return {
+    id,
+    content,
+    type: 'semantic',
+    relevance: 0.8,
+    importance: 0.7,
+    createdAt: '2026-06-06T00:00:00.000Z',
+    provenanceConfidence: 0.9,
+    privacyScope: 'private',
+    ownerId: 'owner-a',
+    projectId: 'project-a',
+    processId: 'process-a',
+    sessionId: 'session-a',
+    topics: ['agent-memory'],
+    ...overrides,
+  };
+}
+
+function source(
+  name: string,
+  items: AgentContextCandidate[] | Error,
+): AgentContextRecallSource {
+  return {
+    name,
+    recall: async () => {
+      if (items instanceof Error) {
+        throw items;
+      }
+      return { items };
+    },
+  };
+}
+
+const baseRequest = {
+  query: 'context packing',
+  scope: {
+    ownerId: 'owner-a',
+    projectId: 'project-a',
+    processId: 'process-a',
+    sessionId: 'session-a',
+  },
+  tokenBudget: 200,
+  now: NOW,
+};
+
+describe('AgentContextRecallService', () => {
+  it('excludes private memories from another owner or project and preserves scope fallback priority', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('session', 'session exact'),
+          candidate('process', 'process fallback', { sessionId: 'session-old' }),
+          candidate('project', 'project fallback', {
+            processId: 'process-old',
+            sessionId: 'session-old',
+          }),
+          candidate('owner', 'owner fallback', {
+            projectId: null,
+            processId: null,
+            sessionId: null,
+          }),
+          candidate('other-owner', 'must never leak owner', { ownerId: 'owner-b' }),
+          candidate('other-project', 'must never leak project', { projectId: 'project-b' }),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.selected.map((item) => item.id)).toEqual([
+      'session',
+      'process',
+      'project',
+      'owner',
+    ]);
+    expect(result.selected.map((item) => item.scopeLevel)).toEqual([
+      'session',
+      'process',
+      'project',
+      'owner',
+    ]);
+    expect(result.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'other-owner',
+          reason: 'privacy_scope_mismatch',
+          score: 0,
+          tokenEstimate: 21,
+        }),
+        expect.objectContaining({
+          id: 'other-project',
+          reason: 'privacy_scope_mismatch',
+          score: 0,
+          tokenEstimate: 21,
+        }),
+      ]),
+    );
+  });
+
+  it('allows team memories only inside the current project', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('team-same-project', 'shared project decision', {
+            privacyScope: 'team',
+            ownerId: 'owner-b',
+            processId: 'other-process',
+            sessionId: 'other-session',
+          }),
+          candidate('team-other-project', 'other project decision', {
+            privacyScope: 'team',
+            ownerId: 'owner-b',
+            projectId: 'project-b',
+          }),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.selected.map((item) => item.id)).toEqual(['team-same-project']);
+    expect(result.selected[0]?.scopeLevel).toBe('project');
+    expect(result.excluded).toContainEqual(
+      expect.objectContaining({
+        id: 'team-other-project',
+        reason: 'privacy_scope_mismatch',
+      }),
+    );
+  });
+
+  it('does not expose project-private memories when the request has no project scope', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('project-private', 'project-only decision'),
+          candidate('owner-private', 'owner fallback', {
+            projectId: null,
+            processId: null,
+            sessionId: null,
+          }),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      scope: { ownerId: 'owner-a' },
+    });
+
+    expect(result.selected.map((item) => item.id)).toEqual(['owner-private']);
+    expect(result.excluded).toContainEqual(
+      expect.objectContaining({
+        id: 'project-private',
+        reason: 'privacy_scope_mismatch',
+      }),
+    );
+  });
+
+  it('never lets relevance or diversity reorder a broader fallback ahead of a narrower scope', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('session-low-score', 'session context', {
+            relevance: 0.1,
+            importance: 0.1,
+            provenanceConfidence: 0.1,
+            topics: ['auth'],
+          }),
+          candidate('project-high-score', 'project context', {
+            processId: 'other-process',
+            sessionId: 'other-session',
+            relevance: 1,
+            importance: 1,
+            provenanceConfidence: 1,
+            type: 'procedural',
+            topics: ['database'],
+          }),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.selected.map((item) => item.id)).toEqual([
+      'session-low-score',
+      'project-high-score',
+    ]);
+  });
+
+  it('returns useful results with explicit degraded diagnostics when one provider fails', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('vector', new Error('provider unavailable')),
+        source('text', [candidate('text-result', 'text fallback result')]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.status).toBe('degraded');
+    expect(result.selected.map((item) => item.id)).toEqual(['text-result']);
+    expect(result.degradedReasons).toEqual([
+      {
+        source: 'vector',
+        code: 'source_failed',
+        message: 'provider unavailable',
+      },
+    ]);
+  });
+
+  it('propagates a fulfilled source fallback as a degraded result', async () => {
+    const fallbackSource: AgentContextRecallSource = {
+      name: 'hybrid',
+      recall: async () => ({
+        items: [candidate('fallback-result', 'fallback result')],
+        degradedReason: {
+          code: 'search_fallback',
+          message: 'hybrid search used a fallback path',
+        },
+      }),
+    };
+    const service = new AgentContextRecallService({
+      sources: [fallbackSource],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.status).toBe('degraded');
+    expect(result.degradedReasons).toEqual([{
+      source: 'hybrid',
+      code: 'search_fallback',
+      message: 'hybrid search used a fallback path',
+    }]);
+  });
+
+  it('returns an explicit empty result when no source has candidates', async () => {
+    const service = new AgentContextRecallService({
+      sources: [source('hybrid', [])],
+    });
+
+    const result = await service.buildContext(baseRequest);
+
+    expect(result.status).toBe('empty');
+    expect(result.selected).toEqual([]);
+    expect(result.tokenUsage).toEqual({
+      budget: 200,
+      used: 0,
+      remaining: 200,
+    });
+  });
+
+  it('deduplicates similar content and selects diverse topics and memory types', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('auth-semantic', 'Use OAuth PKCE for browser authentication', {
+            type: 'semantic',
+            topics: ['auth'],
+            relevance: 1,
+          }),
+          candidate('auth-duplicate', 'Use OAuth PKCE for browser authentication.', {
+            type: 'semantic',
+            topics: ['auth'],
+            relevance: 0.99,
+          }),
+          candidate('auth-episodic', 'OAuth callback failed until redirect URI matched', {
+            type: 'episodic',
+            topics: ['auth'],
+            relevance: 0.95,
+          }),
+          candidate('database-procedural', 'Run schema validation before migration', {
+            type: 'procedural',
+            topics: ['database'],
+            relevance: 0.9,
+          }),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 20 },
+      estimationErrorRatio: 0.1,
+      perItemOverheadTokens: 0,
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      tokenBudget: 66,
+      maxItems: 3,
+    });
+
+    expect(result.selected.map((item) => item.id)).toEqual([
+      'auth-semantic',
+      'database-procedural',
+      'auth-episodic',
+    ]);
+    expect(result.excluded).toContainEqual(
+      expect.objectContaining({
+        id: 'auth-duplicate',
+        reason: 'duplicate',
+        duplicateOf: 'auth-semantic',
+      }),
+    );
+  });
+
+  it('uses stable id tie-breaks and returns identical decisions for identical input', async () => {
+    const candidates = [
+      candidate('memory-b', 'beta decision', { topics: ['beta'] }),
+      candidate('memory-a', 'alpha decision', { topics: ['alpha'] }),
+    ];
+    const service = new AgentContextRecallService({
+      sources: [source('hybrid', candidates)],
+      tokenEstimator: { estimate: () => 10 },
+    });
+
+    const first = await service.buildContext(baseRequest);
+    const second = await service.buildContext(baseRequest);
+
+    expect(first).toEqual(second);
+    expect(first.selected.map((item) => item.id)).toEqual(['memory-a', 'memory-b']);
+  });
+
+  it('fills an exact conservative budget boundary without exceeding it', async () => {
+    const service = new AgentContextRecallService({
+      sources: [
+        source('hybrid', [
+          candidate('fits', 'exact boundary'),
+          candidate('overflow', 'must be excluded'),
+        ]),
+      ],
+      tokenEstimator: { estimate: () => 10 },
+      estimationErrorRatio: 0.2,
+      perItemOverheadTokens: 3,
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      tokenBudget: 15,
+    });
+
+    expect(result.selected.map((item) => item.id)).toEqual(['fits']);
+    expect(result.selected[0]?.tokenEstimate).toBe(15);
+    expect(result.tokenUsage).toEqual({ budget: 15, used: 15, remaining: 0 });
+    expect(result.excluded).toContainEqual(
+      expect.objectContaining({ id: 'overflow', reason: 'token_budget_exceeded' }),
+    );
+  });
+
+  it('treats non-finite and negative limits as zero', async () => {
+    const service = new AgentContextRecallService({
+      sources: [source('hybrid', [candidate('excluded', 'must not be selected')])],
+      tokenEstimator: { estimate: () => 1 },
+      estimationErrorRatio: 0,
+      perItemOverheadTokens: 0,
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      tokenBudget: Number.NaN,
+      maxItems: -1,
+    });
+
+    expect(result.selected).toEqual([]);
+    expect(result.tokenUsage).toEqual({ budget: 0, used: 0, remaining: 0 });
+    expect(result.excluded).toContainEqual(
+      expect.objectContaining({ id: 'excluded', reason: 'max_items_reached' }),
+    );
+  });
+
+  it('keeps token accounting finite when estimator configuration is invalid', async () => {
+    const service = new AgentContextRecallService({
+      sources: [source('hybrid', [candidate('safe', 'finite accounting')])],
+      tokenEstimator: { estimate: () => Number.NaN },
+      estimationErrorRatio: Number.NaN,
+      perItemOverheadTokens: -10,
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      tokenBudget: 1,
+    });
+
+    expect(result.selected[0]?.tokenEstimate).toBe(0);
+    expect(result.tokenUsage).toEqual({ budget: 1, used: 0, remaining: 1 });
+  });
+
+  it('accounts conservatively for tokenizer estimation error', async () => {
+    const actualTokenizer = { estimate: (text: string) => text.length };
+    const underestimatingTokenizer = {
+      estimate: (text: string) => Math.ceil(text.length / 2),
+    };
+    const service = new AgentContextRecallService({
+      sources: [source('hybrid', [candidate('error-safe', '1234567890')])],
+      tokenEstimator: underestimatingTokenizer,
+      estimationErrorRatio: 1,
+      perItemOverheadTokens: 0,
+    });
+
+    const result = await service.buildContext({
+      ...baseRequest,
+      tokenBudget: 10,
+    });
+
+    expect(result.selected[0]?.tokenEstimate).toBe(10);
+    expect(actualTokenizer.estimate(result.selected[0]!.content)).toBeLessThanOrEqual(
+      result.tokenUsage.budget,
+    );
+    expect(result.tokenUsage.used).toBeLessThanOrEqual(result.tokenUsage.budget);
+  });
+});

--- a/packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.ts
@@ -1,0 +1,436 @@
+import type { MemoryType, PrivacyScope } from '../../../shared/types/index.js';
+
+export type AgentContextScopeLevel = 'session' | 'process' | 'project' | 'owner';
+export type AgentContextStatus = 'ok' | 'empty' | 'degraded';
+
+export interface AgentContextScope {
+  ownerId: string;
+  projectId?: string;
+  processId?: string;
+  sessionId?: string;
+}
+
+export interface AgentContextCandidate {
+  id: string;
+  content: string;
+  type: MemoryType;
+  relevance: number;
+  importance: number;
+  createdAt: string;
+  provenanceConfidence: number;
+  privacyScope: PrivacyScope;
+  ownerId: string | null;
+  projectId: string | null;
+  processId: string | null;
+  sessionId: string | null;
+  topics?: string[];
+}
+
+export interface AgentContextRecallSource {
+  name: string;
+  recall(input: {
+    query: string;
+    scope: AgentContextScope;
+    limit: number;
+  }): Promise<AgentContextSourceResult>;
+}
+
+export interface AgentContextSourceResult {
+  items: AgentContextCandidate[];
+  degradedReason?: {
+    code: 'search_fallback';
+    message: string;
+  };
+}
+
+export interface AgentTokenEstimator {
+  estimate(text: string): number;
+}
+
+export interface AgentContextRecallRequest {
+  query: string;
+  scope: AgentContextScope;
+  tokenBudget: number;
+  maxItems?: number;
+  now?: string;
+}
+
+export interface SelectedAgentContextItem extends AgentContextCandidate {
+  score: number;
+  scopeLevel: AgentContextScopeLevel;
+  tokenEstimate: number;
+  selectionReason: 'selected_by_score' | 'selected_for_diversity';
+}
+
+export interface ExcludedAgentContextItem {
+  id: string;
+  reason:
+    | 'privacy_scope_mismatch'
+    | 'scope_mismatch'
+    | 'duplicate'
+    | 'diversity_deferred'
+    | 'token_budget_exceeded'
+    | 'max_items_reached';
+  score: number;
+  tokenEstimate: number;
+  duplicateOf?: string;
+}
+
+export interface AgentContextRecallResult {
+  status: AgentContextStatus;
+  query: string;
+  contextText: string;
+  selected: SelectedAgentContextItem[];
+  excluded: ExcludedAgentContextItem[];
+  tokenUsage: {
+    budget: number;
+    used: number;
+    remaining: number;
+  };
+  degradedReasons: Array<{
+    source: string;
+    code: 'source_failed' | 'search_fallback';
+    message: string;
+  }>;
+}
+
+export interface AgentContextRecallServiceOptions {
+  sources: AgentContextRecallSource[];
+  tokenEstimator?: AgentTokenEstimator;
+  estimationErrorRatio?: number;
+  perItemOverheadTokens?: number;
+}
+
+export class AgentContextRecallService {
+  private readonly sources: AgentContextRecallSource[];
+  private readonly tokenEstimator: AgentTokenEstimator;
+  private readonly estimationErrorRatio: number;
+  private readonly perItemOverheadTokens: number;
+
+  constructor(options: AgentContextRecallServiceOptions) {
+    this.sources = [...options.sources];
+    this.tokenEstimator = options.tokenEstimator ?? {
+      estimate: (text) => Math.ceil(text.length / 3),
+    };
+    this.estimationErrorRatio = nonNegativeNumber(options.estimationErrorRatio ?? 0.25);
+    this.perItemOverheadTokens = nonNegativeInteger(options.perItemOverheadTokens ?? 8);
+  }
+
+  async buildContext(request: AgentContextRecallRequest): Promise<AgentContextRecallResult> {
+    const budget = nonNegativeInteger(request.tokenBudget);
+    const maxItems = nonNegativeInteger(request.maxItems ?? 8);
+    const sourceResults = await Promise.allSettled(
+      this.sources.map((item) =>
+        item.recall({
+          query: request.query,
+          scope: request.scope,
+          limit: Math.max(maxItems * 4, 20),
+        }),
+      ),
+    );
+
+    const degradedReasons: AgentContextRecallResult['degradedReasons'] = [];
+    const candidates: AgentContextCandidate[] = [];
+    sourceResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        candidates.push(...result.value.items);
+        if (result.value.degradedReason) {
+          degradedReasons.push({
+            source: this.sources[index]?.name ?? `source-${index}`,
+            ...result.value.degradedReason,
+          });
+        }
+        return;
+      }
+      degradedReasons.push({
+        source: this.sources[index]?.name ?? `source-${index}`,
+        code: 'source_failed',
+        message: errorMessage(result.reason),
+      });
+    });
+
+    const excluded: ExcludedAgentContextItem[] = [];
+    const eligible = candidates.flatMap((item) => {
+      const privacyReason = getPrivacyExclusionReason(item, request.scope);
+      if (privacyReason) {
+        excluded.push({
+          id: item.id,
+          reason: privacyReason,
+          score: 0,
+          tokenEstimate: this.estimateConservativeTokens(item.content),
+        });
+        return [];
+      }
+
+      const scopeLevel = classifyScope(item, request.scope);
+      if (!scopeLevel) {
+        excluded.push({
+          id: item.id,
+          reason: 'scope_mismatch',
+          score: 0,
+          tokenEstimate: this.estimateConservativeTokens(item.content),
+        });
+        return [];
+      }
+
+      return [{
+        item,
+        scopeLevel,
+        score: scoreCandidate(item, scopeLevel, request.now ?? new Date().toISOString()),
+      }];
+    });
+
+    eligible.sort(compareRankedCandidates);
+    const unique = deduplicateCandidates(
+      eligible,
+      excluded,
+      (content) => this.estimateConservativeTokens(content),
+    );
+    const ordered = diversityOrder(unique);
+    const selected: SelectedAgentContextItem[] = [];
+    let usedTokens = 0;
+
+    for (const ranked of ordered) {
+      const tokenEstimate = this.estimateConservativeTokens(ranked.item.content);
+      if (selected.length >= maxItems) {
+        excluded.push({
+          id: ranked.item.id,
+          reason: 'max_items_reached',
+          score: ranked.score,
+          tokenEstimate,
+        });
+        continue;
+      }
+      if (usedTokens + tokenEstimate > budget) {
+        excluded.push({
+          id: ranked.item.id,
+          reason: 'token_budget_exceeded',
+          score: ranked.score,
+          tokenEstimate,
+        });
+        continue;
+      }
+
+      const selectedForDiversity = selected.length > 0 && addsDiversity(ranked.item, selected);
+      selected.push({
+        ...ranked.item,
+        score: ranked.score,
+        scopeLevel: ranked.scopeLevel,
+        tokenEstimate,
+        selectionReason: selectedForDiversity
+          ? 'selected_for_diversity'
+          : 'selected_by_score',
+      });
+      usedTokens += tokenEstimate;
+    }
+
+    return {
+      status: selected.length === 0
+        ? degradedReasons.length > 0
+          ? 'degraded'
+          : 'empty'
+        : degradedReasons.length > 0
+          ? 'degraded'
+          : 'ok',
+      query: request.query,
+      contextText: selected.map((item) => item.content).join('\n\n'),
+      selected,
+      excluded,
+      tokenUsage: {
+        budget,
+        used: usedTokens,
+        remaining: budget - usedTokens,
+      },
+      degradedReasons,
+    };
+  }
+
+  private estimateConservativeTokens(text: string): number {
+    const estimate = nonNegativeNumber(this.tokenEstimator.estimate(text));
+    return Math.ceil(estimate * (1 + this.estimationErrorRatio))
+      + this.perItemOverheadTokens;
+  }
+}
+
+interface RankedCandidate {
+  item: AgentContextCandidate;
+  scopeLevel: AgentContextScopeLevel;
+  score: number;
+}
+
+const SCOPE_BONUS: Record<AgentContextScopeLevel, number> = {
+  session: 0.08,
+  process: 0.06,
+  project: 0.04,
+  owner: 0.02,
+};
+const SCOPE_ORDER: AgentContextScopeLevel[] = ['session', 'process', 'project', 'owner'];
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+function nonNegativeInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function nonNegativeNumber(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function getPrivacyExclusionReason(
+  candidate: AgentContextCandidate,
+  scope: AgentContextScope,
+): 'privacy_scope_mismatch' | null {
+  if (candidate.privacyScope === 'private') {
+    if (candidate.ownerId !== scope.ownerId) {
+      return 'privacy_scope_mismatch';
+    }
+    if (candidate.projectId !== null && candidate.projectId !== scope.projectId) {
+      return 'privacy_scope_mismatch';
+    }
+    return null;
+  }
+
+  if (candidate.privacyScope === 'team') {
+    if (!scope.projectId || candidate.projectId !== scope.projectId) {
+      return 'privacy_scope_mismatch';
+    }
+  }
+  return null;
+}
+
+function classifyScope(
+  candidate: AgentContextCandidate,
+  scope: AgentContextScope,
+): AgentContextScopeLevel | null {
+  if (scope.sessionId && candidate.sessionId === scope.sessionId) {
+    return 'session';
+  }
+  if (scope.processId && candidate.processId === scope.processId) {
+    return 'process';
+  }
+  if (scope.projectId && candidate.projectId === scope.projectId) {
+    return 'project';
+  }
+  if (candidate.ownerId === scope.ownerId && candidate.projectId === null) {
+    return 'owner';
+  }
+  return null;
+}
+
+function scoreCandidate(
+  candidate: AgentContextCandidate,
+  scopeLevel: AgentContextScopeLevel,
+  now: string,
+): number {
+  const ageMs = Math.max(0, Date.parse(now) - Date.parse(candidate.createdAt));
+  const recency = Number.isFinite(ageMs)
+    ? Math.max(0, 1 - ageMs / (90 * 24 * 60 * 60 * 1000))
+    : 0;
+  const score =
+    clamp01(candidate.relevance) * 0.45
+    + clamp01(candidate.importance) * 0.2
+    + recency * 0.15
+    + clamp01(candidate.provenanceConfidence) * 0.2
+    + SCOPE_BONUS[scopeLevel];
+  return Number(score.toFixed(8));
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function compareRankedCandidates(a: RankedCandidate, b: RankedCandidate): number {
+  return SCOPE_ORDER.indexOf(a.scopeLevel) - SCOPE_ORDER.indexOf(b.scopeLevel)
+    || b.score - a.score
+    || a.item.id.localeCompare(b.item.id);
+}
+
+function deduplicateCandidates(
+  candidates: RankedCandidate[],
+  excluded: ExcludedAgentContextItem[],
+  estimateTokens: (content: string) => number,
+): RankedCandidate[] {
+  const kept: RankedCandidate[] = [];
+  for (const candidate of candidates) {
+    const duplicate = kept.find((existing) =>
+      existing.item.id === candidate.item.id
+      || contentSimilarity(existing.item.content, candidate.item.content) >= 0.85
+    );
+    if (duplicate) {
+      excluded.push({
+        id: candidate.item.id,
+        reason: 'duplicate',
+        score: candidate.score,
+        tokenEstimate: estimateTokens(candidate.item.content),
+        duplicateOf: duplicate.item.id,
+      });
+      continue;
+    }
+    kept.push(candidate);
+  }
+  return kept;
+}
+
+function contentSimilarity(a: string, b: string): number {
+  const left = normalizedTerms(a);
+  const right = normalizedTerms(b);
+  if (left.size === 0 && right.size === 0) {
+    return 1;
+  }
+  const intersection = [...left].filter((term) => right.has(term)).length;
+  const union = new Set([...left, ...right]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function normalizedTerms(content: string): Set<string> {
+  return new Set(
+    content
+      .toLocaleLowerCase('en-US')
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+}
+
+function diversityOrder(candidates: RankedCandidate[]): RankedCandidate[] {
+  const ordered: RankedCandidate[] = [];
+  for (const scopeLevel of SCOPE_ORDER) {
+    ordered.push(...diversityOrderWithinScope(
+      candidates.filter((candidate) => candidate.scopeLevel === scopeLevel),
+    ));
+  }
+  return ordered;
+}
+
+function diversityOrderWithinScope(candidates: RankedCandidate[]): RankedCandidate[] {
+  if (candidates.length <= 1) {
+    return candidates;
+  }
+  const remaining = [...candidates];
+  const ordered: RankedCandidate[] = [remaining.shift()!];
+  while (remaining.length > 0) {
+    const diverseIndex = remaining.findIndex((candidate) =>
+      addsDiversity(candidate.item, ordered.map((item) => item.item))
+    );
+    ordered.push(...remaining.splice(diverseIndex >= 0 ? diverseIndex : 0, 1));
+  }
+  return ordered;
+}
+
+function addsDiversity(
+  candidate: AgentContextCandidate,
+  selected: AgentContextCandidate[],
+): boolean {
+  const selectedTypes = new Set(selected.map((item) => item.type));
+  const selectedTopics = new Set(selected.flatMap((item) => item.topics ?? []));
+  const hasNewType = !selectedTypes.has(candidate.type);
+  const topics = candidate.topics ?? [];
+  const hasNewTopic = topics.length > 0 && topics.some((topic) => !selectedTopics.has(topic));
+  return hasNewType && hasNewTopic;
+}

--- a/packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts
@@ -1,0 +1,129 @@
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HybridSearchEngine } from '../../search/algorithms/hybrid-search-engine.js';
+import { SqliteHybridAgentContextSource } from './sqlite-hybrid-agent-context-source.js';
+
+describe('SqliteHybridAgentContextSource', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE memory_item (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        content TEXT NOT NULL,
+        importance REAL NOT NULL,
+        privacy_scope TEXT NOT NULL,
+        owner_id TEXT,
+        project_id TEXT,
+        process_id TEXT,
+        session_id TEXT,
+        confidence REAL,
+        created_at TEXT NOT NULL,
+        tags TEXT
+      );
+      INSERT INTO memory_item VALUES
+        (
+          'memory-a', 'semantic', 'stored content', 0.8, 'private',
+          'owner-a', 'project-a', 'process-a', 'session-a', 0.75,
+          '2026-06-06T00:00:00.000Z', '["auth"]'
+        );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('maps hybrid hits to scope-aware candidates using authoritative database metadata', async () => {
+    const search = vi.fn().mockResolvedValue({
+      items: [{
+        id: 'memory-a',
+        content: 'search content',
+        type: 'semantic',
+        importance: 0.8,
+        created_at: '2026-06-06T00:00:00.000Z',
+        pinned: false,
+        textScore: 0.7,
+        vectorScore: 0.9,
+        finalScore: 0.85,
+        recall_reason: 'hybrid',
+      }],
+      total_count: 1,
+      query_time: 4,
+      fallback_used: false,
+    });
+    const source = new SqliteHybridAgentContextSource({
+      db,
+      hybridSearchEngine: { search } as unknown as HybridSearchEngine,
+    });
+
+    const result = await source.recall({
+      query: 'authentication',
+      scope: {
+        ownerId: 'owner-a',
+        projectId: 'project-a',
+        processId: 'process-a',
+        sessionId: 'session-a',
+      },
+      limit: 10,
+    });
+
+    expect(search).toHaveBeenCalledWith(db, expect.objectContaining({
+      query: 'authentication',
+      limit: 10,
+    }));
+    expect(result.items).toEqual([{
+      id: 'memory-a',
+      content: 'stored content',
+      type: 'semantic',
+      relevance: 0.85,
+      importance: 0.8,
+      createdAt: '2026-06-06T00:00:00.000Z',
+      provenanceConfidence: 0.75,
+      privacyScope: 'private',
+      ownerId: 'owner-a',
+      projectId: 'project-a',
+      processId: 'process-a',
+      sessionId: 'session-a',
+      topics: ['auth'],
+    }]);
+  });
+
+  it('marks hybrid fallback as degraded without discarding available items', async () => {
+    const search = vi.fn().mockResolvedValue({
+      items: [{
+        id: 'memory-a',
+        content: 'search content',
+        type: 'semantic',
+        importance: 0.8,
+        created_at: '2026-06-06T00:00:00.000Z',
+        pinned: false,
+        textScore: 0.7,
+        vectorScore: 0,
+        finalScore: 0.7,
+        recall_reason: 'text fallback',
+      }],
+      total_count: 1,
+      query_time: 4,
+      fallback_used: true,
+    });
+    const source = new SqliteHybridAgentContextSource({
+      db,
+      hybridSearchEngine: { search } as unknown as HybridSearchEngine,
+    });
+
+    const result = await source.recall({
+      query: 'authentication',
+      scope: { ownerId: 'owner-a', projectId: 'project-a' },
+      limit: 10,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.degradedReason).toEqual({
+      code: 'search_fallback',
+      message: 'hybrid search used a fallback path',
+    });
+  });
+});

--- a/packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts
@@ -1,0 +1,185 @@
+import type Database from 'better-sqlite3';
+import type { HybridSearchEngine } from '../../search/algorithms/hybrid-search-engine.js';
+import type {
+  MemorySearchFilters,
+  MemoryType,
+  PrivacyScope,
+} from '../../../shared/types/index.js';
+import type {
+  AgentContextCandidate,
+  AgentContextRecallSource,
+  AgentContextScope,
+  AgentContextSourceResult,
+} from './agent-context-recall-service.js';
+
+export interface SqliteHybridAgentContextSourceOptions {
+  db: Database.Database;
+  hybridSearchEngine: HybridSearchEngine;
+}
+
+export class SqliteHybridAgentContextSource implements AgentContextRecallSource {
+  readonly name = 'hybrid-search';
+  private readonly db: Database.Database;
+  private readonly hybridSearchEngine: HybridSearchEngine;
+
+  constructor(options: SqliteHybridAgentContextSourceOptions) {
+    this.db = options.db;
+    this.hybridSearchEngine = options.hybridSearchEngine;
+  }
+
+  async recall(input: {
+    query: string;
+    scope: AgentContextScope;
+    limit: number;
+  }): Promise<AgentContextSourceResult> {
+    const searches = scopeSearchFilters(input.scope).map((filters) =>
+      this.hybridSearchEngine.search(this.db, {
+        query: input.query,
+        filters,
+        limit: input.limit,
+        vectorWeight: 0.7,
+        textWeight: 0.3,
+      }),
+    );
+    const results = await Promise.all(searches);
+    const bestHits = new Map<string, number>();
+    for (const result of results) {
+      for (const item of result.items) {
+        bestHits.set(item.id, Math.max(bestHits.get(item.id) ?? 0, item.finalScore));
+      }
+    }
+
+    const rows = this.loadMemoryRows([...bestHits.keys()]);
+    const items = rows
+      .map((row): AgentContextCandidate | null => {
+        const type = asMemoryType(row.type);
+        const privacyScope = asPrivacyScope(row.privacy_scope);
+        if (!type || !privacyScope) {
+          return null;
+        }
+        return {
+          id: row.id,
+          content: row.content,
+          type,
+          relevance: bestHits.get(row.id) ?? 0,
+          importance: row.importance,
+          createdAt: row.created_at,
+          provenanceConfidence: clampConfidence(row.confidence),
+          privacyScope,
+          ownerId: row.owner_id,
+          projectId: row.project_id,
+          processId: row.process_id,
+          sessionId: row.session_id,
+          topics: parseTags(row.tags),
+        };
+      })
+      .filter((item): item is AgentContextCandidate => item !== null)
+      .sort((a, b) => b.relevance - a.relevance || a.id.localeCompare(b.id));
+
+    return {
+      items,
+      ...(results.some((result) =>
+        result.fallback_used === true || result.tfidf_query_embedding_fallback === true
+      )
+        ? {
+            degradedReason: {
+              code: 'search_fallback' as const,
+              message: 'hybrid search used a fallback path',
+            },
+          }
+        : {}),
+    };
+  }
+
+  private loadMemoryRows(ids: string[]): MemoryRow[] {
+    if (ids.length === 0) {
+      return [];
+    }
+    const placeholders = ids.map(() => '?').join(', ');
+    return this.db.prepare(`
+      SELECT
+        id, type, content, importance, privacy_scope,
+        owner_id, project_id, process_id, session_id,
+        confidence, created_at, tags
+      FROM memory_item
+      WHERE id IN (${placeholders})
+    `).all(...ids) as MemoryRow[];
+  }
+}
+
+interface MemoryRow {
+  id: string;
+  type: string;
+  content: string;
+  importance: number;
+  privacy_scope: string;
+  owner_id: string | null;
+  project_id: string | null;
+  process_id: string | null;
+  session_id: string | null;
+  confidence: number | null;
+  created_at: string;
+  tags: string | null;
+}
+
+function scopeSearchFilters(scope: AgentContextScope): MemorySearchFilters[] {
+  const filters: MemorySearchFilters[] = [];
+  if (scope.projectId) {
+    filters.push(
+      {
+        privacy_scope: ['private'],
+        owner_id: scope.ownerId,
+        project_id: scope.projectId,
+      },
+      {
+        privacy_scope: ['team'],
+        project_id: scope.projectId,
+      },
+      {
+        privacy_scope: ['public'],
+        project_id: scope.projectId,
+      },
+    );
+  }
+  filters.push(
+    { privacy_scope: ['private'], owner_id: scope.ownerId },
+    { privacy_scope: ['public'], owner_id: scope.ownerId },
+  );
+  return filters;
+}
+
+function asMemoryType(value: string): MemoryType | null {
+  return value === 'working'
+    || value === 'episodic'
+    || value === 'semantic'
+    || value === 'procedural'
+    ? value
+    : null;
+}
+
+function asPrivacyScope(value: string): PrivacyScope | null {
+  return value === 'private' || value === 'team' || value === 'public'
+    ? value
+    : null;
+}
+
+function clampConfidence(value: number | null): number {
+  if (value === null || !Number.isFinite(value)) {
+    return 0.5;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function parseTags(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -208,6 +208,23 @@ export type {
   PersistedAgentEventInput,
   ProvenanceTrace,
 } from './domains/agent-integration/types.js';
+export { AgentContextRecallService } from './domains/agent-integration/services/agent-context-recall-service.js';
+export type {
+  AgentContextCandidate,
+  AgentContextRecallRequest,
+  AgentContextRecallResult,
+  AgentContextRecallServiceOptions,
+  AgentContextRecallSource,
+  AgentContextScope,
+  AgentContextScopeLevel,
+  AgentContextSourceResult,
+  AgentContextStatus,
+  AgentTokenEstimator,
+  ExcludedAgentContextItem,
+  SelectedAgentContextItem,
+} from './domains/agent-integration/services/agent-context-recall-service.js';
+export { SqliteHybridAgentContextSource } from './domains/agent-integration/services/sqlite-hybrid-agent-context-source.js';
+export type { SqliteHybridAgentContextSourceOptions } from './domains/agent-integration/services/sqlite-hybrid-agent-context-source.js';
 
 export type { RecallResultItem } from './domains/memory/tools/recall-tool.js';
 
@@ -236,4 +253,3 @@ export type {
   EvolutionDemoScenario,
   EvolutionDemoScenarioCatalog,
 } from './domains/evolution-demo/index.js';
-


### PR DESCRIPTION
## 변경 사항
- owner/project/process/session fallback 순서를 갖는 scope-aware recall 정책을 추가합니다.
- private/team/public privacy 경계를 적용하고 다른 owner/project 후보를 명시적으로 제외합니다.
- relevance, importance, recency, provenance confidence 점수와 안정적인 ID tie-break를 사용합니다.
- 유사 content dedup과 topic/type diversity 선택을 수행합니다.
- tokenizer 오차 여유와 item overhead를 포함한 hard token budget packing을 제공합니다.
- 각 후보의 선택/제외 reason 및 부분 검색 실패의 degraded diagnostics를 반환합니다.
- 기존 hybrid search 결과를 DB의 authoritative scope metadata와 결합하는 SQLite source adapter를 추가합니다.

## 변경 유형
- [x] 새로운 기능
- [x] 테스트 추가/수정

## 관련 이슈
- Closes #467
- Related to #456
- Related to #452

## 테스트
- 타깃 테스트 15개 통과
- core build/typecheck, 변경 파일 ESLint 통과
- SQL injection, PII masking, path traversal 정적 검사 통과

전체 core suite는 로컬 ignore-scripts 설치에서 native better-sqlite3 binding이 없어 실행 불가했으며, GitHub Actions의 정상 npm ci 환경에서 전체 매트릭스를 확인합니다.

## 코드 리뷰 포인트
- private/team/public scope 판정과 fallback 우선순위
- conservative token accounting이 budget을 넘지 않는지
- deterministic dedup/diversity 및 degraded result 계약

## 문서 업데이트
- [x] 문서 업데이트 불필요 (PRD/issue 계약 구현)

## 지식 복리
- [x] 문서화 생략 — 신규 기능 구현이며 해결 사례로 분리할 반복 장애가 없음

## 체크리스트
- [x] 코드 스타일 준수
- [x] 자체 검토 완료
- [x] 새로운 경고나 오류 없음
- [x] 새 의존성 없음

## 배포 관련
- [x] 특별한 사항 없음