### PR TITLE
feat(agent-integration): inject scoped context into agent sessions

### DIFF
--- a/packages/memento-agent-integration/src/index.ts
+++ b/packages/memento-agent-integration/src/index.ts
@@ -1,4 +1,5 @@
 export * from './normalize.js';
+export * from './injection-contract.js';
 export * from './priority-queue.js';
 export * from './redaction.js';
 export * from './runtime.js';

--- a/packages/memento-agent-integration/src/injection-contract.spec.ts
+++ b/packages/memento-agent-integration/src/injection-contract.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INJECTION_BUNDLE_VERSION,
+  claudeCodeInjectionFixture,
+  codexInjectionFixture,
+  injectionBundleFixture,
+  validateInjectionBundle,
+} from './injection-contract.js';
+
+describe('injection bundle contract', () => {
+  it('provides a reusable adapter-independent v1 fixture', () => {
+    const bundle = injectionBundleFixture();
+
+    expect(bundle.bundle_version).toBe(INJECTION_BUNDLE_VERSION);
+    expect(bundle.trigger).toBe('session_start');
+    expect(bundle.status).toBe('ok');
+    expect(bundle.items[0]).toMatchObject({
+      memory_id: 'memory-decision-1',
+      selection_reason: 'selected_by_score',
+      scope_level: 'project',
+    });
+    expect(validateInjectionBundle(bundle)).toEqual({ valid: true });
+  });
+
+  it('rejects incompatible versions and token budget overflow', () => {
+    expect(validateInjectionBundle({
+      ...injectionBundleFixture(),
+      bundle_version: 2,
+    })).toEqual({
+      valid: false,
+      reason: 'UNSUPPORTED_BUNDLE_VERSION',
+    });
+
+    expect(validateInjectionBundle({
+      ...injectionBundleFixture(),
+      token_usage: { budget: 10, used: 11, remaining: 0 },
+    })).toEqual({
+      valid: false,
+      reason: 'INVALID_TOKEN_USAGE',
+    });
+  });
+
+  it('provides reusable Codex and Claude lifecycle integration fixtures', () => {
+    const codex = codexInjectionFixture();
+    const claude = claudeCodeInjectionFixture();
+
+    expect(codex.adapter).toBe('codex');
+    expect(codex.session_start.event_type).toBe('SESSION_START');
+    expect(codex.pre_compact.payload.context_summary).toContain('scope-aware');
+    expect(validateInjectionBundle(codex.expected_bundle)).toEqual({ valid: true });
+
+    expect(claude.adapter).toBe('claude-code');
+    expect(claude.session_start.adapter_name).toBe('claude-code');
+    expect(claude.expected_bundle.bundle_version).toBe(INJECTION_BUNDLE_VERSION);
+    expect(validateInjectionBundle(claude.expected_bundle)).toEqual({ valid: true });
+  });
+});

--- a/packages/memento-agent-integration/src/injection-contract.ts
+++ b/packages/memento-agent-integration/src/injection-contract.ts
@@ -1,0 +1,196 @@
+import type { AgentEventEnvelope } from './types.js';
+
+export const INJECTION_BUNDLE_VERSION = 1 as const;
+
+export type InjectionTrigger = 'session_start' | 'pre_compact';
+export type InjectionStatus = 'ok' | 'empty' | 'degraded';
+
+export interface InjectionBundleItem {
+  memory_id: string;
+  content: string;
+  memory_type: 'working' | 'episodic' | 'semantic' | 'procedural';
+  score: number;
+  scope_level: 'session' | 'process' | 'project' | 'owner';
+  token_estimate: number;
+  selection_reason: 'selected_by_score' | 'selected_for_diversity';
+}
+
+export interface InjectionBundleExclusion {
+  memory_id: string;
+  reason:
+    | 'privacy_scope_mismatch'
+    | 'scope_mismatch'
+    | 'duplicate'
+    | 'diversity_deferred'
+    | 'token_budget_exceeded'
+    | 'max_items_reached';
+  score: number;
+  token_estimate: number;
+  duplicate_of?: string;
+}
+
+export interface InjectionBundle {
+  bundle_version: typeof INJECTION_BUNDLE_VERSION;
+  injection_id: string;
+  trigger: InjectionTrigger;
+  status: InjectionStatus;
+  generated_at: string;
+  query: string;
+  context_text: string;
+  items: InjectionBundleItem[];
+  exclusions: InjectionBundleExclusion[];
+  token_usage: {
+    budget: number;
+    used: number;
+    remaining: number;
+  };
+  degraded_reasons: Array<{
+    source: string;
+    code: 'source_failed' | 'search_fallback';
+    message: string;
+  }>;
+  failure_reason?: 'timeout' | 'internal_error';
+}
+
+export interface AgentInjectionIntegrationFixture {
+  adapter: 'codex' | 'claude-code';
+  session_start: AgentEventEnvelope<'SESSION_START'>;
+  pre_compact: AgentEventEnvelope<'PRE_COMPACT'>;
+  expected_bundle: InjectionBundle;
+}
+
+export type InjectionBundleValidation =
+  | { valid: true }
+  | {
+      valid: false;
+      reason:
+        | 'INVALID_BUNDLE'
+        | 'UNSUPPORTED_BUNDLE_VERSION'
+        | 'INVALID_TOKEN_USAGE';
+    };
+
+export function validateInjectionBundle(input: unknown): InjectionBundleValidation {
+  if (!isRecord(input)) {
+    return { valid: false, reason: 'INVALID_BUNDLE' };
+  }
+  if (input.bundle_version !== INJECTION_BUNDLE_VERSION) {
+    return { valid: false, reason: 'UNSUPPORTED_BUNDLE_VERSION' };
+  }
+  if (
+    typeof input.injection_id !== 'string'
+    || !['session_start', 'pre_compact'].includes(String(input.trigger))
+    || !['ok', 'empty', 'degraded'].includes(String(input.status))
+    || typeof input.generated_at !== 'string'
+    || typeof input.query !== 'string'
+    || typeof input.context_text !== 'string'
+    || !Array.isArray(input.items)
+    || !Array.isArray(input.exclusions)
+    || !Array.isArray(input.degraded_reasons)
+    || !isRecord(input.token_usage)
+  ) {
+    return { valid: false, reason: 'INVALID_BUNDLE' };
+  }
+  const { budget, used, remaining } = input.token_usage;
+  if (
+    !isNonNegativeInteger(budget)
+    || !isNonNegativeInteger(used)
+    || !isNonNegativeInteger(remaining)
+    || used > budget
+    || remaining !== budget - used
+  ) {
+    return { valid: false, reason: 'INVALID_TOKEN_USAGE' };
+  }
+  return { valid: true };
+}
+
+export function injectionBundleFixture(
+  overrides: Partial<InjectionBundle> = {},
+): InjectionBundle {
+  return {
+    bundle_version: INJECTION_BUNDLE_VERSION,
+    injection_id: 'injection-fixture-1',
+    trigger: 'session_start',
+    status: 'ok',
+    generated_at: '2026-06-07T00:00:00.000Z',
+    query: 'Continue the agent-memory integration work',
+    context_text: 'Use the existing scope-aware context packer.',
+    items: [{
+      memory_id: 'memory-decision-1',
+      content: 'Use the existing scope-aware context packer.',
+      memory_type: 'procedural',
+      score: 0.92,
+      scope_level: 'project',
+      token_estimate: 18,
+      selection_reason: 'selected_by_score',
+    }],
+    exclusions: [{
+      memory_id: 'memory-duplicate-1',
+      reason: 'duplicate',
+      score: 0.81,
+      token_estimate: 16,
+      duplicate_of: 'memory-decision-1',
+    }],
+    token_usage: { budget: 128, used: 18, remaining: 110 },
+    degraded_reasons: [],
+    ...overrides,
+  };
+}
+
+export function codexInjectionFixture(): AgentInjectionIntegrationFixture {
+  return agentInjectionIntegrationFixture('codex');
+}
+
+export function claudeCodeInjectionFixture(): AgentInjectionIntegrationFixture {
+  return agentInjectionIntegrationFixture('claude-code');
+}
+
+function agentInjectionIntegrationFixture(
+  adapter: AgentInjectionIntegrationFixture['adapter'],
+): AgentInjectionIntegrationFixture {
+  const common = {
+    contract_version: 1 as const,
+    occurred_at: '2026-06-07T00:00:00.000Z',
+    adapter_name: adapter,
+    adapter_version: '1.0.0',
+    session_id: `${adapter}-session-1`,
+    scope: {
+      owner_id: 'owner-1',
+      project_id: 'github.com/jee1/memento',
+      process_id: 'issue-466',
+    },
+  };
+  return {
+    adapter,
+    session_start: {
+      ...common,
+      event_id: `${adapter}-session-start-1`,
+      event_type: 'SESSION_START',
+      sequence_no: 0,
+      payload: {
+        client_version: '1.0.0',
+        initial_context: 'Continue the scope-aware context injection work',
+      },
+    },
+    pre_compact: {
+      ...common,
+      event_id: `${adapter}-pre-compact-1`,
+      event_type: 'PRE_COMPACT',
+      sequence_no: 1,
+      payload: {
+        context_summary: 'Preserve the scope-aware current implementation context',
+        token_budget: 128,
+      },
+    },
+    expected_bundle: injectionBundleFixture({
+      injection_id: `${adapter}-injection-1`,
+    }),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}

--- a/packages/memento-agent-integration/src/redaction-size.spec.ts
+++ b/packages/memento-agent-integration/src/redaction-size.spec.ts
@@ -56,6 +56,20 @@ describe('fail-closed redaction', () => {
     expect(result.metadata).toContainEqual({ rule: 'API_KEY', count: 1 });
   });
 
+  it('preserves the pre-compact token budget control field', () => {
+    const result = redactAgentEvent(eventFixture('PRE_COMPACT', {
+      payload: {
+        context_summary: 'Current implementation context',
+        token_budget: 4096,
+      },
+    }));
+
+    expect(result.action).toBe('ACCEPTED');
+    if (result.action !== 'DROPPED') {
+      expect(result.event.payload).toMatchObject({ token_budget: 4096 });
+    }
+  });
+
   it('drops an observation containing private key material without echoing it', () => {
     const privateKey = '-----BEGIN PRIVATE KEY-----\nraw-private-material\n-----END PRIVATE KEY-----';
 

--- a/packages/memento-agent-integration/src/redaction.ts
+++ b/packages/memento-agent-integration/src/redaction.ts
@@ -32,6 +32,7 @@ const KEY_RULES: Array<[RegExp, RedactionRule]> = [
   [/(?:^|_)password(?:$|_)/i, 'PASSWORD'],
   [/(?:^|_)credential(?:s)?(?:$|_)/i, 'CREDENTIAL'],
 ];
+const NON_SECRET_CONTROL_KEYS = new Set(['token_budget']);
 const INLINE_RULES: Array<[RedactionRule, RegExp]> = [
   ['API_KEY', /\b(?:sk|pk)(?:[_-](?:live|test|proj))?[_-][A-Za-z0-9_-]{16,}\b/g],
   ['TOKEN', /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g],
@@ -89,7 +90,7 @@ function redactValue(
   counts: Map<RedactionRule, number>,
   key?: string,
 ): unknown {
-  if (key) {
+  if (key && !NON_SECRET_CONTROL_KEYS.has(key)) {
     const keyRule = KEY_RULES.find(([pattern]) => pattern.test(key))?.[1];
     if (keyRule && value !== undefined) {
       increment(counts, keyRule);

--- a/packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentContextRecallResult } from './agent-context-recall-service.js';
+import {
+  AgentContextInjectionService,
+  summarizeAgentInjectionTelemetry,
+} from './agent-context-injection-service.js';
+
+const recallResult: AgentContextRecallResult = {
+  status: 'ok',
+  query: 'current task',
+  contextText: 'Use the established context packer.',
+  selected: [{
+    id: 'memory-1',
+    content: 'Use the established context packer.',
+    type: 'procedural',
+    relevance: 0.9,
+    importance: 0.8,
+    createdAt: '2026-06-06T00:00:00.000Z',
+    provenanceConfidence: 1,
+    privacyScope: 'private',
+    ownerId: 'owner-1',
+    projectId: 'project-1',
+    processId: 'issue-466',
+    sessionId: 'previous-session',
+    topics: ['agent-memory'],
+    score: 0.91,
+    scopeLevel: 'project',
+    tokenEstimate: 18,
+    selectionReason: 'selected_by_score',
+  }],
+  excluded: [{
+    id: 'memory-2',
+    reason: 'token_budget_exceeded',
+    score: 0.8,
+    tokenEstimate: 30,
+  }],
+  tokenUsage: { budget: 32, used: 18, remaining: 14 },
+  degradedReasons: [],
+};
+
+describe('AgentContextInjectionService', () => {
+  it('builds the same versioned bundle for session start and pre-compact triggers', async () => {
+    const buildContext = vi.fn().mockResolvedValue(recallResult);
+    const service = new AgentContextInjectionService({
+      recallService: { buildContext },
+      now: () => new Date('2026-06-07T00:00:00.000Z'),
+      createId: () => 'injection-1',
+    });
+
+    const sessionStart = await service.build({
+      trigger: 'session_start',
+      query: 'current task',
+      scope: {
+        ownerId: 'owner-1',
+        projectId: 'project-1',
+        processId: 'issue-466',
+        sessionId: 'session-1',
+      },
+      tokenBudget: 32,
+    });
+    const preCompact = await service.build({
+      trigger: 'pre_compact',
+      currentContextSummary: 'current task',
+      scope: {
+        ownerId: 'owner-1',
+        projectId: 'project-1',
+        processId: 'issue-466',
+        sessionId: 'session-1',
+      },
+      tokenBudget: 32,
+    });
+
+    expect(sessionStart).toMatchObject({
+      bundleVersion: 1,
+      injectionId: 'injection-1',
+      trigger: 'session_start',
+      status: 'ok',
+      contextText: recallResult.contextText,
+      selected: [expect.objectContaining({ id: 'memory-1', score: 0.91 })],
+      excluded: [expect.objectContaining({
+        id: 'memory-2',
+        reason: 'token_budget_exceeded',
+      })],
+    });
+    expect(preCompact.trigger).toBe('pre_compact');
+    expect(buildContext).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      query: 'current task',
+      tokenBudget: 32,
+    }));
+  });
+
+  it('returns an empty bundle without throwing when recall has no candidates', async () => {
+    const service = new AgentContextInjectionService({
+      recallService: {
+        buildContext: async () => ({
+          ...recallResult,
+          status: 'empty',
+          contextText: '',
+          selected: [],
+          excluded: [],
+          tokenUsage: { budget: 64, used: 0, remaining: 64 },
+        }),
+      },
+      createId: () => 'injection-empty',
+    });
+
+    await expect(service.build({
+      trigger: 'session_start',
+      query: '',
+      scope: { ownerId: 'owner-1' },
+      tokenBudget: 64,
+    })).resolves.toMatchObject({
+      status: 'empty',
+      contextText: '',
+      selected: [],
+      failureReason: null,
+    });
+  });
+
+  it('returns a degraded bundle on timeout without blocking agent operation', async () => {
+    vi.useFakeTimers();
+    try {
+      const service = new AgentContextInjectionService({
+        recallService: {
+          buildContext: async () => new Promise<AgentContextRecallResult>(() => undefined),
+        },
+        timeoutMs: 25,
+        createId: () => 'injection-timeout',
+      });
+
+      const pending = service.build({
+        trigger: 'pre_compact',
+        query: 'summary',
+        scope: { ownerId: 'owner-1' },
+        tokenBudget: 128,
+      });
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(pending).resolves.toMatchObject({
+        status: 'degraded',
+        contextText: '',
+        selected: [],
+        failureReason: 'timeout',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves partial recall results and stable degraded reasons', async () => {
+    const service = new AgentContextInjectionService({
+      recallService: {
+        buildContext: async () => ({
+          ...recallResult,
+          status: 'degraded',
+          degradedReasons: [{
+            source: 'vector',
+            code: 'source_failed',
+            message: 'provider unavailable',
+          }],
+        }),
+      },
+      createId: () => 'injection-partial',
+    });
+
+    const bundle = await service.build({
+      trigger: 'session_start',
+      query: 'task',
+      scope: { ownerId: 'owner-1' },
+      tokenBudget: 32,
+    });
+
+    expect(bundle.status).toBe('degraded');
+    expect(bundle.selected).toHaveLength(1);
+    expect(bundle.degradedReasons).toEqual(recallResult.degradedReasons.concat({
+      source: 'vector',
+      code: 'source_failed',
+      message: 'provider unavailable',
+    }));
+  });
+
+  it('reports latency samples while keeping the p95 fixture below 1500ms', async () => {
+    let time = 1_000;
+    const samples: number[] = [];
+    const service = new AgentContextInjectionService({
+      recallService: { buildContext: async () => recallResult },
+      nowMs: () => {
+        const current = time;
+        time += 20;
+        return current;
+      },
+      recordTelemetry: event => samples.push(event.latencyMs),
+    });
+
+    for (let index = 0; index < 20; index += 1) {
+      await service.build({
+        trigger: 'session_start',
+        query: `task-${index}`,
+        scope: { ownerId: 'owner-1' },
+        tokenBudget: 32,
+      });
+    }
+
+    const sorted = [...samples].sort((a, b) => a - b);
+    const p95 = sorted[Math.ceil(sorted.length * 0.95) - 1]!;
+    expect(p95).toBeLessThan(1_500);
+  });
+
+  it('records candidate decisions, scores, tokens, and later tool usage by injection id', async () => {
+    const events: unknown[] = [];
+    const service = new AgentContextInjectionService({
+      recallService: { buildContext: async () => recallResult },
+      createId: () => 'injection-linked',
+      recordTelemetry: event => events.push(event),
+    });
+
+    const bundle = await service.build({
+      trigger: 'session_start',
+      query: 'task',
+      scope: { ownerId: 'owner-1', sessionId: 'session-1' },
+      tokenBudget: 32,
+    });
+    service.recordUsage({
+      injectionId: bundle.injectionId,
+      sessionId: 'session-1',
+      observationId: 'observation-tool-1',
+      toolName: 'functions.exec_command',
+      usedMemoryIds: ['memory-1'],
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: 'injection_built',
+        candidateCount: 2,
+        selected: [{
+          memoryId: 'memory-1',
+          score: 0.91,
+          tokenEstimate: 18,
+          reason: 'selected_by_score',
+        }],
+        exclusions: [{
+          memoryId: 'memory-2',
+          score: 0.8,
+          tokenEstimate: 30,
+          reason: 'token_budget_exceeded',
+        }],
+      }),
+      {
+        kind: 'injection_used',
+        injectionId: 'injection-linked',
+        sessionId: 'session-1',
+        observationId: 'observation-tool-1',
+        toolName: 'functions.exec_command',
+        usedMemoryIds: ['memory-1'],
+      },
+    ]);
+  });
+
+  it('summarizes p50/p95 latency and token-budget metrics', () => {
+    const summary = summarizeAgentInjectionTelemetry([
+      {
+        kind: 'injection_built',
+        injectionId: 'a',
+        trigger: 'session_start',
+        status: 'ok',
+        latencyMs: 100,
+        candidateCount: 2,
+        selectedCount: 1,
+        excludedCount: 1,
+        selected: [],
+        exclusions: [],
+        tokenBudget: 100,
+        tokenUsed: 80,
+        budgetExceeded: false,
+        failureReason: null,
+      },
+      {
+        kind: 'injection_built',
+        injectionId: 'b',
+        trigger: 'pre_compact',
+        status: 'degraded',
+        latencyMs: 1_400,
+        candidateCount: 0,
+        selectedCount: 0,
+        excludedCount: 0,
+        selected: [],
+        exclusions: [],
+        tokenBudget: 100,
+        tokenUsed: 100,
+        budgetExceeded: false,
+        failureReason: 'timeout',
+      },
+    ]);
+
+    expect(summary).toEqual({
+      sampleCount: 2,
+      latencyP50Ms: 100,
+      latencyP95Ms: 1_400,
+      averageBudgetUtilization: 0.9,
+      budgetExceededCount: 0,
+      degradedCount: 1,
+    });
+  });
+});

--- a/packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.ts
+++ b/packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from 'crypto';
+import type {
+  AgentContextRecallRequest,
+  AgentContextRecallResult,
+  AgentContextRecallService,
+  AgentContextScope,
+  ExcludedAgentContextItem,
+  SelectedAgentContextItem,
+} from './agent-context-recall-service.js';
+
+export type AgentContextInjectionTrigger = 'session_start' | 'pre_compact';
+export type AgentContextInjectionFailureReason = 'timeout' | 'internal_error';
+
+export interface AgentContextInjectionRequest {
+  trigger: AgentContextInjectionTrigger;
+  query?: string;
+  currentContextSummary?: string;
+  scope: AgentContextScope;
+  tokenBudget: number;
+  maxItems?: number;
+}
+
+export interface AgentContextInjectionBundle {
+  bundleVersion: 1;
+  injectionId: string;
+  trigger: AgentContextInjectionTrigger;
+  status: 'ok' | 'empty' | 'degraded';
+  generatedAt: string;
+  query: string;
+  contextText: string;
+  selected: SelectedAgentContextItem[];
+  excluded: ExcludedAgentContextItem[];
+  tokenUsage: AgentContextRecallResult['tokenUsage'];
+  degradedReasons: AgentContextRecallResult['degradedReasons'];
+  failureReason: AgentContextInjectionFailureReason | null;
+  latencyMs: number;
+}
+
+export interface AgentInjectionBuiltTelemetryEvent {
+  kind: 'injection_built';
+  injectionId: string;
+  trigger: AgentContextInjectionTrigger;
+  status: AgentContextInjectionBundle['status'];
+  latencyMs: number;
+  candidateCount: number;
+  selectedCount: number;
+  excludedCount: number;
+  selected: Array<{
+    memoryId: string;
+    score: number;
+    tokenEstimate: number;
+    reason: SelectedAgentContextItem['selectionReason'];
+  }>;
+  exclusions: Array<{
+    memoryId: string;
+    score: number;
+    tokenEstimate: number;
+    reason: ExcludedAgentContextItem['reason'];
+  }>;
+  tokenBudget: number;
+  tokenUsed: number;
+  budgetExceeded: boolean;
+  failureReason: AgentContextInjectionFailureReason | null;
+}
+
+export interface AgentInjectionUsageTelemetryEvent {
+  kind: 'injection_used';
+  injectionId: string;
+  sessionId: string;
+  observationId?: string;
+  toolName?: string;
+  usedMemoryIds: string[];
+}
+
+export type AgentInjectionTelemetryEvent =
+  | AgentInjectionBuiltTelemetryEvent
+  | AgentInjectionUsageTelemetryEvent;
+
+export interface AgentInjectionTelemetrySummary {
+  sampleCount: number;
+  latencyP50Ms: number | null;
+  latencyP95Ms: number | null;
+  averageBudgetUtilization: number;
+  budgetExceededCount: number;
+  degradedCount: number;
+}
+
+export interface AgentContextInjectionServiceOptions {
+  recallService: Pick<AgentContextRecallService, 'buildContext'>;
+  timeoutMs?: number;
+  now?: () => Date;
+  nowMs?: () => number;
+  createId?: () => string;
+  recordTelemetry?: (event: AgentInjectionTelemetryEvent) => void;
+}
+
+class InjectionTimeoutError extends Error {}
+
+export class AgentContextInjectionService {
+  private readonly timeoutMs: number;
+  private readonly now: () => Date;
+  private readonly nowMs: () => number;
+  private readonly createId: () => string;
+
+  constructor(private readonly options: AgentContextInjectionServiceOptions) {
+    this.timeoutMs = boundedTimeout(options.timeoutMs);
+    this.now = options.now ?? (() => new Date());
+    this.nowMs = options.nowMs ?? (() => performance.now());
+    this.createId = options.createId ?? randomUUID;
+  }
+
+  async build(request: AgentContextInjectionRequest): Promise<AgentContextInjectionBundle> {
+    const startedAt = this.nowMs();
+    const injectionId = this.createId();
+    const query = request.query ?? request.currentContextSummary ?? '';
+    let bundle: AgentContextInjectionBundle;
+    try {
+      const result = await withTimeout(
+        this.options.recallService.buildContext(toRecallRequest(request, query)),
+        this.timeoutMs,
+      );
+      bundle = {
+        bundleVersion: 1,
+        injectionId,
+        trigger: request.trigger,
+        status: result.status,
+        generatedAt: this.now().toISOString(),
+        query,
+        contextText: result.contextText,
+        selected: result.selected,
+        excluded: result.excluded,
+        tokenUsage: result.tokenUsage,
+        degradedReasons: result.degradedReasons,
+        failureReason: null,
+        latencyMs: elapsedMs(startedAt, this.nowMs()),
+      };
+    } catch (error) {
+      bundle = {
+        bundleVersion: 1,
+        injectionId,
+        trigger: request.trigger,
+        status: 'degraded',
+        generatedAt: this.now().toISOString(),
+        query,
+        contextText: '',
+        selected: [],
+        excluded: [],
+        tokenUsage: {
+          budget: nonNegativeInteger(request.tokenBudget),
+          used: 0,
+          remaining: nonNegativeInteger(request.tokenBudget),
+        },
+        degradedReasons: [],
+        failureReason: error instanceof InjectionTimeoutError ? 'timeout' : 'internal_error',
+        latencyMs: elapsedMs(startedAt, this.nowMs()),
+      };
+    }
+
+    this.recordTelemetry(bundle);
+    return bundle;
+  }
+
+  recordUsage(event: Omit<AgentInjectionUsageTelemetryEvent, 'kind'>): void {
+    try {
+      this.options.recordTelemetry?.({
+        kind: 'injection_used',
+        ...event,
+        usedMemoryIds: [...event.usedMemoryIds],
+      });
+    } catch {
+      return;
+    }
+  }
+
+  private recordTelemetry(bundle: AgentContextInjectionBundle): void {
+    try {
+      this.options.recordTelemetry?.({
+        kind: 'injection_built',
+        injectionId: bundle.injectionId,
+        trigger: bundle.trigger,
+        status: bundle.status,
+        latencyMs: bundle.latencyMs,
+        candidateCount: bundle.selected.length + bundle.excluded.length,
+        selectedCount: bundle.selected.length,
+        excludedCount: bundle.excluded.length,
+        selected: bundle.selected.map(item => ({
+          memoryId: item.id,
+          score: item.score,
+          tokenEstimate: item.tokenEstimate,
+          reason: item.selectionReason,
+        })),
+        exclusions: bundle.excluded.map(item => ({
+          memoryId: item.id,
+          score: item.score,
+          tokenEstimate: item.tokenEstimate,
+          reason: item.reason,
+        })),
+        tokenBudget: bundle.tokenUsage.budget,
+        tokenUsed: bundle.tokenUsage.used,
+        budgetExceeded: bundle.tokenUsage.used > bundle.tokenUsage.budget,
+        failureReason: bundle.failureReason,
+      });
+    } catch {
+      return;
+    }
+  }
+}
+
+export function summarizeAgentInjectionTelemetry(
+  events: readonly AgentInjectionTelemetryEvent[],
+): AgentInjectionTelemetrySummary {
+  const built = events.filter(
+    (event): event is AgentInjectionBuiltTelemetryEvent => event.kind === 'injection_built',
+  );
+  const latencies = built.map(event => event.latencyMs).sort((a, b) => a - b);
+  const utilization = built.map(event =>
+    event.tokenBudget === 0 ? 0 : Math.min(1, event.tokenUsed / event.tokenBudget)
+  );
+  return {
+    sampleCount: built.length,
+    latencyP50Ms: percentile(latencies, 0.5),
+    latencyP95Ms: percentile(latencies, 0.95),
+    averageBudgetUtilization: utilization.length === 0
+      ? 0
+      : utilization.reduce((sum, value) => sum + value, 0) / utilization.length,
+    budgetExceededCount: built.filter(event => event.budgetExceeded).length,
+    degradedCount: built.filter(event => event.status === 'degraded').length,
+  };
+}
+
+function toRecallRequest(
+  request: AgentContextInjectionRequest,
+  query: string,
+): AgentContextRecallRequest {
+  return {
+    query,
+    scope: request.scope,
+    tokenBudget: request.tokenBudget,
+    maxItems: request.maxItems,
+  };
+}
+
+function percentile(sorted: readonly number[], ratio: number): number | null {
+  if (sorted.length === 0) return null;
+  return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)]!;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new InjectionTimeoutError()), timeoutMs);
+    timer.unref?.();
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function boundedTimeout(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 1_250;
+  }
+  return Math.min(10_000, Math.max(1, Math.floor(value!)));
+}
+
+function nonNegativeInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function elapsedMs(startedAt: number, endedAt: number): number {
+  return Math.max(0, Math.round(endedAt - startedAt));
+}

--- a/packages/memento-core/src/domains/telemetry/types/telemetry.types.ts
+++ b/packages/memento-core/src/domains/telemetry/types/telemetry.types.ts
@@ -17,7 +17,9 @@ export type EventType =
   | 'telemetry.cleanup.performed'
   | 'agent.summary.completed'
   | 'agent.summary.failed'
-  | 'agent.summary.skipped';
+  | 'agent.summary.skipped'
+  | 'agent.injection.completed'
+  | 'agent.injection.used';
 
 export type Outcome = 'success' | 'failure' | 'empty';
 

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -219,6 +219,21 @@ export type {
   ProvenanceTrace,
 } from './domains/agent-integration/types.js';
 export { AgentContextRecallService } from './domains/agent-integration/services/agent-context-recall-service.js';
+export {
+  AgentContextInjectionService,
+  summarizeAgentInjectionTelemetry,
+} from './domains/agent-integration/services/agent-context-injection-service.js';
+export type {
+  AgentContextInjectionBundle,
+  AgentContextInjectionFailureReason,
+  AgentContextInjectionRequest,
+  AgentContextInjectionServiceOptions,
+  AgentContextInjectionTrigger,
+  AgentInjectionBuiltTelemetryEvent,
+  AgentInjectionTelemetryEvent,
+  AgentInjectionTelemetrySummary,
+  AgentInjectionUsageTelemetryEvent,
+} from './domains/agent-integration/services/agent-context-injection-service.js';
 export type {
   AgentContextCandidate,
   AgentContextRecallRequest,

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -5,22 +5,25 @@
  */
 
 import {
-canonicalizeHttpBindHostForListen,
-closeDatabase,
-createMementoCore,
-createToolContext,
-executeTool,
-formatHttpBindHostForUrl,
-getBatchScheduler,
-getMementoHttpSecurityStartupViolationMessage,
-getToolRegistry,
-getVectorSearchEngine,
-isHttpBindHostRemotelyReachable,
-logger,
-mementoConfig,
-MementoHttpSecurityStartupError,
-validateConfig,
-type ServerServices
+  AgentContextInjectionService,
+  AgentContextRecallService,
+  canonicalizeHttpBindHostForListen,
+  closeDatabase,
+  createMementoCore,
+  createToolContext,
+  executeTool,
+  formatHttpBindHostForUrl,
+  getBatchScheduler,
+  getMementoHttpSecurityStartupViolationMessage,
+  getToolRegistry,
+  getVectorSearchEngine,
+  isHttpBindHostRemotelyReachable,
+  logger,
+  mementoConfig,
+  MementoHttpSecurityStartupError,
+  SqliteHybridAgentContextSource,
+  validateConfig,
+  type ServerServices,
 } from '@memento/core';
 import Database from 'better-sqlite3';
 import cors from 'cors';
@@ -293,9 +296,28 @@ async function initializeServer() {
     const qualityRouter = createQualityRouter(db);
     const retentionDays = Number(process.env.MEMENTO_AGENT_OBSERVATION_RETENTION_DAYS);
     const abandonedTtlMs = Number(process.env.MEMENTO_AGENT_SESSION_ABANDONED_TTL_MS);
+    const injectionTimeoutMs = Number(process.env.MEMENTO_AGENT_INJECTION_TIMEOUT_MS);
+    const initialInjectionTokenBudget = Number(
+      process.env.MEMENTO_AGENT_INITIAL_INJECTION_TOKEN_BUDGET,
+    );
+    const contextInjectionService = new AgentContextInjectionService({
+      recallService: new AgentContextRecallService({
+        sources: [
+          new SqliteHybridAgentContextSource({
+            db,
+            hybridSearchEngine: serverServices.hybridSearchEngine,
+          }),
+        ],
+      }),
+      timeoutMs: Number.isFinite(injectionTimeoutMs) ? injectionTimeoutMs : undefined,
+    });
     const agentRouter = createAgentRouter(db, {
       retentionDays: Number.isFinite(retentionDays) ? retentionDays : undefined,
       abandonedTtlMs: Number.isFinite(abandonedTtlMs) ? abandonedTtlMs : undefined,
+      contextInjectionService,
+      initialInjectionTokenBudget: Number.isFinite(initialInjectionTokenBudget)
+        ? initialInjectionTokenBudget
+        : undefined,
     });
     
     // 라우터 등록 (/admin, /api는 브라우저 세션; /api/v1/quality, /tools, /mcp는 API 키)

--- a/packages/memento-server/src/server/routes/agent.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.spec.ts
@@ -1,7 +1,11 @@
 import Database from 'better-sqlite3';
 import type { Request, Response } from 'express';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AgentIntegrationSchemaMigration } from '@memento/core';
+import {
+  AgentContextInjectionService,
+  AgentIntegrationSchemaMigration,
+  type AgentContextRecallResult,
+} from '@memento/core';
 import { createAgentRouter } from './agent.routes.js';
 
 function event(overrides: Record<string, unknown> = {}) {
@@ -28,6 +32,40 @@ describe('agent integration routes', () => {
   let db: Database.Database;
   let router: ReturnType<typeof createAgentRouter>;
   let response: Partial<Response>;
+  let buildContext: ReturnType<typeof vi.fn>;
+
+  const recallResult: AgentContextRecallResult = {
+    status: 'ok',
+    query: 'project context',
+    contextText: 'Reuse the established context packer.',
+    selected: [{
+      id: 'memory-selected',
+      content: 'Reuse the established context packer.',
+      type: 'procedural',
+      relevance: 0.95,
+      importance: 0.8,
+      createdAt: '2026-06-05T00:00:00.000Z',
+      provenanceConfidence: 1,
+      privacyScope: 'private',
+      ownerId: 'owner-1',
+      projectId: 'project-1',
+      processId: 'issue-467',
+      sessionId: 'previous-session',
+      topics: ['agent-memory'],
+      score: 0.93,
+      scopeLevel: 'project',
+      tokenEstimate: 20,
+      selectionReason: 'selected_by_score',
+    }],
+    excluded: [{
+      id: 'memory-excluded',
+      reason: 'token_budget_exceeded',
+      score: 0.82,
+      tokenEstimate: 40,
+    }],
+    tokenUsage: { budget: 128, used: 20, remaining: 108 },
+    degradedReasons: [],
+  };
 
   beforeEach(async () => {
     db = new Database(':memory:');
@@ -73,8 +111,26 @@ describe('agent integration routes', () => {
       )
     `);
     await new AgentIntegrationSchemaMigration().up(db);
+    buildContext = vi.fn().mockResolvedValue(recallResult);
     router = createAgentRouter(db, {
       now: () => new Date('2026-06-06T00:00:10.000Z'),
+      contextInjectionService: new AgentContextInjectionService({
+        recallService: { buildContext },
+        now: () => new Date('2026-06-06T00:00:10.000Z'),
+        nowMs: (() => {
+          let current = 1_000;
+          return () => {
+            const value = current;
+            current += 20;
+            return value;
+          };
+        })(),
+        createId: (() => {
+          let sequence = 0;
+          return () => `injection-${sequence += 1}`;
+        })(),
+      }),
+      initialInjectionTokenBudget: 128,
     });
     response = {
       status: vi.fn().mockReturnThis(),
@@ -121,7 +177,190 @@ describe('agent integration routes', () => {
         batch_events: 50,
         batch_payload_bytes: 524288,
       }),
+      features: expect.objectContaining({
+        pre_compact_injection: true,
+      }),
     }));
+  });
+
+  it('returns a versioned initial injection bundle and records detailed telemetry', async () => {
+    await invoke('post', '/sessions', {
+      body: event({
+        payload: {
+          client_version: '1.0.0',
+          working_directory: '/workspace/memento',
+          initial_context: 'Continue issue 466',
+        },
+      }),
+    });
+
+    expect(buildContext).toHaveBeenCalledWith(expect.objectContaining({
+      query: 'Continue issue 466',
+      scope: {
+        ownerId: 'owner-1',
+        projectId: 'project-1',
+        processId: 'issue-454',
+        sessionId: 'session-1',
+      },
+      tokenBudget: 128,
+    }));
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      initial_injection: expect.objectContaining({
+        bundle_version: 1,
+        injection_id: 'injection-1',
+        trigger: 'session_start',
+        status: 'ok',
+        context_text: 'Reuse the established context packer.',
+        items: [
+          expect.objectContaining({
+            memory_id: 'memory-selected',
+            score: 0.93,
+            token_estimate: 20,
+          }),
+        ],
+        exclusions: [
+          expect.objectContaining({
+            memory_id: 'memory-excluded',
+            reason: 'token_budget_exceeded',
+          }),
+        ],
+      }),
+    }));
+
+    const telemetry = db.prepare(`
+      SELECT event_type, latency_ms, outcome, extra_data
+      FROM telemetry_events
+      WHERE event_type = 'agent.injection.completed'
+    `).get() as {
+      event_type: string;
+      latency_ms: number;
+      outcome: string;
+      extra_data: string;
+    };
+    expect(telemetry).toMatchObject({
+      event_type: 'agent.injection.completed',
+      latency_ms: 20,
+      outcome: 'success',
+    });
+    expect(JSON.parse(telemetry.extra_data)).toMatchObject({
+      injection_id: 'injection-1',
+      trigger: 'session_start',
+      candidate_count: 2,
+      selected: [{
+        memory_id: 'memory-selected',
+        score: 0.93,
+        token_estimate: 20,
+      }],
+      exclusions: [{
+        memory_id: 'memory-excluded',
+        reason: 'token_budget_exceeded',
+        score: 0.82,
+      }],
+      token_budget: 128,
+      token_used: 20,
+      budget_exceeded: false,
+    });
+  });
+
+  it('uses the current context summary and event budget for pre-compact injection', async () => {
+    await invoke('post', '/sessions', { body: event() });
+    buildContext.mockClear();
+    response.json = vi.fn().mockReturnThis();
+
+    await invoke('post', '/sessions/:id\\:pre-compact', {
+      params: { id: 'session-1' },
+      body: event({
+        event_id: 'evt-compact',
+        event_type: 'PRE_COMPACT',
+        sequence_no: 1,
+        payload: {
+          context_summary: 'Current implementation and failing test context',
+          token_budget: 256,
+        },
+      }),
+    });
+
+    expect(buildContext).toHaveBeenCalledWith(expect.objectContaining({
+      query: 'Current implementation and failing test context',
+      tokenBudget: 256,
+      scope: expect.objectContaining({
+        ownerId: 'owner-1',
+        sessionId: 'session-1',
+      }),
+    }));
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      injection: expect.objectContaining({
+        bundle_version: 1,
+        trigger: 'pre_compact',
+      }),
+    }));
+  });
+
+  it('keeps session capture non-blocking when an injected implementation rejects', async () => {
+    router = createAgentRouter(db, {
+      now: () => new Date('2026-06-06T00:00:10.000Z'),
+      contextInjectionService: {
+        build: async () => {
+          throw new Error('unexpected adapter boundary failure');
+        },
+      },
+    });
+
+    await invoke('post', '/sessions', { body: event() });
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      session: expect.objectContaining({ status: 'ACTIVE' }),
+      initial_injection: null,
+    }));
+  });
+
+  it('links later usage and exposes p50/p95 and budget metrics', async () => {
+    await invoke('post', '/sessions', { body: event() });
+    const start = vi.mocked(response.json).mock.calls.at(-1)?.[0] as {
+      initial_injection: { injection_id: string };
+    };
+    response.status = vi.fn().mockReturnThis();
+    response.json = vi.fn().mockReturnThis();
+
+    await invoke('post', '/sessions/:id/injections/:injectionId/usage', {
+      params: {
+        id: 'session-1',
+        injectionId: start.initial_injection.injection_id,
+      },
+      body: {
+        observation_id: 'observation-tool-1',
+        tool_name: 'exec_command',
+        used_memory_ids: ['memory-selected'],
+      },
+    });
+
+    expect(response.status).toHaveBeenCalledWith(202);
+    expect(response.json).toHaveBeenCalledWith({
+      accepted: true,
+      injection_id: start.initial_injection.injection_id,
+    });
+    expect(db.prepare(`
+      SELECT event_type, request_id, extra_data
+      FROM telemetry_events
+      WHERE event_type = 'agent.injection.used'
+    `).get()).toEqual(expect.objectContaining({
+      event_type: 'agent.injection.used',
+      request_id: `agent-injection:${start.initial_injection.injection_id}`,
+      extra_data: expect.stringContaining('"tool_name":"exec_command"'),
+    }));
+
+    response.json = vi.fn().mockReturnThis();
+    await invoke('get', '/injections/metrics');
+    expect(response.json).toHaveBeenCalledWith({
+      sample_count: 1,
+      p50_latency_ms: 20,
+      p95_latency_ms: 20,
+      average_token_budget: 128,
+      average_token_used: 20,
+      budget_exceeded_count: 0,
+      budget_exceeded_rate: 0,
+    });
   });
 
   it('starts, reads, paginates, and stops a session', async () => {

--- a/packages/memento-server/src/server/routes/agent.routes.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.ts
@@ -1,5 +1,8 @@
 import {
   AgentIntegrationError,
+  type AgentContextInjectionBundle,
+  type AgentContextInjectionRequest,
+  type AgentContextInjectionService,
   AgentLifecycleService,
   AgentSessionSummaryService,
   SqliteAgentIntegrationRepository,
@@ -21,6 +24,7 @@ import {
   normalizeAgentEvent,
   redactAgentEvent,
   validateAgentEvent,
+  type InjectionBundle,
   type CaptureReason,
 } from '@memento/agent-integration';
 import type Database from 'better-sqlite3';
@@ -199,6 +203,85 @@ function provenanceDto(provenance: MemoryProvenance) {
   };
 }
 
+function injectionDto(bundle: AgentContextInjectionBundle): InjectionBundle {
+  return {
+    bundle_version: bundle.bundleVersion,
+    injection_id: bundle.injectionId,
+    trigger: bundle.trigger,
+    status: bundle.status,
+    generated_at: bundle.generatedAt,
+    query: bundle.query,
+    context_text: bundle.contextText,
+    items: bundle.selected.map(item => ({
+      memory_id: item.id,
+      content: item.content,
+      memory_type: item.type,
+      score: item.score,
+      scope_level: item.scopeLevel,
+      token_estimate: item.tokenEstimate,
+      selection_reason: item.selectionReason,
+    })),
+    exclusions: bundle.excluded.map(item => ({
+      memory_id: item.id,
+      reason: item.reason,
+      score: item.score,
+      token_estimate: item.tokenEstimate,
+      ...(item.duplicateOf ? { duplicate_of: item.duplicateOf } : {}),
+    })),
+    token_usage: bundle.tokenUsage,
+    degraded_reasons: bundle.degradedReasons,
+    ...(bundle.failureReason ? { failure_reason: bundle.failureReason } : {}),
+  };
+}
+
+function parsePayload(prepared: PersistedAgentEventInput): Record<string, unknown> {
+  if (!prepared.payloadJson) return {};
+  try {
+    const parsed: unknown = JSON.parse(prepared.payloadJson);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function initialInjectionQuery(prepared: PersistedAgentEventInput): string {
+  const payload = parsePayload(prepared);
+  if (typeof payload.initial_context === 'string' && payload.initial_context.trim()) {
+    return payload.initial_context.trim();
+  }
+  if (typeof payload.working_directory === 'string' && payload.working_directory.trim()) {
+    return payload.working_directory.trim();
+  }
+  return prepared.scope.processId ?? prepared.scope.projectId ?? 'session start';
+}
+
+function injectionScope(prepared: PersistedAgentEventInput) {
+  return {
+    ownerId: prepared.scope.ownerId ?? '',
+    projectId: prepared.scope.projectId,
+    processId: prepared.scope.processId,
+    sessionId: prepared.sessionId,
+  };
+}
+
+interface AgentRouterOptions extends AgentLifecycleServiceOptions {
+  contextInjectionService?: Pick<AgentContextInjectionService, 'build'>;
+  initialInjectionTokenBudget?: number;
+}
+
+function percentile(sorted: number[], ratio: number): number | null {
+  if (sorted.length === 0) return null;
+  const index = Math.ceil(sorted.length * ratio) - 1;
+  return sorted[Math.max(0, index)]!;
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
 function writeError(res: Response, error: unknown): Response {
   if (error instanceof AgentIntegrationError) {
     return res.status(error.httpStatus).json({
@@ -218,7 +301,7 @@ function writeError(res: Response, error: unknown): Response {
 
 export function createAgentRouter(
   db: Database.Database | null,
-  options: AgentLifecycleServiceOptions = {},
+  options: AgentRouterOptions = {},
 ): Router {
   const router = Router();
   const repository = db ? new SqliteAgentIntegrationRepository(db) : null;
@@ -251,6 +334,68 @@ export function createAgentRouter(
   const service = repository
     ? new AgentLifecycleService(repository, options, summarizer ?? undefined)
     : null;
+  const injectionService = options.contextInjectionService;
+  const initialInjectionTokenBudget = Number.isSafeInteger(options.initialInjectionTokenBudget)
+    ? Math.min(32_768, Math.max(1, options.initialInjectionTokenBudget!))
+    : 2_048;
+
+  const recordInjection = (
+    bundle: AgentContextInjectionBundle,
+    ownerId: string | null,
+    sessionId: string,
+  ) => {
+    try {
+      telemetryRepository?.insertEventSync({
+        eventType: 'agent.injection.completed',
+        requestId: `agent-injection:${bundle.injectionId}`,
+        ownerId,
+        latencyMs: bundle.latencyMs,
+        outcome: bundle.status === 'ok'
+          ? 'success'
+          : bundle.status === 'empty'
+            ? 'empty'
+            : 'failure',
+        errorCode: bundle.failureReason ?? undefined,
+        extraData: {
+          injection_id: bundle.injectionId,
+          session_id: sessionId,
+          trigger: bundle.trigger,
+          candidate_count: bundle.selected.length + bundle.excluded.length,
+          selected_count: bundle.selected.length,
+          exclusion_count: bundle.excluded.length,
+          selected: bundle.selected.map(item => ({
+            memory_id: item.id,
+            score: item.score,
+            token_estimate: item.tokenEstimate,
+            selection_reason: item.selectionReason,
+            scope_level: item.scopeLevel,
+          })),
+          exclusions: bundle.excluded.map(item => ({
+            memory_id: item.id,
+            reason: item.reason,
+            score: item.score,
+            token_estimate: item.tokenEstimate,
+            ...(item.duplicateOf ? { duplicate_of: item.duplicateOf } : {}),
+          })),
+          token_budget: bundle.tokenUsage.budget,
+          token_used: bundle.tokenUsage.used,
+          budget_exceeded: bundle.tokenUsage.used > bundle.tokenUsage.budget,
+          degraded_reasons: bundle.degradedReasons,
+        },
+      });
+    } catch {
+      return;
+    }
+  };
+  const buildInjection = async (
+    request: AgentContextInjectionRequest,
+  ): Promise<AgentContextInjectionBundle | null> => {
+    try {
+      return await injectionService?.build(request) ?? null;
+    } catch {
+      return null;
+    }
+  };
 
   router.get('/capabilities', (_req, res) => {
     return res.json({
@@ -265,13 +410,13 @@ export function createAgentRouter(
       features: {
         session_storage: true,
         provenance_trace: true,
-        pre_compact_injection: false,
+        pre_compact_injection: injectionService !== undefined,
       },
       schema_ready: service?.schemaReady() ?? false,
     });
   });
 
-  router.post('/sessions', (req, res) => {
+  router.post('/sessions', async (req, res) => {
     try {
       if (!service) throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
       const prepared = prepareEvent(req.body);
@@ -279,6 +424,17 @@ export function createAgentRouter(
         throw new AgentIntegrationError('SESSION_START is required', 'INTERNAL_ERROR', 400);
       }
       const result = service.capture(prepared);
+      const injection = injectionService
+        ? await buildInjection({
+            trigger: 'session_start',
+            query: initialInjectionQuery(prepared),
+            scope: injectionScope(prepared),
+            tokenBudget: initialInjectionTokenBudget,
+          })
+        : null;
+      if (injection) {
+        recordInjection(injection, prepared.scope.ownerId ?? null, prepared.sessionId);
+      }
       return res.status(201).json({
         session: sessionDto(service.getSession(prepared.sessionId)!),
         observation: observationDto(
@@ -291,7 +447,7 @@ export function createAgentRouter(
           observation_id: result.observationId,
           late_arrival: result.lateArrival,
         },
-        initial_injection: null,
+        initial_injection: injection ? injectionDto(injection) : null,
       });
     } catch (error) {
       return writeError(res, error);
@@ -391,7 +547,7 @@ export function createAgentRouter(
   });
 
   const captureSessionEvent = (expectedType: 'PRE_COMPACT' | 'STOP') =>
-    (req: Parameters<Parameters<Router['post']>[1]>[0], res: Response) => {
+    async (req: Parameters<Parameters<Router['post']>[1]>[0], res: Response) => {
       try {
         if (!service) throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
         const prepared = prepareEvent({ ...req.body, session_id: req.params.id });
@@ -400,6 +556,23 @@ export function createAgentRouter(
         }
         const result = service.capture(prepared);
         const session = service.getSession(prepared.sessionId)!;
+        const payload = parsePayload(prepared);
+        const requestedTokenBudget = typeof payload.token_budget === 'number'
+          ? payload.token_budget
+          : initialInjectionTokenBudget;
+        const injection = expectedType === 'PRE_COMPACT' && injectionService
+          ? await buildInjection({
+              trigger: 'pre_compact',
+              query: typeof payload.context_summary === 'string'
+                ? payload.context_summary
+                : '',
+              scope: injectionScope(prepared),
+              tokenBudget: requestedTokenBudget,
+            })
+          : null;
+        if (injection) {
+          recordInjection(injection, session.ownerId, session.id);
+        }
         return res.json({
           session: sessionDto(session),
           result: {
@@ -410,7 +583,7 @@ export function createAgentRouter(
             late_arrival: result.lateArrival,
           },
           ...(expectedType === 'PRE_COMPACT'
-            ? { injection: null }
+            ? { injection: injection ? injectionDto(injection) : null }
             : { summary_job_id: session.summaryMemoryId }),
         });
       } catch (error) {
@@ -420,6 +593,83 @@ export function createAgentRouter(
 
   router.post('/sessions/:id\\:pre-compact', captureSessionEvent('PRE_COMPACT'));
   router.post('/sessions/:id\\:stop', captureSessionEvent('STOP'));
+
+  router.post('/sessions/:id/injections/:injectionId/usage', (req, res) => {
+    try {
+      if (!service || !telemetryRepository) {
+        throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
+      }
+      const session = service.getSession(req.params.id);
+      if (!session) {
+        throw new AgentIntegrationError('Agent session not found', 'SESSION_NOT_STARTED', 404);
+      }
+      const injectionId = requireString(req.params.injectionId, 'injection_id');
+      const usedMemoryIds = Array.isArray(req.body?.used_memory_ids)
+        ? req.body.used_memory_ids.filter((item: unknown): item is string =>
+            typeof item === 'string' && item.trim() !== ''
+          )
+        : [];
+      telemetryRepository.insertEventSync({
+        eventType: 'agent.injection.used',
+        requestId: `agent-injection:${injectionId}`,
+        ownerId: session.ownerId,
+        outcome: 'success',
+        extraData: {
+          injection_id: injectionId,
+          session_id: session.id,
+          observation_id: typeof req.body?.observation_id === 'string'
+            ? req.body.observation_id
+            : null,
+          tool_name: typeof req.body?.tool_name === 'string' ? req.body.tool_name : null,
+          used_memory_ids: usedMemoryIds,
+        },
+      });
+      return res.status(202).json({ accepted: true, injection_id: injectionId });
+    } catch (error) {
+      return writeError(res, error);
+    }
+  });
+
+  router.get('/injections/metrics', (_req, res) => {
+    if (!db) {
+      return writeError(
+        res,
+        new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true),
+      );
+    }
+    const rows = db.prepare(`
+      SELECT latency_ms, extra_data
+      FROM telemetry_events
+      WHERE event_type = 'agent.injection.completed'
+      ORDER BY latency_ms
+    `).all() as Array<{ latency_ms: number | null; extra_data: string | null }>;
+    const latencies = rows
+      .map(row => row.latency_ms)
+      .filter((value): value is number => typeof value === 'number');
+    const metrics = rows.map(row => {
+      try {
+        return JSON.parse(row.extra_data ?? '{}') as Record<string, unknown>;
+      } catch {
+        return {};
+      }
+    });
+    const budgets = metrics
+      .map(item => item.token_budget)
+      .filter((value): value is number => typeof value === 'number');
+    const used = metrics
+      .map(item => item.token_used)
+      .filter((value): value is number => typeof value === 'number');
+    const budgetExceededCount = metrics.filter(item => item.budget_exceeded === true).length;
+    return res.json({
+      sample_count: rows.length,
+      p50_latency_ms: percentile(latencies, 0.5),
+      p95_latency_ms: percentile(latencies, 0.95),
+      average_token_budget: average(budgets),
+      average_token_used: average(used),
+      budget_exceeded_count: budgetExceededCount,
+      budget_exceeded_rate: rows.length === 0 ? 0 : budgetExceededCount / rows.length,
+    });
+  });
 
   router.get('/sessions/:id', (req, res) => {
     try {


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항
세션 시작과 PreCompact 시점에 동일한 버전·스코프·토큰 예산 계약으로 Memento 컨텍스트를 주입하고, 선택/제외/사용/지연 텔레메트리를 기록합니다. 주입 실패와 텔레메트리 실패는 에이전트 수명주기 캡처를 중단하지 않습니다.

## 🎯 변경 유형
- [ ] 🐛 버그 수정 (기존 기능의 버그 수정)
- [x] ✨ 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능)
- [ ] 💥 Breaking Change (기존 기능을 깨뜨리는 변경)
- [ ] 📚 문서 업데이트
- [ ] 🎨 코드 스타일 변경 (포맷팅, 세미콜론 등)
- [ ] ♻️ 리팩토링 (기능 변경 없이 코드 개선)
- [x] ⚡ 성능 개선
- [x] ✅ 테스트 추가/수정
- [ ] 🔧 빌드/CI 변경
- [ ] 🗑️ 불필요한 코드 제거

## 🔗 관련 이슈
- Closes #466
- Related to #452
- Related to #464
- Related to #467

## 📋 변경 사항 상세
### 추가된 기능
- adapter-independent `bundle_version: 1` 주입 계약과 Codex/Claude 재사용 fixture
- Start Session 초기 주입 및 PreCompact current-context 재호출
- timeout/empty/degraded/partial failure를 비차단 응답으로 변환
- 후보/선택/제외 사유·점수·토큰·지연 텔레메트리와 사용 연결 endpoint
- p50/p95 지연 및 토큰 예산 지표 endpoint

### 수정된 기능
- `token_budget` 제어 필드가 secret redaction에 오탐되지 않도록 예외 처리
- HTTP 서버가 #467 scope-aware context source/packer를 주입 서비스에 연결

### 제거된 기능
- 없음

## 🧪 테스트
1. strict TDD로 계약 fixture, 서비스 fallback/telemetry, route integration 회귀 테스트를 먼저 실패시킨 뒤 구현했습니다.
2. `npm exec vitest -- run packages/memento-agent-integration/src packages/memento-core/src/domains/agent-integration packages/memento-server/src/server/routes/agent.routes.spec.ts packages/memento-server/src/server/http-server.spec.ts --no-file-parallelism`
3. `npm run type-check`, `npm run build`, `npm run lint -- --quiet`
4. SQL injection, PII masking, path traversal 보안 검사를 실행했습니다.
5. graphify를 재빌드했으며, 대규모 비결정적 community renumbering 산출물은 커밋에서 제외했습니다.

### 테스트 결과
- [x] 모든 관련 기존 테스트 통과 (73 tests)
- [x] 새로운 테스트 추가
- [x] 수동 테스트 완료 (보안 스크립트/빌드/타입/린트)
- p95 fixture: 1,400ms (< 1,500ms)
- lint: 0 errors (기존 security warnings만 존재)

## 📸 스크린샷
UI 변경 없음.

## 🔍 코드 리뷰 포인트
- 주입 실패/timeout/telemetry write 실패가 SESSION_START/PRE_COMPACT 응답을 throw하지 않는지
- #467의 owner/project/process/session scope와 token budget 계약을 그대로 재사용하는지
- `agent.injection.completed`/`agent.injection.used` 상관관계와 metrics 집계
- adapter별 로직 없이 v1 bundle fixture가 공통 계약을 표현하는지

## 📚 문서 업데이트
- [ ] README.md 업데이트 필요
- [ ] API 문서 업데이트 필요
- [ ] 사용자 가이드 업데이트 필요
- [ ] 개발자 가이드 업데이트 필요
- [x] 문서 업데이트 불필요

공개 계약과 사용 예시는 타입/fixture/회귀 테스트에 고정되어 있으며 adapter 설치와 dashboard 문서는 후속 범위입니다.

## 🧠 지식 복리 (Compound Engineering, 선택)
- [ ] 해당 없음 (위에 해당하지 않는 변경)
- [ ] **`/ce-compound` 수행함** — 추가·갱신 문서:
- [x] 문서화 생략 — 사유: 재발 방지 지식(token budget redaction 오탐, non-blocking contract)은 구현 계약과 회귀 테스트에 직접 고정했으며 별도 운영 절차가 없습니다.

## ⚠️ 주의사항
- adapter 설치/배포 및 dashboard는 의도적으로 포함하지 않았습니다.
- 지표는 현재 telemetry event 테이블의 보존 기간과 데이터 품질을 따릅니다.

## ✅ 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [x] 코드에 필요한 계약 타입과 테스트를 추가했습니다
- [x] 변경사항에 해당하는 문서 필요성을 검토했습니다
- [x] 새로운 오류가 없습니다
- [x] 새로운 의존성이 없습니다
- [x] Breaking Change가 없습니다

## 🚀 배포 관련
- [ ] 데이터베이스 마이그레이션 필요
- [x] 환경 변수 변경 필요 (`MEMENTO_AGENT_INJECTION_TIMEOUT_MS`, `MEMENTO_AGENT_INITIAL_INJECTION_TOKEN_BUDGET`; 선택 사항)
- [ ] 새로운 의존성 설치 필요
- [ ] 특별한 배포 절차 필요
- [ ] 특별한 사항 없음
