### PR TITLE
fix(security): redact docker inspect secrets and mask sk-proj keys

### DIFF
--- a/packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts
+++ b/packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { PIIMasker } from '../pii-masker.js';
+
+describe('PIIMasker API key patterns', () => {
+  const skProj =
+    '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';
+
+  it('masks sk-proj OpenAI keys', () => {
+    const result = PIIMasker.mask(`OPENAI_API_KEY=${skProj}`);
+    expect(result.masked).not.toContain('sk-proj');
+    expect(result.masked).toContain('[API_KEY]');
+    expect(result.maskedTypes).toContain('api_key');
+  });
+
+  it('masks legacy sk- keys', () => {
+    const legacy = 'sk-' + 'a'.repeat(48);
+    const result = PIIMasker.mask(legacy);
+    expect(result.masked).not.toContain(legacy);
+    expect(result.masked).toContain('[API_KEY]');
+  });
+
+  it('masks OPENAI_API_KEY env assignments in docker inspect JSON', () => {
+    const json = JSON.stringify({
+      Config: { Env: [`OPENAI_API_KEY=${skProj}`, 'NODE_ENV=production'] },
+    });
+    const result = PIIMasker.mask(json);
+    expect(result.masked).not.toContain('sk-proj');
+    expect(result.masked).toContain('[API_KEY]');
+    expect(result.masked).toContain('NODE_ENV=production');
+  });
+});

--- a/packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts
+++ b/packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts
@@ -28,4 +28,11 @@ describe('PIIMasker API key patterns', () => {
     expect(result.masked).toContain('[API_KEY]');
     expect(result.masked).toContain('NODE_ENV=production');
   });
+  it('does not treat bearer token assignments as API keys', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdefghijklmnop';
+    const result = PIIMasker.mask(`Authorization: token=${jwt}`);
+    expect(result.masked).toContain('[TOKEN]');
+    expect(result.masked).not.toContain('[API_KEY]');
+  });
+
 });

--- a/packages/memento-core/src/shared/utils/pii-masker.ts
+++ b/packages/memento-core/src/shared/utils/pii-masker.ts
@@ -137,8 +137,8 @@ export class PIIMasker {
 
     // API 키 마스킹
     if (types.includes('api_key')) {
-      // OpenAI API 키: sk-... 또는 sk-proj-...
-      const openaiKeyPattern = /sk-[a-zA-Z0-9]{32,}/g;
+      // OpenAI API 키: sk-... 또는 sk-proj-... (하이픈·언더스코어 포함)
+      const openaiKeyPattern = /sk-(?:proj-)?[a-zA-Z0-9_-]{20,}/g;
       const openaiMatches = masked.match(openaiKeyPattern);
       if (openaiMatches) {
         masked = masked.replace(openaiKeyPattern, usePlaceholder ? '[API_KEY]' : '');
@@ -159,8 +159,8 @@ export class PIIMasker {
         totalMaskedCount += googleMatches.length;
       }
 
-      // 일반 API 키 패턴: api_key=..., apikey=... 등
-      const generalApiKeyPattern = /\b(api[_-]?key|apikey)[=:]\s*[a-zA-Z0-9_-]{20,}/gi;
+      // 일반 API 키 패턴: api_key=..., OPENAI_API_KEY=..., *_SECRET=... 등
+      const generalApiKeyPattern = /\b(?:[A-Z0-9_]*(?:API[_-]?KEY|SECRET|TOKEN|PASSWORD)[A-Z0-9_]*|api[_-]?key|apikey)[=:]["']?\s*[^\s&"',]+/gi;
       const generalMatches = masked.match(generalApiKeyPattern);
       if (generalMatches) {
         masked = masked.replace(generalApiKeyPattern, (match) => {

--- a/packages/memento-core/src/shared/utils/pii-masker.ts
+++ b/packages/memento-core/src/shared/utils/pii-masker.ts
@@ -159,8 +159,8 @@ export class PIIMasker {
         totalMaskedCount += googleMatches.length;
       }
 
-      // 일반 API 키 패턴: api_key=..., OPENAI_API_KEY=..., *_SECRET=... 등
-      const generalApiKeyPattern = /\b(?:[A-Z0-9_]*(?:API[_-]?KEY|SECRET|TOKEN|PASSWORD)[A-Z0-9_]*|api[_-]?key|apikey)[=:]["']?\s*[^\s&"',]+/gi;
+      // 일반 API 키 패턴: api_key=..., OPENAI_API_KEY=..., *_SECRET=... (= 할당만; Token: 등은 토큰 마스킹에 위임)
+      const generalApiKeyPattern = /\b(?:[A-Z0-9_]*(?:API[_-]?KEY|SECRET)[A-Z0-9_]*|api[_-]?key|apikey)=[^\s&"',]+/gi;
       const generalMatches = masked.match(generalApiKeyPattern);
       if (generalMatches) {
         masked = masked.replace(generalApiKeyPattern, (match) => {

--- a/scripts/log-issue-monitor/__tests__/detectors.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/detectors.spec.ts
@@ -58,4 +58,17 @@ describe('detectDockerAnomaly', () => {
       title: 'Docker critical: container OOMKilled',
     });
   });
+
+  it('redacts container env vars from docker inspect excerpts', () => {
+    const secret = 'sk-proj-example-secret-value';
+    const event = detectDockerAnomaly({
+      Name: '/memento-mcp-server',
+      State: { Health: { Status: 'unhealthy' }, Status: 'running' },
+      Config: { Env: [`OPENAI_API_KEY=${secret}`, 'NODE_ENV=production'] },
+    });
+
+    expect(event?.excerpt).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(event?.excerpt).toContain('NODE_ENV=[REDACTED]');
+    expect(event?.excerpt).not.toContain(secret);
+  });
 });

--- a/scripts/log-issue-monitor/__tests__/sanitizer.spec.ts
+++ b/scripts/log-issue-monitor/__tests__/sanitizer.spec.ts
@@ -9,4 +9,12 @@ describe('sanitizeExcerpt', () => {
     expect(excerpt).not.toContain('user@example.com');
     expect(Buffer.byteLength(excerpt, 'utf8')).toBeLessThanOrEqual(40);
   });
+  it('masks OpenAI sk-proj keys and env-style API keys', () => {
+    const secret = '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';
+    const excerpt = sanitizeExcerpt(`OPENAI_API_KEY=${secret}`, 4096);
+
+    expect(excerpt).not.toContain('sk-proj');
+    expect(excerpt).toContain('[API_KEY]');
+  });
+
 });

--- a/scripts/log-issue-monitor/detectors.ts
+++ b/scripts/log-issue-monitor/detectors.ts
@@ -11,6 +11,31 @@ function truncateTitle(value: string): string {
   return value.length <= 120 ? value : `${value.slice(0, 117)}...`;
 }
 
+function redactDockerInspectEnv(record: Record<string, unknown>): Record<string, unknown> {
+  const config = record.Config;
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return record;
+  }
+
+  const typedConfig = config as { Env?: unknown };
+  if (!Array.isArray(typedConfig.Env)) {
+    return record;
+  }
+
+  return {
+    ...record,
+    Config: {
+      ...typedConfig,
+      Env: typedConfig.Env.map(entry => {
+        if (typeof entry !== 'string') return '[REDACTED]';
+        const eq = entry.indexOf('=');
+        return eq >= 0 ? `${entry.slice(0, eq)}=[REDACTED]` : '[REDACTED]';
+      }),
+    },
+  };
+}
+
+
 export function detectAppLogEvent(line: ParsedAppLogLine): DetectedEvent | undefined {
   const lower = `${line.level} ${line.message}`.toLowerCase();
   const critical =
@@ -71,7 +96,7 @@ export function detectRuntimeAnomaly(record: Record<string, unknown>): DetectedE
             severity: 'anomaly',
             title: `Runtime anomaly: scheduler errors for ${jobName}`,
             normalizedMessage: `scheduler error count increased for ${jobName}`,
-            excerpt: JSON.stringify(record),
+            excerpt: JSON.stringify(redactDockerInspectEnv(record)),
             observedAt: typeof record.timestamp === 'string' ? record.timestamp : nowIso(),
             context: { jobName, count },
           };
@@ -92,7 +117,7 @@ export function detectDockerAnomaly(record: Record<string, unknown>): DetectedEv
         severity: 'critical',
         title: 'Docker critical: container OOMKilled',
         normalizedMessage: 'container OOMKilled',
-        excerpt: JSON.stringify(record),
+        excerpt: JSON.stringify(redactDockerInspectEnv(record)),
         observedAt: nowIso(),
         context: { status: typedState.Status },
       };
@@ -103,7 +128,7 @@ export function detectDockerAnomaly(record: Record<string, unknown>): DetectedEv
         severity: 'error',
         title: 'Docker error: container unhealthy',
         normalizedMessage: 'container unhealthy',
-        excerpt: JSON.stringify(record),
+        excerpt: JSON.stringify(redactDockerInspectEnv(record)),
         observedAt: nowIso(),
         context: { status: typedState.Status, health: typedState.Health.Status },
       };


### PR DESCRIPTION
## Summary

- GitHub secret scanning alert #1 was caused by `log-issue-monitor` posting full `docker inspect` JSON (including `Config.Env`) to issue #439; the OpenAI key has been revoked and the alert is resolved as `revoked`.
- Extend `PIIMasker` to match `sk-proj-` OpenAI keys and env-style assignments such as `OPENAI_API_KEY=...`.
- Redact all `Config.Env` values in `detectDockerAnomaly` excerpts before they reach GitHub issue bodies (defense in depth alongside `sanitizeExcerpt`).

## Test plan

- [x] `npx vitest run packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts`
- [x] `npx vitest run scripts/log-issue-monitor/__tests__/sanitizer.spec.ts scripts/log-issue-monitor/__tests__/detectors.spec.ts`
- [ ] CI green on PR

## 지식 복리

- **함정**: `PIIMasker` 주석은 `sk-proj-` 지원이라 했지만 regex `/sk-[a-zA-Z0-9]{32,}/`는 하이픈 키를 매칭하지 못함.
- **운영**: `docker inspect` excerpt를 GitHub 이슈에 올릴 때 `Config.Env`는 반드시 redaction 대상.

Made with [Cursor](https://cursor.com)