### PR TITLE
fix(server): MCP tools/call validation errors return -32602 (Closes #444)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-06-13)
 
 ## Corpus Check
-- 1108 files · ~1,510,461 words
+- 1111 files · ~1,494,564 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5528 nodes · 6814 edges · 1100 communities detected
+- 5534 nodes · 6819 edges · 1103 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1110,6 +1110,9 @@
 - [[_COMMUNITY_Community 1097|Community 1097]]
 - [[_COMMUNITY_Community 1098|Community 1098]]
 - [[_COMMUNITY_Community 1099|Community 1099]]
+- [[_COMMUNITY_Community 1100|Community 1100]]
+- [[_COMMUNITY_Community 1101|Community 1101]]
+- [[_COMMUNITY_Community 1102|Community 1102]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -2238,168 +2241,168 @@ Cohesion: 0.48
 Nodes (6): callHttpTool(), checkServerHealth(), getHttpTools(), handleRequest(), main(), sendResponse()
 
 ### Community 275 - "Community 275"
+Cohesion: 0.57
+Nodes (6): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), redactDockerInspectEnv(), truncateTitle()
+
+### Community 276 - "Community 276"
 Cohesion: 0.52
 Nodes (6): booleanFromEnv(), defaultLogsRoot(), labelsFromEnv(), loadMonitorConfig(), numberFromEnv(), optionalString()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (2): number(), setCount()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.33
 Nodes (1): CircuitBreaker
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.6
 Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkLinks(), buildNetworkNodesAndLinks()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.67
 Nodes (4): errorHandler(), isAppErrorContract(), resolveSeverityAndCategory(), resolveStatusCode()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.47
 Nodes (3): cleanupTestDatabase(), createTestDatabaseWithoutServices(), setupTestDatabase()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (2): createJsonRpcError(), processMcpMessage()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.47
 Nodes (4): getAdmin(), getEmbeddingMapHandler(), seedEmbeddings(), vecJson()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.6
 Nodes (5): forgetParams(), memoryInjectionParams(), parseArgvToParams(), recallParams(), rememberParams()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.53
 Nodes (5): defaultProbe(), options(), readSettings(), runCodex(), runCodexConnect()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.53
 Nodes (1): DependencyValidator
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.33
 Nodes (1): TestMigration
 
-### Community 288 - "Community 288"
-Cohesion: 0.33
-Nodes (0): 
-
 ### Community 289 - "Community 289"
 Cohesion: 0.33
-Nodes (1): FlipConsolidationRelationDirectionsMigration
+Nodes (0): 
 
 ### Community 290 - "Community 290"
 Cohesion: 0.33
-Nodes (1): TelemetryDailyMetricsMigration
+Nodes (1): FlipConsolidationRelationDirectionsMigration
 
 ### Community 291 - "Community 291"
 Cohesion: 0.33
-Nodes (1): TelemetryEventsMigration
+Nodes (1): TelemetryDailyMetricsMigration
 
 ### Community 292 - "Community 292"
 Cohesion: 0.33
-Nodes (0): 
+Nodes (1): TelemetryEventsMigration
 
 ### Community 293 - "Community 293"
 Cohesion: 0.33
-Nodes (1): ExampleMigration
+Nodes (0): 
 
 ### Community 294 - "Community 294"
+Cohesion: 0.33
+Nodes (1): ExampleMigration
+
+### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (1): FeedbackRepositorySQLite
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.47
 Nodes (2): generateId(), KgTripleRepositorySqlite
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.33
 Nodes (1): HealthChecker
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.47
 Nodes (3): validateProceduralMemoryFields(), validateTriggerConditions(), validateWorkflowOrSkillName()
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (1): CacheKeyGenerator
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.53
 Nodes (4): getRankingWeights(), loadRankingWeights(), resolveRankingWeightsFilePath(), validateRankingWeights()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.53
 Nodes (4): getRetryOptions(), loadRetryOptions(), validateRetryConfig(), validateRetryOptions()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (1): VectorSearchFactory
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.47
 Nodes (3): defaultTfidfVecRegistry(), mockSqliteMaster(), sqliteMasterPreparedMock()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.47
 Nodes (1): VectorPerformanceRepositoryImpl
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.6
 Nodes (5): applyVersionFilter(), collectMetaMemoryStats(), enrichProceduralVersionInfo(), runMemoryItemPostSearchPipeline(), updateConsolidationScoreMetadata()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.53
 Nodes (1): SummarizationService
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.47
 Nodes (3): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.47
 Nodes (3): chunkSucceeded(), failureMessageFromResult(), TriplePipelineOrchestrator
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.6
 Nodes (5): executePerformanceAlerts(), handleList(), handleResolve(), handleSearch(), handleStats()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.47
 Nodes (1): RuntimeDiagnosticsLogger
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.47
 Nodes (1): MigrateEmbeddingsTool
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.6
 Nodes (5): compositeScore(), generateCandidate(), main(), mulberry32(), parseTuneArgs()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.6
 Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.4
 Nodes (2): emptyState(), loadState()
 
-### Community 314 - "Community 314"
-Cohesion: 0.6
-Nodes (5): recordJsonlSkip(), recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
-
 ### Community 315 - "Community 315"
 Cohesion: 0.6
-Nodes (5): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), truncateTitle()
+Nodes (5): recordJsonlSkip(), recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.8
@@ -2422,48 +2425,48 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 321 - "Community 321"
-Cohesion: 0.6
-Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 322 - "Community 322"
 Cohesion: 0.6
-Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
 
 ### Community 323 - "Community 323"
+Cohesion: 0.6
+Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+
+### Community 324 - "Community 324"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (1): SseServer
-
 ### Community 325 - "Community 325"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): SseServer
 
 ### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (0): 
 
 ### Community 327 - "Community 327"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 328 - "Community 328"
 Cohesion: 0.6
 Nodes (3): createClaudeCodeHttpTransport(), readStream(), runClaudeCodeHookCommand()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (2): seedTwoProjectMemories(), stopBatchSchedulerSingleton()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.6
 Nodes (3): createCodexHttpTransport(), readStream(), runCodexHookCommand()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.6
 Nodes (3): parseOptions(), readSettings(), runClaudeCodeConnect()
-
-### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (0): 
 
 ### Community 332 - "Community 332"
 Cohesion: 0.4
@@ -2490,28 +2493,28 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 338 - "Community 338"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (2): getStopWords(), isStopWord()
 
 ### Community 343 - "Community 343"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.5
+Nodes (2): getStopWords(), isStopWord()
 
 ### Community 344 - "Community 344"
 Cohesion: 0.4
@@ -2522,136 +2525,136 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 346 - "Community 346"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 348 - "Community 348"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 349 - "Community 349"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (1): EvolutionDemoNotFoundError
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.7
 Nodes (4): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults(), handleAutoSetAnchor(), handleIncludeNeighbors()
 
-### Community 359 - "Community 359"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 360 - "Community 360"
 Cohesion: 0.4
-Nodes (1): RecallTool
+Nodes (0): 
 
 ### Community 361 - "Community 361"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (1): RecallTool
 
 ### Community 362 - "Community 362"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 363 - "Community 363"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 364 - "Community 364"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 365 - "Community 365"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): TokenBucketRateLimiter
 
 ### Community 366 - "Community 366"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 367 - "Community 367"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.6
 Nodes (4): buildComparisonHintMarkup(), renderPointSegment(), syncSegmentSelection(), updateComparisonHint()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.7
 Nodes (4): renderConsolidationPanel(), renderEpisodicSources(), renderSearchComparison(), renderSemanticResult()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 378 - "Community 378"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 379 - "Community 379"
 Cohesion: 0.5
@@ -5537,6 +5540,18 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 1100 - "Community 1100"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 1101 - "Community 1101"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 1102 - "Community 1102"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `TimeoutError`, `FeedbackRepository`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -5566,1095 +5581,1101 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 554`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 555`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 556`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 557`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 558`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 559`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 560`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 561`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 562`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 563`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 564`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 565`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
+- **Thin community `Community 566`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 567`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 568`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 569`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 570`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 571`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 572`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 573`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 574`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 575`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 576`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 577`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
+- **Thin community `Community 578`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `event()`, `codex-hook.spec.ts`
+- **Thin community `Community 579`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 580`** (2 nodes): `event()`, `codex-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 581`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 582`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 583`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 584`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 585`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 586`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 587`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 588`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 589`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 590`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 591`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 592`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
+- **Thin community `Community 593`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
+- **Thin community `Community 594`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
+- **Thin community `Community 595`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `runner.ts`, `runCodexHook()`
+- **Thin community `Community 596`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 597`** (2 nodes): `runner.ts`, `runCodexHook()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 598`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 599`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 600`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 601`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 602`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 603`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 604`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 605`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 606`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 607`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 608`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 609`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 610`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 611`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 612`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 613`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 614`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 615`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 616`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 617`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 618`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 619`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 620`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 621`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 622`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 623`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 624`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 625`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 626`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 627`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 628`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 629`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 630`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 631`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
+- **Thin community `Community 632`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 633`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 634`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 635`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 636`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 637`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 638`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 639`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 640`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 641`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 642`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 643`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 644`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 645`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 646`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 647`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 648`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 649`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 650`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 651`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 652`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 653`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 654`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 655`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 656`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 657`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 658`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 659`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 660`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 661`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 662`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 663`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 664`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 665`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 666`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 667`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 668`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 669`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 670`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 671`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 672`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 673`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 674`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 675`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 676`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 677`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 678`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 679`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 680`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 681`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 682`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 683`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 684`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 685`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 686`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 687`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 688`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 689`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 690`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 691`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 692`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 693`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 694`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 695`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 696`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 697`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 698`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 699`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 700`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 701`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 702`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 703`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 704`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 705`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 706`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 707`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 708`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 709`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 710`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 711`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 712`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 713`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 714`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 715`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 716`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 717`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 718`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 719`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 720`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 721`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 722`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 723`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 724`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 725`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 726`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 727`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 728`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 729`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 730`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 731`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 732`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 733`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 734`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 735`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 736`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 737`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 738`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 739`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 740`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 741`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 742`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 743`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 744`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 745`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 746`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 747`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 748`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 749`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 750`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 751`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 752`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `types.ts`
+- **Thin community `Community 753`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 754`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `index.ts`
+- **Thin community `Community 755`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 756`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 757`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 758`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 759`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 760`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 761`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `transport.ts`
+- **Thin community `Community 762`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `index.ts`
+- **Thin community `Community 763`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 764`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 765`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 766`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 767`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 768`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 769`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 770`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 771`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 772`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 774`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 776`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 784`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 785`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 786`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 787`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 790`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `context.ts`
+- **Thin community `Community 792`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `index.ts`
+- **Thin community `Community 797`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `types.ts`
+- **Thin community `Community 802`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 803`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 805`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 806`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 807`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 809`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 810`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 811`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 812`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 813`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 814`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `types.ts`
+- **Thin community `Community 816`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `index.ts`
+- **Thin community `Community 818`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `types.ts`
+- **Thin community `Community 821`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `types.ts`
+- **Thin community `Community 825`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 827`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `index.ts`
+- **Thin community `Community 828`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 831`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 832`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 834`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 835`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 838`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `types.ts`
+- **Thin community `Community 839`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 843`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 849`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 850`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 860`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 878`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 879`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 880`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 881`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 882`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 883`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 884`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 885`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 886`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 887`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 888`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `error-types.ts`
+- **Thin community `Community 889`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 890`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 891`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `search.types.ts`
+- **Thin community `Community 892`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 894`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `constants.ts`
+- **Thin community `Community 895`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 896`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 904`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 905`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 906`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 907`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 908`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 909`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 910`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 911`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 912`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 913`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 914`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 915`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 916`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 918`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 919`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 931`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 932`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 933`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 934`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `index.ts`
+- **Thin community `Community 935`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 936`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `database-types.ts`
+- **Thin community `Community 937`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 938`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 939`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 940`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `types.ts`
+- **Thin community `Community 941`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `index.ts`
+- **Thin community `Community 942`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `spec.ts`
+- **Thin community `Community 943`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 944`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 945`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 959`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `index.ts`
+- **Thin community `Community 963`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 964`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 966`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 968`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 969`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 970`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 971`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `context-port.ts`
+- **Thin community `Community 972`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 973`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 981`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 982`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 983`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 984`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 985`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 986`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 987`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 988`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 989`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 990`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 991`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 992`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 993`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 994`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 995`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 996`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 997`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 998`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 999`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1000`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1001`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1002`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1003`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1004`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1005`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1006`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1007`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1008`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1009`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1010`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1011`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1012`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1013`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1014`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `index.ts`
+- **Thin community `Community 1015`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1016`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1017`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1018`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1019`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1020`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1021`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1027`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1028`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1029`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1031`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1032`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1033`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 1035`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 1036`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `types.ts`
+- **Thin community `Community 1037`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `types.ts`
+- **Thin community `Community 1038`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1039`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1041`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1042`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1043`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1044`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1045`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 1046`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1047`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1048`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1049`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1050`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1051`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1052`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1053`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1054`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1055`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1056`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `types.ts`
+- **Thin community `Community 1057`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1058`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1059`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1060`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1061`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1062`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1063`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1064`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1065`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1066`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1067`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1068`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1069`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1070`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1071`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1072`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1073`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1074`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1075`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1076`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1077`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1078`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1079`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1080`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1081`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1082`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1083`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1084`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `types.ts`
+- **Thin community `Community 1085`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1086`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1087`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1088`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1089`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1090`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1091`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1092`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1093`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1094`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1095`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1096`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1097`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1098`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1099`** (1 nodes): `entrypoint.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1100`** (1 nodes): `index.spec.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1101`** (1 nodes): `memory-evolution-demo-shell-render.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1102`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "vitest.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "assistant.spec.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "types.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "types.spec.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "assistant.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "after-assistant-turn.ts",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "auto-remember-policy.ts",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "channel-scope.ts",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "http-transport.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "mock-transport.spec.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "transport.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "http-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "factory.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "mock-transport.ts",
@@ -529,7 +529,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "CircuitBreaker",
@@ -537,7 +537,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L8",
       "id": "circuit_breaker_circuitbreaker",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".constructor()",
@@ -545,7 +545,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L12",
       "id": "circuit_breaker_circuitbreaker_constructor",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".canPass()",
@@ -553,7 +553,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L14",
       "id": "circuit_breaker_circuitbreaker_canpass",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".recordSuccess()",
@@ -561,7 +561,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L27",
       "id": "circuit_breaker_circuitbreaker_recordsuccess",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".recordFailure()",
@@ -569,7 +569,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L32",
       "id": "circuit_breaker_circuitbreaker_recordfailure",
-      "community": 277
+      "community": 278
     },
     {
       "label": "logger.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "createRateLimitedLogger()",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 375
+      "community": 376
     },
     {
       "label": "levelFromEnv()",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 375
+      "community": 376
     },
     {
       "label": "consoleSink()",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 375
+      "community": 376
     },
     {
       "label": "logger.spec.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "retry-queue.spec.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "retry-queue.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "http.integration.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "start-http-server.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "startTestHttpServer()",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 376
+      "community": 377
     },
     {
       "label": "findFreePort()",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 376
+      "community": 377
     },
     {
       "label": "waitForHealth()",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 376
+      "community": 377
     },
     {
       "label": "http-server-runner.js",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 776
+      "community": 777
     },
     {
       "label": "test-integration.js",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "getRepoRoot()",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 377
+      "community": 378
     },
     {
       "label": "collectEnvKeys()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 377
+      "community": 378
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 377
+      "community": 378
     },
     {
       "label": "server-info.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "context.spec.ts",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "server-factory.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "server-state.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 378
+      "community": 321
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 378
+      "community": 321
     },
     {
       "label": "postJsonRpc()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 378
+      "community": 321
     },
     {
       "label": "openSse()",
@@ -2401,7 +2401,15 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 378
+      "community": 321
+    },
+    {
+      "label": "listenWithMcpRouterAndMocks()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
+      "source_location": "L112",
+      "id": "mcp_routes_streamable_http_spec_listenwithmcprouterandmocks",
+      "community": 321
     },
     {
       "label": "index.ts",
@@ -2481,7 +2489,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2657,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "bootstrap.ts",
@@ -2665,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2673,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_sse_hub_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "resetReviewCandidatesSseHubForTests()",
@@ -2681,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L12",
       "id": "review_candidates_sse_hub_resetreviewcandidatesssehubfortests",
-      "community": 321
+      "community": 322
     },
     {
       "label": "writeSafe()",
@@ -2689,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L23",
       "id": "review_candidates_sse_hub_writesafe",
-      "community": 321
+      "community": 322
     },
     {
       "label": "attachReviewCandidatesSse()",
@@ -2697,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L39",
       "id": "review_candidates_sse_hub_attachreviewcandidatessse",
-      "community": 321
+      "community": 322
     },
     {
       "label": "notifyReviewCandidatesChanged()",
@@ -2705,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L69",
       "id": "review_candidates_sse_hub_notifyreviewcandidateschanged",
-      "community": 321
+      "community": 322
     },
     {
       "label": "index.spec.ts",
@@ -2713,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "sse-server-impl.ts",
@@ -2841,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "batch-run-history.ts",
@@ -2985,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_instance_lock_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "isProcessAlive()",
@@ -2993,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L21",
       "id": "instance_lock_isprocessalive",
-      "community": 322
+      "community": 323
     },
     {
       "label": "getLockFilePath()",
@@ -3001,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L33",
       "id": "instance_lock_getlockfilepath",
-      "community": 322
+      "community": 323
     },
     {
       "label": "tryAcquireLock()",
@@ -3009,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L45",
       "id": "instance_lock_tryacquirelock",
-      "community": 322
+      "community": 323
     },
     {
       "label": "releaseLock()",
@@ -3017,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L70",
       "id": "instance_lock_releaselock",
-      "community": 322
+      "community": 323
     },
     {
       "label": "cors-policy.ts",
@@ -3049,7 +3057,31 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 793
+      "community": 794
+    },
+    {
+      "label": "mcp-tool-call-error.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
+      "community": 795
+    },
+    {
+      "label": "mcp-tool-call-error.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
+      "source_location": "L1",
+      "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
+      "community": 555
+    },
+    {
+      "label": "mapToolExecutionErrorToJsonRpc()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
+      "source_location": "L13",
+      "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
+      "community": 555
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3057,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "buildAnchorMapData()",
@@ -3065,7 +3097,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L57",
       "id": "anchor_map_handler_buildanchormapdata",
-      "community": 278
+      "community": 279
     },
     {
       "label": "buildNetworkNodesAndLinks()",
@@ -3073,7 +3105,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L101",
       "id": "anchor_map_handler_buildnetworknodesandlinks",
-      "community": 278
+      "community": 279
     },
     {
       "label": "buildNetworkLinks()",
@@ -3081,7 +3113,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L201",
       "id": "anchor_map_handler_buildnetworklinks",
-      "community": 278
+      "community": 279
     },
     {
       "label": "broadcastToSubscribers()",
@@ -3089,7 +3121,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L249",
       "id": "anchor_map_handler_broadcasttosubscribers",
-      "community": 278
+      "community": 279
     },
     {
       "label": "broadcastAnchorMapUpdate()",
@@ -3097,7 +3129,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L272",
       "id": "anchor_map_handler_broadcastanchormapupdate",
-      "community": 278
+      "community": 279
     },
     {
       "label": "tool-context-meta-memory-injection.spec.ts",
@@ -3105,7 +3137,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3113,7 +3145,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3121,7 +3153,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3129,7 +3161,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "makeMocks()",
@@ -3137,7 +3169,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 555
+      "community": 556
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3145,7 +3177,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "writeDisabledResponse()",
@@ -3153,7 +3185,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L8",
       "id": "programmatic_auth_middleware_writedisabledresponse",
-      "community": 279
+      "community": 280
     },
     {
       "label": "writeUnauthorized()",
@@ -3161,7 +3193,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L28",
       "id": "programmatic_auth_middleware_writeunauthorized",
-      "community": 279
+      "community": 280
     },
     {
       "label": "readBearerToken()",
@@ -3169,7 +3201,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L48",
       "id": "programmatic_auth_middleware_readbearertoken",
-      "community": 279
+      "community": 280
     },
     {
       "label": "readApiKeyHeader()",
@@ -3177,7 +3209,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L58",
       "id": "programmatic_auth_middleware_readapikeyheader",
-      "community": 279
+      "community": 280
     },
     {
       "label": "createProgrammaticAuthMiddleware()",
@@ -3185,7 +3217,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L68",
       "id": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
-      "community": 279
+      "community": 280
     },
     {
       "label": "error-handler.middleware.ts",
@@ -3193,7 +3225,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_error_handler_middleware_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "isAppErrorContract()",
@@ -3201,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L21",
       "id": "error_handler_middleware_isapperrorcontract",
-      "community": 280
+      "community": 281
     },
     {
       "label": "resolveSeverityAndCategory()",
@@ -3209,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L26",
       "id": "error_handler_middleware_resolveseverityandcategory",
-      "community": 280
+      "community": 281
     },
     {
       "label": "resolveStatusCode()",
@@ -3217,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L64",
       "id": "error_handler_middleware_resolvestatuscode",
-      "community": 280
+      "community": 281
     },
     {
       "label": "errorHandler()",
@@ -3225,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L84",
       "id": "error_handler_middleware_errorhandler",
-      "community": 280
+      "community": 281
     },
     {
       "label": "asyncHandler()",
@@ -3233,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/middleware/error-handler.middleware.ts",
       "source_location": "L135",
       "id": "error_handler_middleware_asynchandler",
-      "community": 280
+      "community": 281
     },
     {
       "label": "tool-context.middleware.ts",
@@ -3241,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3249,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 556
+      "community": 557
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3257,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "createMockResponse()",
@@ -3265,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 557
+      "community": 558
     },
     {
       "label": "index.ts",
@@ -3273,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3313,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "createServiceInjector()",
@@ -3321,7 +3353,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 558
+      "community": 559
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3329,7 +3361,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3337,7 +3369,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 559
+      "community": 560
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3345,7 +3377,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "createMockResponse()",
@@ -3353,7 +3385,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 560
+      "community": 561
     },
     {
       "label": "session-store.spec.ts",
@@ -3361,7 +3393,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "session-store.ts",
@@ -3369,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "createSessionStore()",
@@ -3377,7 +3409,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 561
+      "community": 562
     },
     {
       "label": "stdio-server.ts",
@@ -3385,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 323
+      "community": 324
     },
     {
       "label": "StdioServer",
@@ -3393,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".start()",
@@ -3401,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".stop()",
@@ -3409,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 323
+      "community": 324
     },
     {
       "label": ".cleanup()",
@@ -3417,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 323
+      "community": 324
     },
     {
       "label": "sse-server.ts",
@@ -3425,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 324
+      "community": 325
     },
     {
       "label": "SseServer",
@@ -3433,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".start()",
@@ -3441,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".stop()",
@@ -3449,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 324
+      "community": 325
     },
     {
       "label": ".cleanup()",
@@ -3457,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 324
+      "community": 325
     },
     {
       "label": "test-database.ts",
@@ -3465,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_test_helpers_test_database_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "setupTestDatabase()",
@@ -3473,7 +3505,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L14",
       "id": "test_database_setuptestdatabase",
-      "community": 281
+      "community": 282
     },
     {
       "label": "cleanupTestDatabase()",
@@ -3481,7 +3513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L263",
       "id": "test_database_cleanuptestdatabase",
-      "community": 281
+      "community": 282
     },
     {
       "label": "agent.routes.ts",
@@ -3673,7 +3705,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "agent.routes.spec.ts",
@@ -3705,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_transcript_import_spec_ts",
-      "community": 325
+      "community": 326
     },
     {
       "label": "rawEvent()",
@@ -3713,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L15",
       "id": "agent_transcript_import_spec_rawevent",
-      "community": 325
+      "community": 326
     },
     {
       "label": "preparedEvent()",
@@ -3721,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L26",
       "id": "agent_transcript_import_spec_preparedevent",
-      "community": 325
+      "community": 326
     },
     {
       "label": "jsonl()",
@@ -3729,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L52",
       "id": "agent_transcript_import_spec_jsonl",
-      "community": 325
+      "community": 326
     },
     {
       "label": "importer()",
@@ -3737,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L76",
       "id": "agent_transcript_import_spec_importer",
-      "community": 325
+      "community": 326
     },
     {
       "label": "admin.routes.ts",
@@ -3745,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "createAdminRouter()",
@@ -3753,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L27",
       "id": "admin_routes_createadminrouter",
-      "community": 562
+      "community": 563
     },
     {
       "label": "auth.routes.ts",
@@ -3761,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 326
+      "community": 327
     },
     {
       "label": "readBearerToken()",
@@ -3769,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 326
+      "community": 327
     },
     {
       "label": "readApiKeyHeader()",
@@ -3777,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 326
+      "community": 327
     },
     {
       "label": "readCookie()",
@@ -3785,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 326
+      "community": 327
     },
     {
       "label": "createAuthRouter()",
@@ -3793,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 326
+      "community": 327
     },
     {
       "label": "mcp.routes.ts",
@@ -3801,47 +3833,47 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_routes_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "isJsonRpcNotification()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L49",
+      "source_location": "L50",
       "id": "mcp_routes_isjsonrpcnotification",
-      "community": 282
+      "community": 283
     },
     {
       "label": "isInitializeRequest()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L53",
+      "source_location": "L54",
       "id": "mcp_routes_isinitializerequest",
-      "community": 282
+      "community": 283
     },
     {
       "label": "createJsonRpcError()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L57",
+      "source_location": "L58",
       "id": "mcp_routes_createjsonrpcerror",
-      "community": 282
+      "community": 283
     },
     {
       "label": "processMcpMessage()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L74",
+      "source_location": "L75",
       "id": "mcp_routes_processmcpmessage",
-      "community": 282
+      "community": 283
     },
     {
       "label": "createMcpRouter()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L413",
+      "source_location": "L423",
       "id": "mcp_routes_createmcprouter",
-      "community": 282
+      "community": 283
     },
     {
       "label": "admin.routes.spec.ts",
@@ -4033,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "createToolsRouter()",
@@ -4041,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 563
+      "community": 564
     },
     {
       "label": "api.routes.ts",
@@ -4049,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "createApiRouter()",
@@ -4057,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 564
+      "community": 565
     },
     {
       "label": "quality.routes.ts",
@@ -4065,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "createQualityRouter()",
@@ -4073,7 +4105,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 565
+      "community": 566
     },
     {
       "label": "admin-evolution-demo.routes.ts",
@@ -4081,7 +4113,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "registerAdminEvolutionDemoRoutes()",
@@ -4089,7 +4121,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L13",
       "id": "admin_evolution_demo_routes_registeradminevolutiondemoroutes",
-      "community": 566
+      "community": 567
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -4121,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_response_spec_ts",
-      "community": 283
+      "community": 284
     },
     {
       "label": "getEmbeddingMapHandler()",
@@ -4129,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L33",
       "id": "admin_embedding_map_response_spec_getembeddingmaphandler",
-      "community": 283
+      "community": 284
     },
     {
       "label": "getAdmin()",
@@ -4137,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L43",
       "id": "admin_embedding_map_response_spec_getadmin",
-      "community": 283
+      "community": 284
     },
     {
       "label": "createMinimalSchema()",
@@ -4145,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L82",
       "id": "admin_embedding_map_response_spec_createminimalschema",
-      "community": 283
+      "community": 284
     },
     {
       "label": "vecJson()",
@@ -4153,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L107",
       "id": "admin_embedding_map_response_spec_vecjson",
-      "community": 283
+      "community": 284
     },
     {
       "label": "seedEmbeddings()",
@@ -4161,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.spec.ts",
       "source_location": "L115",
       "id": "admin_embedding_map_response_spec_seedembeddings",
-      "community": 283
+      "community": 284
     },
     {
       "label": "admin-embedding-map.routes.ts",
@@ -4217,7 +4249,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4225,7 +4257,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 567
+      "community": 568
     },
     {
       "label": "admin-graph-response.ts",
@@ -4233,7 +4265,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "buildGraphResponse()",
@@ -4241,7 +4273,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 568
+      "community": 569
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4249,7 +4281,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4257,7 +4289,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 569
+      "community": 570
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4265,7 +4297,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4273,7 +4305,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 570
+      "community": 571
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4281,7 +4313,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4289,7 +4321,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 571
+      "community": 572
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4321,7 +4353,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4329,7 +4361,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 572
+      "community": 573
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4337,7 +4369,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4345,7 +4377,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 573
+      "community": 574
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4353,7 +4385,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4361,7 +4393,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 574
+      "community": 575
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4369,7 +4401,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4377,7 +4409,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 575
+      "community": 576
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4473,7 +4505,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "route()",
@@ -4481,7 +4513,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L48",
       "id": "claude_code_hook_route",
-      "community": 327
+      "community": 328
     },
     {
       "label": "createClaudeCodeHttpTransport()",
@@ -4489,7 +4521,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L73",
       "id": "claude_code_hook_createclaudecodehttptransport",
-      "community": 327
+      "community": 328
     },
     {
       "label": "readStream()",
@@ -4497,7 +4529,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L109",
       "id": "claude_code_hook_readstream",
-      "community": 327
+      "community": 328
     },
     {
       "label": "runClaudeCodeHookCommand()",
@@ -4505,7 +4537,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L115",
       "id": "claude_code_hook_runclaudecodehookcommand",
-      "community": 327
+      "community": 328
     },
     {
       "label": "agent-ask.spec.ts",
@@ -4513,7 +4545,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "argv()",
@@ -4521,7 +4553,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 576
+      "community": 577
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4529,7 +4561,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "stopBatchSchedulerSingleton()",
@@ -4537,7 +4569,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L22",
       "id": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
-      "community": 328
+      "community": 329
     },
     {
       "label": "argvAgentAsk()",
@@ -4545,7 +4577,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L30",
       "id": "agent_ask_issue237_e2e_spec_argvagentask",
-      "community": 328
+      "community": 329
     },
     {
       "label": "captureStdoutWrite()",
@@ -4553,7 +4585,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L38",
       "id": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
-      "community": 328
+      "community": 329
     },
     {
       "label": "seedTwoProjectMemories()",
@@ -4561,7 +4593,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L52",
       "id": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
-      "community": 328
+      "community": 329
     },
     {
       "label": "claude-code-connect.spec.ts",
@@ -4569,7 +4601,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "env-loader.ts",
@@ -4601,7 +4633,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "codex-hook.ts",
@@ -4609,7 +4641,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "route()",
@@ -4617,7 +4649,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L48",
       "id": "codex_hook_route",
-      "community": 329
+      "community": 330
     },
     {
       "label": "createCodexHttpTransport()",
@@ -4625,7 +4657,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L67",
       "id": "codex_hook_createcodexhttptransport",
-      "community": 329
+      "community": 330
     },
     {
       "label": "readStream()",
@@ -4633,7 +4665,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L101",
       "id": "codex_hook_readstream",
-      "community": 329
+      "community": 330
     },
     {
       "label": "runCodexHookCommand()",
@@ -4641,7 +4673,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L107",
       "id": "codex_hook_runcodexhookcommand",
-      "community": 329
+      "community": 330
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4649,7 +4681,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "runCli()",
@@ -4657,7 +4689,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 577
+      "community": 578
     },
     {
       "label": "agent-ask.ts",
@@ -4793,7 +4825,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "defaultProbe()",
@@ -4801,7 +4833,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L29",
       "id": "claude_code_connect_defaultprobe",
-      "community": 330
+      "community": 331
     },
     {
       "label": "parseOptions()",
@@ -4809,7 +4841,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L46",
       "id": "claude_code_connect_parseoptions",
-      "community": 330
+      "community": 331
     },
     {
       "label": "readSettings()",
@@ -4817,7 +4849,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L68",
       "id": "claude_code_connect_readsettings",
-      "community": 330
+      "community": 331
     },
     {
       "label": "runClaudeCodeConnect()",
@@ -4825,7 +4857,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L78",
       "id": "claude_code_connect_runclaudecodeconnect",
-      "community": 330
+      "community": 331
     },
     {
       "label": "option-map.ts",
@@ -4833,7 +4865,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_option_map_ts",
-      "community": 284
+      "community": 285
     },
     {
       "label": "parseArgvToParams()",
@@ -4841,7 +4873,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L9",
       "id": "option_map_parseargvtoparams",
-      "community": 284
+      "community": 285
     },
     {
       "label": "recallParams()",
@@ -4849,7 +4881,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L41",
       "id": "option_map_recallparams",
-      "community": 284
+      "community": 285
     },
     {
       "label": "rememberParams()",
@@ -4857,7 +4889,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L67",
       "id": "option_map_rememberparams",
-      "community": 284
+      "community": 285
     },
     {
       "label": "forgetParams()",
@@ -4865,7 +4897,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L83",
       "id": "option_map_forgetparams",
-      "community": 284
+      "community": 285
     },
     {
       "label": "memoryInjectionParams()",
@@ -4873,7 +4905,7 @@
       "source_file": "packages/memento-server/src/cli/option-map.ts",
       "source_location": "L96",
       "id": "option_map_memoryinjectionparams",
-      "community": 284
+      "community": 285
     },
     {
       "label": "claude-code-hook.spec.ts",
@@ -4881,7 +4913,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_spec_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "event()",
@@ -4889,7 +4921,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L7",
       "id": "claude_code_hook_spec_event",
-      "community": 578
+      "community": 579
     },
     {
       "label": "agent-ops.ts",
@@ -5049,7 +5081,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_spec_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "event()",
@@ -5057,7 +5089,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L7",
       "id": "codex_hook_spec_event",
-      "community": 579
+      "community": 580
     },
     {
       "label": "codex-connect.ts",
@@ -5065,7 +5097,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_ts",
-      "community": 285
+      "community": 286
     },
     {
       "label": "runCodex()",
@@ -5073,7 +5105,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L24",
       "id": "codex_connect_runcodex",
-      "community": 285
+      "community": 286
     },
     {
       "label": "defaultProbe()",
@@ -5081,7 +5113,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L33",
       "id": "codex_connect_defaultprobe",
-      "community": 285
+      "community": 286
     },
     {
       "label": "options()",
@@ -5089,7 +5121,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L40",
       "id": "codex_connect_options",
-      "community": 285
+      "community": 286
     },
     {
       "label": "readSettings()",
@@ -5097,7 +5129,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L59",
       "id": "codex_connect_readsettings",
-      "community": 285
+      "community": 286
     },
     {
       "label": "runCodexConnect()",
@@ -5105,7 +5137,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.ts",
       "source_location": "L69",
       "id": "codex_connect_runcodexconnect",
-      "community": 285
+      "community": 286
     },
     {
       "label": "types.ts",
@@ -5113,7 +5145,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -5145,7 +5177,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "testSimpleAlerts()",
@@ -5153,7 +5185,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -5161,7 +5193,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "testBasicFunctionality()",
@@ -5169,7 +5201,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 581
+      "community": 582
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -5177,7 +5209,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -5185,7 +5217,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 582
+      "community": 583
     },
     {
       "label": "test-server-synchronization.ts",
@@ -5217,7 +5249,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "testErrorLogging()",
@@ -5225,7 +5257,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 583
+      "community": 584
     },
     {
       "label": "debug-http-v2.ts",
@@ -5233,7 +5265,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "testFetch()",
@@ -5241,7 +5273,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 584
+      "community": 585
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -5249,7 +5281,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "initializeTestDatabase()",
@@ -5257,7 +5289,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 585
+      "community": 586
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -5265,7 +5297,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -5273,7 +5305,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -5281,7 +5313,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "testReflexionE2E()",
@@ -5289,7 +5321,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 586
+      "community": 587
     },
     {
       "label": "test-alerts-direct.ts",
@@ -5297,7 +5329,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "testAlertsDirect()",
@@ -5305,7 +5337,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 587
+      "community": 588
     },
     {
       "label": "test-client.ts",
@@ -5337,7 +5369,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "test-http-server-v2.ts",
@@ -5409,7 +5441,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "testPerformanceAlerts()",
@@ -5417,7 +5449,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -5425,7 +5457,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "testPathTraversalE2E()",
@@ -5433,7 +5465,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 589
+      "community": 590
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -5441,7 +5473,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -5449,7 +5481,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 590
+      "community": 591
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -5457,7 +5489,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -5513,7 +5545,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -5521,7 +5553,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "brave-search-provider.ts",
@@ -5585,7 +5617,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "createSearchProvider()",
@@ -5593,7 +5625,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 591
+      "community": 592
     },
     {
       "label": "search-provider.ts",
@@ -5601,7 +5633,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "llm-provider.ts",
@@ -5609,7 +5641,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5617,7 +5649,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "types.ts",
@@ -5625,7 +5657,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "loadAgentConfig()",
@@ -5633,7 +5665,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 592
+      "community": 593
     },
     {
       "label": "system-prompt.ts",
@@ -5641,7 +5673,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "vitest.config.ts",
@@ -5649,7 +5681,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "injection-contract.spec.ts",
@@ -5657,7 +5689,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -5665,7 +5697,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_queue_runtime_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "transport()",
@@ -5673,7 +5705,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L179",
       "id": "queue_runtime_spec_transport",
-      "community": 593
+      "community": 594
     },
     {
       "label": "redaction-size.spec.ts",
@@ -5681,7 +5713,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "injection-contract.ts",
@@ -5809,7 +5841,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "runtime.ts",
@@ -5905,7 +5937,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_test_fixtures_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "eventFixture()",
@@ -5913,7 +5945,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L15",
       "id": "test_fixtures_eventfixture",
-      "community": 594
+      "community": 595
     },
     {
       "label": "schema-normalize.spec.ts",
@@ -5921,7 +5953,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "normalize.ts",
@@ -5961,7 +5993,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "priority-queue.ts",
@@ -6185,7 +6217,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "adapter.ts",
@@ -6281,7 +6313,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "types.ts",
@@ -6289,7 +6321,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "scope.ts",
@@ -6345,7 +6377,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "diagnostics.ts",
@@ -6353,7 +6385,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "diagnoseCodex()",
@@ -6361,7 +6393,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L20",
       "id": "diagnostics_diagnosecodex",
-      "community": 595
+      "community": 596
     },
     {
       "label": "settings.ts",
@@ -6409,7 +6441,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "runCodexHook()",
@@ -6417,7 +6449,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L6",
       "id": "runner_runcodexhook",
-      "community": 596
+      "community": 597
     },
     {
       "label": "adapter.spec.ts",
@@ -6449,7 +6481,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "adapter.ts",
@@ -6521,7 +6553,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "types.ts",
@@ -6529,7 +6561,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "scope.ts",
@@ -6561,7 +6593,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "diagnostics.ts",
@@ -6681,7 +6713,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "utils.spec.ts",
@@ -6689,7 +6721,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "buildMemory()",
@@ -6697,7 +6729,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 597
+      "community": 598
     },
     {
       "label": "context-injector.ts",
@@ -7617,7 +7649,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "agent-api.spec.ts",
@@ -7625,7 +7657,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "logger.ts",
@@ -7713,7 +7745,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "initializeServices()",
@@ -7721,7 +7753,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 598
+      "community": 599
     },
     {
       "label": "context.ts",
@@ -7761,7 +7793,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -7769,7 +7801,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 599
+      "community": 600
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -7777,7 +7809,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -7785,7 +7817,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 600
+      "community": 601
     },
     {
       "label": "anchor-stack.ts",
@@ -7793,7 +7825,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "createAnchorStack()",
@@ -7801,7 +7833,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 601
+      "community": 602
     },
     {
       "label": "failure-reflexion.ts",
@@ -7809,7 +7841,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "startFailureAndReflexion()",
@@ -7817,7 +7849,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 602
+      "community": 603
     },
     {
       "label": "search-and-embedding.ts",
@@ -7825,7 +7857,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -7833,7 +7865,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 603
+      "community": 604
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -7841,7 +7873,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -7849,7 +7881,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 604
+      "community": 605
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -7857,7 +7889,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -7865,7 +7897,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 605
+      "community": 606
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -8673,7 +8705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "createInput()",
@@ -8681,7 +8713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 606
+      "community": 607
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -8689,7 +8721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "extract()",
@@ -8697,7 +8729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 331
+      "community": 332
     },
     {
       "label": "waitForEventProcessing()",
@@ -8705,7 +8737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 331
+      "community": 332
     },
     {
       "label": "createProceduralMemory()",
@@ -8713,7 +8745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 331
+      "community": 332
     },
     {
       "label": "createFailureEvent()",
@@ -8721,7 +8753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 331
+      "community": 332
     },
     {
       "label": "relation-graph-factory.ts",
@@ -8729,7 +8761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "createRelationGraph()",
@@ -8737,7 +8769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 607
+      "community": 608
     },
     {
       "label": "consolidation-score-service.ts",
@@ -8825,7 +8857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -9273,7 +9305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "createBaseSchema()",
@@ -9281,7 +9313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 608
+      "community": 609
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -9385,7 +9417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -9393,7 +9425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 609
+      "community": 610
     },
     {
       "label": "migration-monitor-service.ts",
@@ -9497,7 +9529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "openLockTestDatabase()",
@@ -9505,7 +9537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 610
+      "community": 611
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -9545,7 +9577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "createProgress()",
@@ -9553,7 +9585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 611
+      "community": 612
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -9561,7 +9593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -9569,7 +9601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -9577,7 +9609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -9585,7 +9617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 612
+      "community": 613
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -9593,7 +9625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -9601,7 +9633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "createCoreMemoryTable()",
@@ -9609,7 +9641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 613
+      "community": 614
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -9641,7 +9673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -9737,7 +9769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "init.ts",
@@ -9857,7 +9889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "createDbPath()",
@@ -9865,7 +9897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 614
+      "community": 615
     },
     {
       "label": "migrate.spec.ts",
@@ -9873,7 +9905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "migrate.ts",
@@ -9905,7 +9937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "migration-runner.ts",
@@ -9985,7 +10017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "createBaseSchema()",
@@ -9993,7 +10025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 615
+      "community": 616
     },
     {
       "label": "migration-logger.spec.ts",
@@ -10001,7 +10033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "migration-detector.ts",
@@ -10193,7 +10225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "migration-detector.spec.ts",
@@ -10201,7 +10233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "backup-manager.ts",
@@ -10281,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "dependency-validator.ts",
@@ -10289,7 +10321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_ts",
-      "community": 286
+      "community": 287
     },
     {
       "label": "DependencyValidator",
@@ -10297,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L53",
       "id": "dependency_validator_dependencyvalidator",
-      "community": 286
+      "community": 287
     },
     {
       "label": ".validateAll()",
@@ -10305,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L57",
       "id": "dependency_validator_dependencyvalidator_validateall",
-      "community": 286
+      "community": 287
     },
     {
       "label": ".validateMemoryEmbeddingForeignKey()",
@@ -10313,7 +10345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L81",
       "id": "dependency_validator_dependencyvalidator_validatememoryembeddingforeignkey",
-      "community": 286
+      "community": 287
     },
     {
       "label": ".validateFTS5Triggers()",
@@ -10321,7 +10353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L169",
       "id": "dependency_validator_dependencyvalidator_validatefts5triggers",
-      "community": 286
+      "community": 287
     },
     {
       "label": ".validateVECTriggers()",
@@ -10329,7 +10361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts",
       "source_location": "L241",
       "id": "dependency_validator_dependencyvalidator_validatevectriggers",
-      "community": 286
+      "community": 287
     },
     {
       "label": "migration-runner.spec.ts",
@@ -10337,7 +10369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_spec_ts",
-      "community": 287
+      "community": 288
     },
     {
       "label": "TestMigration",
@@ -10345,7 +10377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L19",
       "id": "migration_runner_spec_testmigration",
-      "community": 287
+      "community": 288
     },
     {
       "label": ".up()",
@@ -10353,7 +10385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L24",
       "id": "migration_runner_spec_testmigration_up",
-      "community": 287
+      "community": 288
     },
     {
       "label": ".down()",
@@ -10361,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L33",
       "id": "migration_runner_spec_testmigration_down",
-      "community": 287
+      "community": 288
     },
     {
       "label": ".validateBefore()",
@@ -10369,7 +10401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L37",
       "id": "migration_runner_spec_testmigration_validatebefore",
-      "community": 287
+      "community": 288
     },
     {
       "label": ".validateAfter()",
@@ -10377,7 +10409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.spec.ts",
       "source_location": "L47",
       "id": "migration_runner_spec_testmigration_validateafter",
-      "community": 287
+      "community": 288
     },
     {
       "label": "dependency-validator.spec.ts",
@@ -10385,7 +10417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "schema-version-manager.ts",
@@ -10473,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -10873,7 +10905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "createMemoryItemTable()",
@@ -10881,7 +10913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 332
+      "community": 333
     },
     {
       "label": "createSchemaVersionTable()",
@@ -10889,7 +10921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 332
+      "community": 333
     },
     {
       "label": "columnExists()",
@@ -10897,7 +10929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 332
+      "community": 333
     },
     {
       "label": "indexExists()",
@@ -10905,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 332
+      "community": 333
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -10985,7 +11017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "createMemoryItemTable()",
@@ -10993,7 +11025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 333
+      "community": 334
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11001,7 +11033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 333
+      "community": 334
     },
     {
       "label": "columnExists()",
@@ -11009,7 +11041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 333
+      "community": 334
     },
     {
       "label": "indexExists()",
@@ -11017,7 +11049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 333
+      "community": 334
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -11025,7 +11057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_spec_ts",
-      "community": 288
+      "community": 289
     },
     {
       "label": "createBaseSchema()",
@@ -11033,7 +11065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L19",
       "id": "018_kg_triple_table_spec_createbaseschema",
-      "community": 288
+      "community": 289
     },
     {
       "label": "tableExists()",
@@ -11041,7 +11073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L67",
       "id": "018_kg_triple_table_spec_tableexists",
-      "community": 288
+      "community": 289
     },
     {
       "label": "columnExists()",
@@ -11049,7 +11081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L74",
       "id": "018_kg_triple_table_spec_columnexists",
-      "community": 288
+      "community": 289
     },
     {
       "label": "indexExists()",
@@ -11057,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L79",
       "id": "018_kg_triple_table_spec_indexexists",
-      "community": 288
+      "community": 289
     },
     {
       "label": "uniqueConstraintExists()",
@@ -11065,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.spec.ts",
       "source_location": "L86",
       "id": "018_kg_triple_table_spec_uniqueconstraintexists",
-      "community": 288
+      "community": 289
     },
     {
       "label": "033-memory-review-candidate-schema.ts",
@@ -11201,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_026_flip_consolidation_relation_directions_ts",
-      "community": 289
+      "community": 290
     },
     {
       "label": "FlipConsolidationRelationDirectionsMigration",
@@ -11209,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L19",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".validateBefore()",
@@ -11217,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L25",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_validatebefore",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".validateAfter()",
@@ -11225,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L27",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_validateafter",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".up()",
@@ -11233,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L29",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_up",
-      "community": 289
+      "community": 290
     },
     {
       "label": ".down()",
@@ -11241,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/026-flip-consolidation-relation-directions.ts",
       "source_location": "L90",
       "id": "026_flip_consolidation_relation_directions_flipconsolidationrelationdirectionsmigration_down",
-      "community": 289
+      "community": 290
     },
     {
       "label": "008-arigraph-schema-expansion.spec.ts",
@@ -11249,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "createBaseSchema()",
@@ -11257,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 616
+      "community": 617
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -11497,7 +11529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "createBaseSchema()",
@@ -11505,7 +11537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 617
+      "community": 618
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -11801,7 +11833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "createBaseSchema()",
@@ -11809,7 +11841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 618
+      "community": 619
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -11817,7 +11849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 334
+      "community": 335
     },
     {
       "label": "createMemoryItemTable()",
@@ -11825,7 +11857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 334
+      "community": 335
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11833,7 +11865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 334
+      "community": 335
     },
     {
       "label": "columnExists()",
@@ -11841,7 +11873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 334
+      "community": 335
     },
     {
       "label": "indexExists()",
@@ -11849,7 +11881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 334
+      "community": 335
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -12201,7 +12233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_028_telemetry_daily_metrics_ts",
-      "community": 290
+      "community": 291
     },
     {
       "label": "TelemetryDailyMetricsMigration",
@@ -12209,7 +12241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L10",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".validateBefore()",
@@ -12217,7 +12249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L15",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_validatebefore",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".validateAfter()",
@@ -12225,7 +12257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L17",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_validateafter",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".up()",
@@ -12233,7 +12265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L19",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_up",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".down()",
@@ -12241,7 +12273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/028-telemetry-daily-metrics.ts",
       "source_location": "L39",
       "id": "028_telemetry_daily_metrics_telemetrydailymetricsmigration_down",
-      "community": 290
+      "community": 291
     },
     {
       "label": "022-feedback-event-comment.ts",
@@ -12529,7 +12561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "createBaseSchema()",
@@ -12537,7 +12569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 619
+      "community": 620
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -12641,7 +12673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "createSchemaWith018()",
@@ -12649,7 +12681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 620
+      "community": 621
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -12657,7 +12689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "createBaseSchema()",
@@ -12665,7 +12697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 621
+      "community": 622
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -12833,7 +12865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_027_telemetry_events_ts",
-      "community": 291
+      "community": 292
     },
     {
       "label": "TelemetryEventsMigration",
@@ -12841,7 +12873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L9",
       "id": "027_telemetry_events_telemetryeventsmigration",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".validateBefore()",
@@ -12849,7 +12881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L14",
       "id": "027_telemetry_events_telemetryeventsmigration_validatebefore",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".validateAfter()",
@@ -12857,7 +12889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L16",
       "id": "027_telemetry_events_telemetryeventsmigration_validateafter",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".up()",
@@ -12865,7 +12897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L18",
       "id": "027_telemetry_events_telemetryeventsmigration_up",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".down()",
@@ -12873,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/027-telemetry-events.ts",
       "source_location": "L41",
       "id": "027_telemetry_events_telemetryeventsmigration_down",
-      "community": 291
+      "community": 292
     },
     {
       "label": "013-procedural-version-fields.ts",
@@ -12945,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createMemoryItemTable()",
@@ -12953,7 +12985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createSchemaVersionTable()",
@@ -12961,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 335
+      "community": 336
     },
     {
       "label": "columnExists()",
@@ -12969,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 335
+      "community": 336
     },
     {
       "label": "indexExists()",
@@ -12977,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 335
+      "community": 336
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -13057,7 +13089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -13065,7 +13097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "createMemoryItemTable()",
@@ -13073,7 +13105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 336
+      "community": 337
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13081,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 336
+      "community": 337
     },
     {
       "label": "columnExists()",
@@ -13089,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 336
+      "community": 337
     },
     {
       "label": "indexExists()",
@@ -13097,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 336
+      "community": 337
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -13289,7 +13321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -13361,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "createBaseSchema()",
@@ -13369,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 622
+      "community": 623
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -13449,7 +13481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_006_fts5_reflection_notes_spec_ts",
-      "community": 292
+      "community": 293
     },
     {
       "label": "createBaseSchema()",
@@ -13457,7 +13489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L28",
       "id": "006_fts5_reflection_notes_spec_createbaseschema",
-      "community": 292
+      "community": 293
     },
     {
       "label": "step1CreateNewTable()",
@@ -13465,7 +13497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L208",
       "id": "006_fts5_reflection_notes_spec_step1createnewtable",
-      "community": 292
+      "community": 293
     },
     {
       "label": "step2ReindexData()",
@@ -13473,7 +13505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L233",
       "id": "006_fts5_reflection_notes_spec_step2reindexdata",
-      "community": 292
+      "community": 293
     },
     {
       "label": "step3CreateDualTriggers()",
@@ -13481,7 +13513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L268",
       "id": "006_fts5_reflection_notes_spec_step3createdualtriggers",
-      "community": 292
+      "community": 293
     },
     {
       "label": "setupMigrationSteps()",
@@ -13489,7 +13521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/006-fts5-reflection-notes.spec.ts",
       "source_location": "L496",
       "id": "006_fts5_reflection_notes_spec_setupmigrationsteps",
-      "community": 292
+      "community": 293
     },
     {
       "label": "007-procedural-memory-enhancement.spec.ts",
@@ -13497,7 +13529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "createBaseSchema()",
@@ -13505,7 +13537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 623
+      "community": 624
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -13609,7 +13641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "createBaseSchema()",
@@ -13617,7 +13649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 624
+      "community": 625
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -13689,7 +13721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_tests_migration_runner_api_example_spec_ts",
-      "community": 293
+      "community": 294
     },
     {
       "label": "ExampleMigration",
@@ -13697,7 +13729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L19",
       "id": "migration_runner_api_example_spec_examplemigration",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".up()",
@@ -13705,7 +13737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L24",
       "id": "migration_runner_api_example_spec_examplemigration_up",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".down()",
@@ -13713,7 +13745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L34",
       "id": "migration_runner_api_example_spec_examplemigration_down",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".validateBefore()",
@@ -13721,7 +13753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L38",
       "id": "migration_runner_api_example_spec_examplemigration_validatebefore",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".validateAfter()",
@@ -13729,7 +13761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/__tests__/migration-runner-api-example.spec.ts",
       "source_location": "L49",
       "id": "migration_runner_api_example_spec_examplemigration_validateafter",
-      "community": 293
+      "community": 294
     },
     {
       "label": "sqlite-core-memory-adapter.ts",
@@ -13833,7 +13865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -13865,7 +13897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_feedback_repository_sqlite_impl_ts",
-      "community": 294
+      "community": 295
     },
     {
       "label": "FeedbackRepositorySQLite",
@@ -13873,7 +13905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L11",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".constructor()",
@@ -13881,7 +13913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L12",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_constructor",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".insertFeedback()",
@@ -13889,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L14",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_insertfeedback",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".getNetScores()",
@@ -13897,7 +13929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L36",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_getnetscores",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".getNetScoreRows()",
@@ -13905,7 +13937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/feedback-repository-sqlite.impl.ts",
       "source_location": "L72",
       "id": "feedback_repository_sqlite_impl_feedbackrepositorysqlite_getnetscorerows",
-      "community": 294
+      "community": 295
     },
     {
       "label": "core-memory-repository-sqlite.impl.ts",
@@ -14561,7 +14593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_kg_triple_repository_sqlite_impl_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "generateId()",
@@ -14569,7 +14601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L12",
       "id": "kg_triple_repository_sqlite_impl_generateid",
-      "community": 295
+      "community": 296
     },
     {
       "label": "KgTripleRepositorySqlite",
@@ -14577,7 +14609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L18",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".constructor()",
@@ -14585,7 +14617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L21",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_constructor",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".upsertTriple()",
@@ -14593,7 +14625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L29",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_upserttriple",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".getBySubjectPredicateObject()",
@@ -14601,7 +14633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/kg-triple-repository-sqlite.impl.ts",
       "source_location": "L52",
       "id": "kg_triple_repository_sqlite_impl_kgtriplerepositorysqlite_getbysubjectpredicateobject",
-      "community": 295
+      "community": 296
     },
     {
       "label": "core-memory-repository-sqlite.impl.spec.ts",
@@ -14609,7 +14641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "cache-service.ts",
@@ -14937,7 +14969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "batch-scheduler.ts",
@@ -15353,7 +15385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_health_checker_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "HealthChecker",
@@ -15361,7 +15393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L33",
       "id": "health_checker_healthchecker",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".constructor()",
@@ -15369,7 +15401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L37",
       "id": "health_checker_healthchecker_constructor",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".setStartTime()",
@@ -15377,7 +15409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L51",
       "id": "health_checker_healthchecker_setstarttime",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".check()",
@@ -15385,7 +15417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L64",
       "id": "health_checker_healthchecker_check",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".triggerGarbageCollection()",
@@ -15393,7 +15425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/health-checker.ts",
       "source_location": "L120",
       "id": "health_checker_healthchecker_triggergarbagecollection",
-      "community": 296
+      "community": 297
     },
     {
       "label": "batch-scheduler-default-config.ts",
@@ -15401,7 +15433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -15409,7 +15441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 625
+      "community": 626
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -15417,7 +15449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -15425,7 +15457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 626
+      "community": 627
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -15489,7 +15521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -15497,7 +15529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "validateBatchJobConfig()",
@@ -15505,7 +15537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 627
+      "community": 628
     },
     {
       "label": "retry-manager.ts",
@@ -15961,7 +15993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -15969,7 +16001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 337
+      "community": 338
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -15977,7 +16009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 337
+      "community": 338
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -15985,7 +16017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L113",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 337
+      "community": 338
     },
     {
       "label": "runLogRotation()",
@@ -15993,7 +16025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L168",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 337
+      "community": 338
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -16001,7 +16033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -16089,7 +16121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -16097,7 +16129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 338
+      "community": 339
     },
     {
       "label": "runMemoryCleanup()",
@@ -16105,7 +16137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 338
+      "community": 339
     },
     {
       "label": "runMonitoring()",
@@ -16113,7 +16145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 338
+      "community": 339
     },
     {
       "label": "runHealthCheck()",
@@ -16121,7 +16153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 338
+      "community": 339
     },
     {
       "label": "file-logger.spec.ts",
@@ -16129,7 +16161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -16201,7 +16233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "retry-manager.spec.ts",
@@ -16209,7 +16241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "shouldRetry()",
@@ -16217,7 +16249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 628
+      "community": 629
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -16225,7 +16257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "baseResult()",
@@ -16233,7 +16265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 629
+      "community": 630
     },
     {
       "label": "job-queue.spec.ts",
@@ -16241,7 +16273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "job()",
@@ -16249,7 +16281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 339
+      "community": 340
     },
     {
       "label": "job1()",
@@ -16257,7 +16289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 339
+      "community": 340
     },
     {
       "label": "job2()",
@@ -16265,7 +16297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 339
+      "community": 340
     },
     {
       "label": "job3()",
@@ -16273,7 +16305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 339
+      "community": 340
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -16281,7 +16313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -16289,7 +16321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "initializeTestDatabase()",
@@ -16297,7 +16329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 630
+      "community": 631
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -16393,7 +16425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -16433,7 +16465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -16529,7 +16561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "createQualityTables()",
@@ -16537,7 +16569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 631
+      "community": 632
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -16569,7 +16601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "jsonl-rotation.ts",
@@ -16577,7 +16609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_jsonl_rotation_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "rotateJsonlIfNeeded()",
@@ -16585,7 +16617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L3",
       "id": "jsonl_rotation_rotatejsonlifneeded",
-      "community": 632
+      "community": 633
     },
     {
       "label": "stopwords.spec.ts",
@@ -16593,7 +16625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "type-guards.ts",
@@ -16801,7 +16833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -16809,7 +16841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 633
+      "community": 634
     },
     {
       "label": "environment-check.ts",
@@ -16849,7 +16881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -16857,7 +16889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -16865,7 +16897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -16873,7 +16905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 340
+      "community": 341
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -16881,7 +16913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 340
+      "community": 341
     },
     {
       "label": "extractKeyTokens()",
@@ -16889,7 +16921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 340
+      "community": 341
     },
     {
       "label": "getSearchQueryExamples()",
@@ -16897,7 +16929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 340
+      "community": 341
     },
     {
       "label": "relation-type-converter.ts",
@@ -16905,7 +16937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "toDbRelationType()",
@@ -16913,7 +16945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 341
+      "community": 342
     },
     {
       "label": "fromDbRelationType()",
@@ -16921,7 +16953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 341
+      "community": 342
     },
     {
       "label": "isValidDbRelationType()",
@@ -16929,7 +16961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 341
+      "community": 342
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -16937,7 +16969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 341
+      "community": 342
     },
     {
       "label": "db-path.ts",
@@ -16945,7 +16977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -16953,7 +16985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 634
+      "community": 635
     },
     {
       "label": "error-handling.spec.ts",
@@ -16961,7 +16993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "operation()",
@@ -16969,7 +17001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 635
+      "community": 636
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -17105,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "validateTypeParam()",
@@ -17113,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L32",
       "id": "type_param_validator_validatetypeparam",
-      "community": 297
+      "community": 298
     },
     {
       "label": "parseTypeParamMode()",
@@ -17121,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L100",
       "id": "type_param_validator_parsetypeparammode",
-      "community": 297
+      "community": 298
     },
     {
       "label": "validateTriggerConditions()",
@@ -17129,7 +17161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L126",
       "id": "type_param_validator_validatetriggerconditions",
-      "community": 297
+      "community": 298
     },
     {
       "label": "validateWorkflowOrSkillName()",
@@ -17137,7 +17169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L168",
       "id": "type_param_validator_validateworkfloworskillname",
-      "community": 297
+      "community": 298
     },
     {
       "label": "validateProceduralMemoryFields()",
@@ -17145,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L194",
       "id": "type_param_validator_validateproceduralmemoryfields",
-      "community": 297
+      "community": 298
     },
     {
       "label": "procedural-memory-extractor.types.ts",
@@ -17153,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "relation-visualizer.ts",
@@ -17577,7 +17609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "cache-key-generator.ts",
@@ -17585,7 +17617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_cache_key_generator_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "CacheKeyGenerator",
@@ -17593,7 +17625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L31",
       "id": "cache_key_generator_cachekeygenerator",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".generateRelationGraphKey()",
@@ -17601,7 +17633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L39",
       "id": "cache_key_generator_cachekeygenerator_generaterelationgraphkey",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".generateRelationExtractionKey()",
@@ -17609,7 +17641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L61",
       "id": "cache_key_generator_cachekeygenerator_generaterelationextractionkey",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".generateLLMRelationExtractionKey()",
@@ -17617,7 +17649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L95",
       "id": "cache_key_generator_cachekeygenerator_generatellmrelationextractionkey",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".generateEmbeddingKey()",
@@ -17625,7 +17657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/cache-key-generator.ts",
       "source_location": "L110",
       "id": "cache_key_generator_cachekeygenerator_generateembeddingkey",
-      "community": 298
+      "community": 299
     },
     {
       "label": "database.spec.ts",
@@ -17769,7 +17801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "path-validator.ts",
@@ -17833,7 +17865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -17841,7 +17873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 636
+      "community": 637
     },
     {
       "label": "error-handling.ts",
@@ -17849,7 +17881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "withErrorHandling()",
@@ -17857,7 +17889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 637
+      "community": 638
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -17865,7 +17897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -17873,7 +17905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -18073,7 +18105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -18081,7 +18113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 638
+      "community": 639
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -18113,7 +18145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "initializeTestDatabase()",
@@ -18121,7 +18153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 639
+      "community": 640
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -18129,7 +18161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -18137,7 +18169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 640
+      "community": 641
     },
     {
       "label": "logging-helpers.ts",
@@ -18233,7 +18265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "pii-masker.ts",
@@ -18305,7 +18337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "getStopWords()",
@@ -18313,7 +18345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 342
+      "community": 343
     },
     {
       "label": "getEnglishStopWords()",
@@ -18321,7 +18353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 342
+      "community": 343
     },
     {
       "label": "getKoreanStopWords()",
@@ -18329,7 +18361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 342
+      "community": 343
     },
     {
       "label": "isStopWord()",
@@ -18337,7 +18369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 342
+      "community": 343
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -18345,7 +18377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -18353,7 +18385,15 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 867
+      "community": 869
+    },
+    {
+      "label": "pii-masker-api-key.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
+      "community": 870
     },
     {
       "label": "path-validator.spec.ts",
@@ -18361,7 +18401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 868
+      "community": 871
     },
     {
       "label": "triple-cache.spec.ts",
@@ -18369,7 +18409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 869
+      "community": 872
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -18377,7 +18417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 870
+      "community": 873
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -18385,7 +18425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 871
+      "community": 874
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -18393,7 +18433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 872
+      "community": 875
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -18401,7 +18441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 873
+      "community": 876
     },
     {
       "label": "logger-schema.spec.ts",
@@ -18409,7 +18449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 874
+      "community": 877
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -18417,7 +18457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 875
+      "community": 878
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -18425,7 +18465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "initializeTestDatabase()",
@@ -18433,7 +18473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 641
+      "community": 642
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -18441,7 +18481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 876
+      "community": 879
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -18449,7 +18489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 877
+      "community": 880
     },
     {
       "label": "benchmark.types.ts",
@@ -18457,7 +18497,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "assertMacroCategory()",
@@ -18465,7 +18505,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 642
+      "community": 643
     },
     {
       "label": "migration.types.ts",
@@ -18473,7 +18513,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 878
+      "community": 881
     },
     {
       "label": "consolidation-score.types.ts",
@@ -18481,7 +18521,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 879
+      "community": 882
     },
     {
       "label": "consolidation.types.ts",
@@ -18489,7 +18529,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 880
+      "community": 883
     },
     {
       "label": "vector-search.types.ts",
@@ -18497,7 +18537,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 881
+      "community": 884
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -18505,7 +18545,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 882
+      "community": 885
     },
     {
       "label": "procedural-versioning.ts",
@@ -18513,7 +18553,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 883
+      "community": 886
     },
     {
       "label": "triple-extraction.ts",
@@ -18521,7 +18561,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 884
+      "community": 887
     },
     {
       "label": "feedback.types.ts",
@@ -18529,7 +18569,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 885
+      "community": 888
     },
     {
       "label": "embedding.types.ts",
@@ -18537,7 +18577,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 886
+      "community": 889
     },
     {
       "label": "relation-graph.ts",
@@ -18545,7 +18585,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 887
+      "community": 890
     },
     {
       "label": "failure-event.ts",
@@ -18553,7 +18593,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 888
+      "community": 891
     },
     {
       "label": "index.ts",
@@ -18585,7 +18625,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 889
+      "community": 892
     },
     {
       "label": "ranking.types.ts",
@@ -18593,7 +18633,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 890
+      "community": 893
     },
     {
       "label": "alerts.types.ts",
@@ -18601,7 +18641,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 891
+      "community": 894
     },
     {
       "label": "relation.ts",
@@ -18641,7 +18681,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 892
+      "community": 895
     },
     {
       "label": "index.spec.ts",
@@ -18649,7 +18689,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 893
+      "community": 896
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -18657,7 +18697,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 894
+      "community": 897
     },
     {
       "label": "constants.ts",
@@ -18665,7 +18705,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 895
+      "community": 898
     },
     {
       "label": "environment.ts",
@@ -18761,7 +18801,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "resolveRankingWeightsFilePath()",
@@ -18769,7 +18809,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L56",
       "id": "ranking_weights_loader_resolverankingweightsfilepath",
-      "community": 299
+      "community": 300
     },
     {
       "label": "loadRankingWeights()",
@@ -18777,7 +18817,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L78",
       "id": "ranking_weights_loader_loadrankingweights",
-      "community": 299
+      "community": 300
     },
     {
       "label": "validateRankingWeights()",
@@ -18785,7 +18825,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L138",
       "id": "ranking_weights_loader_validaterankingweights",
-      "community": 299
+      "community": 300
     },
     {
       "label": "getRankingWeights()",
@@ -18793,7 +18833,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L182",
       "id": "ranking_weights_loader_getrankingweights",
-      "community": 299
+      "community": 300
     },
     {
       "label": "resetRankingWeightsCache()",
@@ -18801,7 +18841,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.ts",
       "source_location": "L190",
       "id": "ranking_weights_loader_resetrankingweightscache",
-      "community": 299
+      "community": 300
     },
     {
       "label": "vector-search.config.ts",
@@ -18809,7 +18849,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 896
+      "community": 899
     },
     {
       "label": "retry-options-loader.ts",
@@ -18817,7 +18857,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_retry_options_loader_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "loadRetryOptions()",
@@ -18825,7 +18865,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L47",
       "id": "retry_options_loader_loadretryoptions",
-      "community": 300
+      "community": 301
     },
     {
       "label": "validateRetryOptions()",
@@ -18833,7 +18873,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L129",
       "id": "retry_options_loader_validateretryoptions",
-      "community": 300
+      "community": 301
     },
     {
       "label": "validateRetryConfig()",
@@ -18841,7 +18881,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L156",
       "id": "retry_options_loader_validateretryconfig",
-      "community": 300
+      "community": 301
     },
     {
       "label": "getRetryOptions()",
@@ -18849,7 +18889,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L180",
       "id": "retry_options_loader_getretryoptions",
-      "community": 300
+      "community": 301
     },
     {
       "label": "resetRetryOptionsCache()",
@@ -18857,7 +18897,7 @@
       "source_file": "packages/memento-core/src/shared/config/retry-options-loader.ts",
       "source_location": "L190",
       "id": "retry_options_loader_resetretryoptionscache",
-      "community": 300
+      "community": 301
     },
     {
       "label": "llm-model-resolver.ts",
@@ -18889,7 +18929,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "validateConfig()",
@@ -18897,7 +18937,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L161",
       "id": "index_validateconfig",
-      "community": 643
+      "community": 644
     },
     {
       "label": "config-loader-utils.ts",
@@ -18969,7 +19009,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 897
+      "community": 900
     },
     {
       "label": "constants.spec.ts",
@@ -18977,7 +19017,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 898
+      "community": 901
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -18985,7 +19025,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 899
+      "community": 902
     },
     {
       "label": "config-validation.spec.ts",
@@ -18993,7 +19033,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 900
+      "community": 903
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -19001,7 +19041,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 901
+      "community": 904
     },
     {
       "label": "environment-paths.spec.ts",
@@ -19009,7 +19049,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 902
+      "community": 905
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -19017,7 +19057,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 903
+      "community": 906
     },
     {
       "label": "relation-constants.ts",
@@ -19025,7 +19065,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 904
+      "community": 907
     },
     {
       "label": "introspection-constants.ts",
@@ -19033,7 +19073,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 905
+      "community": 908
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -19041,7 +19081,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 906
+      "community": 909
     },
     {
       "label": "http-bind-policy.ts",
@@ -19121,7 +19161,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 907
+      "community": 910
     },
     {
       "label": "retry-manager.interface.ts",
@@ -19129,7 +19169,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 908
+      "community": 911
     },
     {
       "label": "cache.interface.ts",
@@ -19137,7 +19177,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 909
+      "community": 912
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -19145,7 +19185,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 910
+      "community": 913
     },
     {
       "label": "error-logging.interface.ts",
@@ -19153,7 +19193,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 911
+      "community": 914
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -19161,7 +19201,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 912
+      "community": 915
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -19169,7 +19209,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 913
+      "community": 916
     },
     {
       "label": "database.interface.ts",
@@ -19177,7 +19217,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 914
+      "community": 917
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -19185,7 +19225,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 915
+      "community": 918
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -19193,7 +19233,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 916
+      "community": 919
     },
     {
       "label": "llm-client-initializer.ts",
@@ -19401,7 +19441,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 917
+      "community": 920
     },
     {
       "label": "openai-client.spec.ts",
@@ -19409,7 +19449,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 918
+      "community": 921
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -19417,7 +19457,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 919
+      "community": 922
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -19425,7 +19465,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 920
+      "community": 923
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -19433,7 +19473,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 921
+      "community": 924
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -19441,7 +19481,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 922
+      "community": 925
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -19449,7 +19489,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 923
+      "community": 926
     },
     {
       "label": "environment-priority.spec.ts",
@@ -19457,7 +19497,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 924
+      "community": 927
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -19465,7 +19505,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 925
+      "community": 928
     },
     {
       "label": "gemini-client.spec.ts",
@@ -19473,7 +19513,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 926
+      "community": 929
     },
     {
       "label": "search-local-tool.ts",
@@ -19641,7 +19681,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "initializeTestDatabase()",
@@ -19649,7 +19689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createMockEmbeddingService()",
@@ -19657,7 +19697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -19665,7 +19705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -19673,7 +19713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 343
+      "community": 344
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -19681,7 +19721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "initializeTestDatabase()",
@@ -19689,7 +19729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createMockEmbeddingService()",
@@ -19697,7 +19737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -19705,7 +19745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -19713,7 +19753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 344
+      "community": 345
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -19721,7 +19761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "initializeTestDatabase()",
@@ -19729,7 +19769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createMockEmbeddingService()",
@@ -19737,7 +19777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -19745,7 +19785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 345
+      "community": 346
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -19753,7 +19793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 345
+      "community": 346
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -19761,7 +19801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "initializeTestDatabase()",
@@ -19769,7 +19809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 644
+      "community": 645
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -19777,7 +19817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "initializeTestDatabase()",
@@ -19785,7 +19825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 645
+      "community": 646
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -19793,7 +19833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 927
+      "community": 930
     },
     {
       "label": "query-filter-strategy.ts",
@@ -19801,7 +19841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "QueryFilterStrategy",
@@ -19809,7 +19849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".constructor()",
@@ -19817,7 +19857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".filter()",
@@ -19825,7 +19865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 346
+      "community": 347
     },
     {
       "label": ".execute()",
@@ -19833,7 +19873,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 346
+      "community": 347
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -19841,7 +19881,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 928
+      "community": 931
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -19849,7 +19889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 929
+      "community": 932
     },
     {
       "label": "local-search-service.ts",
@@ -19921,7 +19961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 930
+      "community": 933
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -19929,7 +19969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 931
+      "community": 934
     },
     {
       "label": "anchor-interfaces.ts",
@@ -20057,7 +20097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 932
+      "community": 935
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -20065,7 +20105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -20073,7 +20113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 646
+      "community": 647
     },
     {
       "label": "embedding-types.ts",
@@ -20081,7 +20121,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 933
+      "community": 936
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -20089,7 +20129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 934
+      "community": 937
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -20097,7 +20137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "NHopSearchStrategy",
@@ -20105,7 +20145,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".constructor()",
@@ -20113,7 +20153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".search()",
@@ -20121,7 +20161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 347
+      "community": 348
     },
     {
       "label": ".execute()",
@@ -20129,7 +20169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 347
+      "community": 348
     },
     {
       "label": "query-filter-service.ts",
@@ -20297,7 +20337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "FallbackSearchService",
@@ -20305,7 +20345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 348
+      "community": 349
     },
     {
       "label": ".setDatabase()",
@@ -20313,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 348
+      "community": 349
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -20321,7 +20361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 348
+      "community": 349
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -20329,7 +20369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 348
+      "community": 349
     },
     {
       "label": "index.ts",
@@ -20337,7 +20377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 935
+      "community": 938
     },
     {
       "label": "fallback-strategy.ts",
@@ -20345,7 +20385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "FallbackStrategy",
@@ -20353,7 +20393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 349
+      "community": 350
     },
     {
       "label": ".constructor()",
@@ -20361,7 +20401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 349
+      "community": 350
     },
     {
       "label": ".fallback()",
@@ -20369,7 +20409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 349
+      "community": 350
     },
     {
       "label": ".execute()",
@@ -20377,7 +20417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 349
+      "community": 350
     },
     {
       "label": "anchor-search-service.ts",
@@ -20521,7 +20561,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 936
+      "community": 939
     },
     {
       "label": "anchor-cache-service.ts",
@@ -20769,7 +20809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 937
+      "community": 940
     },
     {
       "label": "local-search-service.spec.ts",
@@ -20777,7 +20817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 938
+      "community": 941
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -20785,7 +20825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 939
+      "community": 942
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -20793,7 +20833,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 940
+      "community": 943
     },
     {
       "label": "store.ts",
@@ -20833,7 +20873,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 941
+      "community": 944
     },
     {
       "label": "index.ts",
@@ -20841,7 +20881,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 942
+      "community": 945
     },
     {
       "label": "getters.ts",
@@ -20849,7 +20889,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_getters_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "EvolutionDemoNotFoundError",
@@ -20857,7 +20897,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L44",
       "id": "getters_evolutiondemonotfounderror",
-      "community": 350
+      "community": 351
     },
     {
       "label": ".constructor()",
@@ -20865,7 +20905,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L45",
       "id": "getters_evolutiondemonotfounderror_constructor",
-      "community": 350
+      "community": 351
     },
     {
       "label": "listEvolutionDemoScenarios()",
@@ -20873,7 +20913,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L55",
       "id": "getters_listevolutiondemoscenarios",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getEvolutionDemoSnapshot()",
@@ -20881,7 +20921,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L61",
       "id": "getters_getevolutiondemosnapshot",
-      "community": 350
+      "community": 351
     },
     {
       "label": "spec.ts",
@@ -20889,7 +20929,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 943
+      "community": 946
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -20897,7 +20937,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 944
+      "community": 947
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -20905,7 +20945,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 945
+      "community": 948
     },
     {
       "label": "vector-search.factory.ts",
@@ -20913,7 +20953,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_vector_search_factory_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "VectorSearchFactory",
@@ -20921,7 +20961,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L12",
       "id": "vector_search_factory_vectorsearchfactory",
-      "community": 301
+      "community": 302
     },
     {
       "label": ".createFacade()",
@@ -20929,7 +20969,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L16",
       "id": "vector_search_factory_vectorsearchfactory_createfacade",
-      "community": 301
+      "community": 302
     },
     {
       "label": ".createSearchService()",
@@ -20937,7 +20977,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L35",
       "id": "vector_search_factory_vectorsearchfactory_createsearchservice",
-      "community": 301
+      "community": 302
     },
     {
       "label": ".createIndexManager()",
@@ -20945,7 +20985,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L44",
       "id": "vector_search_factory_vectorsearchfactory_createindexmanager",
-      "community": 301
+      "community": 302
     },
     {
       "label": ".createPerformanceTester()",
@@ -20953,7 +20993,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/vector-search.factory.ts",
       "source_location": "L53",
       "id": "vector_search_factory_vectorsearchfactory_createperformancetester",
-      "community": 301
+      "community": 302
     },
     {
       "label": "hybrid-search.factory.ts",
@@ -21033,7 +21073,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -21041,7 +21081,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 647
+      "community": 648
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -21049,7 +21089,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 946
+      "community": 949
     },
     {
       "label": "search-result-combiner.ts",
@@ -22121,7 +22161,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -22129,7 +22169,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 648
+      "community": 649
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -22137,7 +22177,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_vector_search_engine_spec_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "sqliteMasterPreparedMock()",
@@ -22145,7 +22185,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L21",
       "id": "vector_search_engine_spec_sqlitemasterpreparedmock",
-      "community": 302
+      "community": 303
     },
     {
       "label": "createMockVectorRows()",
@@ -22153,7 +22193,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L40",
       "id": "vector_search_engine_spec_createmockvectorrows",
-      "community": 302
+      "community": 303
     },
     {
       "label": "createMockImplementation()",
@@ -22161,7 +22201,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L54",
       "id": "vector_search_engine_spec_createmockimplementation",
-      "community": 302
+      "community": 303
     },
     {
       "label": "mockSqliteMaster()",
@@ -22169,7 +22209,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L92",
       "id": "vector_search_engine_spec_mocksqlitemaster",
-      "community": 302
+      "community": 303
     },
     {
       "label": "defaultTfidfVecRegistry()",
@@ -22177,7 +22217,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/vector-search-engine.spec.ts",
       "source_location": "L96",
       "id": "vector_search_engine_spec_defaulttfidfvecregistry",
-      "community": 302
+      "community": 303
     },
     {
       "label": "procedural-memory-matcher.ts",
@@ -22281,7 +22321,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 947
+      "community": 950
     },
     {
       "label": "search-ranking.spec.ts",
@@ -22289,7 +22329,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 948
+      "community": 951
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -22393,7 +22433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 949
+      "community": 952
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -22401,7 +22441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 950
+      "community": 953
     },
     {
       "label": "search-engine.spec.ts",
@@ -22441,7 +22481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 951
+      "community": 954
     },
     {
       "label": "vector-search.repository.ts",
@@ -22593,7 +22633,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_performance_repository_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "VectorPerformanceRepositoryImpl",
@@ -22601,7 +22641,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L13",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".constructor()",
@@ -22609,7 +22649,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L17",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_constructor",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".checkVecAvailability()",
@@ -22617,7 +22657,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L25",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_checkvecavailability",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".runPerformanceTest()",
@@ -22625,7 +22665,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L85",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_runperformancetest",
-      "community": 303
+      "community": 304
     },
     {
       "label": ".executeSearch()",
@@ -22633,7 +22673,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L139",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_executesearch",
-      "community": 303
+      "community": 304
     },
     {
       "label": "vector-performance.repository.spec.ts",
@@ -22641,7 +22681,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 952
+      "community": 955
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -22649,7 +22689,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 953
+      "community": 956
     },
     {
       "label": "vector-search.service.ts",
@@ -22745,7 +22785,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -22753,7 +22793,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 649
+      "community": 650
     },
     {
       "label": "vector-performance-tester.ts",
@@ -22817,7 +22857,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "createMockRepository()",
@@ -22825,7 +22865,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 650
+      "community": 651
     },
     {
       "label": "vector-index-manager.ts",
@@ -23089,7 +23129,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "selectScore()",
@@ -23097,7 +23137,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 351
+      "community": 352
     },
     {
       "label": "computeNormalizationRange()",
@@ -23105,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 351
+      "community": 352
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -23113,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 351
+      "community": 352
     },
     {
       "label": ".normalize()",
@@ -23121,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 351
+      "community": 352
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -23129,7 +23169,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "createMockRepositories()",
@@ -23137,7 +23177,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 651
+      "community": 652
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -23145,7 +23185,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 954
+      "community": 957
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -23153,7 +23193,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "createMockIndexRepository()",
@@ -23161,7 +23201,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 652
+      "community": 653
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -23337,7 +23377,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 955
+      "community": 958
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -23345,7 +23385,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 956
+      "community": 959
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -23353,7 +23393,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 957
+      "community": 960
     },
     {
       "label": "spaced-repetition.ts",
@@ -23681,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 958
+      "community": 961
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -23721,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 959
+      "community": 962
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -23857,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 960
+      "community": 963
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -23865,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 961
+      "community": 964
     },
     {
       "label": "priority-calculation.service.ts",
@@ -24745,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 962
+      "community": 965
     },
     {
       "label": "recall-probability.service.ts",
@@ -24849,7 +24889,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 963
+      "community": 966
     },
     {
       "label": "telemetry.types.ts",
@@ -24857,7 +24897,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 964
+      "community": 967
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -24865,7 +24905,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "openTelemetryDb()",
@@ -24873,7 +24913,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 653
+      "community": 654
     },
     {
       "label": "telemetry-repository.ts",
@@ -25033,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "makeSearchQuality()",
@@ -25041,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 352
+      "community": 353
     },
     {
       "label": "makeMemoryQuality()",
@@ -25049,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 352
+      "community": 353
     },
     {
       "label": "makeConsolidationQuality()",
@@ -25057,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 352
+      "community": 353
     },
     {
       "label": "makeContext()",
@@ -25065,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 352
+      "community": 353
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -25105,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 965
+      "community": 968
     },
     {
       "label": "telemetry-service.ts",
@@ -25233,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 966
+      "community": 969
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -25241,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 967
+      "community": 970
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -25249,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 968
+      "community": 971
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -25257,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -25265,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 654
+      "community": 655
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -25337,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 969
+      "community": 972
     },
     {
       "label": "llm-port.ts",
@@ -25345,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 970
+      "community": 973
     },
     {
       "label": "persistence-port.ts",
@@ -25353,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 971
+      "community": 974
     },
     {
       "label": "context-port.ts",
@@ -25361,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 972
+      "community": 975
     },
     {
       "label": "agent-types.ts",
@@ -25369,7 +25409,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 973
+      "community": 976
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -25401,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 974
+      "community": 977
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -25409,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 975
+      "community": 978
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -25417,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "parseRememberSuccess()",
@@ -25425,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 353
+      "community": 354
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -25433,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".constructor()",
@@ -25441,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 353
+      "community": 354
     },
     {
       "label": ".persistApproved()",
@@ -25449,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 353
+      "community": 354
     },
     {
       "label": "openai-chat-llm-adapter.ts",
@@ -25489,7 +25529,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 976
+      "community": 979
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -25561,7 +25601,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -25569,7 +25609,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".constructor()",
@@ -25577,7 +25617,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".buildContext()",
@@ -25585,7 +25625,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".proposeCandidates()",
@@ -25593,7 +25633,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 354
+      "community": 355
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -25601,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -25609,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".constructor()",
@@ -25617,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".complete()",
@@ -25625,7 +25665,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".createRequestId()",
@@ -25633,7 +25673,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 355
+      "community": 356
     },
     {
       "label": "gemini-chat-llm-adapter.spec.ts",
@@ -25641,7 +25681,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 977
+      "community": 980
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -25649,7 +25689,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 978
+      "community": 981
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -25657,7 +25697,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 979
+      "community": 982
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -25665,7 +25705,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "baseCandidate()",
@@ -25673,7 +25713,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 655
+      "community": 656
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -25681,7 +25721,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "normalizeOwnerId()",
@@ -25689,7 +25729,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 356
+      "community": 357
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -25697,7 +25737,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 356
+      "community": 357
     },
     {
       "label": "assertUnreachable()",
@@ -25705,7 +25745,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 356
+      "community": 357
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -25713,7 +25753,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 356
+      "community": 357
     },
     {
       "label": "create-personal-agent-llm-port.spec.ts",
@@ -25721,7 +25761,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 980
+      "community": 983
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -25729,7 +25769,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "makeDeps()",
@@ -25737,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 656
+      "community": 657
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -25745,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -25753,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".constructor()",
@@ -25761,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".runOneTurn()",
@@ -25769,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -25777,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 357
+      "community": 358
     },
     {
       "label": "create-personal-agent-llm-port.ts",
@@ -25785,7 +25825,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -25793,7 +25833,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 657
+      "community": 658
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -25801,7 +25841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -25809,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 658
+      "community": 659
     },
     {
       "label": "core-memory-repository.ts",
@@ -25817,7 +25857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 981
+      "community": 984
     },
     {
       "label": "kg-triple-repository.ts",
@@ -25825,7 +25865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 982
+      "community": 985
     },
     {
       "label": "process-attribute-repository.ts",
@@ -25833,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 983
+      "community": 986
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -25841,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 984
+      "community": 987
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -25849,7 +25889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 985
+      "community": 988
     },
     {
       "label": "feedback-repository.ts",
@@ -25881,7 +25921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 986
+      "community": 989
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -25889,7 +25929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 987
+      "community": 990
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -25897,7 +25937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 988
+      "community": 991
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -25905,7 +25945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 989
+      "community": 992
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -25913,7 +25953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 990
+      "community": 993
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -25921,7 +25961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "createKgTripleTable()",
@@ -25929,7 +25969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 659
+      "community": 660
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -25937,7 +25977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "createProcessAttributeTable()",
@@ -25945,7 +25985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 660
+      "community": 661
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -25953,7 +25993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -25961,7 +26001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 661
+      "community": 662
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -25969,7 +26009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 991
+      "community": 994
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -25977,7 +26017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "createCoreMemoryTable()",
@@ -25985,7 +26025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 662
+      "community": 663
     },
     {
       "label": "recall-tool-host.ts",
@@ -25993,7 +26033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 992
+      "community": 995
     },
     {
       "label": "recall-tool-definition.ts",
@@ -26001,7 +26041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 993
+      "community": 996
     },
     {
       "label": "remember-tool.ts",
@@ -26113,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "normalizeProviderFilter()",
@@ -26121,7 +26161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 663
+      "community": 664
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -26433,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -26441,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 664
+      "community": 665
     },
     {
       "label": "pin-tool.ts",
@@ -26545,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_post_search_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "applyVersionFilter()",
@@ -26553,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L27",
       "id": "recall_tool_post_search_applyversionfilter",
-      "community": 304
+      "community": 305
     },
     {
       "label": "enrichProceduralVersionInfo()",
@@ -26561,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L62",
       "id": "recall_tool_post_search_enrichproceduralversioninfo",
-      "community": 304
+      "community": 305
     },
     {
       "label": "collectMetaMemoryStats()",
@@ -26569,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L104",
       "id": "recall_tool_post_search_collectmetamemorystats",
-      "community": 304
+      "community": 305
     },
     {
       "label": "updateConsolidationScoreMetadata()",
@@ -26577,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L140",
       "id": "recall_tool_post_search_updateconsolidationscoremetadata",
-      "community": 304
+      "community": 305
     },
     {
       "label": "runMemoryItemPostSearchPipeline()",
@@ -26585,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L249",
       "id": "recall_tool_post_search_runmemoryitempostsearchpipeline",
-      "community": 304
+      "community": 305
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -26825,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "getMetaStatsForResults()",
@@ -26833,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L34",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 358
+      "community": 359
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -26841,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L81",
       "id": "recall_tool_envelope_handleautosetanchor",
-      "community": 358
+      "community": 359
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -26849,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L227",
       "id": "recall_tool_envelope_handleincludeneighbors",
-      "community": 358
+      "community": 359
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -26857,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L338",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 358
+      "community": 359
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -26865,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -26873,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 359
+      "community": 360
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -26881,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 359
+      "community": 360
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -26889,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 359
+      "community": 360
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -26897,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 359
+      "community": 360
     },
     {
       "label": "recall-tool-results.ts",
@@ -26905,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -26913,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 665
+      "community": 666
     },
     {
       "label": "recall-tool.ts",
@@ -26921,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "RecallTool",
@@ -26929,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L36",
       "id": "recall_tool_recalltool",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".constructor()",
@@ -26937,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L37",
       "id": "recall_tool_recalltool_constructor",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".host()",
@@ -26945,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L42",
       "id": "recall_tool_recalltool_host",
-      "community": 360
+      "community": 361
     },
     {
       "label": ".handle()",
@@ -26953,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L52",
       "id": "recall_tool_recalltool_handle",
-      "community": 360
+      "community": 361
     },
     {
       "label": "recall-tool-types.ts",
@@ -26961,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 994
+      "community": 997
     },
     {
       "label": "forget-tool.ts",
@@ -27105,7 +27145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "createSchema()",
@@ -27113,7 +27153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 666
+      "community": 667
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -27121,7 +27161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 995
+      "community": 998
     },
     {
       "label": "remember-tool.spec.ts",
@@ -27153,7 +27193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 996
+      "community": 999
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -27161,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "createSchema()",
@@ -27169,7 +27209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 667
+      "community": 668
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -27209,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 997
+      "community": 1000
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -27217,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 998
+      "community": 1001
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -27225,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "initializeTestDatabase()",
@@ -27233,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 668
+      "community": 669
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -27241,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "parseData()",
@@ -27249,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 669
+      "community": 670
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -27257,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 999
+      "community": 1002
     },
     {
       "label": "recall-tool.spec.ts",
@@ -27289,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1000
+      "community": 1003
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -27297,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1001
+      "community": 1004
     },
     {
       "label": "pin-tool.spec.ts",
@@ -27305,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1002
+      "community": 1005
     },
     {
       "label": "meta-memory-service.ts",
@@ -27465,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -27473,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".constructor()",
@@ -27481,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".notFound()",
@@ -27489,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".notActionable()",
@@ -27497,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 361
+      "community": 362
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -27537,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "createBaseSchema()",
@@ -27545,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L21",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 670
+      "community": 671
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -27625,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "baseRow()",
@@ -27633,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 671
+      "community": 672
     },
     {
       "label": "procedural-versioning.ts",
@@ -27809,7 +27849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "IntrospectionScanCache",
@@ -27817,7 +27857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".set()",
@@ -27825,7 +27865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".get()",
@@ -27833,7 +27873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".clear()",
@@ -27841,7 +27881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 362
+      "community": 363
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -27849,7 +27889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1003
+      "community": 1006
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -27857,7 +27897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -27865,7 +27905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 672
+      "community": 673
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -27873,7 +27913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "openDb()",
@@ -27881,7 +27921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 673
+      "community": 674
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -28473,7 +28513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "createBaseSchema()",
@@ -28481,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 674
+      "community": 675
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -28745,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1004
+      "community": 1007
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -28777,7 +28817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1005
+      "community": 1008
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -28785,7 +28825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1006
+      "community": 1009
     },
     {
       "label": "core-memory-service.ts",
@@ -28945,7 +28985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "createBaseSchema()",
@@ -28953,7 +28993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 675
+      "community": 676
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -28961,7 +29001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -28969,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 676
+      "community": 677
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -29049,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1007
+      "community": 1010
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -29057,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1008
+      "community": 1011
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -29065,7 +29105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "createSchema()",
@@ -29073,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 677
+      "community": 678
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -29081,7 +29121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1009
+      "community": 1012
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -29089,7 +29129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "createSchema()",
@@ -29097,7 +29137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 678
+      "community": 679
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -29105,7 +29145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1010
+      "community": 1013
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -29113,7 +29153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "createBaseSchema()",
@@ -29121,7 +29161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 679
+      "community": 680
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -29129,7 +29169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1011
+      "community": 1014
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -29137,7 +29177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "createSchema()",
@@ -29145,7 +29185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 680
+      "community": 681
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -29153,7 +29193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1012
+      "community": 1015
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -29161,7 +29201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1013
+      "community": 1016
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -29281,7 +29321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1014
+      "community": 1017
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -29545,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1015
+      "community": 1018
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -29553,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -29561,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 681
+      "community": 682
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -29569,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1016
+      "community": 1019
     },
     {
       "label": "consolidation-repository.ts",
@@ -29801,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "row()",
@@ -29809,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 682
+      "community": 683
     },
     {
       "label": "summarization-service.ts",
@@ -29817,7 +29857,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "SummarizationService",
@@ -29825,7 +29865,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L17",
       "id": "summarization_service_summarizationservice",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".hasLlmConfigured()",
@@ -29833,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L18",
       "id": "summarization_service_summarizationservice_hasllmconfigured",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".extractiveFallback()",
@@ -29841,7 +29881,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L24",
       "id": "summarization_service_summarizationservice_extractivefallback",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".summarizeCluster()",
@@ -29849,7 +29889,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L37",
       "id": "summarization_service_summarizationservice_summarizecluster",
-      "community": 305
+      "community": 306
     },
     {
       "label": ".summarizeMergeForConsolidation()",
@@ -29857,7 +29897,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L119",
       "id": "summarization_service_summarizationservice_summarizemergeforconsolidation",
-      "community": 305
+      "community": 306
     },
     {
       "label": "sleep-consolidation-service.spec.ts",
@@ -29865,7 +29905,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 363
+      "community": 364
     },
     {
       "label": "insertEpisodic()",
@@ -29873,7 +29913,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 363
+      "community": 364
     },
     {
       "label": "insertEmbedding()",
@@ -29881,7 +29921,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 363
+      "community": 364
     },
     {
       "label": "FailingRepo",
@@ -29889,7 +29929,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".insertSemanticMemory()",
@@ -29897,7 +29937,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 363
+      "community": 364
     },
     {
       "label": "clustering-service.spec.ts",
@@ -29905,7 +29945,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "ep()",
@@ -29913,7 +29953,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 683
+      "community": 684
     },
     {
       "label": "relation-graph.port.ts",
@@ -29921,7 +29961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1017
+      "community": 1020
     },
     {
       "label": "get-relations-tool.ts",
@@ -29961,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -29969,7 +30009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 684
+      "community": 685
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -30105,7 +30145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "resolveExtractTriplesOwner()",
@@ -30113,7 +30153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L37",
       "id": "extract_triples_tool_resolveextracttriplesowner",
-      "community": 306
+      "community": 307
     },
     {
       "label": "normalizeChunkOverlapForPipeline()",
@@ -30121,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L42",
       "id": "extract_triples_tool_normalizechunkoverlapforpipeline",
-      "community": 306
+      "community": 307
     },
     {
       "label": "ExtractTriplesTool",
@@ -30129,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L52",
       "id": "extract_triples_tool_extracttriplestool",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".constructor()",
@@ -30137,7 +30177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L53",
       "id": "extract_triples_tool_extracttriplestool_constructor",
-      "community": 306
+      "community": 307
     },
     {
       "label": ".handle()",
@@ -30145,7 +30185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L84",
       "id": "extract_triples_tool_extracttriplestool_handle",
-      "community": 306
+      "community": 307
     },
     {
       "label": "get-relations-tool.spec.ts",
@@ -30225,7 +30265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1018
+      "community": 1021
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -31065,7 +31105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1019
+      "community": 1022
     },
     {
       "label": "relation-graph.spec.ts",
@@ -31097,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "createTestMemory()",
@@ -31105,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 685
+      "community": 686
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -31145,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "createTestMemory()",
@@ -31153,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 686
+      "community": 687
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -31217,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1020
+      "community": 1023
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -31225,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1021
+      "community": 1024
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -31257,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1022
+      "community": 1025
     },
     {
       "label": "provider-openai.spec.ts",
@@ -31265,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1023
+      "community": 1026
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -31273,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1024
+      "community": 1027
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -31281,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1025
+      "community": 1028
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -31289,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 364
+      "community": 365
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -31297,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".constructor()",
@@ -31305,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".consume()",
@@ -31313,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 364
+      "community": 365
     },
     {
       "label": ".refill()",
@@ -31321,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 364
+      "community": 365
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -31361,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "chunkSucceeded()",
@@ -31369,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L20",
       "id": "triple_pipeline_orchestrator_chunksucceeded",
-      "community": 307
+      "community": 308
     },
     {
       "label": "failureMessageFromResult()",
@@ -31377,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L27",
       "id": "triple_pipeline_orchestrator_failuremessagefromresult",
-      "community": 307
+      "community": 308
     },
     {
       "label": "TriplePipelineOrchestrator",
@@ -31385,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L35",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".constructor()",
@@ -31393,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L36",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_constructor",
-      "community": 307
+      "community": 308
     },
     {
       "label": ".run()",
@@ -31401,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L40",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_run",
-      "community": 307
+      "community": 308
     },
     {
       "label": "triple-extraction-statistics.ts",
@@ -31601,7 +31641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "extract()",
@@ -31609,7 +31649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 687
+      "community": 688
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -31641,7 +31681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1026
+      "community": 1029
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -31649,7 +31689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 365
+      "community": 366
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -31657,7 +31697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 365
+      "community": 366
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -31665,7 +31705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L38",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 365
+      "community": 366
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -31673,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L71",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 365
+      "community": 366
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -31681,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L105",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 365
+      "community": 366
     },
     {
       "label": "triple-extraction-service.ts",
@@ -31825,7 +31865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1027
+      "community": 1030
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -31833,7 +31873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1028
+      "community": 1031
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -31841,7 +31881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1029
+      "community": 1032
     },
     {
       "label": "triple-extractor.ts",
@@ -32017,7 +32057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1030
+      "community": 1033
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -32057,7 +32097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1031
+      "community": 1034
     },
     {
       "label": "triple-parser.ts",
@@ -32065,7 +32105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 366
+      "community": 367
     },
     {
       "label": "TripleParser",
@@ -32073,7 +32113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 366
+      "community": 367
     },
     {
       "label": ".parse()",
@@ -32081,7 +32121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 366
+      "community": 367
     },
     {
       "label": ".extractJSON()",
@@ -32089,7 +32129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 366
+      "community": 367
     },
     {
       "label": ".isValidTriple()",
@@ -32097,7 +32137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 366
+      "community": 367
     },
     {
       "label": "triple-text-chunker.ts",
@@ -32105,7 +32145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "splitTextIntoChunks()",
@@ -32113,7 +32153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 688
+      "community": 689
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -32121,7 +32161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -32129,7 +32169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 689
+      "community": 690
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -32217,7 +32257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1032
+      "community": 1035
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -32225,7 +32265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1033
+      "community": 1036
     },
     {
       "label": "interfaces.spec.ts",
@@ -32233,7 +32273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1034
+      "community": 1037
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -32241,7 +32281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1035
+      "community": 1038
     },
     {
       "label": "triple-parser.spec.ts",
@@ -32249,7 +32289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1036
+      "community": 1039
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -32257,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -32265,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 690
+      "community": 691
     },
     {
       "label": "extract-relations-openai.ts",
@@ -32273,7 +32313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -32281,7 +32321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 691
+      "community": 692
     },
     {
       "label": "types.ts",
@@ -32289,7 +32329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1037
+      "community": 1040
     },
     {
       "label": "ollama-chat-support.ts",
@@ -32329,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -32337,7 +32377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 692
+      "community": 693
     },
     {
       "label": "provider-selection.ts",
@@ -32369,7 +32409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -32377,7 +32417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 693
+      "community": 694
     },
     {
       "label": "llm-response-parse.ts",
@@ -32385,7 +32425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 367
+      "community": 368
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -32393,7 +32433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 367
+      "community": 368
     },
     {
       "label": "trimToValidJsonObject()",
@@ -32401,7 +32441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 367
+      "community": 368
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -32409,7 +32449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 367
+      "community": 368
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -32417,7 +32457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 367
+      "community": 368
     },
     {
       "label": "types.ts",
@@ -32425,7 +32465,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1038
+      "community": 1041
     },
     {
       "label": "agent-integration-repository.ts",
@@ -32433,7 +32473,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1039
+      "community": 1042
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -32465,7 +32505,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1040
+      "community": 1043
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -32473,7 +32513,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1041
+      "community": 1044
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -32961,7 +33001,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1042
+      "community": 1045
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -33489,7 +33529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1043
+      "community": 1046
     },
     {
       "label": "embedding-service.ts",
@@ -34601,7 +34641,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1044
+      "community": 1047
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -34609,7 +34649,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1045
+      "community": 1048
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -34641,7 +34681,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 1046
+      "community": 1049
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -34649,7 +34689,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1047
+      "community": 1050
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -34657,7 +34697,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1048
+      "community": 1051
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -34697,7 +34737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_alerts_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "executePerformanceAlerts()",
@@ -34705,7 +34745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L66",
       "id": "performance_alerts_executeperformancealerts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "handleStats()",
@@ -34713,7 +34753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L113",
       "id": "performance_alerts_handlestats",
-      "community": 308
+      "community": 309
     },
     {
       "label": "handleList()",
@@ -34721,7 +34761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L145",
       "id": "performance_alerts_handlelist",
-      "community": 308
+      "community": 309
     },
     {
       "label": "handleSearch()",
@@ -34729,7 +34769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L183",
       "id": "performance_alerts_handlesearch",
-      "community": 308
+      "community": 309
     },
     {
       "label": "handleResolve()",
@@ -34737,7 +34777,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L208",
       "id": "performance_alerts_handleresolve",
-      "community": 308
+      "community": 309
     },
     {
       "label": "performance-stats-tool.ts",
@@ -34777,7 +34817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "executeResolveError()",
@@ -34785,7 +34825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 694
+      "community": 695
     },
     {
       "label": "error-stats.ts",
@@ -34793,7 +34833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "executeErrorStats()",
@@ -34801,7 +34841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 695
+      "community": 696
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -34809,7 +34849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1049
+      "community": 1052
     },
     {
       "label": "resolve-error.spec.ts",
@@ -34817,7 +34857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1050
+      "community": 1053
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -34825,7 +34865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -34833,7 +34873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 696
+      "community": 697
     },
     {
       "label": "error-stats.spec.ts",
@@ -34841,7 +34881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1051
+      "community": 1054
     },
     {
       "label": "performance-monitor.ts",
@@ -35585,7 +35625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_runtime_diagnostics_logger_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "RuntimeDiagnosticsLogger",
@@ -35593,7 +35633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L5",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".constructor()",
@@ -35601,7 +35641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_constructor",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".writeSample()",
@@ -35609,7 +35649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L13",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writesample",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".writeEvent()",
@@ -35617,7 +35657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L21",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writeevent",
-      "community": 309
+      "community": 310
     },
     {
       "label": ".appendJsonl()",
@@ -35625,7 +35665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L29",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_appendjsonl",
-      "community": 309
+      "community": 310
     },
     {
       "label": "error-logging-service.ts",
@@ -35753,7 +35793,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1052
+      "community": 1055
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -35761,7 +35801,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1053
+      "community": 1056
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -35769,7 +35809,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1054
+      "community": 1057
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -35777,7 +35817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1055
+      "community": 1058
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -35785,7 +35825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 368
+      "community": 369
     },
     {
       "label": "toBytes()",
@@ -35793,7 +35833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 368
+      "community": 369
     },
     {
       "label": "createMetrics()",
@@ -35801,7 +35841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 368
+      "community": 369
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -35809,7 +35849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 368
+      "community": 369
     },
     {
       "label": "makeMonitor()",
@@ -35817,7 +35857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 368
+      "community": 369
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -35825,7 +35865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "restoreEnvValue()",
@@ -35833,7 +35873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 697
+      "community": 698
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -35937,7 +35977,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -35945,7 +35985,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 698
+      "community": 699
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -36025,7 +36065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -36033,7 +36073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 699
+      "community": 700
     },
     {
       "label": "quality-reporter.ts",
@@ -36153,7 +36193,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1056
+      "community": 1059
     },
     {
       "label": "quality-assurance-service.ts",
@@ -36465,7 +36505,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_migrate_embeddings_tool_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "MigrateEmbeddingsTool",
@@ -36473,7 +36513,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L38",
       "id": "migrate_embeddings_tool_migrateembeddingstool",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".constructor()",
@@ -36481,7 +36521,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L42",
       "id": "migrate_embeddings_tool_migrateembeddingstool_constructor",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".loadVecExtension()",
@@ -36489,7 +36529,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L82",
       "id": "migrate_embeddings_tool_migrateembeddingstool_loadvecextension",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".createAndStoreEmbeddingForProvider()",
@@ -36497,7 +36537,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L95",
       "id": "migrate_embeddings_tool_migrateembeddingstool_createandstoreembeddingforprovider",
-      "community": 310
+      "community": 311
     },
     {
       "label": ".handle()",
@@ -36505,7 +36545,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L183",
       "id": "migrate_embeddings_tool_migrateembeddingstool_handle",
-      "community": 310
+      "community": 311
     },
     {
       "label": "tool-registry.ts",
@@ -36649,7 +36689,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1057
+      "community": 1060
     },
     {
       "label": "base-tool.ts",
@@ -36945,7 +36985,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "testBootstrapIntegration()",
@@ -36953,7 +36993,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 700
+      "community": 701
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -36961,7 +37001,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "measureRecall()",
@@ -36969,7 +37009,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 701
+      "community": 702
     },
     {
       "label": "test-embedding.ts",
@@ -36977,7 +37017,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -36985,7 +37025,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 702
+      "community": 703
     },
     {
       "label": "test-tool-consistency.ts",
@@ -37041,7 +37081,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 369
+      "community": 370
     },
     {
       "label": "PerformanceBenchmark",
@@ -37049,7 +37089,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".measureOperation()",
@@ -37057,7 +37097,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".getResults()",
@@ -37065,7 +37105,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".getSummary()",
@@ -37073,7 +37113,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 369
+      "community": 370
     },
     {
       "label": "test-search.ts",
@@ -37081,7 +37121,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "testSearchFunctionality()",
@@ -37089,7 +37129,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 703
+      "community": 704
     },
     {
       "label": "test-forgetting.ts",
@@ -37097,7 +37137,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "testForgettingFunctionality()",
@@ -37105,7 +37145,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 704
+      "community": 705
     },
     {
       "label": "mock-database.spec.ts",
@@ -37113,7 +37153,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1058
+      "community": 1061
     },
     {
       "label": "test-m1-completion.ts",
@@ -37121,7 +37161,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "testM1Completion()",
@@ -37129,7 +37169,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 705
+      "community": 706
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -37137,7 +37177,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -37145,7 +37185,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 706
+      "community": 707
     },
     {
       "label": "vitest.setup.ts",
@@ -37153,7 +37193,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1059
+      "community": 1062
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -37161,7 +37201,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "parseItems()",
@@ -37169,7 +37209,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 707
+      "community": 708
     },
     {
       "label": "test-memory-resource.ts",
@@ -37201,7 +37241,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "testRegression()",
@@ -37209,7 +37249,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 708
+      "community": 709
     },
     {
       "label": "test-anchor-system.ts",
@@ -37273,7 +37313,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1060
+      "community": 1063
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -37345,7 +37385,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "testSingleProviderRegression()",
@@ -37353,7 +37393,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 709
+      "community": 710
     },
     {
       "label": "visualize-recency.ts",
@@ -37417,7 +37457,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1061
+      "community": 1064
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -37481,7 +37521,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "constructor()",
@@ -37489,7 +37529,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 710
+      "community": 711
     },
     {
       "label": "mock-database.ts",
@@ -37721,7 +37761,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1062
+      "community": 1065
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -37761,7 +37801,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "createTestMemories()",
@@ -37769,7 +37809,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 711
+      "community": 712
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -37777,7 +37817,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -37785,7 +37825,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 712
+      "community": 713
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -37793,7 +37833,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1063
+      "community": 1066
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -37801,7 +37841,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "seedCluster()",
@@ -37809,7 +37849,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 713
+      "community": 714
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -37873,7 +37913,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "writeFixtureDir()",
@@ -37881,7 +37921,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 714
+      "community": 715
     },
     {
       "label": "search-quality-metrics.ts",
@@ -37977,7 +38017,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1064
+      "community": 1067
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -38073,7 +38113,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1065
+      "community": 1068
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -38081,7 +38121,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1066
+      "community": 1069
     },
     {
       "label": "test-database.ts",
@@ -38089,7 +38129,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_test_database_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "createTestDatabaseWithoutServices()",
@@ -38097,7 +38137,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L198",
       "id": "test_database_createtestdatabasewithoutservices",
-      "community": 281
+      "community": 282
     },
     {
       "label": "createTestMemory()",
@@ -38105,7 +38145,7 @@
       "source_file": "packages/memento-core/src/test/helpers/test-database.ts",
       "source_location": "L209",
       "id": "test_database_createtestmemory",
-      "community": 281
+      "community": 282
     },
     {
       "label": "search-quality-candidate-builder.ts",
@@ -38113,7 +38153,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "mergeCandidateIds()",
@@ -38121,7 +38161,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 715
+      "community": 716
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -38153,7 +38193,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1067
+      "community": 1070
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -38161,7 +38201,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1068
+      "community": 1071
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -38361,7 +38401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1069
+      "community": 1072
     },
     {
       "label": "query-counter.ts",
@@ -38761,7 +38801,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 716
+      "community": 717
     },
     {
       "label": "copyDir()",
@@ -38769,7 +38809,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 716
+      "community": 717
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -38777,7 +38817,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "readRootPackageJson()",
@@ -38785,7 +38825,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 717
+      "community": 718
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -38793,7 +38833,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "readJson()",
@@ -38801,7 +38841,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 718
+      "community": 719
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -38809,7 +38849,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "readWorkflow()",
@@ -38817,7 +38857,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 719
+      "community": 720
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -38881,7 +38921,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "readStaticFile()",
@@ -38889,7 +38929,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 720
+      "community": 721
     },
     {
       "label": "smoke.spec.ts",
@@ -38897,7 +38937,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "extractFencedBlocks()",
@@ -38905,7 +38945,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 721
+      "community": 722
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -39089,7 +39129,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 722
+      "community": 723
     },
     {
       "label": "shouldInclude()",
@@ -39097,7 +39137,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 722
+      "community": 723
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -39185,7 +39225,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 723
+      "community": 724
     },
     {
       "label": "fixMigration()",
@@ -39193,7 +39233,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 723
+      "community": 724
     },
     {
       "label": "sync-root-server-dist.js",
@@ -39201,7 +39241,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1070
+      "community": 1073
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -39857,7 +39897,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 370
+      "community": 371
     },
     {
       "label": "parseArgs()",
@@ -39865,7 +39905,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 370
+      "community": 371
     },
     {
       "label": "printHelp()",
@@ -39873,7 +39913,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 370
+      "community": 371
     },
     {
       "label": "printThresholds()",
@@ -39881,7 +39921,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 370
+      "community": 371
     },
     {
       "label": "main()",
@@ -39889,7 +39929,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 370
+      "community": 371
     },
     {
       "label": "simple-update.js",
@@ -39897,7 +39937,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 724
+      "community": 725
     },
     {
       "label": "updateEmbeddings()",
@@ -39905,7 +39945,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 724
+      "community": 725
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -40073,7 +40113,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "analyzeEmbeddings()",
@@ -40081,7 +40121,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 725
+      "community": 726
     },
     {
       "label": "test-docker.js",
@@ -40089,7 +40129,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 726
+      "community": 727
     },
     {
       "label": "testDockerServer()",
@@ -40097,7 +40137,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 726
+      "community": 727
     },
     {
       "label": "pack-with-restore.js",
@@ -40105,7 +40145,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1071
+      "community": 1074
     },
     {
       "label": "run-migration.js",
@@ -40113,7 +40153,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 727
+      "community": 728
     },
     {
       "label": "runMigration()",
@@ -40121,7 +40161,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 727
+      "community": 728
     },
     {
       "label": "safe-migration.js",
@@ -40129,7 +40169,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 728
+      "community": 729
     },
     {
       "label": "safeMigration()",
@@ -40137,7 +40177,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 728
+      "community": 729
     },
     {
       "label": "generate-ground-truth.ts",
@@ -40201,7 +40241,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "saveWorkMemory()",
@@ -40209,7 +40249,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 729
+      "community": 730
     },
     {
       "label": "check-file-sizes.ts",
@@ -40377,7 +40417,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1072
+      "community": 1075
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -40385,7 +40425,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "main()",
@@ -40393,7 +40433,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 730
+      "community": 731
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -40433,7 +40473,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1073
+      "community": 1076
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -40441,7 +40481,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1074
+      "community": 1077
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -40449,7 +40489,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 371
+      "community": 372
     },
     {
       "label": "getTriggerInfo()",
@@ -40457,7 +40497,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 371
+      "community": 372
     },
     {
       "label": "fixTriggers()",
@@ -40465,7 +40505,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 371
+      "community": 372
     },
     {
       "label": "checkMigrationVersion()",
@@ -40473,7 +40513,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 371
+      "community": 372
     },
     {
       "label": "main()",
@@ -40481,7 +40521,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 371
+      "community": 372
     },
     {
       "label": "simple-migrate.js",
@@ -40489,7 +40529,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 731
+      "community": 732
     },
     {
       "label": "analyzeEmbeddings()",
@@ -40497,7 +40537,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 731
+      "community": 732
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -40505,7 +40545,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 732
+      "community": 733
     },
     {
       "label": "fixVectorDimensions()",
@@ -40513,7 +40553,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 732
+      "community": 733
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -40577,7 +40617,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "runUpdateMigration()",
@@ -40585,7 +40625,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 733
+      "community": 734
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -40617,7 +40657,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 734
+      "community": 735
     },
     {
       "label": "regenerateEmbeddings()",
@@ -40625,7 +40665,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 734
+      "community": 735
     },
     {
       "label": "generate-relation-report.ts",
@@ -40777,7 +40817,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "sampleReport()",
@@ -40785,7 +40825,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 735
+      "community": 736
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -40793,7 +40833,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1075
+      "community": 1078
     },
     {
       "label": "debug-embeddings.js",
@@ -40801,7 +40841,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 736
+      "community": 737
     },
     {
       "label": "debugEmbeddings()",
@@ -40809,7 +40849,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 736
+      "community": 737
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -40817,7 +40857,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1076
+      "community": 1079
     },
     {
       "label": "tune-weights.ts",
@@ -40825,7 +40865,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L1",
       "id": "scripts_tune_weights_ts",
-      "community": 311
+      "community": 312
     },
     {
       "label": "mulberry32()",
@@ -40833,7 +40873,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L24",
       "id": "tune_weights_mulberry32",
-      "community": 311
+      "community": 312
     },
     {
       "label": "parseTuneArgs()",
@@ -40841,7 +40881,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L43",
       "id": "tune_weights_parsetuneargs",
-      "community": 311
+      "community": 312
     },
     {
       "label": "generateCandidate()",
@@ -40849,7 +40889,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L71",
       "id": "tune_weights_generatecandidate",
-      "community": 311
+      "community": 312
     },
     {
       "label": "compositeScore()",
@@ -40857,7 +40897,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L88",
       "id": "tune_weights_compositescore",
-      "community": 311
+      "community": 312
     },
     {
       "label": "main()",
@@ -40865,7 +40905,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L106",
       "id": "tune_weights_main",
-      "community": 311
+      "community": 312
     },
     {
       "label": "check-db-integrity.js",
@@ -41169,7 +41209,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 737
+      "community": 738
     },
     {
       "label": "backupEmbeddings()",
@@ -41177,7 +41217,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 737
+      "community": 738
     },
     {
       "label": "count-any-types.ts",
@@ -41393,7 +41433,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "makeRng()",
@@ -41401,7 +41441,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 738
+      "community": 739
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -41409,7 +41449,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1077
+      "community": 1080
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -41417,7 +41457,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1078
+      "community": 1081
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -41425,7 +41465,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1079
+      "community": 1082
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -41433,7 +41473,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "jsonEmbedding()",
@@ -41441,7 +41481,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 739
+      "community": 740
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -41449,7 +41489,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1080
+      "community": 1083
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -41457,7 +41497,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1081
+      "community": 1084
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -41465,7 +41505,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1082
+      "community": 1085
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -41473,7 +41513,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -41481,7 +41521,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 740
+      "community": 741
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -41489,7 +41529,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1083
+      "community": 1086
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -41497,7 +41537,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "jsonEmbedding()",
@@ -41505,7 +41545,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 741
+      "community": 742
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -41513,7 +41553,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "main()",
@@ -41521,7 +41561,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 742
+      "community": 743
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -41529,7 +41569,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -41537,7 +41577,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 743
+      "community": 744
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -41569,7 +41609,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1084
+      "community": 1087
     },
     {
       "label": "check-retry-usage.ts",
@@ -41641,7 +41681,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_simple_throws_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "isTestFile()",
@@ -41649,7 +41689,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L29",
       "id": "analyze_simple_throws_istestfile",
-      "community": 312
+      "community": 313
     },
     {
       "label": "shouldExcludeDir()",
@@ -41657,7 +41697,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L38",
       "id": "analyze_simple_throws_shouldexcludedir",
-      "community": 312
+      "community": 313
     },
     {
       "label": "findThrows()",
@@ -41665,7 +41705,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L45",
       "id": "analyze_simple_throws_findthrows",
-      "community": 312
+      "community": 313
     },
     {
       "label": "scanDirectory()",
@@ -41673,7 +41713,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L102",
       "id": "analyze_simple_throws_scandirectory",
-      "community": 312
+      "community": 313
     },
     {
       "label": "main()",
@@ -41681,7 +41721,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L126",
       "id": "analyze_simple_throws_main",
-      "community": 312
+      "community": 313
     },
     {
       "label": "analyze-benchmark-test-data.ts",
@@ -41689,7 +41729,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -41697,7 +41737,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 744
+      "community": 745
     },
     {
       "label": "check-no-console-violations.ts",
@@ -41793,7 +41833,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "fixVecTableDimensions()",
@@ -41801,7 +41841,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 745
+      "community": 746
     },
     {
       "label": "sources.ts",
@@ -41889,7 +41929,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1085
+      "community": 1088
     },
     {
       "label": "issue-body.ts",
@@ -42041,7 +42081,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -42049,7 +42089,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 746
+      "community": 747
     },
     {
       "label": "state-store.ts",
@@ -42057,7 +42097,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_state_store_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "emptyState()",
@@ -42065,7 +42105,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L5",
       "id": "state_store_emptystate",
-      "community": 313
+      "community": 314
     },
     {
       "label": "loadState()",
@@ -42073,7 +42113,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L9",
       "id": "state_store_loadstate",
-      "community": 313
+      "community": 314
     },
     {
       "label": "saveState()",
@@ -42081,7 +42121,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L20",
       "id": "state_store_savestate",
-      "community": 313
+      "community": 314
     },
     {
       "label": "upsertOccurrence()",
@@ -42089,7 +42129,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L27",
       "id": "state_store_upsertoccurrence",
-      "community": 313
+      "community": 314
     },
     {
       "label": "appendOccurrence()",
@@ -42097,7 +42137,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L55",
       "id": "state_store_appendoccurrence",
-      "community": 313
+      "community": 314
     },
     {
       "label": "monitor.ts",
@@ -42105,7 +42145,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "recordMonitorError()",
@@ -42113,7 +42153,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L21",
       "id": "monitor_recordmonitorerror",
-      "community": 314
+      "community": 315
     },
     {
       "label": "recordJsonlSkip()",
@@ -42121,7 +42161,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L30",
       "id": "monitor_recordjsonlskip",
-      "community": 314
+      "community": 315
     },
     {
       "label": "withFingerprint()",
@@ -42129,7 +42169,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_withfingerprint",
-      "community": 314
+      "community": 315
     },
     {
       "label": "syncFingerprint()",
@@ -42137,7 +42177,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L63",
       "id": "monitor_syncfingerprint",
-      "community": 314
+      "community": 315
     },
     {
       "label": "runMonitorCycle()",
@@ -42145,7 +42185,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L120",
       "id": "monitor_runmonitorcycle",
-      "community": 314
+      "community": 315
     },
     {
       "label": "github-client.ts",
@@ -42217,7 +42257,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_detectors_ts",
-      "community": 315
+      "community": 275
     },
     {
       "label": "nowIso()",
@@ -42225,7 +42265,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L6",
       "id": "detectors_nowiso",
-      "community": 315
+      "community": 275
     },
     {
       "label": "truncateTitle()",
@@ -42233,31 +42273,39 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L10",
       "id": "detectors_truncatetitle",
-      "community": 315
+      "community": 275
+    },
+    {
+      "label": "redactDockerInspectEnv()",
+      "file_type": "code",
+      "source_file": "scripts/log-issue-monitor/detectors.ts",
+      "source_location": "L14",
+      "id": "detectors_redactdockerinspectenv",
+      "community": 275
     },
     {
       "label": "detectAppLogEvent()",
       "file_type": "code",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L14",
+      "source_location": "L39",
       "id": "detectors_detectapplogevent",
-      "community": 315
+      "community": 275
     },
     {
       "label": "detectRuntimeAnomaly()",
       "file_type": "code",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L62",
+      "source_location": "L87",
       "id": "detectors_detectruntimeanomaly",
-      "community": 315
+      "community": 275
     },
     {
       "label": "detectDockerAnomaly()",
       "file_type": "code",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L85",
+      "source_location": "L110",
       "id": "detectors_detectdockeranomaly",
-      "community": 315
+      "community": 275
     },
     {
       "label": "config.ts",
@@ -42265,7 +42313,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_config_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "defaultLogsRoot()",
@@ -42273,7 +42321,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L5",
       "id": "config_defaultlogsroot",
-      "community": 275
+      "community": 276
     },
     {
       "label": "optionalString()",
@@ -42281,7 +42329,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L7",
       "id": "config_optionalstring",
-      "community": 275
+      "community": 276
     },
     {
       "label": "numberFromEnv()",
@@ -42289,7 +42337,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L12",
       "id": "config_numberfromenv",
-      "community": 275
+      "community": 276
     },
     {
       "label": "booleanFromEnv()",
@@ -42297,7 +42345,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L19",
       "id": "config_booleanfromenv",
-      "community": 275
+      "community": 276
     },
     {
       "label": "labelsFromEnv()",
@@ -42305,7 +42353,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L27",
       "id": "config_labelsfromenv",
-      "community": 275
+      "community": 276
     },
     {
       "label": "loadMonitorConfig()",
@@ -42313,7 +42361,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L32",
       "id": "config_loadmonitorconfig",
-      "community": 275
+      "community": 276
     },
     {
       "label": "promotion.spec.ts",
@@ -42321,7 +42369,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1086
+      "community": 1089
     },
     {
       "label": "issue-body.spec.ts",
@@ -42329,7 +42377,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1087
+      "community": 1090
     },
     {
       "label": "github-client.spec.ts",
@@ -42337,7 +42385,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1088
+      "community": 1091
     },
     {
       "label": "config.spec.ts",
@@ -42345,7 +42393,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1089
+      "community": 1092
     },
     {
       "label": "detectors.spec.ts",
@@ -42353,7 +42401,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1090
+      "community": 1093
     },
     {
       "label": "sources.spec.ts",
@@ -42361,7 +42409,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1091
+      "community": 1094
     },
     {
       "label": "parsers.spec.ts",
@@ -42369,7 +42417,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1092
+      "community": 1095
     },
     {
       "label": "monitor.spec.ts",
@@ -42377,7 +42425,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "config()",
@@ -42385,7 +42433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 747
+      "community": 748
     },
     {
       "label": "fingerprint.spec.ts",
@@ -42393,7 +42441,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1093
+      "community": 1096
     },
     {
       "label": "state-store.spec.ts",
@@ -42401,7 +42449,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1094
+      "community": 1097
     },
     {
       "label": "sanitizer.spec.ts",
@@ -42409,7 +42457,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1095
+      "community": 1098
     },
     {
       "label": "entrypoint.spec.ts",
@@ -42417,7 +42465,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1096
+      "community": 1099
     },
     {
       "label": "index.ts",
@@ -42457,7 +42505,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1097
+      "community": 1100
     },
     {
       "label": "memento-admin-fetch.js",
@@ -42513,7 +42561,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1098
+      "community": 1101
     },
     {
       "label": "dashboard-auth.js",
@@ -43025,7 +43073,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 748
+      "community": 749
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -43033,7 +43081,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 748
+      "community": 749
     },
     {
       "label": "graph.js",
@@ -43169,7 +43217,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_timeline_js",
-      "community": 372
+      "community": 373
     },
     {
       "label": "buildComparisonHintMarkup()",
@@ -43177,7 +43225,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_timeline_buildcomparisonhintmarkup",
-      "community": 372
+      "community": 373
     },
     {
       "label": "updateComparisonHint()",
@@ -43185,7 +43233,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L36",
       "id": "memory_evolution_demo_shell_render_timeline_updatecomparisonhint",
-      "community": 372
+      "community": 373
     },
     {
       "label": "syncSegmentSelection()",
@@ -43193,7 +43241,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L51",
       "id": "memory_evolution_demo_shell_render_timeline_syncsegmentselection",
-      "community": 372
+      "community": 373
     },
     {
       "label": "renderPointSegment()",
@@ -43201,7 +43249,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L66",
       "id": "memory_evolution_demo_shell_render_timeline_renderpointsegment",
-      "community": 372
+      "community": 373
     },
     {
       "label": "agent-sessions-panel-data.js",
@@ -43425,7 +43473,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1099
+      "community": 1102
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -43433,7 +43481,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_js",
-      "community": 276
+      "community": 277
     },
     {
       "label": "number()",
@@ -43441,7 +43489,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_render_number",
-      "community": 276
+      "community": 277
     },
     {
       "label": "setCount()",
@@ -43449,7 +43497,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L16",
       "id": "agent_sessions_panel_render_setcount",
-      "community": 276
+      "community": 277
     },
     {
       "label": "addBadge()",
@@ -43457,7 +43505,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L23",
       "id": "agent_sessions_panel_render_addbadge",
-      "community": 276
+      "community": 277
     },
     {
       "label": "addDefinition()",
@@ -43465,7 +43513,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L27",
       "id": "agent_sessions_panel_render_adddefinition",
-      "community": 276
+      "community": 277
     },
     {
       "label": "sessionAggregate()",
@@ -43473,7 +43521,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L34",
       "id": "agent_sessions_panel_render_sessionaggregate",
-      "community": 276
+      "community": 277
     },
     {
       "label": "eventCategory()",
@@ -43481,7 +43529,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L118",
       "id": "agent_sessions_panel_render_eventcategory",
-      "community": 276
+      "community": 277
     },
     {
       "label": "agent-sessions-panel-import.js",
@@ -43569,7 +43617,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_consolidation_js",
-      "community": 373
+      "community": 374
     },
     {
       "label": "renderEpisodicSources()",
@@ -43577,7 +43625,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_consolidation_renderepisodicsources",
-      "community": 373
+      "community": 374
     },
     {
       "label": "renderSemanticResult()",
@@ -43585,7 +43633,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersemanticresult",
-      "community": 373
+      "community": 374
     },
     {
       "label": "renderSearchComparison()",
@@ -43593,7 +43641,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L110",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersearchcomparison",
-      "community": 373
+      "community": 374
     },
     {
       "label": "renderConsolidationPanel()",
@@ -43601,7 +43649,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L128",
       "id": "memory_evolution_demo_shell_render_consolidation_renderconsolidationpanel",
-      "community": 373
+      "community": 374
     },
     {
       "label": "memory-evolution-demo-shell.js",
@@ -43609,7 +43657,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 749
+      "community": 750
     },
     {
       "label": "init()",
@@ -43617,7 +43665,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 749
+      "community": 750
     },
     {
       "label": "review-candidates-panel-health.js",
@@ -43945,7 +43993,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 374
+      "community": 375
     },
     {
       "label": "getTabButtons()",
@@ -43953,7 +44001,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 374
+      "community": 375
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -43961,7 +44009,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 374
+      "community": 375
     },
     {
       "label": "setRovingTabindex()",
@@ -43969,7 +44017,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 374
+      "community": 375
     },
     {
       "label": "activateTab()",
@@ -43977,7 +44025,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 374
+      "community": 375
     },
     {
       "label": "review-candidates-panel-render.js",
@@ -48120,6 +48168,18 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
+      "source_location": "L112",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
+      "_tgt": "mcp_routes_streamable_http_spec_listenwithmcprouterandmocks",
+      "source": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
+      "target": "mcp_routes_streamable_http_spec_listenwithmcprouterandmocks",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L52",
       "weight": 1.0,
@@ -49284,6 +49344,18 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
+      "_tgt": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
+      "source": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
+      "target": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L57",
       "weight": 1.0,
@@ -50305,7 +50377,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L49",
+      "source_location": "L50",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_mcp_routes_ts",
       "_tgt": "mcp_routes_isjsonrpcnotification",
@@ -50317,7 +50389,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L53",
+      "source_location": "L54",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_mcp_routes_ts",
       "_tgt": "mcp_routes_isinitializerequest",
@@ -50329,7 +50401,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L57",
+      "source_location": "L58",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_mcp_routes_ts",
       "_tgt": "mcp_routes_createjsonrpcerror",
@@ -50341,7 +50413,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L74",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_mcp_routes_ts",
       "_tgt": "mcp_routes_processmcpmessage",
@@ -50353,7 +50425,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L413",
+      "source_location": "L423",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_routes_mcp_routes_ts",
       "_tgt": "mcp_routes_createmcprouter",
@@ -50365,7 +50437,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
-      "source_location": "L122",
+      "source_location": "L123",
       "weight": 1.0,
       "_src": "mcp_routes_processmcpmessage",
       "_tgt": "mcp_routes_createjsonrpcerror",
@@ -121084,6 +121156,18 @@
       "source_location": "L14",
       "weight": 1.0,
       "_src": "scripts_log_issue_monitor_detectors_ts",
+      "_tgt": "detectors_redactdockerinspectenv",
+      "source": "scripts_log_issue_monitor_detectors_ts",
+      "target": "detectors_redactdockerinspectenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/log-issue-monitor/detectors.ts",
+      "source_location": "L39",
+      "weight": 1.0,
+      "_src": "scripts_log_issue_monitor_detectors_ts",
       "_tgt": "detectors_detectapplogevent",
       "source": "scripts_log_issue_monitor_detectors_ts",
       "target": "detectors_detectapplogevent",
@@ -121093,7 +121177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L62",
+      "source_location": "L87",
       "weight": 1.0,
       "_src": "scripts_log_issue_monitor_detectors_ts",
       "_tgt": "detectors_detectruntimeanomaly",
@@ -121105,7 +121189,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L85",
+      "source_location": "L110",
       "weight": 1.0,
       "_src": "scripts_log_issue_monitor_detectors_ts",
       "_tgt": "detectors_detectdockeranomaly",
@@ -121117,7 +121201,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L30",
+      "source_location": "L55",
       "weight": 1.0,
       "_src": "detectors_detectapplogevent",
       "_tgt": "detectors_nowiso",
@@ -121129,7 +121213,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L75",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "detectors_detectruntimeanomaly",
       "_tgt": "detectors_nowiso",
@@ -121141,7 +121225,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L96",
+      "source_location": "L121",
       "weight": 1.0,
       "_src": "detectors_detectdockeranomaly",
       "_tgt": "detectors_nowiso",
@@ -121153,12 +121237,36 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/log-issue-monitor/detectors.ts",
-      "source_location": "L27",
+      "source_location": "L52",
       "weight": 1.0,
       "_src": "detectors_detectapplogevent",
       "_tgt": "detectors_truncatetitle",
       "source": "detectors_truncatetitle",
       "target": "detectors_detectapplogevent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/log-issue-monitor/detectors.ts",
+      "source_location": "L99",
+      "weight": 1.0,
+      "_src": "detectors_detectruntimeanomaly",
+      "_tgt": "detectors_redactdockerinspectenv",
+      "source": "detectors_redactdockerinspectenv",
+      "target": "detectors_detectruntimeanomaly",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/log-issue-monitor/detectors.ts",
+      "source_location": "L120",
+      "weight": 1.0,
+      "_src": "detectors_detectdockeranomaly",
+      "_tgt": "detectors_redactdockerinspectenv",
+      "source": "detectors_redactdockerinspectenv",
+      "target": "detectors_detectdockeranomaly",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts
+++ b/packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts
@@ -108,6 +108,31 @@ function openSse(
   });
 }
 
+
+async function listenWithMcpRouterAndMocks(): Promise<{ port: number; close: () => Promise<void> }> {
+  const core = await import('@memento/core');
+  const { createMcpRouter } = await import('./routes/mcp.routes.js');
+  const app = express();
+  const transports: Record<string, unknown> = {};
+
+  app.use(express.json());
+  app.use(createMcpRouter({} as never, {} as never, transports as any));
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.once('error', reject);
+  });
+
+  return {
+    port: (server.address() as import('node:net').AddressInfo).port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      })
+  };
+}
+
 describe('mcp.routes streamable_http', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -289,4 +314,54 @@ describe('mcp.routes streamable_http', () => {
       await close();
     }
   });
+  it('POST /mcp tools/call should return -32602 for Zod validation errors without streamable ERROR log', async () => {
+    const { z } = await import('zod');
+    const core = await import('@memento/core');
+    const errorSpy = vi.spyOn(core.logger, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(core.logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(core, 'executeTool').mockRejectedValue(
+      new z.ZodError([
+        {
+          code: 'custom',
+          path: ['content'],
+          message: "type='core' 또는 'vault'일 때는 key, value가 필수이고, 나머지는 content가 필수입니다"
+        }
+      ])
+    );
+
+    const { port, close } = await listenWithMcpRouterAndMocks();
+
+    try {
+      const res = await postJsonRpc(port, '/mcp', {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'remember',
+          arguments: {}
+        }
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as {
+        jsonrpc: string;
+        id: number;
+        error: { code: number; message: string; data: unknown };
+      };
+      expect(body.error.code).toBe(-32602);
+      expect(body.error.message).toBe('Invalid params');
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        'MCP streamable_http processing failed',
+        expect.anything()
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'MCP tools/call rejected invalid params',
+        expect.objectContaining({ tool: 'remember' })
+      );
+    } finally {
+      await close();
+    }
+  });
+
+
 });

--- a/packages/memento-server/src/server/routes/mcp.routes.ts
+++ b/packages/memento-server/src/server/routes/mcp.routes.ts
@@ -19,6 +19,7 @@ import {
   mementoConfig
 } from '@memento/core';
 import { buildMcpManualCorsHeaders } from '../utils/cors-policy.js';
+import { mapToolExecutionErrorToJsonRpc } from '../utils/mcp-tool-call-error.js';
 
 /**
  * SSE Transport 타입
@@ -140,13 +141,22 @@ async function processMcpMessage(
       services: serverServices
     };
     const toolContext = createToolContext(serverContext);
-    const toolResult = await executeTool(name, args, toolContext);
+    try {
+      const toolResult = await executeTool(name, args, toolContext);
 
-    return {
-      jsonrpc: '2.0',
-      id: message.id,
-      result: { content: [{ type: 'text', text: JSON.stringify(toolResult) }] }
-    };
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { content: [{ type: 'text', text: JSON.stringify(toolResult) }] }
+      };
+    } catch (error) {
+      const mapped = mapToolExecutionErrorToJsonRpc(error);
+      if (mapped) {
+        logger.warn('MCP tools/call rejected invalid params', { tool: name, error: mapped.data });
+        return createJsonRpcError(message.id, mapped.code, mapped.message, mapped.data);
+      }
+      throw error;
+    }
   }
 
   if (message.method === 'prompts/list') {

--- a/packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts
+++ b/packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { mapToolExecutionErrorToJsonRpc } from './mcp-tool-call-error.js';
+
+describe('mapToolExecutionErrorToJsonRpc', () => {
+  it('maps ZodError to -32602 Invalid params with flattened details', () => {
+    const schema = z.object({ content: z.string().min(1) });
+    let caught: z.ZodError | undefined;
+    try {
+      schema.parse({});
+    } catch (error) {
+      caught = error as z.ZodError;
+    }
+
+    expect(caught).toBeInstanceOf(z.ZodError);
+    const mapped = mapToolExecutionErrorToJsonRpc(caught);
+
+    expect(mapped).toEqual({
+      code: -32602,
+      message: 'Invalid params',
+      data: caught!.flatten()
+    });
+  });
+
+  it('maps Unknown tool errors to -32601 Method not found', () => {
+    const mapped = mapToolExecutionErrorToJsonRpc(new Error('Unknown tool: not_a_real_tool'));
+
+    expect(mapped).toEqual({
+      code: -32601,
+      message: 'Method not found',
+      data: 'Unknown tool: not_a_real_tool'
+    });
+  });
+
+  it('returns null for unmapped errors', () => {
+    expect(mapToolExecutionErrorToJsonRpc(new Error('database unavailable'))).toBeNull();
+    expect(mapToolExecutionErrorToJsonRpc('not an error')).toBeNull();
+  });
+});

--- a/packages/memento-server/src/server/utils/mcp-tool-call-error.ts
+++ b/packages/memento-server/src/server/utils/mcp-tool-call-error.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export type JsonRpcErrorPayload = {
+  code: number;
+  message: string;
+  data: unknown;
+};
+
+/**
+ * Maps tool execution errors to JSON-RPC client error payloads.
+ * Returns null when the error should propagate to the outer handler.
+ */
+export function mapToolExecutionErrorToJsonRpc(error: unknown): JsonRpcErrorPayload | null {
+  if (error instanceof z.ZodError) {
+    return {
+      code: -32602,
+      message: 'Invalid params',
+      data: error.flatten()
+    };
+  }
+
+  if (error instanceof Error && error.message.startsWith('Unknown tool:')) {
+    return {
+      code: -32601,
+      message: 'Method not found',
+      data: error.message
+    };
+  }
+
+  return null;
+}

--- a/specs/023-fix-remember-mcp-validation/plan.md
+++ b/specs/023-fix-remember-mcp-validation/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: MCP remember 검증 오류 처리
+
+**Branch**: `023-fix-remember-mcp-validation` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)  
+**Input**: GitHub Issue #444
+
+## Summary
+
+`packages/memento-server/src/server/routes/mcp.routes.ts`의 `processMcpMessage`에서 `tools/call` 시 `executeTool`이 throw하는 `ZodError`(예: `remember` without `content`)가 outer catch까지 전파되어 `MCP streamable_http processing failed` ERROR가 기록된다. 도구 실행 오류를 JSON-RPC 클라이언트 오류로 매핑하는 유틸 `mapToolExecutionErrorToJsonRpc`를 추가하고, `tools/call` 분기에서 매핑 가능한 오류는 WARN + `-32602`/`-32601`로 응답한다.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js ≥ 24, ES modules  
+**Primary Dependencies**: `zod`, `@memento/core`, Express 5.x, Vitest  
+**Storage**: N/A (스키마 변경 없음)  
+**Testing**: Vitest co-located specs  
+**Target Platform**: memento-server HTTP MCP (streamable HTTP `/mcp`)  
+**Constraints**: MCP backward compatibility — 오류 code/message만 정정; 성공 응답 형식 불변
+
+## Project Structure
+
+```text
+specs/023-fix-remember-mcp-validation/
+├── spec.md
+├── plan.md
+└── tasks.md
+
+packages/memento-server/src/server/
+├── utils/
+│   ├── mcp-tool-call-error.ts       # [신규] mapToolExecutionErrorToJsonRpc
+│   └── mcp-tool-call-error.spec.ts  # [신규] Vitest
+├── routes/
+│   └── mcp.routes.ts                # [수정] tools/call try/catch
+└── mcp.routes.streamable-http.spec.ts  # [선택] 통합 테스트
+```
+
+## Implementation Notes
+
+| Error type | JSON-RPC code | message | data |
+|------------|---------------|---------|------|
+| `z.ZodError` | -32602 | Invalid params | `error.flatten()` |
+| `Error` matching `Unknown tool:` | -32601 | Method not found | error.message |
+| Other | — | re-throw | outer catch → -32603 |
+
+## Constitution Check
+
+| Gate | Status |
+|------|--------|
+| Test-First | mapper unit tests + optional streamable-http test |
+| Backward Compatibility | 성공 경로 불변; 클라이언트 오류 code 정확화 |
+| Schema Discipline | DB/스키마 변경 없음 |
+| Quality Gates | lint, type-check, test |

--- a/specs/023-fix-remember-mcp-validation/spec.md
+++ b/specs/023-fix-remember-mcp-validation/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: MCP remember 검증 오류 처리
+
+**Feature Branch**: `023-fix-remember-mcp-validation`  
+**Created**: 2026-06-13  
+**Status**: Draft  
+**Input**: GitHub Issue #444 — `remember` 호출 시 `content` 누락 등 Zod 검증 실패가 streamable HTTP outer catch로 전파되어 ERROR 로그가 발생
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — 잘못된 도구 인자는 클라이언트 오류로 응답 (Priority: P1)
+
+MCP 클라이언트(Cursor, Claude Code 등)가 `tools/call`로 `remember` 등 도구를 호출할 때 필수 파라미터(`content` 등)가 없으면, 서버는 JSON-RPC `-32602 Invalid params` 오류를 반환하고 클라이언트가 인자를 수정해 재시도할 수 있어야 한다.
+
+**Why this priority**: 현재는 내부 검증 실패가 `-32603 Internal error`와 ERROR 로그로 처리되어 운영 노이즈와 잘못된 진단을 유발한다.
+
+**Independent Test**: streamable HTTP `POST /mcp`에 `content` 없이 `remember`를 호출하면 응답 `error.code === -32602`이고 `MCP streamable_http processing failed` ERROR 로그가 없다.
+
+**Acceptance Scenarios**:
+
+1. **Given** MCP streamable HTTP 엔드포인트가 준비됨, **When** `tools/call`로 `remember`에 `content` 없이 호출, **Then** JSON-RPC `-32602`/`Invalid params`가 반환된다.
+2. **Given** 동일 조건, **When** 응답 처리, **Then** 서버 ERROR 로그(`MCP streamable_http processing failed`)가 기록되지 않는다.
+3. **Given** 존재하지 않는 도구 이름, **When** `tools/call` 실행, **Then** JSON-RPC 클라이언트 오류(매핑된 code/message)가 반환되고 outer catch로 전파되지 않는다.
+
+---
+
+### User Story 2 — 예상치 못한 서버 오류는 기존과 동일 (Priority: P2)
+
+DB 장애 등 검증·알 수 없는 도구 이외의 실행 오류는 기존처럼 outer catch에서 `-32603`으로 처리된다.
+
+**Independent Test**: 매핑 대상이 아닌 Error를 throw하면 outer catch가 호출된다(단위 테스트).
+
+**Acceptance Scenarios**:
+
+1. **Given** `executeTool`이 일반 Error를 throw, **When** `processMcpMessage` tools/call 처리, **Then** 매핑되지 않고 re-throw되어 streamable HTTP outer catch가 `-32603`을 반환한다.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `processMcpMessage`의 `tools/call` 분기는 `executeTool`을 try/catch로 감싸야 한다.
+- **FR-002**: `ZodError`는 JSON-RPC `-32602`/`Invalid params`로 매핑하고 `data`에 검증 상세를 포함해야 한다.
+- **FR-003**: `Unknown tool: …` 오류는 JSON-RPC 클라이언트 오류로 매핑하고 outer catch로 전파하지 않아야 한다.
+- **FR-004**: 매핑된 오류는 `logger.warn('MCP tools/call rejected invalid params', { tool, error })`로 기록해야 한다.
+- **FR-005**: 매핑되지 않은 오류는 re-throw하여 기존 outer catch 동작을 유지해야 한다.
+
+## Out of Scope
+
+- `remember` Zod 스키마 자체 변경
+- stdio/WebSocket MCP 경로 동일 처리(본 이슈는 streamable HTTP)
+- MCP 프로토콜 버전·capabilities 변경
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `content` 누락 `remember` 호출 시 `-32602` 응답, ERROR 로그 0건
+- **SC-002**: `mapToolExecutionErrorToJsonRpc` 단위 테스트 통과
+- **SC-003**: `npm run lint`, `npm run type-check`, `npm test` 통과

--- a/specs/023-fix-remember-mcp-validation/tasks.md
+++ b/specs/023-fix-remember-mcp-validation/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: MCP remember 검증 오류 처리
+
+**Input**: `specs/023-fix-remember-mcp-validation/` (spec.md, plan.md)  
+**Issue**: #444
+
+## Phase 1: Core fix
+
+- [ ] T001 [US1] `mcp-tool-call-error.ts` — `mapToolExecutionErrorToJsonRpc(error)` 구현 (ZodError → -32602, Unknown tool → -32601, else null)
+- [ ] T002 [US1] `mcp-tool-call-error.spec.ts` — Vitest 단위 테스트
+- [ ] T003 [US1] `mcp.routes.ts` — `tools/call`에서 executeTool try/catch, mapped 시 warn + createJsonRpcError, unmapped re-throw
+
+## Phase 2: Integration & verification
+
+- [ ] T004 [US1] `mcp.routes.streamable-http.spec.ts` — ZodError 시 -32602 및 ERROR 로그 미발생 테스트 (가능 시)
+- [ ] T005 [POLISH] `npm run lint`, `npm run type-check`, `npm test` 통과
+- [ ] T006 [POLISH] graphify 코드 그래프 재빌드
+
+## Dependencies
+
+T001 → T002 → T003 → T004 → T005 → T006


### PR DESCRIPTION
## Summary

- Add `mapToolExecutionErrorToJsonRpc` to map `ZodError` → `-32602 Invalid params` and `Unknown tool:` → `-32601 Method not found`
- Wrap `executeTool` in `processMcpMessage` `tools/call` with try/catch so validation failures return client errors via WARN instead of hitting the streamable HTTP outer catch (ERROR log)
- Add Vitest coverage for the mapper and streamable HTTP Zod rejection path
- Add spec-kit artifacts under `specs/023-fix-remember-mcp-validation/`

Closes #444

## Test plan

- [x] `npx vitest --run packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts` (11 tests passed)
- [x] `npm run lint` (0 errors)
- [x] `npm ci && npm run build:packages && npm test` — **4548 passed**, 1 skipped (379 files)
- [x] CI: lint-typecheck, Security Check, test-root/core/server/client — all pass