### PR TITLE
fix(scheduler): per-memory triple extraction job timeout (#475)

### DIFF
--- a/env.example
+++ b/env.example
@@ -38,6 +38,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 GEMINI_MODEL=text-embedding-004
 GEMINI_LLM_MODEL=gemini-2.0-flash  # LLM 채팅/추출용 (임베딩 GEMINI_MODEL과 구분)
 # 용도별 LLM 모델 override (설정 시 OPENAI_LLM_MODEL/GEMINI_LLM_MODEL보다 우선)
+# Per-memory triple extraction queue job timeout (default 30m). Issue #475
+# TRIPLE_EXTRACTION_JOB_TIMEOUT_MS=1800000
+
 # LLM_MODEL_TRIPLE_EXTRACTION=
 # LLM_MODEL_RELATION_EXTRACTION=
 # LLM_MODEL_PROCEDURAL=

--- a/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BatchJobExecutionCoordinator } from '../batch-job-execution-coordinator.js';
+import type { BatchJobConfig } from '../batch-scheduler-types.js';
+import { JobQueue } from '../job-queue.js';
+import { RetryManager } from '../retry-manager.js';
+
+function createCoordinator(config: Partial<BatchJobConfig>, log = vi.fn()) {
+  const jobQueue = new JobQueue(10);
+  const retryManager = new RetryManager({ maxAttempts: 3, baseDelay: 10, maxErrorCount: 10 });
+  const mergedConfig: BatchJobConfig = {
+    cleanupInterval: 60_000,
+    monitoringInterval: 10_000,
+    healthCheckInterval: 10_000,
+    consolidationScoreIncrementalInterval: 60_000,
+    consolidationScoreFullSweepInterval: 86_400_000,
+    consolidationScoreFullSweepHour: 3,
+    relationValidationInterval: 604_800_000,
+    relationValidationDayOfWeek: 0,
+    relationValidationHour: 2,
+    logRotationInterval: 86_400_000,
+    tripleExtractionInterval: 3_600_000,
+    tripleExtractionBatchSize: 10,
+    tripleExtractionTimeout: 30_000,
+    qualityMeasurementInterval: 86_400_000,
+    metaMemoryIntrospectionInterval: 21_600_000,
+    sleepConsolidationInterval: 3_600_000,
+    telemetryCleanupInterval: 86_400_000,
+    memoryReviewCandidatesInterval: 86_400_000,
+    memoryReviewCandidatesSchedulerEnabled: true,
+    maxBatchSize: 1000,
+    enableLogging: true,
+    enableNotifications: false,
+    enableMetrics: true,
+    maxConcurrentJobs: 3,
+    jobTimeout: 100,
+    retryAttempts: 3,
+    retryDelay: 10,
+    tripleExtractionJobTimeout: 500,
+    ...config,
+  };
+
+  const coordinator = new BatchJobExecutionCoordinator({
+    jobQueue,
+    retryManager,
+    getConfig: () => mergedConfig,
+    getIsRunning: () => true,
+    lastExecution: new Map(),
+    totalExecutions: new Map(),
+    lastJobRunMeta: new Map(),
+    writeDiagnosticsEvent: vi.fn().mockResolvedValue(undefined),
+    log,
+    checkSchedulerHealth: vi.fn().mockResolvedValue(undefined),
+  });
+
+  return { coordinator, jobQueue, log };
+}
+
+describe('BatchJobExecutionCoordinator timeout policy', () => {
+  it('allows triple_extraction_* jobs to use the longer dedicated timeout', async () => {
+    const { coordinator, log } = createCoordinator({});
+
+    await coordinator.executeJobWithRetry(
+      'triple_extraction_mem_test',
+      async () => {
+        await new Promise(resolve => setTimeout(resolve, 200));
+      },
+      5,
+      0
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      'Job triple_extraction_mem_test completed successfully',
+      expect.objectContaining({ retryCount: 0 })
+    );
+  });
+
+  it('logs warn and skips retry when triple_extraction_* job times out', async () => {
+    const { coordinator, log, jobQueue } = createCoordinator({});
+
+    await coordinator.executeJobWithRetry(
+      'triple_extraction_mem_slow',
+      async () => {
+        await new Promise(resolve => setTimeout(resolve, 700));
+      },
+      5,
+      0
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      'Job triple_extraction_mem_slow timed out',
+      expect.objectContaining({ error: 'Job timeout after 500ms' }),
+      'warn'
+    );
+    expect(log).toHaveBeenCalledWith(
+      'Skipping immediate retry for triple_extraction_mem_slow; batch triple extraction will handle backlog',
+      expect.objectContaining({ jobName: 'triple_extraction_mem_slow' }),
+      'warn'
+    );
+    expect(jobQueue.isEmpty).toBe(true);
+  });
+
+  it('still errors and schedules retry for generic jobs on timeout', async () => {
+    vi.useFakeTimers();
+    const { coordinator, log } = createCoordinator({});
+    const addSpy = vi.spyOn(coordinator, 'addJobToQueue');
+
+    const runPromise = coordinator.executeJobWithRetry(
+      'custom_slow_job',
+      async () => {
+        await new Promise(resolve => setTimeout(resolve, 200));
+      },
+      5,
+      0
+    );
+
+    await vi.advanceTimersByTimeAsync(200);
+    await runPromise;
+
+    expect(log).toHaveBeenCalledWith(
+      'Job custom_slow_job failed',
+      expect.objectContaining({ error: 'Job timeout after 100ms' }),
+      'error'
+    );
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(addSpy).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { BatchJobConfig } from '../batch-scheduler-types.js';
+import {
+  isJobTimeoutError,
+  isTripleExtractionQueueJob,
+  resolveBatchJobTimeout,
+} from '../batch-job-timeout-resolver.js';
+
+const baseConfig = {
+  jobTimeout: 5 * 60 * 1000,
+  tripleExtractionJobTimeout: 30 * 60 * 1000,
+} as BatchJobConfig;
+
+describe('batch-job-timeout-resolver', () => {
+  it('detects per-memory triple extraction queue jobs', () => {
+    expect(isTripleExtractionQueueJob('triple_extraction_mem_123')).toBe(true);
+    expect(isTripleExtractionQueueJob('triple_extraction_batch')).toBe(true);
+    expect(isTripleExtractionQueueJob('cleanup')).toBe(false);
+  });
+
+  it('uses tripleExtractionJobTimeout for triple_extraction_* jobs', () => {
+    expect(resolveBatchJobTimeout('triple_extraction_mem_abc', baseConfig)).toBe(
+      30 * 60 * 1000
+    );
+  });
+
+  it('falls back to jobTimeout when tripleExtractionJobTimeout is unset', () => {
+    const config = { ...baseConfig, tripleExtractionJobTimeout: undefined };
+    expect(resolveBatchJobTimeout('triple_extraction_mem_abc', config)).toBe(5 * 60 * 1000);
+  });
+
+  it('uses jobTimeout for non-triple jobs', () => {
+    expect(resolveBatchJobTimeout('quality_measurement_batch', baseConfig)).toBe(5 * 60 * 1000);
+  });
+
+  it('detects timeout errors', () => {
+    expect(isJobTimeoutError(new Error('Job timeout after 300000ms'))).toBe(true);
+    expect(isJobTimeoutError(new Error('network failure'))).toBe(false);
+  });
+});

--- a/packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts
@@ -2,6 +2,11 @@ import type { BatchJobConfig } from './batch-scheduler-types.js';
 import { JobQueue } from './job-queue.js';
 import { RetryManager } from './retry-manager.js';
 import { resolveValidatedNumber } from '../../shared/config/environment.js';
+import {
+  isJobTimeoutError,
+  isTripleExtractionQueueJob,
+  resolveBatchJobTimeout
+} from './batch-job-timeout-resolver.js';
 
 export interface BatchJobExecutionCoordinatorDeps {
   jobQueue: JobQueue;
@@ -113,7 +118,8 @@ export class BatchJobExecutionCoordinator {
     });
 
     try {
-      await this.executeWithTimeout(job, this.deps.getConfig().jobTimeout);
+      const jobTimeoutMs = resolveBatchJobTimeout(name, this.deps.getConfig());
+      await this.executeWithTimeout(job, jobTimeoutMs);
       jobOk = true;
       this.deps.lastExecution.set(name, new Date());
       this.deps.totalExecutions.set(name, (this.deps.totalExecutions.get(name) || 0) + 1);
@@ -144,12 +150,29 @@ export class BatchJobExecutionCoordinator {
         duration: Date.now() - startTime
       };
 
-      this.deps.log(`Job ${name} failed`, errorInfo, 'error');
+      const isTripleExtractionTimeout =
+        isTripleExtractionQueueJob(name) && isJobTimeoutError(error);
+
+      this.deps.log(
+        isTripleExtractionTimeout ? `Job ${name} timed out` : `Job ${name} failed`,
+        errorInfo,
+        isTripleExtractionTimeout ? 'warn' : 'error'
+      );
       await this.deps.writeDiagnosticsEvent({
         type: 'batch_job_failure',
         jobName: name,
-        ...errorInfo
+        ...errorInfo,
+        severity: isTripleExtractionTimeout ? 'warn' : 'error'
       });
+
+      if (isTripleExtractionTimeout) {
+        this.deps.log(
+          `Skipping immediate retry for ${name}; batch triple extraction will handle backlog`,
+          { jobName: name, duration: errorInfo.duration },
+          'warn'
+        );
+        return;
+      }
 
       const retryResult = this.deps.retryManager.shouldRetry(name, retryCount, totalErrorCount);
 

--- a/packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts
@@ -1,0 +1,24 @@
+import type { BatchJobConfig } from './batch-scheduler-types.js';
+
+export const TRIPLE_EXTRACTION_JOB_NAME_PREFIX = 'triple_extraction_';
+
+export function isTripleExtractionQueueJob(jobName: string): boolean {
+  return jobName.startsWith(TRIPLE_EXTRACTION_JOB_NAME_PREFIX);
+}
+
+export function isJobTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes('timeout');
+}
+
+/**
+ * Resolves coordinator timeout per queued job name.
+ * Per-memory triple extraction jobs need longer LLM-bound timeouts than generic batch jobs.
+ */
+export function resolveBatchJobTimeout(jobName: string, config: BatchJobConfig): number {
+  if (isTripleExtractionQueueJob(jobName)) {
+    return config.tripleExtractionJobTimeout ?? config.jobTimeout;
+  }
+
+  return config.jobTimeout;
+}

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts
@@ -62,6 +62,12 @@ export function mergeBatchSchedulerJobConfig(overrides?: Partial<BatchJobConfig>
       n => n >= 60_000,
       '최솟값 60000'
     ),
+    tripleExtractionJobTimeout: resolveValidatedNumber(
+      'TRIPLE_EXTRACTION_JOB_TIMEOUT_MS',
+      30 * 60 * 1000,
+      n => n >= 60_000,
+      '최솟값 60000'
+    ),
     ...overrides
   };
 }

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
@@ -40,6 +40,8 @@ export interface BatchJobConfig {
   retryAttempts: number;
   retryDelay: number;
   weeklyRelationValidationTimeout?: number;
+  /** Per-memory remember() triple extraction queue jobs (Issue #475) */
+  tripleExtractionJobTimeout?: number;
 }
 
 export interface BatchJobResult {

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts
@@ -61,4 +61,16 @@ export function validateBatchJobConfig(config: BatchJobConfig): void {
       throw new Error('weeklyRelationValidationTimeout must be at least 1 second');
     }
   }
+  if (config.tripleExtractionJobTimeout !== undefined) {
+    if (
+      typeof config.tripleExtractionJobTimeout !== 'number' ||
+      Number.isNaN(config.tripleExtractionJobTimeout) ||
+      config.tripleExtractionJobTimeout <= 0
+    ) {
+      throw new Error('tripleExtractionJobTimeout must be a positive number (at least 1 second)');
+    }
+    if (config.tripleExtractionJobTimeout < 1000) {
+      throw new Error('tripleExtractionJobTimeout must be at least 1 second');
+    }
+  }
 }

--- a/specs/025-fix-triple-extraction-job-timeout/plan.md
+++ b/specs/025-fix-triple-extraction-job-timeout/plan.md
@@ -1,0 +1,10 @@
+# Implementation Plan: Issue #475
+
+**Branch**: `025-fix-triple-extraction-job-timeout`
+
+## Changes
+
+- `batch-job-timeout-resolver.ts`
+- `batch-scheduler-types.ts`, `batch-scheduler-default-config.ts`, `batch-scheduler-validate-config.ts`
+- `batch-job-execution-coordinator.ts`
+- `env.example`, tests

--- a/specs/025-fix-triple-extraction-job-timeout/spec.md
+++ b/specs/025-fix-triple-extraction-job-timeout/spec.md
@@ -1,0 +1,19 @@
+# Feature Specification: Triple Extraction Per-Memory Job Timeout
+
+**Feature Branch**: `025-fix-triple-extraction-job-timeout`  
+**Created**: 2026-06-13  
+**Issue**: [#475](https://github.com/jee1/memento/issues/475)
+
+## Requirements
+
+- FR-001: `triple_extraction_*` jobs use `TRIPLE_EXTRACTION_JOB_TIMEOUT_MS` (default 30 min).
+- FR-002: Other jobs keep generic `jobTimeout`.
+- FR-003: Triple extraction job timeout logs at WARN, not ERROR (#446 pattern).
+- FR-004: No immediate retry on triple extraction timeout (batch backoff handles retry).
+- FR-005: Config validation min 1 second via `resolveValidatedNumber`.
+
+## Success Criteria
+
+- Per-memory triple extraction uses 30 min default timeout.
+- No ERROR from 5 min generic coordinator timeout for these jobs.
+- lint, type-check, test pass.

--- a/specs/025-fix-triple-extraction-job-timeout/tasks.md
+++ b/specs/025-fix-triple-extraction-job-timeout/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #475
+
+- [x] T001 resolver + config
+- [x] T002 coordinator
+- [x] T003 tests + env
+- [x] T004 verify
+- [x] T005 PR


### PR DESCRIPTION
## Summary

- Per-memory `triple_extraction_*` queue jobs (from `remember`) now use dedicated `TRIPLE_EXTRACTION_JOB_TIMEOUT_MS` (default 30 minutes) instead of the generic 5-minute `jobTimeout`.
- Coordinator logs triple extraction timeouts at **WARN** (not ERROR) to avoid log-issue-monitor false positives (#446 pattern).
- Immediate retry is skipped on triple extraction timeout; periodic batch triple extraction handles backlog with existing backoff.

## Spec Kit

- Stage: implement (025-fix-triple-extraction-job-timeout)
- Artifacts: `specs/025-fix-triple-extraction-job-timeout/{spec,plan,tasks}.md`

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` (4556 passed)
- [x] New unit tests: `batch-job-timeout-resolver.spec.ts`, `batch-job-execution-coordinator.spec.ts`

Fixes #475

## 지식 복리

해당 없음 (운영 타임아웃 설정·로그 레벨 조정)


Made with [Cursor](https://cursor.com)