### PR TITLE
refactor(core): Suspicious god function·any 축소 (#499)

### DIFF
--- a/packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts
+++ b/packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts
@@ -19,6 +19,30 @@ import { mapRecallSearchItemsToResultItems } from './recall-tool-results.js';
 import type { RecallHybridOrTextSearchResult, RecallParams } from './recall-tool-schema.js';
 import type { RecallResultItem, RecallSearchItem } from './recall-tool-types.js';
 
+function filterLatestOnly(procedural: RecallSearchItem[]): RecallSearchItem[] {
+  const bySeries = new Map<string, RecallSearchItem>();
+  for (const item of procedural) {
+    const sid = item.version_series_id ?? item.id ?? '';
+    if (!sid) continue;
+    const cur = bySeries.get(sid);
+    const v = item.version ?? 0;
+    if (!cur || (cur.version ?? 0) < v) bySeries.set(sid, item);
+  }
+  return Array.from(bySeries.values());
+}
+
+function filterSpecificVersion(
+  procedural: RecallSearchItem[],
+  versionSeriesId?: string,
+  versionNumber?: number,
+): RecallSearchItem[] {
+  return procedural.filter((i: RecallSearchItem) => {
+    if (versionSeriesId && i.version_series_id !== versionSeriesId) return false;
+    if (versionNumber !== undefined && (i.version ?? 0) !== versionNumber) return false;
+    return true;
+  });
+}
+
 /**
  * version_filter에 따라 검색 결과를 필터링합니다.
  * latest_only: version_series_id별 최신(version 최대) 1건만 유지.
@@ -33,26 +57,8 @@ export function applyVersionFilter(
   const procedural = items.filter((i: RecallSearchItem) => i.type === 'procedural');
   const nonProcedural = items.filter((i: RecallSearchItem) => i.type !== 'procedural');
   if (procedural.length === 0) return items;
-
-  if (versionFilter === 'latest_only') {
-    const bySeries = new Map<string, RecallSearchItem>();
-    for (const item of procedural) {
-      const sid = item.version_series_id ?? item.id ?? '';
-      if (!sid) continue;
-      const cur = bySeries.get(sid);
-      const v = item.version ?? 0;
-      if (!cur || (cur.version ?? 0) < v) bySeries.set(sid, item);
-    }
-    return [...nonProcedural, ...Array.from(bySeries.values())];
-  }
-  if (versionFilter === 'specific_version') {
-    const filtered = procedural.filter((i: RecallSearchItem) => {
-      if (versionSeriesId && i.version_series_id !== versionSeriesId) return false;
-      if (versionNumber !== undefined && (i.version ?? 0) !== versionNumber) return false;
-      return true;
-    });
-    return [...nonProcedural, ...filtered];
-  }
+  if (versionFilter === 'latest_only') return [...nonProcedural, ...filterLatestOnly(procedural)];
+  if (versionFilter === 'specific_version') return [...nonProcedural, ...filterSpecificVersion(procedural, versionSeriesId, versionNumber)];
   return items;
 }
 

--- a/packages/memento-core/src/shared/utils/configuration-validator.ts
+++ b/packages/memento-core/src/shared/utils/configuration-validator.ts
@@ -20,8 +20,8 @@ export interface ConfigValidationResult {
 interface ValidateOptions {
   throwOnError?: boolean;
   logger?: {
-    warn?: (message?: any, ...optionalParams: any[]) => void;
-    error?: (message?: any, ...optionalParams: any[]) => void;
+    warn?: (message?: unknown, ...optionalParams: unknown[]) => void;
+    error?: (message?: unknown, ...optionalParams: unknown[]) => void;
   };
 }
 


### PR DESCRIPTION
## Summary

`packages/memento-core/src` Suspicious 파일 1차 목록 대응.

### 수정된 파일

| 파일 | 변경 | Before | After |
|------|------|--------|-------|
| `configuration-validator.ts` | `any×5` → `unknown` | Score=40 SUSPICIOUS | CLEAN |
| `recall-tool-post-search.ts` | `filterLatestOnly`/`filterSpecificVersion` 추출 | Score=35, complexity=17 | Score=30 |

### 팀 합의 예외 (Documented Exception)

아래 파일은 동작 보존 리팩터 리스크 또는 비즈니스 로직의 고유 복잡성으로 인해 현재 주기에서 제외:

| 파일 | 이유 |
|------|------|
| `remember-tool.ts` | `handle()` 1157줄/complexity=212 — 전용 이슈·별도 스프린트 필요 |
| `relation-graph.ts` | SQL BFS 쿼리, 동작 보존 추출 어려움 |
| `hybrid-search-engine.ts` | 알고리즘 복잡성 (search/executeVecSearch/fallback) |
| `reflexion-worker.ts` | 오케스트레이션 로직 |
| `triple-extractor.ts` | 추출 파이프라인 |
| `recall-tool-envelope.ts` | Score=20 (이미 CLEAN) |
| `agent-lifecycle-service.ts` | Score=20 (이미 CLEAN) |

## Test plan
- [x] `configuration-validator.spec.ts` 5/5 통과
- [x] `recall-tool.spec.ts` 103/103 통과

Closes #499. 상위 #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)